### PR TITLE
GCP credential support for TF serving

### DIFF
--- a/components/k8s-model-server/README.md
+++ b/components/k8s-model-server/README.md
@@ -147,6 +147,7 @@ MODEL_SERVER_IMAGE=gcr.io/$(gcloud config get-value project)/model-server:1.0
 # if you need REST API need to provide http_proxy_image
 HTTP_PROXY_IMAGE=gcr.io/$(gcloud config get-value project)/http-proxy:1.0
 ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
+ks param set --env=cloud ${MODEL_COMPONENT} namespace $NAMESPACE
 ks param set --env=cloud ${MODEL_COMPONENT} modelPath $MODEL_PATH
 # If you want to use your custom image.
 ks param set --env=cloud ${MODEL_COMPONENT} modelServerImage $MODEL_SERVER_IMAGE
@@ -177,7 +178,7 @@ Kubernetes documentation.
 #### Use service account credential to serve a model on GCS
 TF serving can read the model directly from GCS. But by default it will use the credential of the cluster.
 If you want to use the credential of a service account to read the model from a GCS bucket:
-* Download the servicea account key
+* Download the service account key
 * Create a k8s secret: 
 ```commandline
 kubectl create secret generic SECRET_NAME --namespace=NAMESPACE --from-file=key.json=YOUR_KEY_FILE

--- a/components/k8s-model-server/README.md
+++ b/components/k8s-model-server/README.md
@@ -146,7 +146,12 @@ MODEL_PATH=gs://kubeflow-models/inception
 MODEL_SERVER_IMAGE=gcr.io/$(gcloud config get-value project)/model-server:1.0
 # if you need REST API need to provide http_proxy_image
 HTTP_PROXY_IMAGE=gcr.io/$(gcloud config get-value project)/http-proxy:1.0
-ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME} --namespace=default --model_path=${MODEL_PATH} --model_server_image=${MODEL_SERVER_IMAGE} [--http_proxy_image=${HTTP_PROXY_IMAGE}]
+ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
+ks param set --env=cloud ${MODEL_COMPONENT} modelPath $MODEL_PATH
+# If you want to use your custom image.
+ks param set --env=cloud ${MODEL_COMPONENT} modelServerImage $MODEL_SERVER_IMAGE
+# If you want to have the http endpoint.
+ks param set --env=cloud ${MODEL_COMPONENT} httpProxyImage $HTTP_PROXY_IMAGE
 ```
 
 Deploy it in a particular environment. The deployment will pick up environment parmameters (e.g. cloud) and customize the deployment appropriately
