### PR TITLE
E2e test for TF serving with GPU

### DIFF
--- a/components/k8s-model-server/images/releaser/components/workflows.libsonnet
+++ b/components/k8s-model-server/images/releaser/components/workflows.libsonnet
@@ -357,39 +357,11 @@
             buildTemplate(
               "deploy-tf-serving",
               deploy_tf_serving_command,
-              [
-                {
-                  name: "DOCKER_HOST",
-                  value: "127.0.0.1",
-                },
-              ],
-              [{
-                name: "dind",
-                image: "docker:17.10-dind",
-                securityContext: {
-                  privileged: true,
-                },
-                mirrorVolumeMounts: true,
-              }],
-            ),  // deploy-tf-serving
+            ),
             buildTemplate(
               "deploy-tf-serving-gpu",
               deploy_tf_serving_gpu_command,
-              [
-                {
-                  name: "DOCKER_HOST",
-                  value: "127.0.0.1",
-                },
-              ],
-              [{
-                name: "dind",
-                image: "docker:17.10-dind",
-                securityContext: {
-                  privileged: true,
-                },
-                mirrorVolumeMounts: true,
-              }],
-            ),  // deploy-tf-serving-gpu
+            ),
 
             buildTestTfImageTemplate("test-tf-serving", "inception-cpu",
                 "/components/k8s-model-server/images/test-worker/result.txt"),

--- a/components/k8s-model-server/images/releaser/components/workflows.libsonnet
+++ b/components/k8s-model-server/images/releaser/components/workflows.libsonnet
@@ -101,7 +101,7 @@
         namespace: stepsNamespace,
         modelPath: "gs://kubeflow-models/inception",
         numGpus: 1,
-      }
+      };
 
       local toPair = function(k, v) k + "=" + v;
       local deployParamsList = std.join(",", [toPair(k, deployParams[k]) for k in std.objectFields(deployParams)]);

--- a/components/k8s-model-server/images/releaser/components/workflows.libsonnet
+++ b/components/k8s-model-server/images/releaser/components/workflows.libsonnet
@@ -232,6 +232,16 @@
           template: "test-tf-serving",
           dependencies: ["deploy-tf-serving"],
         },
+        {
+          name: "deploy-tf-servin-gpu",
+          template: "deploy-tf-serving-gpu",
+          dependencies: ["checkout"],
+        },
+        {
+          name: "test-tf-serving-gpu",
+          template: "test-tf-serving-gpu",
+          dependencies: ["deploy-tf-serving-gpu"],
+        },
       ];
       local e2e_tasks = e2e_tasks_base + if build_image then [
         {
@@ -265,7 +275,7 @@
         "--test_dir=" + testDir,
         "--artifacts_dir=" + artifactsDir,
         "deploy_model",
-      ]
+      ];
       local deploy_tf_serving_command = deploy_tf_serving_command_base + [
         "--params=" + deployParamsList,
       ];

--- a/components/k8s-model-server/images/test-worker/result-gpu.txt
+++ b/components/k8s-model-server/images/test-worker/result-gpu.txt
@@ -1,0 +1,38 @@
+outputs {
+  key: "classes"
+  value {
+    dtype: DT_STRING
+    tensor_shape {
+      dim {
+        size: 1
+      }
+      dim {
+        size: 5
+      }
+    }
+    string_val: "sleeping bag"
+    string_val: "Border terrier"
+    string_val: "tabby, tabby cat"
+    string_val: "quilt, comforter, comfort, puff"
+    string_val: "studio couch, day bed"
+  }
+}
+outputs {
+  key: "scores"
+  value {
+    dtype: DT_FLOAT
+    tensor_shape {
+      dim {
+        size: 1
+      }
+      dim {
+        size: 5
+      }
+    }
+    float_val: 8.51593017578
+    float_val: 7.85044574738
+    float_val: 5.88767147064
+    float_val: 5.70612812042
+    float_val: 5.55422496796
+  }
+}

--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -223,7 +223,10 @@ def teardown(args):
   core_api.delete_namespace(args.namespace, {})
 
 def determine_test_name(args):
-  return args.func.__name__ + "-" + args.deploy_name if args.deploy_name else args.func.__name__
+  if args.deploy_name:
+    return args.func.__name__ + "-" + args.deploy_name
+  else:
+    return args.func.__name__
 
 # TODO(jlewi): We should probably make this a generic function in
 # kubeflow.testing.`

--- a/testing/test_tf_serving.py
+++ b/testing/test_tf_serving.py
@@ -68,7 +68,7 @@ def main():
 
   t = test_util.TestCase()
   t.class_name = "Kubeflow"
-  t.name = "tf-serving-image"
+  t.name = "tf-serving-image-" + args.service_name
 
   start = time.time()
   try:
@@ -82,7 +82,7 @@ def main():
     # Send request
     # See prediction_service.proto for gRPC request/response details.
     request = predict_pb2.PredictRequest()
-    request.model_spec.name = 'inception'
+    request.model_spec.name = args.service_name
     request.model_spec.signature_name = 'predict_images'
     request.inputs['images'].CopyFrom(
         tf.make_tensor_proto(raw_image, shape=[1,]))
@@ -91,7 +91,7 @@ def main():
     result = None
     while True:
       try:
-        result = str(stub.Predict(request, 10.0))  # 10 secs timeout
+        result = stub.Predict(request, 10.0)  # 10 secs timeout
       except Exception as e:
         num_try += 1
         if num_try > 3:
@@ -100,18 +100,19 @@ def main():
         time.sleep(5)
       else:
         break
-    logging.info('Got result: {}'.format(result))
+    logging.info('Got result: {}'.format(str(result)))
     if args.result_path:
       with open(args.result_path) as f:
         expected_result = f.read()
         logging.info('Expected result: {}'.format(expected_result))
-        assert(expected_result == result)
+        assert(expected_result == str(result))
   except Exception as e:
     t.failure = "Test failed; " + e.message
+    raise
   finally:
     t.time = time.time() - start
     junit_path = os.path.join(
-        args.artifacts_dir, "junit_kubeflow-tf-serving-image.xml")
+        args.artifacts_dir, "junit_kubeflow-tf-serving-image-{}.xml".format(args.service_name))
     logging.info("Writing test results to %s", junit_path)
     test_util.create_junit_xml_file([t], junit_path)
 

--- a/testing/test_tf_serving.py
+++ b/testing/test_tf_serving.py
@@ -91,7 +91,7 @@ def main():
     result = None
     while True:
       try:
-        result = stub.Predict(request, 10.0)  # 10 secs timeout
+        result = str(stub.Predict(request, 10.0))  # 10 secs timeout
       except Exception as e:
         num_try += 1
         if num_try > 3:
@@ -100,12 +100,12 @@ def main():
         time.sleep(5)
       else:
         break
-    logging.info('Got result: {}'.format(str(result)))
+    logging.info('Got result: {}'.format(result))
     if args.result_path:
       with open(args.result_path) as f:
         expected_result = f.read()
         logging.info('Expected result: {}'.format(expected_result))
-        assert(expected_result == str(result))
+        assert(expected_result == result)
   except Exception as e:
     t.failure = "Test failed; " + e.message
     raise


### PR DESCRIPTION
Fix #291 
- refactor workflow to avoid code duplication
- Append cpu/gpu to the workflow name and junit name so that they can be distinguished
- Added result file for GPU. It's slightly different (0.0001) than CPU result (not sure why)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/442)
<!-- Reviewable:end -->
