### PR TITLE
remove the pip install tensorboard

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -183,7 +183,6 @@ SHELL ["/bin/bash", "-c"]
 RUN git clone https://github.com/tensorflow/models.git /home/$NB_USER/tensorflow-models && git clone https://github.com/tensorflow/benchmarks.git /home/$NB_USER/tensorflow-benchmarks
 # Import matplotlib the first time to build the font cache.
 ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
-RUN pip install jupyter-tensorboard
 
 # Create a conda environment for Python 2. We want to include as many of the
 # packages from our root environment as we reasonably can, so we explicitly


### PR DESCRIPTION
/assign @jlewi

This is for the issue #428 "remove tensorboard link from jupyter" and #297 "add prototypes for TensorBoard". In general we're utilizing the ksonnet way to launch tensorboard rather than using a button in jupyterhub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/446)
<!-- Reviewable:end -->