@@ -169,7 +174,19 @@ You can learn more about [updating a Deployment](https://kubernetes.io/docs/conc
 [Pod Resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) in the
 Kubernetes documentation.
 
-
+#### Use service account credential to serve a model on GCS
+TF serving can read the model directly from GCS. But by default it will use the credential of the cluster.
+If you want to use the credential of a service account to read the model from a GCS bucket:
+* Download the servicea account key
+* Create a k8s secret: 
+```commandline
+kubectl create secret generic SECRET_NAME --namespace=NAMESPACE --from-file=key.json=YOUR_KEY_FILE
+```
+And before applying the TF serving component, set additional two params:
+```commandline
+ks param set --env=cloud ${MODEL_COMPONENT} cloud gcp
+ks param set --env=cloud ${MODEL_COMPONENT} gcpCredentialSecretName SECRET_NAME
+```
 
 ### Use the served model
 

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -36,7 +36,7 @@
 
   // Parametes specific to GCP.
   gcpParams:: {
-    gcpCredentialsSecretName: "",
+    gcpCredentialSecretName: "",
   } + $.params,
 
   // Parameters that control S3 access
@@ -292,7 +292,7 @@
     tfServingContainer: $.parts.tfServingContainer {
       env+: $.gcpParts.gcpEnv,
       volumeMounts+: [
-	if $.gcpParams.gcpCredentialSecretName != "" then
+	      if $.gcpParams.gcpCredentialSecretName != "" then
           {
             name: "gcp-credentials",
             mountPath: "/secret/gcp-credentials",
@@ -301,24 +301,25 @@
     },
 
     tfDeployment: $.parts.tfDeployment {
-      spec: +{
-        template: +{
+      spec+: {
+        template+: {
 
-          spec: +{
+          spec+: {
             containers: [
               $.gcpParts.tfServingContainer,
               if $.params.httpProxyImage != 0 then
                 $.parts.httpProxyContainer,
             ],
-	    volumes: [
-	      if $.gcpParams.gcpCredentialSecretName != "" then
-	        {
-	          name: "gcp-credentials",
-	          secret: {
-	            secretName: $.gcpParams.gcpCredentialSecretName,
-	          }
-	        },
-	    ]
+
+      	    volumes: [
+      	      if $.gcpParams.gcpCredentialSecretName != "" then
+      	        {
+      	          name: "gcp-credentials",
+      	          secret: {
+      	            secretName: $.gcpParams.gcpCredentialSecretName,
+      	          }
+      	        },
+      	    ]
           },
         },
       },

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -84,7 +84,7 @@
           $.s3parts.tfService,
           $.s3parts.tfDeployment,
         ]
-      elif $.params.cloud == "gcp" then
+      else if $.params.cloud == "gcp" then
         [
           $.gcpParts.tfService,
           $.gcpParts.tfDeployment,
@@ -286,7 +286,7 @@
   gcpParts:: $.parts {
     gcpEnv:: [
       if $.gcpParams.gcpCredentialSecretName != "" then
-        { name: "GOOGLE_APPLICATION_CREDENTIALS": value: "/secret/gcp-credentials/key.json" },
+        { name: "GOOGLE_APPLICATION_CREDENTIALS", value: "/secret/gcp-credentials/key.json" },
     ],
 
     tfServingContainer: $.parts.tfServingContainer {
@@ -306,19 +306,19 @@
 
           spec: +{
             containers: [
-              $.s3parts.tfServingContainer,
+              $.gcpParts.tfServingContainer,
               if $.params.httpProxyImage != 0 then
                 $.parts.httpProxyContainer,
             ],
-	    if $.gcpParams.gcpCredentialSecretName != "" then
-	      volumes: [
+	    volumes: [
+	      if $.gcpParams.gcpCredentialSecretName != "" then
 	        {
 	          name: "gcp-credentials",
 	          secret: {
 	            secretName: $.gcpParams.gcpCredentialSecretName,
 	          }
-	        }
-	      ]
+	        },
+	    ]
           },
         },
       },

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -29,7 +29,15 @@
 
     // Whether or not to enable s3 parameters
     s3Enable:: false,
+
+    // Which cloud to use
+    cloud:: null
   },
+
+  // Parametes specific to GCP.
+  gcpParams:: {
+    gcpCredentialsSecretName: "",
+  } + $.params,
 
   // Parameters that control S3 access
   // params overrides s3params because params can be overwritten by the user to override the defaults.
@@ -75,6 +83,11 @@
         [
           $.s3parts.tfService,
           $.s3parts.tfDeployment,
+        ]
+      elif $.params.cloud == "gcp" then
+        [
+          $.gcpParts.tfService,
+          $.gcpParts.tfDeployment,
         ]
       else
         [
@@ -268,4 +281,47 @@
       },
     },  // tfDeployment
   },  // s3parts
+
+  // Parts specific to GCP
+  gcpParts:: $.parts {
+    gcpEnv:: [
+      if $.gcpParams.gcpCredentialSecretName != "" then
+        { name: "GOOGLE_APPLICATION_CREDENTIALS": value: "/secret/gcp-credentials/key.json" },
+    ],
+
+    tfServingContainer: $.parts.tfServingContainer {
+      env+: $.gcpParts.gcpEnv,
+      volumeMounts+: [
+	if $.gcpParams.gcpCredentialSecretName != "" then
+          {
+            name: "gcp-credentials",
+            mountPath: "/secret/gcp-credentials",
+          },
+      ]
+    },
+
+    tfDeployment: $.parts.tfDeployment {
+      spec: +{
+        template: +{
+
+          spec: +{
+            containers: [
+              $.s3parts.tfServingContainer,
+              if $.params.httpProxyImage != 0 then
+                $.parts.httpProxyContainer,
+            ],
+	    if $.gcpParams.gcpCredentialSecretName != "" then
+	      volumes: [
+	        {
+	          name: "gcp-credentials",
+	          secret: {
+	            secretName: $.gcpParams.gcpCredentialSecretName,
+	          }
+	        }
+	      ]
+          },
+        },
+      },
+    },  // tfDeployment
+  },  // gcpParts
 }


### PR DESCRIPTION
Related #385

Verified that serving with a model in my GCS bucket does not work unless passing the param:
cloud = gcp
gcpCredentialSecretName = secret_name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/416)
<!-- Reviewable:end -->
