### PR TITLE
Adding S3 support to model serving.

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -8,6 +8,12 @@
 // @optionalParam model_server_image string gcr.io/kubeflow-images-staging/tf-model-server:v20180227-master Container for TF model server
 // @optionalParam http_proxy_image string gcr.io/kubeflow/http-proxy:1.0 Container for http_proxy of TF model server
 // @optionalParam service_type string ClusterIP The service type for TFServing deployment.
+// @optionalParam aws_access_key_id string key_id S3 access key id
+// @optionalParam aws_secret_access_key string secret_key S3 secret access key
+// @optionalParam aws_region string us-west-1 S3 Region
+// @optionalParam s3_use_https string true Whether or not to use https for S3 connections
+// @optionalParam s3_verify_ssl string true Whether or not to verify https certificates for S3 connections
+// @optionalParam s3_endpoint string http://s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint.
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
 // because ksonnet doesn't support inheriting it from the environment yet.
@@ -21,8 +27,26 @@ local modelPath = import "param://model_path";
 local modelServerImage = import "param://model_server_image";
 local httpProxyImage = import "param://http_proxy_image";
 local serviceType = import "param://service_type";
+local awsAccessKeyID = import "param://aws_access_key_id";
+local awsSecretAccessKey = import "param://aws_secret_access_key";
+local awsRegion = import "param://aws_region";
+local s3UseHTTPS = import "param://s3_use_https";
+local s3VerifySSL = import "param://s3_verify_ssl";
+local s3Endpoint = import "param://s3_endpoint";
+
+
+local modelServerEnv = [
+  { name: "AWS_ACCESS_KEY_ID", valueFrom: { secretKeyRef: { name: name, key: "aws-access-key-id" }, }, },
+  { name: "AWS_SECRET_ACCESS_KEY", valueFrom: { secretKeyRef: { name: name, key: "aws-secret-access-key" }, }, },
+  { name: "AWS_REGION", value: awsRegion },
+  { name: "S3_REGION", value: awsRegion },
+  { name: "S3_USE_HTTPS", value: s3UseHTTPS },
+  { name: "S3_VERIFY_SSL", value: s3VerifySSL },
+  { name: "S3_ENDPOINT", value: s3Endpoint },
+];
 
 std.prune(k.core.v1.list.new([
-  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, httpProxyImage),
+  tfServing.parts.deployment.modelSecret(name, namespace, awsAccessKeyID, awsSecretAccessKey),
+  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage),
   tfServing.parts.deployment.modelService(name, namespace, serviceType),
 ]))

--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -8,12 +8,9 @@
 // @optionalParam model_server_image string gcr.io/kubeflow-images-staging/tf-model-server:v20180227-master Container for TF model server
 // @optionalParam http_proxy_image string gcr.io/kubeflow/http-proxy:1.0 Container for http_proxy of TF model server
 // @optionalParam service_type string ClusterIP The service type for TFServing deployment.
-// @optionalParam s3_create_secret string true Whether or not to create a secret containing aws-access-key-id and aws-secret-access-key. Otherwise will use provided secret.
-// @optionalParam s3_secret_name string s3-credentials Name of the k8s secrets containing S3 credentials.
+// @optionalParam s3_secret_name string  Name of the k8s secrets containing S3 credentials.
 // @optionalParam s3_secret_accesskeyid_key_name string aws-access-key-id Name of the key in the k8s secret containing AWS_ACCESS_KEY_ID.
 // @optionalParam s3_secret_secretaccesskey_key_name string aws-secret-access-key Name of the key in the k8s secret containing AWS_SECRET_ACCESS_KEY.
-// @optionalParam s3_aws_access_key_id string key_id S3 access key id
-// @optionalParam s3_aws_secret_access_key string secret_key S3 secret access key
 // @optionalParam s3_aws_region string us-west-1 S3 Region
 // @optionalParam s3_use_https string true Whether or not to use https for S3 connections
 // @optionalParam s3_verify_ssl string true Whether or not to verify https certificates for S3 connections
@@ -31,19 +28,16 @@ local modelPath = import "param://model_path";
 local modelServerImage = import "param://model_server_image";
 local httpProxyImage = import "param://http_proxy_image";
 local serviceType = import "param://service_type";
-local s3CreateSecret = import "param://s3_create_secret";
 local s3SecretName = import "param://s3_secret_name";
 local s3SecretAccesskeyidKeyName = import "param://s3_secret_accesskeyid_key_name";
 local s3SecretSecretaccesskeyKeyName = import "param://s3_secret_secretaccesskey_key_name";
