### PR TITLE
Allow creating ingress with hostname

### DIFF
--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -83,7 +83,7 @@ The instructions below reference the following environment variables which you w
 
 
 ```
-ks generate iap-ingress iap-ingress --secretName=${SECRET_NAME} --ipName=${IP_NAME} --namespace=${NAMESPACE}
+ks generate iap-ingress iap-ingress --secretName=${SECRET_NAME} --ipName=${IP_NAME} --namespace=${NAMESPACE} --hostname=${FQDN}
 ks apply ${ENVIRONMENT} -c iap-ingress
 ```
 

--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -9,9 +9,9 @@
     // We do this because updating the ingress causes the backend service to change which disables IAP
     // and changes the backend service which is used for the JWT audience.
     // So we want to avoid updating the ingress when updating the Envoy pods or other backend services.
-    ingressParts(secretName, ipName):: std.prune(k.core.v1.list.new([
+    ingressParts(secretName, ipName, hostname):: std.prune(k.core.v1.list.new([
       $.parts(namespace).service,
-      $.parts(namespace).ingress(secretName, ipName),
+      $.parts(namespace).ingress(secretName, ipName, hostname),
     ])),
 
     envoy(envoyImage, audiences, disableJwt):: std.prune(k.core.v1.list.new([
@@ -486,7 +486,7 @@
       },
     },
 
-    ingress(secretName, ipName):: {
+    ingress(secretName, ipName, hostname):: {
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
@@ -499,6 +499,7 @@
       spec: {
         rules: [
           {
+            [if hostname != "null" then "host"]: hostname,
             http: {
               paths: [
                 {

--- a/kubeflow/core/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/core/prototypes/iap-ingress.jsonnet
@@ -6,6 +6,7 @@
 // @optionalParam namespace string default Namespace
 // @param secretName string The name of the secret containing the SSL certificates.
 // @param ipName string The name of the global ip address to use.
+// @optionalParam hostname string null The hostname associated with this ingress. Eg: mykubeflow.example.com
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
 // because ksonnet doesn't support inheriting it from the environment yet.
@@ -17,5 +18,6 @@ local name = import "param://name";
 local namespace = import "param://namespace";
 local secretName = import "param://secretName";
 local ipName = import "param://ipName";
+local hostname = import "param://hostname";
 
-iap.parts(namespace).ingressParts(secretName, ipName)
+iap.parts(namespace).ingressParts(secretName, ipName, hostname)


### PR DESCRIPTION
This will help us create valid letsencrypt TLS certficates for ${FQDN}

Related to https://github.com/kubeflow/kubeflow/issues/255