### PR TITLE
Use kubeflow-images-staging to store envoy image instead of kubeflow-dev

### DIFF
--- a/kubeflow/core/prototypes/iap-envoy.jsonnet
+++ b/kubeflow/core/prototypes/iap-envoy.jsonnet
@@ -4,7 +4,7 @@
 // @shortDescription Envoy proxies to handle ingress and IAP.
 // @param name string Name to give to each of the components
 // @optionalParam namespace string default Namespace
-// @optionalParam envoyImage string gcr.io/kubeflow-dev/envoy:0fb4886b463698702b6a08955045731903a18738 The image for envoy.
+// @optionalParam envoyImage string gcr.io/kubeflow-images-staging/envoy:v20180309-0fb4886b463698702b6a08955045731903a18738 The image for envoy.
 // @optionalParam disableJwtChecking string false Disable JWT checking.
 // @param audiences string Comma separated list of JWT audiences to accept
 


### PR DESCRIPTION
Related to #401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/409)
<!-- Reviewable:end -->
