### PR TITLE
Use the correct jwt validation config

### DIFF
--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -284,15 +284,13 @@
                   type: "decoder",
                   name: "jwt-auth",
                   config: {
-                    issuers: [
+                    jwts: [
                       {
-                        name: "https://cloud.google.com/iap",
+                        issuer: "https://cloud.google.com/iap",
                         audiences: audiences,
-                        pubkey: {
-                          type: "jwks",
-                          uri: "https://www.gstatic.com/iap/verify/public_key-jwk",
-                          cluster: "iap_issuer",
-                        },
+                        jwks_uri: "https://www.gstatic.com/iap/verify/public_key-jwk",
+                        jwks_uri_envoy_cluster: "iap_issuer",
+                        jwt_headers: ["x-goog-iap-jwt-assertion"]
                       },
                     ],
                   },

--- a/kubeflow/core/prototypes/iap-envoy.jsonnet
+++ b/kubeflow/core/prototypes/iap-envoy.jsonnet
@@ -4,7 +4,7 @@
 // @shortDescription Envoy proxies to handle ingress and IAP.
 // @param name string Name to give to each of the components
 // @optionalParam namespace string default Namespace
-// @optionalParam envoyImage string gcr.io/kubeflow/envoy:v20180124-0.4.0-50-g0d29aac-dirty-4d9e20 The image for envoy.
+// @optionalParam envoyImage string gcr.io/kubeflow-dev/envoy:0fb4886b463698702b6a08955045731903a18738 The image for envoy.
 // @optionalParam disableJwtChecking string false Disable JWT checking.
 // @param audiences string Comma separated list of JWT audiences to accept
 


### PR DESCRIPTION
It is defined in https://github.com/istio/proxy/blob/master/src/envoy/http/jwt_auth/config.proto in the JWT message

Tested by deploying to dev.kubeflow.org and verifying that JWT validation works when IAP is turned off

Related https://github.com/kubeflow/kubeflow/issues/394
Related https://github.com/kubeflow/kubeflow/issues/60

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/401)
<!-- Reviewable:end -->
