### PR TITLE
Fix the TFCnn prototype which was broken by #444.

### DIFF
--- a/kubeflow/tf-job/prototypes/tf-cnn-benchmarks.jsonnet
+++ b/kubeflow/tf-job/prototypes/tf-cnn-benchmarks.jsonnet
@@ -94,7 +94,7 @@ local job =
     if numPs < 1 then
       error "num_ps must be >= 1"
     else
-      tfJob.parts.tfJob(name, namespace, replicas) + {
+      tfJob.parts.tfJob(name, namespace, replicas, null) + {
         spec+: {
           tfImage: image,
           terminationPolicy: { chief: { replicaName: "WORKER", replicaIndex: 0 } },


### PR DESCRIPTION
* #444 add an argument for the termination policy but the TFCnn prototype
  isn't setting it.

* The TFCnn prototype overrides the termination policy so we can just pass null
  for the TP.

* Fix #458

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/461)
<!-- Reviewable:end -->
