### PR TITLE
Use cert-manager for obtaining valid certificates

### DIFF
--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -56,7 +56,7 @@ The instructions below reference the following environment variables which you w
   * **FQDN** The fully qualified domain name to use for your Kubeflow deployment.
   * **IP_NAME** The name of the GCP static IP that you created above and will be associated with **DOMAIN**.
   * **NAMESPACE** The namespace where Kubeflow is deployed.
-  * **ACCOUNT** The email address for the ACME registered account, typically the value of `gcloud config get-value account`.
+  * **ACCOUNT** The email address for your ACME account where certificate expiration notifications will be sent.
 
 
 ```
@@ -72,8 +72,8 @@ the [enable_iap.sh](https://github.com/kubeflow/kubeflow/tree/master/docs/gke/en
 
 
 ```
-CLIENT_ID=<Client id for OAuth client created in the previous step>
-CLIENT_SECRET=<Client secret for OAuth client created in the previous step>
+export CLIENT_ID=<Client id for OAuth client created in the previous step>
+export CLIENT_SECRET=<Client secret for OAuth client created in the previous step>
 SERVICE=envoy
 ./enable_iap.sh ${PROJECT} ${NAMESPACE} ${SERVICE}
 ```

--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -22,31 +22,6 @@ Use your DNS provider (e.g. Google Domains) create a type A custom resource reco
 with the IP address that you just reserved.
   * Instructions for [Google Domains](https://support.google.com/domains/answer/3290350?hl=en&_ga=2.237821440.1874220825.1516857441-1976053267.1499435562&_gac=1.82147044.1516857441.Cj0KCQiA-qDTBRD-ARIsAJ_10yKS7G1HPa1aoM8Mk_4VagV9wIi5uKkMp5UWJGDNejKxWPKUO_A6ri4aAsahEALw_wcB)
 
-##### Create a self signed certificate
-
-The certificate is needed for HTTPs
-
-```
-${FQDN}=${HOST}.${YOURDOMAIN}
-mkdir -p ~/tmp/${DOMAIN}
-TLS_KEY_FILE=~/tmp/${FQDN}/tls.key
-TLS_CRT_FILE=~/tmp/${FQDN}/tls.crt
-
-openssl req -x509 -nodes -days 365 -newkey rsa:2048 \
-  -subj "/CN=${FQDN}/O=Google LTD./C=US" \
-  -keyout ${TLS_KEY_FILE} -out ${TLS_CRT_FILE}
-```
-
-  * HOST will be the value of the custom resource record that you created to map to your IP address.
-
-Create a K8s secret to store the SSL certificate.
-
-```
-SECRET_NAME=<Name for your secret.>
-kubectl -n ${NAMESPACE} create secret generic ${SECRET_NAME}  --from-file=${TLS_KEY_FILE} --from-file=${TLS_CRT_FILE}
-```
-
-
 #### Create oauth client credentials
 
 Create an OAuth Client ID to be used to identify IAP when requesting acces to user's email to verify their identity.
@@ -72,6 +47,8 @@ Create an OAuth Client ID to be used to identify IAP when requesting acces to us
 If you haven't already, follow the instructions in the [user_guide](https://github.com/kubeflow/kubeflow/blob/master/user_guide.md#deploy-kubeflow)
 to create a ksonnet app to deploy Kubeflow.
 
+[cert-manager](https://github.com/jetstack/cert-manager) is used to automatically request valid SSL certifiactes using the [ACME](https://en.wikipedia.org/wiki/Automated_Certificate_Management_Environment) issuer.
+
 The instructions below reference the following environment variables which you will need to set for your deployment
 
   * **CORE_NAME** The name assigned to the core Kubeflow ksonnet components (this is the name chosen when you ran `ks generate...`).
@@ -79,11 +56,14 @@ The instructions below reference the following environment variables which you w
   * **FQDN** The fully qualified domain name to use for your Kubeflow deployment.
   * **IP_NAME** The name of the GCP static IP that you created above and will be associated with **DOMAIN**.
   * **NAMESPACE** The namespace where Kubeflow is deployed.
-  * **SECRET_NAME** The name of the K8s secret that stores the SSL certificate.
+  * **ACCOUNT** The email address for the ACME registered account, typically the value of `gcloud config get-value account`.
 
 
 ```
