### PR TITLE
update image to use prow_config if exists

### DIFF
--- a/testing/run.sh
+++ b/testing/run.sh
@@ -26,7 +26,8 @@ if [ -f /src/${REPO_OWNER}/${REPO_NAME}/prow_config.yaml ]; then
       --zone=us-east1-d \
       --cluster=kubeflow-testing \
       --bucket=kubernetes-jenkins \
-      --config_file=/src/${REPO_OWNER}/${REPO_NAME}/prow_config.yaml
+      --config_file=/src/${REPO_OWNER}/${REPO_NAME}/prow_config.yaml \
+      --repos_dir=/src
 else
   python -m kubeflow.testing.run_e2e_workflow \
       --project=mlkube-testing \

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -26,4 +26,6 @@ python -m kubeflow.testing.run_e2e_workflow \
 	--cluster=kubeflow-testing \
 	--bucket=kubernetes-jenkins \
 	--component=workflows \
-	--app_dir=/src/kubeflow/kubeflow/testing/workflows
+	--app_dir=/src/kubeflow/kubeflow/testing/workflows \
+        --config_file=/src/${REPO_OWNER}/${REPO_NAME}/prow_config.yaml
+

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -34,6 +34,6 @@ else
       --cluster=kubeflow-testing \
       --bucket=kubernetes-jenkins \
       --component=workflows \
-      --app_dir=/src/kubeflow/kubeflow/testing/workflows \
+      --app_dir=/src/kubeflow/kubeflow/testing/workflows
 fi
 

--- a/testing/run.sh
+++ b/testing/run.sh
@@ -19,13 +19,21 @@ set -ex
 # Checkout the code.
 /usr/local/bin/checkout.sh /src
 
-# Trigger a workflow	          
-python -m kubeflow.testing.run_e2e_workflow \
-	--project=mlkube-testing \
-	--zone=us-east1-d \
-	--cluster=kubeflow-testing \
-	--bucket=kubernetes-jenkins \
-	--component=workflows \
-	--app_dir=/src/kubeflow/kubeflow/testing/workflows \
-        --config_file=/src/${REPO_OWNER}/${REPO_NAME}/prow_config.yaml
+# Trigger a workflow
+if [ -f /src/${REPO_OWNER}/${REPO_NAME}/prow_config.yaml ]; then
+  python -m kubeflow.testing.run_e2e_workflow \
+      --project=mlkube-testing \
+      --zone=us-east1-d \
+      --cluster=kubeflow-testing \
+      --bucket=kubernetes-jenkins \
+      --config_file=/src/${REPO_OWNER}/${REPO_NAME}/prow_config.yaml
+else
+  python -m kubeflow.testing.run_e2e_workflow \
+      --project=mlkube-testing \
+      --zone=us-east1-d \
+      --cluster=kubeflow-testing \
+      --bucket=kubernetes-jenkins \
+      --component=workflows \
+      --app_dir=/src/kubeflow/kubeflow/testing/workflows \
+fi
 


### PR DESCRIPTION
depending on https://github.com/kubeflow/testing/pull/39

After this change, we will update the testing image for kubeflow/kubeflow to:
 - use prow_config.yaml if exists
 - else, use legacy workflow

This will be backward compatible, and we can check in the prow_config.yaml later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/275)
<!-- Reviewable:end -->
