### PR TITLE
add option service_type to set TFServing service type

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -7,6 +7,7 @@
 // @param model_path string Path to the model. This can be a GCS path.
 // @optionalParam model_server_image string gcr.io/kubeflow/model-server:1.0 Container for TF model server
 // @optionalParam http_proxy_image string gcr.io/kubeflow/http-proxy:1.0 Container for http_proxy of TF model server
+// @optionalParam service_type string ClusterIP The service type for TFServing deployment.
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
 // because ksonnet doesn't support inheriting it from the environment yet.
@@ -19,8 +20,9 @@ local namespace = import "param://namespace";
 local modelPath = import "param://model_path";
 local modelServerImage = import "param://model_server_image";
 local httpProxyImage = import "param://http_proxy_image";
+local serviceType = import "param://service_type";
 
 std.prune(k.core.v1.list.new([
   tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, httpProxyImage),
-  tfServing.parts.deployment.modelService(name, namespace),
+  tfServing.parts.deployment.modelService(name, namespace, serviceType),
 ]))

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -23,7 +23,7 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
-      modelService(name, namespace, labels={ app: name }): {
+      modelService(name, namespace, serviceType, labels={ app: name }): {
         apiVersion: "v1",
         kind: "Service",
         metadata: {
@@ -45,7 +45,7 @@ local networkSpec = networkPolicy.mixin.spec;
             },
           ],
           selector: labels,
-          type: "ClusterIP",
+          type: serviceType,
         },
       },
 


### PR DESCRIPTION
#295 
tf-serving : added optional parameter "service_type" default to clusterIP.
this parameter is then passed to modelService().

This can be tested as follows:
```BASH
ks param set ${MODEL_COMPONENT} service_type LoadBalancer
ks apply ${KF_ENV} -c ${MODEL_COMPONENT}
```
should see your serving component is now of type LoadBalancer instead of ClusterIP
```
NAME         TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                         AGE
inception1   LoadBalancer   10.59.249.163   *.*.*.*   9000:31346/TCP,8000:32337/TCP   14m
```
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/302)
<!-- Reviewable:end -->
