### PR TITLE
Changing tensorflow.org to kubeflow.org. Fixing CRD deployment.

### DIFF
--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -6,7 +6,7 @@
 // @optionalParam namespace string default Namespace
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
-// @optionalParam tfJobImage string gcr.io/tf-on-k8s-dogfood/tf_operator:v20180117-04425d9-dirty-e3b0c44 The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/tf-on-k8s-dogfood/tf_operator:v20180131-cabc1c0-dirty-e3b0c44 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
@@ -84,6 +84,7 @@ std.prune(k.core.v1.list.new([
   tfjob.parts(namespace).serviceAccount,
   tfjob.parts(namespace).operatorRole,
   tfjob.parts(namespace).operatorRoleBinding,
+  tfjob.parts(namespace).crd,
 
   // TFJob controller ui
   tfjob.parts(namespace).ui(tfJobImage),

--- a/kubeflow/core/tf-job.libsonnet
+++ b/kubeflow/core/tf-job.libsonnet
@@ -6,10 +6,10 @@
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",
       metadata: {
-        name: "tfjobs.tensorflow.org",
+        name: "tfjobs.kubeflow.org",
       },
       spec: {
-        group: "tensorflow.org",
+        group: "kubeflow.org",
         version: "v1alpha1",
         names: {
           kind: "TFJob",
@@ -162,7 +162,7 @@
       rules: [
         {
           apiGroups: [
-            "tensorflow.org",
+            "tensorflow.org", "kubeflow.org",
           ],
           resources: [
             "tfjobs",
@@ -350,7 +350,7 @@
       rules: [
         {
           apiGroups: [
-            "tensorflow.org",
+            "tensorflow.org", "kubeflow.org",
           ],
           resources: [
             "tfjobs",

--- a/kubeflow/tf-job/tf-job.libsonnet
+++ b/kubeflow/tf-job/tf-job.libsonnet
@@ -35,7 +35,7 @@ local k = import 'k.libsonnet';
       else {},
 
     tfJob(name, namespace, replicas):: {
-      apiVersion: "tensorflow.org/v1alpha1",
+      apiVersion: "kubeflow.org/v1alpha1",
       kind: "TFJob",
       metadata: {
         name: name,


### PR DESCRIPTION
Sidenote: I've managed to pin most things to make sure the documentation is more robust. However I don't know how best to pin the kubeflow repo itself.

Ideally in the docs something like `ks registry add kubeflow github.com/kubeflow/kubeflow/tree/9a3e71f3/kubeflow` is done, however without a target tag I'd have to do a follow up PR to pin everything to the desired commit.

