### PR TITLE
Redirect / to /hub for the envoy pods

### DIFF
--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -240,6 +240,21 @@
                             ],
                           },
                         },
+                        // Redirect to jupyterhub when visiting /
+                        {
+                          timeout_ms: 10000,
+                          path: "/",
+                          prefix_rewrite: "/hub",
+                          use_websocket: true,
+                          weighted_clusters: {
+                            clusters: [
+                              {
+                                name: "cluster_jupyterhub",
+                                weight: 100.0,
+                              },
+                            ],
+                          },
+                        },
                         {
                           // Route remaining traffic to Ambassador which supports dynamically adding
                           // routes based on service annotations.

--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -240,6 +240,9 @@
                             ],
                           },
                         },
+                        // TODO(ankushagarwal): We should eventually
+                        // redirect to the central UI once its ready
+                        // See https://github.com/kubeflow/kubeflow/pull/146
                         // Redirect to jupyterhub when visiting /
                         {
                           timeout_ms: 10000,


### PR DESCRIPTION
Visiting / returns a 404 right now. This change will redirect
/ to jupyterhub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/257)
<!-- Reviewable:end -->
