### PR TITLE
Improve the Python 2 kernels for both CPU and GPU instances.

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile.cpu
+++ b/components/tensorflow-notebook-image/Dockerfile.cpu
@@ -72,7 +72,6 @@ RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER $CONDA_DIR
 
-
 # Setup work directory for backward-compatibility
 RUN mkdir /home/$NB_USER/work
 
@@ -103,7 +102,6 @@ WORKDIR $HOME
 # Configure container startup
 ENTRYPOINT ["tini", "--"]
 CMD ["start-notebook.sh"]
-
 
 # Install CUDA Profile Tools and other python packages
 RUN pip --no-cache-dir install \
@@ -176,26 +174,41 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
 # Activate ipywidgets extension in the environment that runs the notebook server
 RUN jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
-RUN chown -R $NB_USER /home/$NB_USER/
-
 RUN curl -L -o bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.8.0/bazel-0.8.0-installer-linux-x86_64.sh && chmod a+x ./bazel.sh && ./bazel.sh && rm ./bazel.sh
 SHELL ["/bin/bash", "-c"]
 
 RUN git clone https://github.com/tensorflow/models.git /home/$NB_USER/tensorflow-models && git clone https://github.com/tensorflow/benchmarks.git /home/$NB_USER/tensorflow-benchmarks
-RUN conda create -n ipykernel_py2 python=2 ipykernel && \
-    source activate ipykernel_py2 && \
-    python -m ipykernel install --user && \
-    source deactivate
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
 RUN pip install jupyter-tensorboard
+
+# Create a conda environment for Python 2. We want to include as many of the
+# packages from our root environment as we reasonably can, so we explicitly
+# list that environment, then include everything unless it is Conda (which
+# can only be in the root environment), Jupyterhub (which requires Python 3),
+# or Python itself. We also want to include the pip packages, but we cannot
+# install those via conda, so we list them, drop any conda packages, and
+# then install them via pip. We do this on a best-effort basis, so if any
+# packages from the Python 3 environment cannot be installed with Python 2,
+# then we just skip them.
+RUN conda_packages=$(conda list -e | cut -d '=' -f 1 | grep -v '#' | sort) && \
+    pip_packages=$(pip --no-cache-dir list --format=freeze | cut -d '=' -f 1 | grep -v '#' | sort) && \
+    pip_only_packages=$(comm -23 <(echo "${pip_packages}") <(echo "${conda_packages}")) && \
+    conda create -n ipykernel_py2 python=2 --file <(echo "${conda_packages}" | grep -v conda | grep -v python | grep -v jupyterhub) && \
+    source activate ipykernel_py2 && \
+    python -m ipykernel install --user && \
+    echo "${pip_only_packages}" | xargs -n 1 -I "{}" /bin/bash -c 'pip install --no-cache-dir {} || true' && \
+    pip install --no-cache-dir tensorflow-transform && \
+    source deactivate
 
 # Add local files as late as possible to avoid cache busting
 COPY start.sh /usr/local/bin/
 COPY start-notebook.sh /usr/local/bin/
 COPY start-singleuser.sh /usr/local/bin/
 COPY jupyter_notebook_config.py /etc/jupyter/