-ks generate iap-ingress iap-ingress --secretName=${SECRET_NAME} --ipName=${IP_NAME} --namespace=${NAMESPACE} --hostname=${FQDN}
+ks generate cert-manager cert-manager --namespace=${NAMESPACE} --acmeEmail=${ACCOUNT}
+ks apply ${ENVIRONMENT} -c cert-manager
+
+ks generate iap-ingress iap-ingress --ipName=${IP_NAME} --namespace=${NAMESPACE} --hostname=${FQDN}
 ks apply ${ENVIRONMENT} -c iap-ingress
 ```
 
@@ -95,7 +75,7 @@ the [enable_iap.sh](https://github.com/kubeflow/kubeflow/tree/master/docs/gke/en
 CLIENT_ID=<Client id for OAuth client created in the previous step>
 CLIENT_SECRET=<Client secret for OAuth client created in the previous step>
 SERVICE=envoy
-enable_iap.sh ${PROJECT} ${NAMESPACE} ${SERVICE}
+./enable_iap.sh ${PROJECT} ${NAMESPACE} ${SERVICE}
 ```
 The above command will output the audience such as:
 

--- a/kubeflow/core/cert-manager.libsonnet
+++ b/kubeflow/core/cert-manager.libsonnet
@@ -1,0 +1,181 @@
+{
+  parts(namespace):: {
+    local k = import "k.libsonnet",
+
+    certManagerParts(acmeEmail, acmeUrl):: std.prune(k.core.v1.list.new([
+      $.parts(namespace).certificateCRD,
+      $.parts(namespace).clusterIssuerCRD,
+      $.parts(namespace).issuerCRD,
+      $.parts(namespace).serviceAccount,
+      $.parts(namespace).clusterRole,
+      $.parts(namespace).clusterRoleBinding,
+      $.parts(namespace).deploy,
+      $.parts(namespace).issuerLEProd(acmeEmail, acmeUrl),
+    ])),
+
+    certificateCRD:: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "certificates.certmanager.k8s.io"
+      },
+      spec: {
+        group: "certmanager.k8s.io",
+        version: "v1alpha1",
+        names: {
+          kind: "Certificate",
+          plural: "certificates",
+        },
+        scope: "Namespaced",
+      },
+    },
+
+    clusterIssuerCRD:: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "clusterissuers.certmanager.k8s.io",
+      },
+        
+      spec: {
+        group: "certmanager.k8s.io",
+        version: "v1alpha1",
+        names: {
+          kind: "ClusterIssuer",
+          plural: "clusterissuers",
+        },
+        scope: "Cluster",
+      },
+    },
+
+    issuerCRD:: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "issuers.certmanager.k8s.io"
+      },
+      spec: {
+        group: "certmanager.k8s.io",
+        version: "v1alpha1",
+        names: {
+          kind: "Issuer",
+          plural: "issuers",
+        },
+        scope: "Namespaced",
+      },
+    },
+    
+    serviceAccount:: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "cert-manager",
+        namespace: namespace,
+      }
+    },
+
+    clusterRole:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRole",
+      metadata: {
+        name: "cert-manager",
+      },
+      rules: [
+        {
+          apiGroups: ["certmanager.k8s.io"],
+          resources: ["certificates", "issuers", "clusterissuers"],
+          verbs: ["*"],
+        },
+        {
+          apiGroups: [""],
+          resources: ["secrets", "events", "endpoints", "services", "pods"],
+          verbs: ["*"],
+        },
+        {
+          apiGroups: ["extensions"],
+          resources: ["ingresses"],
+          verbs: ["*"],
+        },
+      ],
+    },
+
+    clusterRoleBinding:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRoleBinding",
+      metadata: {
+        name: "cert-manager",
+      },
+      roleRef: {
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "ClusterRole",
+        name: "cert-manager",
+      },
+      subjects: [
+        {
+          name: "cert-manager",
+          namespace: namespace,
+          kind: "ServiceAccount",
+        },
+      ],
+    },
+
+    deploy:: {
+      apiVersion: "apps/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: "cert-manager",
+        namespace: namespace,
+        labels: {
+          app: "cert-manager",
+        },
+      },
+      spec: {
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              app: "cert-manager",
+            },
+          },
+          spec: {
+            serviceAccountName: "cert-manager",
+            containers: [
+              {
+                name: "cert-manager",
+                image: "quay.io/jetstack/cert-manager-controller:v0.2.3",
+                imagePullPolicy: "IfNotPresent",
+              },
+              {
+                name: "ingress-shim",
+                image: "quay.io/jetstack/cert-manager-ingress-shim:v0.2.3",
+                imagePullPolicy: "IfNotPresent",
+              },
+            ],
+          },
+        },
+      },
+    },
+
+    issuerLEProd(acmeEmail, acmeUrl):: {
+      apiVersion: "certmanager.k8s.io/v1alpha1",
+      kind: "Issuer",
+      metadata: {
+        name: "letsencrypt-prod",
+        namespace: namespace,
+      },
+      spec: {
+        acme: {
+          server: acmeUrl,
+          email: acmeEmail,
+          privateKeySecretRef: {
+            name: "letsencrypt-prod-secret",
+          },
+          http01: {
+            // Dummy field used to jsonnet does not remove empty 'http01: {}' entry.
+            method: "GET",
+          },
+        },
+      },
+    },
+  },
+}

