### PR TITLE
Add classify support for http-proxy

### DIFF
--- a/components/k8s-model-server/http-proxy/server.py
+++ b/components/k8s-model-server/http-proxy/server.py
@@ -124,6 +124,10 @@ def decode_b64_if_needed(value):
 
 
 class PredictHandler(tornado.web.RequestHandler):
+    """
+    Predict Hanlder proxy predict method, the input of tf savedModel is expected to be a `Map<strinbg, tf.Tensor>` protobuf
+    Defined here https://github.com/tensorflow/serving/blob/master/tensorflow_serving/apis/prediction_service.proto#L23
+    """
     @gen.coroutine
     def post(self, model, version=None):
         request_key = self.settings['request_key']
@@ -158,6 +162,10 @@ class PredictHandler(tornado.web.RequestHandler):
 
 
 class ClassifyHandler(tornado.web.RequestHandler):
+    """
+    Classify Hanlder proxy classify method, the input of tf savedModel is expected to be a `tf.Examples` protobuf
+    Defined here https://github.com/tensorflow/serving/blob/master/tensorflow_serving/apis/prediction_service.proto#L17
+    """
     @gen.coroutine
     def post(self, model, version=None):
         request_key = self.settings['request_key']

--- a/components/k8s-model-server/http-proxy/server.py
+++ b/components/k8s-model-server/http-proxy/server.py
@@ -20,12 +20,16 @@ from itertools import repeat
 import base64
 import logging
 
+from google.protobuf.json_format import MessageToDict
 from grpc.beta import implementations
+from tensorflow_serving.apis import classification_pb2
+from tensorflow_serving.apis import input_pb2
 from tensorflow_serving.apis import predict_pb2
 from tensorflow_serving.apis import prediction_service_pb2
 from tornado import gen
 from tornado.ioloop import IOLoop
 from tornado.options import define, options, parse_command_line
+import numpy as np
 import tensorflow as tf
 import tornado.web
 
@@ -38,6 +42,38 @@ define("instances_key", default='instances', help="requested instances json obje
 define("debug", default=False, help="run in debug mode")
 B64_KEY = 'b64'
 WELCOME = "Hello World"
+
+
+DATA_TYPE = {
+        np.string_: lambda r: {'bytes_list': tf.train.BytesList(value=r)},
+        np.float64: lambda r: {'float_list': tf.train.FloatList(value=r)},
+        np.int64: lambda r: {'int64_list': tf.train.Int64List(value=r)}
+             }
+
+
+def from_data_to_feature(data):
+    return tf.train.Feature(**DATA_TYPE[data.dtype.type](data))
+
+
+def prepare_classify_requests(instances, model_name, model_version):
+    request = classification_pb2.ClassificationRequest()
+    request.model_spec.name = model_name
+
+    if model_version is not None:
+        request.model_spec.version = model_version
+
+    instance_examples = []
+    for instance in instances:
+        feature_dict = {}
+        for key, value in instance.items():
+            if not isinstance(value, list):
+                value = [value]
+            feature_dict[key] = from_data_to_feature(np.array(value).ravel())
+        instance_examples.append(tf.train.Example(features=tf.train.Features(feature=feature_dict)))
+
+    request.input.CopyFrom(input_pb2.Input(example_list=input_pb2.ExampleList(examples=instance_examples)))
+    return request
+
 
 #### START code took from https://github.com/grpc/grpc/wiki/Integration-with-tornado-(python)
 
@@ -86,6 +122,7 @@ def decode_b64_if_needed(value):
     else:
         return value
 
+
 class PredictHandler(tornado.web.RequestHandler):
     @gen.coroutine
     def post(self, model, version=None):
@@ -120,6 +157,28 @@ class PredictHandler(tornado.web.RequestHandler):
         self.write(dict(predictions=predictions))
 
 
+class ClassifyHandler(tornado.web.RequestHandler):
+    @gen.coroutine
+    def post(self, model, version=None):
+        request_key = self.settings['request_key']
+        request_data = tornado.escape.json_decode(self.request.body)
+        instances = request_data.get(request_key)
+        if not instances:
+            self.send_error('Request json object have to use the key: %s'%request_key)
+
+        if len(instances) < 1 or not isinstance(instances, (list, tuple)):
+            self.send_error('Request instances object have to use be a list')
+
+        instances = decode_b64_if_needed(instances)
+
+        request = prepare_classify_requests(instances, model, version)
+
+        stub = self.settings['stub']
+        result = yield fwrap(stub.Classify.future(request, self.settings['rpc_timeout']))
+
+        self.write(MessageToDict(result))
+
+
 class IndexHanlder(tornado.web.RequestHandler):
     def get(self):
         self.write('Hello World')
@@ -129,7 +188,9 @@ def get_application(**settings):
     return tornado.web.Application(
             [
             (r"/model/(.*):predict", PredictHandler),
+            (r"/model/(.*):classify", ClassifyHandler),
             (r"/model/(.*)/version/(.*):predict", PredictHandler),
+            (r"/model/(.*)/version/(.*):classify", ClassifyHandler),
             (r"/", IndexHanlder),
             ],
             xsrf_cookies=False,


### PR DESCRIPTION
Right now, the default tf-model exported example is using classify api, this pr add classify support.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/341)
<!-- Reviewable:end -->
