### PR TITLE
Fix bug with using LoadBalancer for JupyterHub.

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -200,6 +200,8 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
         namespace: namespace,
       },
       spec: {
+        // We want a headless service so we set the ClusterIP to be None.
+        // This headless server is used by individual Jupyter pods to connect back to the Hub.
         clusterIP: "None",
         ports: [
           {
@@ -218,15 +220,12 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
       kind: "Service",
       metadata: {
         labels: {
-          app: "tf-hub",
+          app: "tf-hub-lb",
         },
-        name: "tf-hub-0",
+        name: "tf-hub-lb",
         namespace: namespace,
       },
       spec: {
-        // We want a headless service so we set the ClusterIP to be None.
-        // This headless server is used by individual Jupyter pods to connect back to the Hub.
-        clusterIP: "None",
         ports: [
           {
             name: "hub",


### PR DESCRIPTION
* The two services were incorrectly using the same name.
* The LB should not set the ClusterIP to None as this causes a problem
  when the service type is loadbalancer.

* Fix #203 