### PR TITLE
set termination policy to worker 0 by default when no master exists

### DIFF
--- a/kubeflow/tf-job/prototypes/tf-job.jsonnet
+++ b/kubeflow/tf-job/prototypes/tf-job.jsonnet
@@ -37,6 +37,11 @@ local numPs = import "param://num_ps";
 local numWorkers = import "param://num_workers";
 local numGpus = import "param://num_gpus";
 
+local terminationPolicy = if numMasters == 1 then
+  tfJob.parts.tfJobTerminationPolicy("MASTER", 0)
+else
+  tfJob.parts.tfJobTerminationPolicy("WORKER", 0);
+
 local workerSpec = if numGpus > 0 then
   tfJob.parts.tfJobReplica("WORKER", numWorkers, args, imageGpu, numGpus)
 else
@@ -46,6 +51,7 @@ std.prune(k.core.v1.list.new([
   tfJob.parts.tfJob(name, namespace, [
     tfJob.parts.tfJobReplica("MASTER", numMasters, args, image),
     workerSpec,
-    tfJob.parts.tfJobReplica("PS", numPs, args, image),
-  ]),
+    tfJob.parts.tfJobReplica("PS", numPs, args, image),],
+    terminationPolicy
+  ),
 ]))

--- a/kubeflow/tf-job/tf-job.libsonnet
+++ b/kubeflow/tf-job/tf-job.libsonnet
@@ -34,7 +34,14 @@ local k = import "k.libsonnet";
         }
       else {},
 
-    tfJob(name, namespace, replicas):: {
+    tfJobTerminationPolicy(replicaName, replicaIndex):: {
+      chief: {
+          replicaName: replicaName,
+          replicaIndex: replicaIndex,
+      },
+    },
+
+    tfJob(name, namespace, replicas, tp):: {
       apiVersion: "kubeflow.org/v1alpha1",
       kind: "TFJob",
       metadata: {
@@ -43,6 +50,7 @@ local k = import "k.libsonnet";
       },
       spec: {
         replicaSpecs: replicas,
+        terminationPolicy: tp,
       },
     },
   },


### PR DESCRIPTION
most tensorflow training examples use worker 0 as the chief worker instead of master. 
using ksonnet tf-job prototype to create training jobs dosen't allow that
and will make the tfjob fails if we set num_masters to 0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/444)
<!-- Reviewable:end -->
