### PR TITLE
 Add tensorflow-serving-api to jupyter image 

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -2,6 +2,13 @@
 # Distributed under the terms of the Modified BSD License.
 
 ARG BASE_IMAGE=ubuntu:latest
+# TODO(inc0): When tf-serving-api becomes available for py3, this should be
+# removed
+FROM python:2.7 as tf-serving-install
+
+RUN mkdir -p /opt/conda/lib/python3.6/site-packages
+RUN pip install tensorflow-serving-api
+
 FROM $BASE_IMAGE
 
 USER root
@@ -164,6 +171,9 @@ RUN apt-get update && apt-get install -yq --no-install-recommends graphviz \
 ARG TF_PACKAGE=tf-nightly
 RUN echo Installing $TF_PACKAGE && pip install --quiet --no-cache-dir $TF_PACKAGE
 
+# Hack recommended in tf-serving-api to use it with py3. Remove when proper pip package is available.
+COPY --from=tf-serving-install /usr/local/lib/python2.7/site-packages/tensorflow_serving /opt/conda/lib/python3.6/site-packages/tensorflow_serving
+
 ENV CLOUD_SDK_VERSION 168.0.0
 RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
@@ -215,3 +225,4 @@ RUN chown -R $NB_USER:users /etc/jupyter/ && \
 
 USER $NB_USER
 ENV PATH=/home/jovyan/bin:$PATH
+

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -6,7 +6,6 @@ ARG BASE_IMAGE=ubuntu:latest
 # removed
 FROM python:2.7 as tf-serving-install
 
-RUN mkdir -p /opt/conda/lib/python3.6/site-packages
 RUN pip install tensorflow-serving-api
 
 FROM $BASE_IMAGE
@@ -225,4 +224,3 @@ RUN chown -R $NB_USER:users /etc/jupyter/ && \
 
 USER $NB_USER
 ENV PATH=/home/jovyan/bin:$PATH
-


### PR DESCRIPTION
It's really hacky way to add api to jupyter image. We should remove it
and make it properly once package becomes available for python 3.

Fixes #355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/358)
<!-- Reviewable:end -->