-RUN chown -R $NB_USER:users /etc/jupyter/
+RUN chown -R $NB_USER:users /etc/jupyter/ && \
+    chown -R $NB_USER /home/$NB_USER/ && \
+    chmod a+rx /usr/local/bin/*
 
 USER $NB_USER
 ENV PATH=/home/jovyan/bin:$PATH

--- a/components/tensorflow-notebook-image/Dockerfile.gpu
+++ b/components/tensorflow-notebook-image/Dockerfile.gpu
@@ -72,8 +72,6 @@ RUN useradd -m -s /bin/bash -N -u $NB_UID $NB_USER && \
     mkdir -p $CONDA_DIR && \
     chown $NB_USER $CONDA_DIR
 
-USER $NB_USER
-
 # Setup work directory for backward-compatibility
 RUN mkdir /home/$NB_USER/work
 
@@ -98,21 +96,12 @@ RUN conda install --quiet --yes \
     'jupyterlab=0.31.*' \
     && conda clean -tipsy
 
-USER root
-
 EXPOSE 8888
 WORKDIR $HOME
 
 # Configure container startup
 ENTRYPOINT ["tini", "--"]
 CMD ["start-notebook.sh"]
-
-# Add local files as late as possible to avoid cache busting
-COPY start.sh /usr/local/bin/
-COPY start-notebook.sh /usr/local/bin/
-COPY start-singleuser.sh /usr/local/bin/
-COPY jupyter_notebook_config.py /etc/jupyter/
-RUN chown -R $NB_USER:users /etc/jupyter/
 
 # Install CUDA Profile Tools and other python packages
 RUN pip --no-cache-dir install \
@@ -121,7 +110,6 @@ RUN pip --no-cache-dir install \
     ipykernel \
     matplotlib \
     numpy \
-    pandas \
     scipy \
     sklearn \
     kubernetes \
@@ -186,19 +174,41 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
 # Activate ipywidgets extension in the environment that runs the notebook server
 RUN jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
-RUN chown -R $NB_USER /home/$NB_USER/
-
 RUN curl -L -o bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.8.0/bazel-0.8.0-installer-linux-x86_64.sh && chmod a+x ./bazel.sh && ./bazel.sh && rm ./bazel.sh
-USER $NB_USER
 SHELL ["/bin/bash", "-c"]
 
 RUN git clone https://github.com/tensorflow/models.git /home/$NB_USER/tensorflow-models && git clone https://github.com/tensorflow/benchmarks.git /home/$NB_USER/tensorflow-benchmarks
-RUN conda create -n ipykernel_py2 python=2 ipykernel && \
-    source activate ipykernel_py2 && \
-    python -m ipykernel install --user && \
-    source deactivate
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
 RUN pip install jupyter-tensorboard
 
+# Create a conda environment for Python 2. We want to include as many of the
+# packages from our root environment as we reasonably can, so we explicitly
+# list that environment, then include everything unless it is Conda (which
+# can only be in the root environment), Jupyterhub (which requires Python 3),
+# or Python itself. We also want to include the pip packages, but we cannot
+# install those via conda, so we list them, drop any conda packages, and
+# then install them via pip. We do this on a best-effort basis, so if any
+# packages from the Python 3 environment cannot be installed with Python 2,
+# then we just skip them.
+RUN conda_packages=$(conda list -e | cut -d '=' -f 1 | grep -v '#' | sort) && \
+    pip_packages=$(pip --no-cache-dir list --format=freeze | cut -d '=' -f 1 | grep -v '#' | sort) && \
+    pip_only_packages=$(comm -23 <(echo "${pip_packages}") <(echo "${conda_packages}")) && \
+    conda create -n ipykernel_py2 python=2 --file <(echo "${conda_packages}" | grep -v conda | grep -v python | grep -v jupyterhub) && \
+    source activate ipykernel_py2 && \
+    python -m ipykernel install --user && \
+    echo "${pip_only_packages}" | xargs -n 1 -I "{}" /bin/bash -c 'pip install --no-cache-dir {} || true' && \
+    pip install --no-cache-dir tensorflow-transform && \
+    source deactivate
+
+# Add local files as late as possible to avoid cache busting
+COPY start.sh /usr/local/bin/
+COPY start-notebook.sh /usr/local/bin/
+COPY start-singleuser.sh /usr/local/bin/
+COPY jupyter_notebook_config.py /etc/jupyter/
+RUN chown -R $NB_USER:users /etc/jupyter/ && \
+    chown -R $NB_USER /home/$NB_USER/ && \
+    chmod a+rx /usr/local/bin/*
+
+USER $NB_USER
 ENV PATH=/home/jovyan/bin:$PATH


### PR DESCRIPTION
The main purpose of this change is to fix two limitations of Python 2 kernels:

1. The set of libraries installed by default for Python 3 kernels were
   not being installed for the Python 2 kernels.
2. The tensorflow-transform libary (which only works in Python 2 for now)
   was not being included in the Python 2 kernels even though it could be.

To address these limitations, this change does the following:

1. Move the creation of the Python 2 conda environment after the last
   installation of a Python package in the default (root) environment.
2. Create the Python 2 conda environment with every Python package from
   the Python 3 environment that can be installed in it.
3. Install tensorflow-transform inside of the Python 2 environment.

Two additional changes had to be included in order to unblock this
improvement in both Dockerfiles:

1. Permissions issues in the Dockerfile.cpu image (when running the
   image as a non-0-uid user) had to be fixed.
2. A number of differences that had accumulated between the two images
   had to be reconciled.

This fixes #244

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/335)
<!-- Reviewable:end -->
