### PR TITLE
use tini to start model server

### DIFF
--- a/components/k8s-model-server/images/Dockerfile.cpu
+++ b/components/k8s-model-server/images/Dockerfile.cpu
@@ -53,3 +53,11 @@ RUN set -x \
     && useradd $MS_USER \
     && [ `id -u $MS_USER` -eq 1000 ] \
     && [ `id -g $MS_USER` -eq 1000 ]
+
+ENV TINI_VERSION v0.17.0
+
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+
+RUN chmod +x /tini
+
+ENTRYPOINT ["/tini", "--"]

--- a/components/k8s-model-server/images/Dockerfile.gpu
+++ b/components/k8s-model-server/images/Dockerfile.gpu
@@ -101,3 +101,11 @@ RUN set -x \
     && useradd $MS_USER \
     && [ `id -u $MS_USER` -eq 1000 ] \
     && [ `id -g $MS_USER` -eq 1000 ]
+
+ENV TINI_VERSION v0.17.0
+
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+
+RUN chmod +x /tini
+
+ENTRYPOINT ["/tini", "--"]

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -81,8 +81,8 @@
       name: $.params.name,
       image: $.params.modelServerImage,
       imagePullPolicy: "IfNotPresent",
-      command: ["/usr/bin/tensorflow_model_server"],
       args: [
+	"/usr/bin/tensorflow_model_server",
         "--port=9000",
         "--model_name=" + $.params.modelName,
         "--model_base_path=" + $.params.modelPath,


### PR DESCRIPTION
Even though model server itself can be the entry point itself but then run with PID 1 would make the server not responding to SIGINT or SIGTERM

which is problematic during k8s rolling up new version

Using [Tini](https://github.com/krallin/tini) has several benefits:

- It protects you from software that accidentally creates zombie processes,
  which can (over time!) starve your entire system for PIDs (and make it
  unusable).
- It ensures that the *default signal handlers* work for the software you run
  in your Docker image. For example, with Tini, `SIGTERM` properly terminates
  your process even if you didn't explicitly install a signal handler for it.
- It does so completely transparently! Docker images that work without Tini
  will work with Tini without any changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/400)
<!-- Reviewable:end -->
