### PR TITLE
Use kubeflow-ci/test-worker as worker image

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -36,7 +36,7 @@
       local srcRootDir = testDir + "/src";
       // The directory containing the kubeflow/kubeflow repo
       local srcDir = srcRootDir + "/kubeflow/kubeflow";
-      local image = "gcr.io/mlkube-testing/test-worker:latest";
+      local image = "gcr.io/kubeflow-ci/test-worker:latest";
       // The name of the NFS volume claim to use for test files.
       local nfsVolumeClaim = "nfs-external";
       // The name to use for the volume to use to contain test data.

--- a/testing/workflows/debug_pod.yaml
+++ b/testing/workflows/debug_pod.yaml
@@ -9,18 +9,18 @@ spec:
     spec:
       containers:
       - name: test-container
-        image: gcr.io/mlkube-testing/kubeflow-testing:latest
+        image: gcr.io/kubeflow-ci/test-worker:latest
         command: ["tail", "-f", "/dev/null"]
         volumeMounts:
           - mountPath: /mnt/test-data-volume
             name: kubeflow-test-volume
           - mountPath: /secret/gcp-credentials
             name: gcp-credentials
-        env:        
+        env:
           - name: GOOGLE_APPLICATION_CREDENTIALS
             value: /secret/gcp-credentials/key.json
       restartPolicy: Never
-      volumes:      
+      volumes:
         - name: kubeflow-test-volume
           persistentVolumeClaim:
             claimName: kubeflow-testing


### PR DESCRIPTION
We now push worker images to kubeflow-ci

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/440)
<!-- Reviewable:end -->
