### PR TITLE
install Ksonnet 0.8.0 in both CPU and GPU dockerfile.

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile.cpu
+++ b/components/tensorflow-notebook-image/Dockerfile.cpu
@@ -50,6 +50,12 @@ RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.10.0/tini 
     mv tini /usr/local/bin/tini && \
     chmod +x /usr/local/bin/tini
 
+# Install ksonnet
+RUN wget --quiet https://github.com/ksonnet/ksonnet/releases/download/v0.8.0/ks_0.8.0_linux_amd64.tar.gz && \
+    tar -zvxf ks_0.8.0_linux_amd64.tar.gz && \
+    mv ks_0.8.0_linux_amd64/ks /usr/local/bin/ks && \
+    chmod +x /usr/local/bin/ks
+
 # Configure environment
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH

--- a/components/tensorflow-notebook-image/Dockerfile.gpu
+++ b/components/tensorflow-notebook-image/Dockerfile.gpu
@@ -50,6 +50,12 @@ RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.10.0/tini 
     mv tini /usr/local/bin/tini && \
     chmod +x /usr/local/bin/tini
 
+# Install ksonnet
+RUN wget --quiet https://github.com/ksonnet/ksonnet/releases/download/v0.8.0/ks_0.8.0_linux_amd64.tar.gz && \
+    tar -zvxf ks_0.8.0_linux_amd64.tar.gz && \
+    mv ks_0.8.0_linux_amd64/ks /usr/local/bin/ks && \
+    chmod +x /usr/local/bin/ks
+
 # Configure environment
 ENV CONDA_DIR /opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH


### PR DESCRIPTION
- to fix #138 
- added Ksonnet 0.8.0 install to both CPU and GPU dockerfile
- verified in docker CLI that jovyan is able to execute ks
```shell
jovyan@658114ba5b01:~$ ks

You can use the `ks` commands to write, share, and deploy your Kubernetes
application configuration to remote clusters.
```
