### PR TITLE
Add ksonnet template for http proxy

### DIFF
--- a/components/k8s-model-server/README.md
+++ b/components/k8s-model-server/README.md
@@ -144,8 +144,9 @@ MODEL_NAME=inception
 #Replace this with the url to your bucket if using your own model
 MODEL_PATH=gs://kubeflow-models/inception
 MODEL_SERVER_IMAGE=gcr.io/$(gcloud config get-value project)/model-server:1.0
+# if you need REST API need to provide http_proxy_image
 HTTP_PROXY_IMAGE=gcr.io/$(gcloud config get-value project)/http-proxy:1.0
-ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME} --namespace=default --model_path=${MODEL_PATH} --model_server_image=${MODEL_SERVER_IMAGE} --http_proxy_image=${HTTP_PROXY_IMAGE}
+ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME} --namespace=default --model_path=${MODEL_PATH} --model_server_image=${MODEL_SERVER_IMAGE} [--http_proxy_image=${HTTP_PROXY_IMAGE}]
 ```
 
 Deploy it in a particular environment. The deployment will pick up environment parmameters (e.g. cloud) and customize the deployment appropriately

--- a/components/k8s-model-server/README.md
+++ b/components/k8s-model-server/README.md
@@ -144,7 +144,8 @@ MODEL_NAME=inception
 #Replace this with the url to your bucket if using your own model
 MODEL_PATH=gs://kubeflow-models/inception
 MODEL_SERVER_IMAGE=gcr.io/$(gcloud config get-value project)/model-server:1.0
-ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME} --namespace=default --model_path=${MODEL_PATH} --model_server_image=${MODEL_SERVER_IMAGE}
+HTTP_PROXY_IMAGE=gcr.io/$(gcloud config get-value project)/http-proxy:1.0
+ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME} --namespace=default --model_path=${MODEL_PATH} --model_server_image=${MODEL_SERVER_IMAGE} --http_proxy_image=${HTTP_PROXY_IMAGE}
 ```
 
 Deploy it in a particular environment. The deployment will pick up environment parmameters (e.g. cloud) and customize the deployment appropriately
@@ -183,7 +184,7 @@ listed under the value you used for the `MODEL_NAME` parameter in the ksonnet co
 ```commandline
 kubectl get services
 NAME         TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)			 AGE
-$MODEL_NAME  LoadBalancer   <INTERNAL IP>   <SERVICE IP>     <SERVICE PORT>:<NODE PORT>  <TIME SINCE DEPLOYMENT>
+$MODEL_NAME  LoadBalancer   <INTERNAL IP>   <SERVICE IP>     <SERVICE PORT>:<NODE PORT>,<HTTP SERVICE PORT>:<NODE PORT>  <TIME SINCE DEPLOYMENT>
 ```
 
 We will feed the `<SERVICE IP>` and `<SERVICE PORT>` to the labelling script. We will use it to label the following image of a
@@ -208,6 +209,43 @@ Run the script as follows:
 
 ```commandline
 python label.py -s <SERVICE IP> -p <SERVICE PORT> images/sleeping-pepper.jpg
+```
+
+#### Run the REST API script
+
+You can query the model with `curl` directly.
+
+```commandline
+(echo '{"instances": [{"image_contents": {"b64": "'; base64 ./inception-client/images/sleeping-pepper.jpg; echo '"}}]}') | curl -H "Content-Type: application/json" -X POST -d @-  <SERVICE IP>:<HTTP SERVICE PORT>/model/image_classification:predict
+```
+
+OUTPUTS
+
+```
+{"predictions":
+	[
+		{
+		  "labels": "Border terrier",
+		  "probs": 0.12965676188468933
+		},
+		{
+		  "labels": "bull mastiff",
+		  "probs": 0.10835129022598267
+		},
+		{
+		  "labels": "malinois",
+		  "probs": 0.10788080841302872
+		},
+		{
+		  "labels": "boxer",
+		  "probs": 0.03579695522785187
+		},
+		{
+		  "labels": "French bulldog",
+		  "probs": 0.02937905490398407
+		}
+	  ]
+}
 ```
 
 #### Run in Docker container with publicly exposed service

