### PR TITLE
add prow_config.yaml

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,0 +1,10 @@
+# This file configures the workflows to trigger in our Prow jobs.
+# see kubeflow/testing/py/run_e2e_workflow.py
+workflows:
+  - app_dir: kubeflow/kubeflow/testing/workflows
+    component: workflows
+    name: kubeflow-e2e
+
+  - app_dir: kubeflow/kubeflow/components/k8s-model-server/images/releaser
+    component: workflows
+    name: tf-serving-image

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -8,3 +8,4 @@ workflows:
   - app_dir: kubeflow/kubeflow/components/k8s-model-server/images/releaser
     component: workflows
     name: tf-serving-image
+

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -4,8 +4,3 @@ workflows:
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: workflows
     name: kubeflow-e2e
-
-  - app_dir: kubeflow/kubeflow/components/k8s-model-server/images/releaser
-    component: workflows
-    name: tf-serving-image
-


### PR DESCRIPTION
prow_config.yaml contains the workflows that we want to run by prow.

By using prow_config.yaml, we can use the same testing image for different kubeflow repos.

Related to #276 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/271)
<!-- Reviewable:end -->
