### PR TITLE
Fix tf-serving command and args

### DIFF
--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -76,11 +76,11 @@ local networkSpec = networkPolicy.mixin.spec;
                     name: name,
                     image: modelServerImage,
                     imagePullPolicy: defaults.imagePullPolicy,
+                    command: ["/usr/bin/tensorflow_model_server"],
                     args: [
-                      "/usr/bin/tensorflow_model_server",
-		      " --port=9000",
-		      " --model_name=" + name,
-		      " --model_base_path=" + modelPath,
+                      "--port=9000",
+                      "--model_name=" + name,
+                      "--model_base_path=" + modelPath,
                     ],
                     env: [],
                     ports: [


### PR DESCRIPTION
* Remove spaces from argument prefixes
* Make the binary name a command instead of argument

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/280)
<!-- Reviewable:end -->
