### PR TITLE
Add names to tfserving service ports

### DIFF
--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -34,10 +34,12 @@ local networkSpec = networkPolicy.mixin.spec;
         spec: {
           ports: [
             {
+              name: tf-serving
               port: 9000,
               targetPort: 9000,
             },
             {
+              name: tf-serving-proxy
               port: 8000,
               targetPort: 8000,
             },

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -34,12 +34,12 @@ local networkSpec = networkPolicy.mixin.spec;
         spec: {
           ports: [
             {
-              name: tf-serving
+              name: "tf-serving",
               port: 9000,
               targetPort: 9000,
             },
             {
-              name: tf-serving-proxy
+              name: "tf-serving-proxy",
               port: 8000,
               targetPort: 8000,
             },


### PR DESCRIPTION
Kubernetes requires port names for services with
more than one port

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/283)
<!-- Reviewable:end -->
