### PR TITLE
Replace ClusterRole/ClusterRoleBinding for ambassador with Role/RoleBinding

### DIFF
--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -4,9 +4,9 @@
     all:: [
       $.parts(namespace).service,
       $.parts(namespace).adminService,
-      $.parts(namespace).clusterRole,
+      $.parts(namespace).role,
       $.parts(namespace).serviceAccount,
-      $.parts(namespace).clusterRoleBinding,
+      $.parts(namespace).roleBinding,
       $.parts(namespace).deploy,
       $.parts(namespace).k8sDashboard,
     ],
@@ -62,11 +62,12 @@
       },
     },  // adminService
 
-    clusterRole:: {
+    role:: {
       apiVersion: "rbac.authorization.k8s.io/v1beta1",
-      kind: "ClusterRole",
+      kind: "Role",
       metadata: {
         name: "ambassador",
+        namespace: namespace,
       },
       rules: [
         {
@@ -112,7 +113,7 @@
           ],
         },
       ],
-    },  // cluserRole
+    },  // role
 
     serviceAccount:: {
       apiVersion: "v1",
@@ -123,15 +124,16 @@
       },
     },  // serviceAccount
 
-    clusterRoleBinding:: {
+    roleBinding:: {
       apiVersion: "rbac.authorization.k8s.io/v1beta1",
-      kind: "ClusterRoleBinding",
+      kind: "RoleBinding",
       metadata: {
         name: "ambassador",
+        namespace: namespace,
       },
       roleRef: {
         apiGroup: "rbac.authorization.k8s.io",
-        kind: "ClusterRole",
+        kind: "Role",
         name: "ambassador",
       },
       subjects: [
@@ -141,7 +143,7 @@
           namespace: namespace,
         },
       ],
-    },  // clusterRoleBinding
+    },  // roleBinding
 
     deploy:: {
       apiVersion: "extensions/v1beta1",
@@ -169,6 +171,10 @@
                         fieldPath: "metadata.namespace",
                       },
                     },
+                  },
+                  {
+                    name: "AMBASSADOR_SINGLE_NAMESPACE",
+                    value: "true",
                   },
                 ],
                 image: ambassadorImage,

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -82,7 +82,7 @@
       image: $.params.modelServerImage,
       imagePullPolicy: "IfNotPresent",
       args: [
-	"/usr/bin/tensorflow_model_server",
+        "/usr/bin/tensorflow_model_server",
         "--port=9000",
         "--model_name=" + $.params.modelName,
         "--model_base_path=" + $.params.modelPath,


### PR DESCRIPTION
This change restricts the ambassador deployment to a single k8s
namespace. The idea is that we should be able to deploy multiple
instances of kubeflow to a single k8s cluster by restricting each
kubeflow instance to a single namespace.

Tested on my cluster and verified that ambassador and ambassador
admin both work fine after this change.

Related to https://github.com/kubeflow/kubeflow/issues/374

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/408)
<!-- Reviewable:end -->
