### PR TITLE
Fix typo in user_guide.md

### DIFF
--- a/user_guide.md
+++ b/user_guide.md
@@ -269,7 +269,7 @@ Create the disks
 Configure the environment to use the disks.
 
 ```
-ks param set --env=cloud nfs disks ${PD_DISK1},${PD_DISK2}
+ks param set --env=cloud kubeflow-core disks ${PD_DISK1},${PD_DISK2}
 ```
 
 Deploy the environment


### PR DESCRIPTION
`disks` parameter should be set for the `kubeflow-core` component

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/259)
<!-- Reviewable:end -->
