### PR TITLE
Tfjob servicetype

### DIFF
--- a/kubeflow/core/all.libsonnet
+++ b/kubeflow/core/all.libsonnet
@@ -6,26 +6,10 @@
     local tfjob = import "kubeflow/core/tf-job.libsonnet",
     local spartakus = import "kubeflow/core/spartakus.libsonnet",
 
-    local name = params.name,
-    local namespace = params.namespace,
-    local diskParam = params.disks,
-
-    local diskNames = if diskParam != "null" && std.length(diskParam) > 0 then
-      std.split(diskParam, ",")
-    else [],
-
-    local jupyterConfigMap = if std.length(diskNames) == 0 then
-      jupyter.parts(namespace).jupyterHubConfigMap
-    else jupyter.parts(namespace).jupyterHubConfigMapWithVolumes(diskNames),
-
-    local updated_params = params {
-      kubeSpawner:: jupyter.parts(namespace).kubeSpawner(params.jupyterHubAuthenticator, diskNames),
-    },
-    all:: jupyter.all(updated_params)
-          // TODO(jlewi): We should make `all` top level within each libsonnet file and
-          // not a field within parts.
-          + tfjob.parts(params.namespace).all(params)
-          + ambassador.parts(namespace).all + nfs.nfsComponents(namespace, name, diskNames)
+    all:: jupyter.all(params)
+          + tfjob.all(params)
+          + ambassador.all(params) 
+          + nfs.all(params)
           + spartakus.all(params),
   },
 }

--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -228,6 +228,7 @@
       metadata: {
         name: "k8s-dashboard",
         namespace: namespace,
+
         annotations: {
           "getambassador.io/config":
             std.join("\n", [
@@ -259,5 +260,6 @@
         type: "ClusterIP",
       },
     },  // k8sDashboard
+
   },  // parts
 }

--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -1,18 +1,17 @@
 {
+  all(params):: [
+    $.parts(params.namespace).service(params.tfAmbassadorServiceType),
+    $.parts(params.namespace).adminService,
+    $.parts(params.namespace).role,
+    $.parts(params.namespace).serviceAccount,
+    $.parts(params.namespace).roleBinding,
+    $.parts(params.namespace).deploy,
+    $.parts(params.namespace).k8sDashboard,
+  ],
+
   parts(namespace):: {
-
-    all:: [
-      $.parts(namespace).service,
-      $.parts(namespace).adminService,
-      $.parts(namespace).role,
-      $.parts(namespace).serviceAccount,
-      $.parts(namespace).roleBinding,
-      $.parts(namespace).deploy,
-      $.parts(namespace).k8sDashboard,
-    ],
-
     local ambassadorImage = "quay.io/datawire/ambassador:0.26.0",
-    service:: {
+    service(serviceType): {
       apiVersion: "v1",
       kind: "Service",
       metadata: {
@@ -33,7 +32,7 @@
         selector: {
           service: "ambassador",
         },
-        type: "ClusterIP",
+        type: serviceType,
       },
     },  // service
 
@@ -113,7 +112,7 @@
           ],
         },
       ],
