### PR TITLE
Model Server Component documentation triage.

### DIFF
--- a/components/k8s-model-server/README.md
+++ b/components/k8s-model-server/README.md
@@ -189,7 +189,7 @@ $MODEL_NAME  LoadBalancer   <INTERNAL IP>   <SERVICE IP>     <SERVICE PORT>:<NOD
 We will feed the `<SERVICE IP>` and `<SERVICE PORT>` to the labelling script. We will use it to label the following image of a
 cat sleeping on a comforter atop a sofa:
 
-![Cat on comforter on sofa](./inception-client/images/sleeping-pepper.jpg =200x)
+![Cat on comforter on sofa](./inception-client/images/sleeping-pepper.jpg)
 
 You can also use it to label your own images.
 

--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -5,6 +5,7 @@
 // @param name string Name to give to each of the components
 // @optionalParam namespace string default Namespace
 // @param model_path string Path to the model. This can be a GCS path.
+// @optionalParam model_server_image string gcr.io/kubeflow/model-server:1.0 Container for TF model server
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
 // because ksonnet doesn't support inheriting it from the environment yet.
@@ -15,8 +16,9 @@ local tfServing = import 'kubeflow/tf-serving/tf-serving.libsonnet';
 local name = import 'param://name';
 local namespace = import 'param://namespace';
 local modelPath = import 'param://model_path';
+local modelServerImage = import 'param://model_server_image';
 
 std.prune(k.core.v1.list.new([
-  tfServing.parts.deployment.modelServer(name, namespace, modelPath),
+  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage),
   tfServing.parts.deployment.modelService(name, namespace),
 ]))

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -10,7 +10,6 @@ local networkSpec = networkPolicy.mixin.spec;
   parts:: {
     deployment:: {
       local defaults = {
-        image:: "gcr.io/kubeflow/model-server:1.0",
         imagePullPolicy:: "IfNotPresent",
         resources:: {
           requests: {
@@ -44,16 +43,16 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
-      modelServer(name, namespace, modelPath, labels={ app: name },):
+      modelServer(name, namespace, modelPath, modelServerImage, labels={ app: name },):
         // TODO(jlewi): Allow the model to be served from a PVC.
         local volume = {
           name: "redis-data",
           namespace: namespace,
           emptyDir: {},
         };
-        base(name, namespace, modelPath, labels),
+        base(name, namespace, modelPath, modelServerImage, labels),
 
-      local base(name, namespace, modelPath, labels) =
+      local base(name, namespace, modelPath, modelServerImage, labels) =
         {
           apiVersion: "extensions/v1beta1",
           kind: "Deployment",
@@ -71,7 +70,7 @@ local networkSpec = networkPolicy.mixin.spec;
                 containers: [
                   {
                     name: name,
-                    image: defaults.image,
+                    image: modelServerImage,
                     imagePullPolicy: defaults.imagePullPolicy,
                     // TODO(jlewi): Talk to owensk to figure out why we wrap in a shell.
                     command: [


### PR DESCRIPTION
- Made it so that the image created in the instructions is utilizied
- Removed downloaded model due to incompatibility with recent TF server versions
- Made tf-serving image configurable
- Minor flow/grammar tweaks