### PR TITLE
Add mount of pvc

### DIFF
--- a/kubeflow/core/jupyterhub_spawner.py
+++ b/kubeflow/core/jupyterhub_spawner.py
@@ -91,3 +91,18 @@ c.KubeSpawner.user_storage_pvc_ensure = True
 # How much disk space do we want?
 c.KubeSpawner.user_storage_capacity = '10Gi'
 c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
+c.KubeSpawner.volumes = [
+  {
+    'name': 'volume-{username}{servername}',
+    'persistentVolumeClaim': {
+      'claimName': 'claim-{username}{servername}'
+    }
+  }
+]
+c.KubeSpawner.volume_mounts = [
+  {
+    'mountPath': '/home/jovyan/work',
+    'name': 'volume-{username}{servername}'
+  }
+]
+


### PR DESCRIPTION
While we were adding pvc for every jupyter instance, we didn't mount it
anywhere.
Let's mount it to work dir, as I assume this is dir where users will
likely put their notebooks. This will ensure that work will be retained
even if pod dies.

Fix #19
Fix #22 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/270)
<!-- Reviewable:end -->