-local s3awsAccessKeyID = import "param://s3_aws_access_key_id";
-local s3awsSecretAccessKey = import "param://s3_aws_secret_access_key";
 local s3awsRegion = import "param://s3_aws_region";
 local s3UseHTTPS = import "param://s3_use_https";
 local s3VerifySSL = import "param://s3_verify_ssl";
 local s3Endpoint = import "param://s3_endpoint";
 
 
-local modelServerEnv = [
+local modelServerEnv = if s3SecretName != "" then [
   { name: "AWS_ACCESS_KEY_ID", valueFrom: { secretKeyRef: { name: s3SecretName, key: s3SecretAccesskeyidKeyName }, }, },
   { name: "AWS_SECRET_ACCESS_KEY", valueFrom: { secretKeyRef: { name: s3SecretName, key: s3SecretSecretaccesskeyKeyName }, }, },
   { name: "AWS_REGION", value: s3awsRegion },
@@ -51,13 +45,9 @@ local modelServerEnv = [
   { name: "S3_USE_HTTPS", value: s3UseHTTPS },
   { name: "S3_VERIFY_SSL", value: s3VerifySSL },
   { name: "S3_ENDPOINT", value: s3Endpoint },
-];
+] else [];
 
-local objects = [
-  tfServing.parts.deployment.modelService(name, namespace, serviceType),
+std.prune(k.core.v1.list.new([
   tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage),
-  if s3CreateSecret == "true" then
-    tfServing.parts.deployment.modelSecret(s3SecretName, namespace, s3awsAccessKeyID, s3awsSecretAccessKey),
-];
-
-std.prune(k.core.v1.list.new(objects))
+  tfServing.parts.deployment.modelService(name, namespace, serviceType),
+]))

--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -8,9 +8,13 @@
 // @optionalParam model_server_image string gcr.io/kubeflow-images-staging/tf-model-server:v20180227-master Container for TF model server
 // @optionalParam http_proxy_image string gcr.io/kubeflow/http-proxy:1.0 Container for http_proxy of TF model server
 // @optionalParam service_type string ClusterIP The service type for TFServing deployment.
-// @optionalParam aws_access_key_id string key_id S3 access key id
-// @optionalParam aws_secret_access_key string secret_key S3 secret access key
-// @optionalParam aws_region string us-west-1 S3 Region
+// @optionalParam s3_create_secret string true Whether or not to create a secret containing aws-access-key-id and aws-secret-access-key. Otherwise will use provided secret.
+// @optionalParam s3_secret_name string s3-credentials Name of the k8s secrets containing S3 credentials.
+// @optionalParam s3_secret_accesskeyid_key_name string aws-access-key-id Name of the key in the k8s secret containing AWS_ACCESS_KEY_ID.
+// @optionalParam s3_secret_secretaccesskey_key_name string aws-secret-access-key Name of the key in the k8s secret containing AWS_SECRET_ACCESS_KEY.
+// @optionalParam s3_aws_access_key_id string key_id S3 access key id
+// @optionalParam s3_aws_secret_access_key string secret_key S3 secret access key
+// @optionalParam s3_aws_region string us-west-1 S3 Region
 // @optionalParam s3_use_https string true Whether or not to use https for S3 connections
 // @optionalParam s3_verify_ssl string true Whether or not to verify https certificates for S3 connections
 // @optionalParam s3_endpoint string http://s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint.
@@ -27,26 +31,33 @@ local modelPath = import "param://model_path";
 local modelServerImage = import "param://model_server_image";
 local httpProxyImage = import "param://http_proxy_image";
 local serviceType = import "param://service_type";
