### PR TITLE
Use a CentOS 7 base image for the jupyterhub-k8s image

### DIFF
--- a/components/jupyterhub/docker/Dockerfile
+++ b/components/jupyterhub/docker/Dockerfile
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.6
+FROM centos:centos7
 
-RUN apt-get update && \
-    apt-get install -y npm nodejs-legacy
+RUN yum update -y && \
+    yum install -y epel-release && \
+    yum install -y python36 npm nodejs010 python34-pip && \
+    yum clean all -y
 
 RUN npm install -g configurable-http-proxy && \
     pip3 install --no-cache-dir \


### PR DESCRIPTION
There are some notes about motivation on this similar PR for tf-operator

https://github.com/kubeflow/tf-operator/pull/469

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/438)
<!-- Reviewable:end -->
