### PR TITLE
Update docs so that namespace is only set at ks env level

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The Kubeflow project is dedicated to making **deployment** of machine learning o
 Contained in this repository are manifests for creating:
 
 * A [**JupyterHub**](https://jupyterhub.readthedocs.io/en/latest/) to create
-  and manage interactive [Jupyter notebooks](http://jupyter.org). 
-  [Project Jupyter](http://jupyter.org/about) is a non-profit, open-source 
+  and manage interactive [Jupyter notebooks](http://jupyter.org).
+  [Project Jupyter](http://jupyter.org/about) is a non-profit, open-source
   project to support interactive data science and scientific computing across
   all programming languages.
 * A **TensorFlow Training Controller** that can be configured to use either CPUs or GPUs and dynamically adjusted to the size of a cluster with a single setting
@@ -67,10 +67,15 @@ If you want to use GPUs, be sure to follow the Kubernetes [instructions for enab
 In order to quickly set up all components, execute the following commands:
 
 ```commandline
-# Initialize a ksonnet APP
+# Create a namespace for kubeflow deployment
+NAMESPACE=kubeflow
+kubectl create namespace ${NAMESPACE}
+
+# Initialize a ksonnet app. Set the namespace for it's default environment.
 APP_NAME=my-kubeflow
 ks init ${APP_NAME}
 cd ${APP_NAME}
+ks env set default --namespace ${NAMESPACE}
 
 # Install Kubeflow components
 ks registry add kubeflow github.com/kubeflow/kubeflow/tree/master/kubeflow
@@ -79,9 +84,7 @@ ks pkg install kubeflow/tf-serving
 ks pkg install kubeflow/tf-job
 
 # Create templates for core components
-NAMESPACE=kubeflow
-kubectl create namespace ${NAMESPACE}
-ks generate core kubeflow-core --name=kubeflow-core --namespace=${NAMESPACE}
+ks generate kubeflow-core kubeflow-core
 
 # If your cluster is running on Azure you will need to set the cloud parameter.
 # If the cluster was created with AKS or ACS choose aks, it if was created

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you want to use GPUs, be sure to follow the Kubernetes [instructions for enab
 
 ### Requirements
 
-  * ksonnet version [0.8.0](https://ksonnet.io/#get-started) or later.
+  * ksonnet version [0.9.1](https://ksonnet.io/#get-started) or later.
   * Kubernetes >= 1.8 [see here](https://github.com/kubeflow/tf-operator#requirements)
 
 ### Steps

--- a/components/k8s-model-server/README.md
+++ b/components/k8s-model-server/README.md
@@ -139,6 +139,8 @@ cd my-model-server
 ks registry add kubeflow github.com/kubeflow/kubeflow/tree/master/kubeflow
 ks pkg install kubeflow/tf-serving
 ks env add  cloud
+ks env set cloud --namespace ${NAMESPACE}
+
 MODEL_COMPONENT=serveInception
 MODEL_NAME=inception
 #Replace this with the url to your bucket if using your own model
@@ -147,7 +149,6 @@ MODEL_SERVER_IMAGE=gcr.io/$(gcloud config get-value project)/model-server:1.0
 # if you need REST API need to provide http_proxy_image
 HTTP_PROXY_IMAGE=gcr.io/$(gcloud config get-value project)/http-proxy:1.0
 ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
-ks param set --env=cloud ${MODEL_COMPONENT} namespace $NAMESPACE
 ks param set --env=cloud ${MODEL_COMPONENT} modelPath $MODEL_PATH
 # If you want to use your custom image.
 ks param set --env=cloud ${MODEL_COMPONENT} modelServerImage $MODEL_SERVER_IMAGE
@@ -179,9 +180,9 @@ Kubernetes documentation.
 TF serving can read the model directly from GCS. But by default it will use the credential of the cluster.
 If you want to use the credential of a service account to read the model from a GCS bucket:
 * Download the service account key
-* Create a k8s secret: 
+* Create a k8s secret:
 ```commandline
-kubectl create secret generic SECRET_NAME --namespace=NAMESPACE --from-file=key.json=YOUR_KEY_FILE
+kubectl create secret generic SECRET_NAME --namespace={NAMESPACE} --from-file=key.json=YOUR_KEY_FILE
 ```
 And before applying the TF serving component, set additional two params:
 ```commandline

--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -60,10 +60,10 @@ The instructions below reference the following environment variables which you w
 
 
 ```
-ks generate cert-manager cert-manager --namespace=${NAMESPACE} --acmeEmail=${ACCOUNT}
+ks generate cert-manager cert-manager --acmeEmail=${ACCOUNT}
 ks apply ${ENVIRONMENT} -c cert-manager
 
-ks generate iap-ingress iap-ingress --ipName=${IP_NAME} --namespace=${NAMESPACE} --hostname=${FQDN}
+ks generate iap-ingress iap-ingress --ipName=${IP_NAME} --hostname=${FQDN}
 ks apply ${ENVIRONMENT} -c iap-ingress
 ```
 
@@ -94,7 +94,7 @@ As a result you will have to repeat the steps below to properly configure IAP.
 The next step is to deploy Envoy as a reverse proxy.
 
 ```
-ks generate iap-envoy iap-envoy --namespace=${NAMESPACE} --audiences=${JWT_AUDIENCE}
+ks generate iap-envoy iap-envoy --audiences=${JWT_AUDIENCE}
 ks apply ${ENVIRONMENT} -c iap-envoy
 ```
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -36,9 +36,7 @@ Create the Kubeflow core component. The core component includes:
 
 
 ```
-NAMESPACE=kubeflow
-kubectl create namespace ${NAMESPACE}
-ks generate core kubeflow-core --name=kubeflow-core --namespace=${NAMESPACE}
+ks generate core kubeflow-core --name=kubeflow-core
 
 # Enable collection of anonymous usage metrics
 # Skip this step if you don't want to enable collection.
@@ -46,7 +44,7 @@ ks generate core kubeflow-core --name=kubeflow-core --namespace=${NAMESPACE}
 ks param set kubeflow-core reportUsage true
 ks param set kubeflow-core usageId $(uuidgen)
 ```
-  * Feel free to change the namespace to a value that better suits your kubernetes cluster.
+
 
 
 Ksonnet allows us to parameterize the Kubeflow deployment according to our needs. We will define two environments: nocloud, and cloud.
@@ -84,6 +82,15 @@ Now let's set `${KF_ENV}` to `cloud` or `nocloud` to reflect our environment for
 $ KF_ENV=cloud|nocloud
 ```
 
+Create a namespace for your deployment and set it as part of the environment. Feel free to change the namespace to a value that better suits your kubernetes cluster.
+
+```
+NAMESPACE=kubeflow
+kubectl create namespace ${NAMESPACE}
+ks env set ${KF_ENV} --namespace ${NAMESPACE}
+```
+
+
 And apply the components to our Kubernetes cluster
 
 ```
@@ -118,7 +125,7 @@ kubectl delete -n ${NAMESPACE} deploy spartakus-volunteer
 ```
 
 **Reporting usage data is one of the most signifcant contributions you can make to Kubeflow; so please consider turning it on.** This data
-allows us to improve the project and helps the many companies working on Kubeflow justify continued investement. 
+allows us to improve the project and helps the many companies working on Kubeflow justify continued investement.
 
 You can improve the quality of the data by giving each Kubeflow deployment a unique id
 
@@ -157,7 +164,7 @@ You should see a sign in prompt.
 1. Select a CPU or GPU image from the Image dropdown menu depending on whether you are doing CPU or GPU training, or whether or not you have GPUs in your cluster. The current defaults offered for both are `gcr.io/kubeflow-images-staging/tensorflow-notebook-cpu` and `gcr.io/kubeflow-images-staging/tensorflow-notebook-gpu` respectively. Or you can type in the name of any TF image you want to run.
 1. Allocate memory, CPU, GPU, or other resources according to your need (1 CPU and 2Gi of Memory are good starting points)
     * To allocate GPUs, make sure that you have GPUs available in your cluster
-    * Run the following command to check if there are any nvidia gpus available: 
+    * Run the following command to check if there are any nvidia gpus available:
     `kubectl get nodes "-o=custom-columns=NAME:.metadata.name,GPU:.status.allocatable.nvidia\.com/gpu"`
     * If you have GPUs available, you can schedule your server on a GPU node by specifying the following json in `Extra Resource Limits` section: `{"nvidia.com/gpu": "1"}`
   1. Click Spawn
@@ -212,8 +219,7 @@ Create a component for your model
 MODEL_COMPONENT=serveInception
 MODEL_NAME=inception
 MODEL_PATH=gs://kubeflow-models/inception
-ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME} 
-ks param set ${MODEL_COMPONENT} namespace ${NAMESPACE} 
+ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
 ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
 ```
 
@@ -236,7 +242,7 @@ In this example, you should be able to use the inception_client to hit ww.xx.yy.
 ### Serve a model using Seldon
 [Seldon-core](https://github.com/SeldonIO/seldon-core) provides deployment for any machine learning runtime that can be [packaged in a Docker container](https://github.com/SeldonIO/seldon-core/blob/master/docs/wrappers/readme.md).
 
-Install the seldon package 
+Install the seldon package
 
 ```
 ks pkg install kubeflow/seldon
@@ -259,7 +265,7 @@ Create a component for your job.
 
 ```
 JOB_NAME=myjob
-ks generate tf-job ${JOB_NAME} --name=${JOB_NAME} --namespace=${NAMESPACE}
+ks generate tf-job ${JOB_NAME} --name=${JOB_NAME}
 ```
 
 To configure your job you need to set a bunch of parameters. To see a list of parameters run
@@ -303,7 +309,7 @@ Create the component
 
 ```
 CNN_JOB_NAME=mycnnjob
-ks generate tf-cnn ${CNN_JOB_NAME} --name=${CNN_JOB_NAME} --namespace=${NAMESPACE}
+ks generate tf-cnn ${CNN_JOB_NAME} --name=${CNN_JOB_NAME}
 ```
 
 Submit it

--- a/user_guide.md
+++ b/user_guide.md
@@ -8,7 +8,7 @@ This guide will walk you through the basics of deploying and interacting with Ku
 
 ## Requirements
  * Kubernetes >= 1.8 [see here](https://github.com/kubeflow/tf-operator#requirements)
- * ksonnet version [0.8.0](https://ksonnet.io/#get-started) or later. (See [below](#why-kubeflow-uses-ksonnet) for an explanation of why we use ksonnet)
+ * ksonnet version [0.9.1](https://ksonnet.io/#get-started) or later. (See [below](#why-kubeflow-uses-ksonnet) for an explanation of why we use ksonnet)
 
 ## Deploy Kubeflow
 


### PR DESCRIPTION
Now that https://github.com/kubeflow/kubeflow/pull/426 is merged, we do
not need to set namespace at the component level. namespace will be
automatically inherited by the component from env.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/463)
<!-- Reviewable:end -->
