### PR TITLE
*: Replace tensorflow/k8s with kubeflow/tf-operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you want to use GPUs, be sure to follow the Kubernetes [instructions for enab
 ### Requirements
 
   * ksonnet version [0.8.0](https://ksonnet.io/#get-started) or later.
-  * Kubernetes >= 1.8 [see here](https://github.com/tensorflow/k8s#requirements)
+  * Kubernetes >= 1.8 [see here](https://github.com/kubeflow/tf-operator#requirements)
 
 ### Steps
 

--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -17,12 +17,12 @@
 """Test deploying Kubeflow.
 
 Requirements:
-  This project assumes the py directory in github.com/tensorflow/k8s corresponds
+  This project assumes the py directory in github.com/kubeflow/tf-operator corresponds
   to a top level Python package on the Python path.
 
   TODO(jlewi): Come up with a better story for how we reuse the py package
-  in tensorflow/k8s. We should probably turn that into a legit Python pip
-  package that is built and released as part of the tensorflow/k8s project.
+  in kubeflow/tf-operator. We should probably turn that into a legit Python pip
+  package that is built and released as part of the kubeflow/tf-operator project.
 """
 
 import argparse

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -45,7 +45,7 @@
       // The directory within the kubeflow_testing submodule containing
       // py scripts to use.
       local kubeflowTestingPy = srcRootDir + "/kubeflow/testing/py";
-      local tfOperatorRoot = srcRootDir + "/tensorflow/k8s";
+      local tfOperatorRoot = srcRootDir + "/kubeflow/tf-operator";
       local tfOperatorPy = tfOperatorRoot;
 
       local project = "mlkube-testing";
@@ -180,8 +180,8 @@
                   srcRootDir,
                 ],
                 env: prow_env + [{
-                  name: "EXTRA_REPOS",                  
-                  value: "tensorflow/k8s@HEAD;kubeflow/testing@HEAD",
+                  name: "EXTRA_REPOS",
+                  value: "kubeflow/tf-operator@HEAD;kubeflow/testing@HEAD",
                 }],
                 image: image,
                 volumeMounts: [

--- a/user_guide.md
+++ b/user_guide.md
@@ -7,7 +7,7 @@ This guide will walk you through the basics of deploying and interacting with Ku
 * [Ksonnet](https://ksonnet.io/docs/tutorial)
 
 ## Requirements
- * Kubernetes >= 1.8 [see here](https://github.com/tensorflow/k8s#requirements)
+ * Kubernetes >= 1.8 [see here](https://github.com/kubeflow/tf-operator#requirements)
  * ksonnet version [0.8.0](https://ksonnet.io/#get-started) or later. (See [below](#why-kubeflow-uses-ksonnet) for an explanation of why we use ksonnet)
 
 ## Deploy Kubeflow
@@ -181,7 +181,7 @@ In this example, you should be able to use the inception_client to hit ww.xx.yy.
 ### Submiting a TensorFlow training job
 
 **Note:** Before submitting a training job, you should have [deployed kubeflow to your cluster](#deploy-kubeflow). Doing so ensures that
-the [`TFJob` custom resource](https://github.com/tensorflow/k8s) is available when you submit the training job.
+the [`TFJob` custom resource](https://github.com/kubeflow/tf-operator) is available when you submit the training job.
 
 We treat each TensorFlow job as a [component](https://ksonnet.io/docs/tutorial#2-generate-and-deploy-an-app-component) in your APP.
 
@@ -216,7 +216,7 @@ To run your job
 ks apply ${KF_ENV} -c ${JOB_NAME}
 ```
 
-For information on monitoring your job please refer to the [TfJob docs](https://github.com/tensorflow/k8s#monitoring-your-job).
+For information on monitoring your job please refer to the [TfJob docs](https://github.com/kubeflow/tf-operator#monitoring-your-job).
 
 #### Run the TfCnn example
 


### PR DESCRIPTION
See https://github.com/kubeflow/tf-operator/issues/350

We have migrated tensorflow/k8s to kubeflow/tf-operator, then we should update the repo name.

Signed-off-by: Ce Gao <gaoce@caicloud.io>