### PR TITLE
update the cuda base docker image version to 9.0 to align with tf-nightly-gpu

### DIFF
--- a/components/tensorflow-notebook-image/Makefile
+++ b/components/tensorflow-notebook-image/Makefile
@@ -20,7 +20,7 @@ IMAGE=tensorflow-notebook
 
 define container
 	docker build --pull --build-arg "BASE_IMAGE=ubuntu:latest" --build-arg "TF_PACKAGE=tf-nightly" -t $(1)/${IMAGE}-cpu:${TAG} -f Dockerfile .
-	docker build --pull --build-arg "BASE_IMAGE=nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04" --build-arg "TF_PACKAGE=tf-nightly-gpu" -t $(1)/${IMAGE}-gpu:${TAG} -f Dockerfile .
+	docker build --pull --build-arg "BASE_IMAGE=nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04" --build-arg "TF_PACKAGE=tf-nightly-gpu" -t $(1)/${IMAGE}-gpu:${TAG} -f Dockerfile .
 endef
 
 all:


### PR DESCRIPTION
this is to fix https://github.com/kubeflow/kubeflow/issues/414

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/427)
<!-- Reviewable:end -->