--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -6,6 +6,7 @@
 // @optionalParam namespace string default Namespace
 // @param model_path string Path to the model. This can be a GCS path.
 // @optionalParam model_server_image string gcr.io/kubeflow/model-server:1.0 Container for TF model server
+// @optionalParam http_proxy_image string gcr.io/kubeflow/http-proxy:1.0 Container for http_proxy of TF model server
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
 // because ksonnet doesn't support inheriting it from the environment yet.
@@ -17,8 +18,9 @@ local name = import 'param://name';
 local namespace = import 'param://namespace';
 local modelPath = import 'param://model_path';
 local modelServerImage = import 'param://model_server_image';
+local httpProxyImage = import 'param://http_proxy_image';
 
 std.prune(k.core.v1.list.new([
-  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage),
+  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, httpProxyImage),
   tfServing.parts.deployment.modelService(name, namespace),
 ]))

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -98,11 +98,11 @@ local networkSpec = networkPolicy.mixin.spec;
                     image: httpProxyImage,
                     imagePullPolicy: defaults.imagePullPolicy,
                     command: [
-                      "/bin/sh",
-                      "-c",
-                    ],
-                    args: [
-                      "python /usr/src/app/server.py --port=8000 --rpc_port=9000 --rpc_timeout=10.0",
+                      "python",
+                      "/usr/src/app/server.py",
+		      "--port=8000",
+		      "--rpc_port=9000",
+		      "--rpc_timeout=10.0"
                     ],
                     env: [],
                     ports: [

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -47,7 +47,7 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
-      modelServer(name, namespace, modelPath, modelServerImage, httpProxyImage, labels={ app: name },):
+      modelServer(name, namespace, modelPath, modelServerImage, httpProxyImage=0, labels={ app: name },):
         // TODO(jlewi): Allow the model to be served from a PVC.
         local volume = {
           name: "redis-data",
@@ -92,6 +92,7 @@ local networkSpec = networkPolicy.mixin.spec;
                     // model-server doesn't have something we can use out of the box.
                     resources: defaults.resources,
                   },
+		  if httpProxyImage != 0 then
 		  {
 		    name: name+"-http-proxy",
                     image: httpProxyImage,

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -37,6 +37,10 @@ local networkSpec = networkPolicy.mixin.spec;
               port: 9000,
               targetPort: 9000,
             },
+            {
+              port: 8000,
+              targetPort: 8000,
+            },
           ],
           selector: labels,
           type: "ClusterIP",

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -43,16 +43,16 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
-      modelServer(name, namespace, modelPath, modelServerImage, labels={ app: name },):
+      modelServer(name, namespace, modelPath, modelServerImage, httpProxyImage, labels={ app: name },):
         // TODO(jlewi): Allow the model to be served from a PVC.
         local volume = {
           name: "redis-data",
           namespace: namespace,
           emptyDir: {},
         };
-        base(name, namespace, modelPath, modelServerImage, labels),
+        base(name, namespace, modelPath, modelServerImage, httpProxyImage, labels),
 
-      local base(name, namespace, modelPath, modelServerImage, labels) =
+      local base(name, namespace, modelPath, modelServerImage, httpProxyImage, labels) =
         {
           apiVersion: "extensions/v1beta1",
           kind: "Deployment",
@@ -88,6 +88,25 @@ local networkSpec = networkPolicy.mixin.spec;
                     // model-server doesn't have something we can use out of the box.
                     resources: defaults.resources,
                   },
+		  {
+		    name: name+"-http-proxy",
+                    image: httpProxyImage,
+                    imagePullPolicy: defaults.imagePullPolicy,
+                    command: [
+                      "/bin/sh",
+                      "-c",
+                    ],
+                    args: [
+                      "python /usr/src/app/server.py --port=8000 --rpc_port=9000 --rpc_timeout=10.0",
+                    ],
+                    env: [],
+                    ports: [
+                      {
+                        containerPort: 8000,
+                      },
+                    ],
+                    resources: defaults.resources,
+		  },
                 ],
                 // See:  https://github.com/kubeflow/kubeflow/tree/master/components/k8s-model-server#set-the-user-optional
                 // The is user and group should be defined in the Docker image.


### PR DESCRIPTION
with the http-proxy image, now user can finally test the inception model without client requirements

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/228)
<!-- Reviewable:end -->
