### PR TITLE
Allow seperate naming of model name vs deployment name for TF Serving.

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -5,6 +5,7 @@
 // @param name string Name to give to each of the components
 // @optionalParam namespace string default Namespace
 // @param model_path string Path to the model. This can be a GCS path.
+// @optionalParam model_name string unset_model_name Name of the model in the serving api.
 // @optionalParam model_server_image string gcr.io/kubeflow-images-staging/tf-model-server:v20180227-master Container for TF model server
 // @optionalParam http_proxy_image string gcr.io/kubeflow/http-proxy:1.0 Container for http_proxy of TF model server
 // @optionalParam service_type string ClusterIP The service type for TFServing deployment.
@@ -25,6 +26,7 @@ local tfServing = import "kubeflow/tf-serving/tf-serving.libsonnet";
 local name = import "param://name";
 local namespace = import "param://namespace";
 local modelPath = import "param://model_path";
+local modelNametmp = import "param://model_name";
 local modelServerImage = import "param://model_server_image";
 local httpProxyImage = import "param://http_proxy_image";
 local serviceType = import "param://service_type";
@@ -47,7 +49,9 @@ local modelServerEnv = if s3SecretName != "" then [
   { name: "S3_ENDPOINT", value: s3Endpoint },
 ] else [];
 
+local modelName = if modelNametmp == 'unset_model_name' then name else import "param://model_name";
+
 std.prune(k.core.v1.list.new([
-  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage),
+  tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelName, modelServerImage, modelServerEnv, httpProxyImage),
   tfServing.parts.deployment.modelService(name, namespace, serviceType),
 ]))

--- a/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-all-features.jsonnet
@@ -5,7 +5,7 @@
 // @param name string Name to give to each of the components
 // @optionalParam namespace string default Namespace
 // @param model_path string Path to the model. This can be a GCS path.
-// @optionalParam model_name string unset_model_name Name of the model in the serving api.
+// @optionalParam model_name string  Name of the model in the serving api.
 // @optionalParam model_server_image string gcr.io/kubeflow-images-staging/tf-model-server:v20180227-master Container for TF model server
 // @optionalParam http_proxy_image string gcr.io/kubeflow/http-proxy:1.0 Container for http_proxy of TF model server
 // @optionalParam service_type string ClusterIP The service type for TFServing deployment.
@@ -49,7 +49,7 @@ local modelServerEnv = if s3SecretName != "" then [
   { name: "S3_ENDPOINT", value: s3Endpoint },
 ] else [];
 
-local modelName = if modelNametmp == 'unset_model_name' then name else import "param://model_name";
+local modelName = if modelNametmp == "" then name else import "param://model_name";
 
 std.prune(k.core.v1.list.new([
   tfServing.parts.deployment.modelServer(name, namespace, modelPath, modelName, modelServerImage, modelServerEnv, httpProxyImage),

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -70,16 +70,16 @@ local networkSpec = networkPolicy.mixin.spec;
         },
       },
 
-      modelServer(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage=0, labels={ app: name },):
+      modelServer(name, namespace, modelPath, modelName, modelServerImage, modelServerEnv, httpProxyImage=0, labels={ app: name },):
         // TODO(jlewi): Allow the model to be served from a PVC.
         local volume = {
           name: "redis-data",
           namespace: namespace,
           emptyDir: {},
         };
-        base(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage, labels),
+        base(name, namespace, modelPath, modelName, modelServerImage, modelServerEnv, httpProxyImage, labels),
 
-      local base(name, namespace, modelPath, modelServerImage, modelServerEnv, httpProxyImage, labels) =
+      local base(name, namespace, modelPath, modelName, modelServerImage, modelServerEnv, httpProxyImage, labels) =
         {
           apiVersion: "extensions/v1beta1",
           kind: "Deployment",
@@ -102,7 +102,7 @@ local networkSpec = networkPolicy.mixin.spec;
                     command: ["/usr/bin/tensorflow_model_server"],
                     args: [
                       "--port=9000",
-                      "--model_name=" + name,
+                      "--model_name=" + modelName,
                       "--model_base_path=" + modelPath,
                     ],
                     env: modelServerEnv,


### PR DESCRIPTION
There are situations in which many models will be deployed with different names, however currently the model name uses the deployment name, which means changing the client to match each individual deployment.

This makes it so that you can set the model name independently, and reuse an unmodified client to query each deployed model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/359)
<!-- Reviewable:end -->