-local awsAccessKeyID = import "param://aws_access_key_id";
-local awsSecretAccessKey = import "param://aws_secret_access_key";
-local awsRegion = import "param://aws_region";
+local s3CreateSecret = import "param://s3_create_secret";
+local s3SecretName = import "param://s3_secret_name";
+local s3SecretAccesskeyidKeyName = import "param://s3_secret_accesskeyid_key_name";
+local s3SecretSecretaccesskeyKeyName = import "param://s3_secret_secretaccesskey_key_name";
+local s3awsAccessKeyID = import "param://s3_aws_access_key_id";
+local s3awsSecretAccessKey = import "param://s3_aws_secret_access_key";
+local s3awsRegion = import "param://s3_aws_region";
 local s3UseHTTPS = import "param://s3_use_https";
 local s3VerifySSL = import "param://s3_verify_ssl";
 local s3Endpoint = import "param://s3_endpoint";
 
 
 local modelServerEnv = [
-  { name: "AWS_ACCESS_KEY_ID", valueFrom: { secretKeyRef: { name: name, key: "aws-access-key-id" }, }, },
-  { name: "AWS_SECRET_ACCESS_KEY", valueFrom: { secretKeyRef: { name: name, key: "aws-secret-access-key" }, }, },
-  { name: "AWS_REGION", value: awsRegion },
-  { name: "S3_REGION", value: awsRegion },
+  { name: "AWS_ACCESS_KEY_ID", valueFrom: { secretKeyRef: { name: s3SecretName, key: s3SecretAccesskeyidKeyName }, }, },
+  { name: "AWS_SECRET_ACCESS_KEY", valueFrom: { secretKeyRef: { name: s3SecretName, key: s3SecretSecretaccesskeyKeyName }, }, },
+  { name: "AWS_REGION", value: s3awsRegion },
+  { name: "S3_REGION", value: s3awsRegion },
   { name: "S3_USE_HTTPS", value: s3UseHTTPS },
   { name: "S3_VERIFY_SSL", value: s3VerifySSL },
   { name: "S3_ENDPOINT", value: s3Endpoint },
 ];
 
-std.prune(k.core.v1.list.new([
-  tfServing.parts.deployment.modelSecret(name, namespace, awsAccessKeyID, awsSecretAccessKey),
-  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage),
+local objects = [
   tfServing.parts.deployment.modelService(name, namespace, serviceType),
-]))
+  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage),
+  if s3CreateSecret == "true" then
+    tfServing.parts.deployment.modelSecret(s3SecretName, namespace, s3awsAccessKeyID, s3awsSecretAccessKey),
+];
+
+std.prune(k.core.v1.list.new(objects))

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -23,6 +23,19 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
+      modelSecret(name, namespace, awsAccessKeyID, awsSecretAccessKey, labels={ app: name}): {
+        apiVersion: "v1",
+        kind: "Secret",
+        metadata: {
+          name: name,
+        },
+        type: "Opaque",
+        data: {
+          "aws-access-key-id": std.base64(awsAccessKeyID),
+          "aws-secret-access-key": std.base64(awsSecretAccessKey),
+        },
+      },
+
       modelService(name, namespace, serviceType, labels={ app: name }): {
         apiVersion: "v1",
         kind: "Service",
@@ -70,16 +83,16 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
-      modelServer(name, namespace, modelPath, modelServerImage, httpProxyImage=0, labels={ app: name },):
+      modelServer(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage=0, labels={ app: name },):
         // TODO(jlewi): Allow the model to be served from a PVC.
         local volume = {
           name: "redis-data",
           namespace: namespace,
           emptyDir: {},
         };
-        base(name, namespace, modelPath, modelServerImage, httpProxyImage, labels),
+        base(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage, labels),
 
-      local base(name, namespace, modelPath, modelServerImage, httpProxyImage, labels) =
+      local base(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage, labels) =
         {
           apiVersion: "extensions/v1beta1",
           kind: "Deployment",
@@ -105,7 +118,7 @@ local networkSpec = networkPolicy.mixin.spec;
                       "--model_name=" + name,
                       "--model_base_path=" + modelPath,
                     ],
-                    env: [],
+                    env: modelServerEnv,
                     ports: [
                       {
                         containerPort: 9000,

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -28,6 +28,7 @@ local networkSpec = networkPolicy.mixin.spec;
         kind: "Secret",
         metadata: {
           name: name,
+          namespace: namespace,
         },
         type: "Opaque",
         data: {

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -23,20 +23,6 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
-      modelSecret(name, namespace, awsAccessKeyID, awsSecretAccessKey, labels={ app: name}): {
-        apiVersion: "v1",
-        kind: "Secret",
-        metadata: {
-          name: name,
-          namespace: namespace,
-        },
-        type: "Opaque",
-        data: {
-          "aws-access-key-id": std.base64(awsAccessKeyID),
-          "aws-secret-access-key": std.base64(awsSecretAccessKey),
-        },
-      },
-
       modelService(name, namespace, serviceType, labels={ app: name }): {
         apiVersion: "v1",
         kind: "Service",


### PR DESCRIPTION
This allows the model serving image to download from any S3 compatible API.

The pattern may also find its way into other components such as tf-job in order to facilitate reading/writing to s3 during training.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/323)
<!-- Reviewable:end -->