--- a/kubeflow/core/prototypes/cert-manager.jsonnet
+++ b/kubeflow/core/prototypes/cert-manager.jsonnet
@@ -1,0 +1,21 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.cert-manager
+// @description Provides cert-manager prototypes for generating SSL certificates.
+// @shortDescription Certificate generation on GKE.
+// @param name string Name for the component
+// @optionalParam namespace string default Namespace
+// @param acmeEmail string The Lets Encrypt account email address
+// @optionalParam acmeUrl string https://acme-v01.api.letsencrypt.org/directory The Lets Encrypt account email address, set to https://acme-staging.api.letsencrypt.org/directory for staging API.
+
+// TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
+// because ksonnet doesn't support inheriting it from the environment yet.
+
+local k = import "k.libsonnet";
+local certManager = import "kubeflow/core/cert-manager.libsonnet";
+
+local name = import "param://name";
+local namespace = import "param://namespace";
+local acmeEmail = import "param://acmeEmail";
+local acmeUrl = import "param://acmeUrl";
+
+certManager.parts(namespace).certManagerParts(acmeEmail, acmeUrl)

--- a/kubeflow/core/prototypes/cert-manager.jsonnet
+++ b/kubeflow/core/prototypes/cert-manager.jsonnet
@@ -5,7 +5,7 @@
 // @param name string Name for the component
 // @optionalParam namespace string default Namespace
 // @param acmeEmail string The Lets Encrypt account email address
-// @optionalParam acmeUrl string https://acme-v01.api.letsencrypt.org/directory The Lets Encrypt account email address, set to https://acme-staging.api.letsencrypt.org/directory for staging API.
+// @optionalParam acmeUrl string https://acme-v01.api.letsencrypt.org/directory The ACME server URL, set to https://acme-staging.api.letsencrypt.org/directory for staging API.
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
 // because ksonnet doesn't support inheriting it from the environment yet.

--- a/kubeflow/core/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/core/prototypes/iap-ingress.jsonnet
@@ -4,9 +4,10 @@
 // @shortDescription Ingress for IAP on GKE.
 // @param name string Name for the component
 // @optionalParam namespace string default Namespace
-// @param secretName string The name of the secret containing the SSL certificates.
+// @optionalParam secretName string envoy-ingress-tls The name of the secret containing the SSL certificates.
 // @param ipName string The name of the global ip address to use.
 // @optionalParam hostname string null The hostname associated with this ingress. Eg: mykubeflow.example.com
+// @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
 // because ksonnet doesn't support inheriting it from the environment yet.
@@ -19,5 +20,6 @@ local namespace = import "param://namespace";
 local secretName = import "param://secretName";
 local ipName = import "param://ipName";
 local hostname = import "param://hostname";
+local issuer = import "param://issuer";
 
-iap.parts(namespace).ingressParts(secretName, ipName, hostname)
+iap.parts(namespace).ingressParts(secretName, ipName, hostname, issuer)


### PR DESCRIPTION
Fixes #255 and alternative solution to #437 

Import of ksonnet components to install cert-mananger and certificate for the Ingress used by IAP component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/441)
<!-- Reviewable:end -->