-    },  // role
+    },  // Role
 
     serviceAccount:: {
       apiVersion: "v1",
@@ -149,16 +148,20 @@
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
       metadata: {
+        labels: {
+          service: "ambassador-admin",
+        },
         name: "ambassador",
         namespace: namespace,
       },
       spec: {
-        replicas: 3,
+        replicas: 1,
         template: {
           metadata: {
             labels: {
               service: "ambassador",
             },
+            namespace: namespace,
           },
           spec: {
             containers: [
@@ -174,7 +177,7 @@
                   },
                   {
                     name: "AMBASSADOR_SINGLE_NAMESPACE",
-                    value: "true",
+                    value: "True",
                   },
                 ],
                 image: ambassadorImage,
@@ -225,7 +228,6 @@
       metadata: {
         name: "k8s-dashboard",
         namespace: namespace,
-
         annotations: {
           "getambassador.io/config":
             std.join("\n", [
@@ -257,6 +259,5 @@
         type: "ClusterIP",
       },
     },  // k8sDashboard
-
   },  // parts
 }

--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -155,7 +155,7 @@
         namespace: namespace,
       },
       spec: {
-        replicas: 1,
+        replicas: 3,
         template: {
           metadata: {
             labels: {
@@ -177,7 +177,7 @@
                   },
                   {
                     name: "AMBASSADOR_SINGLE_NAMESPACE",
-                    value: "True",
+                    value: "true",
                   },
                 ],
                 image: ambassadorImage,

--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -112,7 +112,7 @@
           ],
         },
       ],
-    },  // Role
+    },  // role
 
     serviceAccount:: {
       apiVersion: "v1",

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -6,9 +6,11 @@
 // @optionalParam namespace string default Namespace
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
+// @optionalParam tfAmbassadorServiceType string ClusterIP The service type for the API Gateway.
 // @optionalParam tfJobImage string gcr.io/kubeflow-images-staging/tf_operator:v20180226-403 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
+// @optionalParam tfDefaultTensorboardImage string gcr.io/google-samples/appengine-tensorboard:latest The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
 // @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:1.0.1 The image to use for JupyterHub.
 // @optionalParam jupyterHubAuthenticator string null The authenticator to use

--- a/kubeflow/core/tf-job.libsonnet
+++ b/kubeflow/core/tf-job.libsonnet
@@ -1,15 +1,16 @@
 {
   // TODO(https://github.com/ksonnet/ksonnet/issues/222): Taking namespace as an argument is a work around for the fact that ksonnet
   // doesn't support automatically piping in the namespace from the environment to prototypes.
+  all(params):: [
+    $.parts(params.namespace).tfJobDeploy(params.tfJobImage),
+    $.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
+    $.parts(params.namespace).serviceAccount,
+    $.parts(params.namespace).operatorRole,
+    $.parts(params.namespace).operatorRoleBinding,
+    $.parts(params.namespace).crd,
+  ],
+
   parts(namespace):: {
-    all(params):: [
-      $.parts(params.namespace).tfJobDeploy(params.tfJobImage),
-      $.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
-      $.parts(params.namespace).serviceAccount,
-      $.parts(params.namespace).operatorRole,
-      $.parts(params.namespace).operatorRoleBinding,
-      $.parts(params.namespace).crd,
-    ],
     crd: {
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",

--- a/kubeflow/core/tf-job.libsonnet
+++ b/kubeflow/core/tf-job.libsonnet
@@ -8,6 +8,11 @@
     $.parts(params.namespace).operatorRole,
     $.parts(params.namespace).operatorRoleBinding,
     $.parts(params.namespace).crd,
+    $.parts(params.namespace).uiService(params.tfJobUiServiceType),
+    $.parts(params.namespace).uiServiceAccount,
+    $.parts(params.namespace).ui(params.tfDefaultTensorboardImage),
+    $.parts(params.namespace).uiRole,
+    $.parts(params.namespace).uiRoleBinding,
   ],
 
   parts(namespace):: {

--- a/kubeflow/core/util.libsonnet
+++ b/kubeflow/core/util.libsonnet
@@ -22,4 +22,12 @@
       else
         false,
   }.result,
+
+  // Convert a comma-delimited string to an Array
+  toArray:: function(str) {
+    result:: 
+      if str != "null" && std.length(str) > 0 then
+        std.split(str, ",")
+      else [],
+  }.result,
 }


### PR DESCRIPTION
- [x] kubeflow/core/all.libsonnet now only calls all(params) for the other libraries
- [x] tried to enable the tf-job-dashboard but we haven't built the tensorboard image anywhere. Should I do this and make it available under gcr.io/images/kubeflow or gcr.io/images/kubeflow or gcr.io/images/kubeflow-images-staging?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/418)
<!-- Reviewable:end -->
