### PR TITLE
Add parameter to mount path for notebook PVC

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -182,7 +182,6 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
                   {
                     name: "NOTEBOOK_PVC_MOUNT",
                     value: notebookPVCMount
-
                   },
                 ]
               },  // jupyterHub container

--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -3,7 +3,7 @@
     $.parts(params.namespace).jupyterHubConfigMap(params.jupyterHubAuthenticator, params.disks),
     $.parts(params.namespace).jupyterHubService,
     $.parts(params.namespace).jupyterHubLoadBalancer(params.jupyterHubServiceType),
-    $.parts(params.namespace).jupyterHub(params.jupyterHubImage),
+    $.parts(params.namespace).jupyterHub(params.jupyterHubImage, params.jupyterNotebookPVCMount),
     $.parts(params.namespace).jupyterHubRole,
     $.parts(params.namespace).jupyterHubServiceAccount,
     $.parts(params.namespace).jupyterHubRoleBinding,
@@ -136,7 +136,7 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
     },
 
     // image: Image for JupyterHub
-    jupyterHub(image): {
+    jupyterHub(image, notebookPVCMount): {
       apiVersion: "apps/v1beta1",
       kind: "StatefulSet",
       metadata: {
@@ -178,6 +178,13 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
                     containerPort: 8081,
                   },
                 ],
+                env: [
+                  {
+                    name: "NOTEBOOK_PVC_MOUNT",
+                    value: notebookPVCMount
+
+                  },
+                ]
               },  // jupyterHub container
             ],
             serviceAccountName: "jupyter-hub",

--- a/kubeflow/core/jupyterhub_spawner.py
+++ b/kubeflow/core/jupyterhub_spawner.py
@@ -93,7 +93,7 @@ c.KubeSpawner.start_timeout = 60 * 30
 # TODO(jlewi): Verify this works on minikube.
 # TODO(jlewi): Should we set c.KubeSpawner.singleuser_fs_gid = 1000
 # see https://github.com/kubeflow/kubeflow/pull/22#issuecomment-350500944
-pvc_mount = os.environ.get("NOTEBOOK_PVC_MOUNT")
+pvc_mount = os.environ.get('NOTEBOOK_PVC_MOUNT')
 if pvc_mount:
     c.KubeSpawner.user_storage_pvc_ensure = True
     # How much disk space do we want?

--- a/kubeflow/core/jupyterhub_spawner.py
+++ b/kubeflow/core/jupyterhub_spawner.py
@@ -93,21 +93,24 @@ c.KubeSpawner.start_timeout = 60 * 30
 # TODO(jlewi): Verify this works on minikube.
 # TODO(jlewi): Should we set c.KubeSpawner.singleuser_fs_gid = 1000
 # see https://github.com/kubeflow/kubeflow/pull/22#issuecomment-350500944
-c.KubeSpawner.user_storage_pvc_ensure = True
-# How much disk space do we want?
-c.KubeSpawner.user_storage_capacity = '10Gi'
-c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
-c.KubeSpawner.volumes = [
-  {
-    'name': 'volume-{username}{servername}',
-    'persistentVolumeClaim': {
-      'claimName': 'claim-{username}{servername}'
-    }
-  }
-]
-c.KubeSpawner.volume_mounts = [
-  {
-    'mountPath': '/home/jovyan/work',
-    'name': 'volume-{username}{servername}'
-  }
-]
+pvc_mount = os.environ.get("NOTEBOOK_PVC_MOUNT")
+if pvc_mount:
+    c.KubeSpawner.user_storage_pvc_ensure = True
+    # How much disk space do we want?
+    c.KubeSpawner.user_storage_capacity = '10Gi'
+    c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
+    c.KubeSpawner.volumes = [
+      {
+        'name': 'volume-{username}{servername}',
+        'persistentVolumeClaim': {
+          'claimName': 'claim-{username}{servername}'
+        }
+      }
+    ]
+    c.KubeSpawner.volume_mounts = [
+      {
+        'mountPath': pvc_mount,
+        'name': 'volume-{username}{servername}'
+      }
+    ]
+

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -13,6 +13,7 @@
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
 // @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:1.0.1 The image to use for JupyterHub.
 // @optionalParam jupyterHubAuthenticator string null The authenticator to use
+// @optionalParam jupyterNotebookPVCMount string /home/jovyan/work Mount path for PVC. Set empty to disable PVC
 // @optionalParam reportUsage string false Whether or not to report Kubeflow usage to kubeflow.org.
 // @optionalParam usageId string unknown_cluster Optional id to use when reporting usage to kubeflow.org
 

--- a/kubeflow/core/tests/jupyterhub_test.jsonnet
+++ b/kubeflow/core/tests/jupyterhub_test.jsonnet
@@ -104,10 +104,14 @@ std.assertEqual(jupyterhub.parts(params.namespace).jupyterHub(params.jupyterHubI
                         "containerPort": 8081
                      }
                   ],
+		  "env": [
+			"name": "NOTEBOOK_PVC_MOUNT",
+			"value": "/home/jovyan/work",
+                  ]
                   "volumeMounts": [
                      {
                         "mountPath": "/etc/config",
-                        "name": "config-volume"
+                        "name": "config-volume",
                      }
                   ]
                }


### PR DESCRIPTION
This change allows command ks param set kubeflow-core
jupyterNotebookPVCMount << mount path >>. If you specify empty string
("") there it will remove PVC creation at all, which is useful in envs
without proper StorageClass.

Fixes #365

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/469)
<!-- Reviewable:end -->
