### PR TITLE
Update tensorflow-notebook-image workflow to pin tf and cuda version

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -59,9 +59,9 @@ RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.10.0/tini 
     chmod +x /usr/local/bin/tini
 
 # Install ksonnet
-RUN wget --quiet https://github.com/ksonnet/ksonnet/releases/download/v0.8.0/ks_0.8.0_linux_amd64.tar.gz && \
-    tar -zvxf ks_0.8.0_linux_amd64.tar.gz && \
-    mv ks_0.8.0_linux_amd64/ks /usr/local/bin/ks && \
+RUN wget --quiet https://github.com/ksonnet/ksonnet/releases/download/v0.9.1/ks_0.9.1_linux_amd64.tar.gz && \
+    tar -zvxf ks_0.9.1_linux_amd64.tar.gz && \
+    mv ks_0.9.1_linux_amd64/ks /usr/local/bin/ks && \
     chmod +x /usr/local/bin/ks
 
 # Configure environment
@@ -161,14 +161,8 @@ RUN conda install --quiet --yes \
     conda remove --quiet --yes --force qt pyqt && \
     conda clean -tipsy
 
-# Install graphviz package
-RUN apt-get update && apt-get install -yq --no-install-recommends graphviz \
-    && apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
-
-# Install Python 3 Tensorflow without GPU support
 ARG TF_PACKAGE=tf-nightly
-RUN echo Installing $TF_PACKAGE && pip install --quiet --no-cache-dir $TF_PACKAGE
+RUN echo Installing $TF_PACKAGE && pip install --upgrade --quiet --no-cache-dir $TF_PACKAGE
 
 # Hack recommended in tf-serving-api to use it with py3. Remove when proper pip package is available.
 COPY --from=tf-serving-install /usr/local/lib/python2.7/site-packages/tensorflow_serving /opt/conda/lib/python3.6/site-packages/tensorflow_serving
@@ -186,7 +180,7 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
 # Activate ipywidgets extension in the environment that runs the notebook server
 RUN jupyter nbextension enable --py widgetsnbextension --sys-prefix
 
-RUN curl -L -o bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.8.0/bazel-0.8.0-installer-linux-x86_64.sh && chmod a+x ./bazel.sh && ./bazel.sh && rm ./bazel.sh
+RUN curl -L -o bazel.sh https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-installer-linux-x86_64.sh && chmod a+x ./bazel.sh && ./bazel.sh && rm ./bazel.sh
 SHELL ["/bin/bash", "-c"]
 
 RUN git clone https://github.com/tensorflow/models.git /home/$NB_USER/tensorflow-models && git clone https://github.com/tensorflow/benchmarks.git /home/$NB_USER/tensorflow-benchmarks

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -215,5 +215,10 @@ RUN chown -R $NB_USER:users /etc/jupyter/ && \
     chown -R $NB_USER /home/$NB_USER/ && \
     chmod a+rx /usr/local/bin/*
 
+# tornado 5 has breaking changes (https://github.com/jupyter/notebook/issues/3407)
+# and does not work with the current jupyterhub. Pin tornado to 4.5.3
+# TODO(ankushagarwal): Figure out the right way to fix this
+RUN pip install tornado==4.5.3
+
 USER $NB_USER
 ENV PATH=/home/jovyan/bin:$PATH

--- a/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
@@ -123,13 +123,13 @@
         sidecars: sidecars,
       };  // buildTemplate
       local buildImageTemplate(tf_version, device) = {
-        local image = params.registry + "/tensorflow-notebook-" + tf_version + "-" + device + ":" + params.versionTag,
+        local image = params.registry + "/tensorflow-" + tf_version + "-notebook-" +  device + ":" + params.versionTag,
         local base_image =
           if device == "cpu" then
             "ubuntu:latest"
           // device = gpu
           else if std.startsWith(tf_version, "1.4.") then
-            "nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04"
+            "nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04"
           else
             "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
         local tf_package =

--- a/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
@@ -55,8 +55,6 @@
 
       local stepsNamespace = name;
 
-      local cpuImage = params.registry + "/tensorflow-notebook-cpu" + ":" + params.versionTag;
-      local gpuImage = params.registry + "/tensorflow-notebook-gpu" + ":" + params.versionTag;
       // mountPath is the directory where the volume to store the test data
       // should be mounted.
       local mountPath = "/mnt/" + "test-data-volume";
@@ -124,10 +122,26 @@
         },
         sidecars: sidecars,
       };  // buildTemplate
-
-      local buildImageTemplate(step_name, image, base_image, tf_package) =
-        buildTemplate(
-          step_name,
+      local buildImageTemplate(tf_version, device) = {
+        local image = params.registry + "/tensorflow-notebook-" + device + ":" + tf_version + "-" + params.versionTag,
+        local base_image =
+          if device == "cpu" then
+            "ubuntu:latest"
+          // device = gpu
+          else if std.startsWith(tf_version, "1.4.") then
+            "nvidia/cuda:8.0-cudnn7-devel-ubuntu16.04"
+          else
+            "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+        local tf_package =
+          "https://storage.googleapis.com/tensorflow/linux/" +
+          device +
+          "/tensorflow" +
+          (if device == "gpu" then "_gpu" else "") +
+          "-" +
+          tf_version +
+          "-cp36-cp36m-linux_x86_64.whl",
+        result:: buildTemplate(
+          "build-" + tf_version + "-" + device,
           [
             // We need to explicitly specify bash because
             // build_image.sh is not in the container its a volume mounted file.
@@ -153,7 +167,8 @@
             },
             mirrorVolumeMounts: true,
           }],
-        );  // buildImageTemplate
+        ),  // buildImageTemplate
+      }.result;
       {
         apiVersion: "argoproj.io/v1alpha1",
         kind: "Workflow",
@@ -198,13 +213,33 @@
                     template: "checkout",
                   },
                   {
-                    name: "build-cpu-notebook",
-                    template: "build-cpu-notebook",
+                    name: "build-1.4.1-gpu",
+                    template: "build-1.4.1-gpu",
                     dependencies: ["checkout"],
                   },
                   {
-                    name: "build-gpu-notebook",
-                    template: "build-gpu-notebook",
+                    name: "build-1.4.1-cpu",
+                    template: "build-1.4.1-cpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "build-1.5.1-gpu",
+                    template: "build-1.5.1-gpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "build-1.5.1-cpu",
+                    template: "build-1.5.1-cpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "build-1.6.0-gpu",
+                    template: "build-1.6.0-gpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "build-1.6.0-cpu",
+                    template: "build-1.6.0-cpu",
                     dependencies: ["checkout"],
                   },
                   {
@@ -215,6 +250,12 @@
                 ],
               },  //dag
             },
+            buildImageTemplate("1.4.1", "cpu"),
+            buildImageTemplate("1.4.1", "gpu"),
+            buildImageTemplate("1.5.1", "cpu"),
+            buildImageTemplate("1.5.1", "gpu"),
+            buildImageTemplate("1.6.0", "cpu"),
+            buildImageTemplate("1.6.0", "gpu"),
             {
               name: "exit-handler",
               steps: [
@@ -246,8 +287,6 @@
                 ],
               },
             },  // checkout
-            buildImageTemplate("build-cpu-notebook", cpuImage, "ubuntu:latest", "tf-nightly"),
-            buildImageTemplate("build-gpu-notebook", gpuImage, "nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04", "tf-nightly-gpu"),
             buildTemplate("create-pr-symlink", [
               "python",
               "-m",

--- a/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
@@ -123,7 +123,7 @@
         sidecars: sidecars,
       };  // buildTemplate
       local buildImageTemplate(tf_version, device) = {
-        local image = params.registry + "/tensorflow-notebook-" + device + ":" + tf_version + "-" + params.versionTag,
+        local image = params.registry + "/tensorflow-notebook-" + tf_version + "-" + device + ":" + params.versionTag,
         local base_image =
           if device == "cpu" then
             "ubuntu:latest"

--- a/releasing.md
+++ b/releasing.md
@@ -40,7 +40,7 @@ ks param set --env=${ENV} workflows versionTag "${VERSION_TAG}"
 ks apply ${ENV} -c workflows
 ```
 
-You can monitor the workflow using the Argo UI. For our release cluster we don't expose the Argo UI publicly 
+You can monitor the workflow using the Argo UI. For our release cluster we don't expose the Argo UI publicly
 so right now you need to connect via kubectl port-forward
 
 ```
@@ -105,7 +105,7 @@ cd components/tensorflow-notebook-image/releaser
 PULL_BASE_SHA=<commit to build>
 DATE=`date +%Y%m%d`
 VERSION_TAG="v${DATE}-${PULL_BASE_SHA}"
-JOB_NAME="tf-operator-release"
+JOB_NAME="tensorflow-notebook-image-release"
 JOB_TYPE=postsubmit
 BUILD_NUMBER=$(uuidgen)
 BUILD_NUMBER=${BUILD_NUMBER:0:4}


### PR DESCRIPTION
* Build 1.4.1, 1.5.1, 1.6.0 versions for gpu and cpu
* Update ksonnet version
* Update bazel version
* Built all images locally to test it.

The images will have the following URI format
```
gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-gpu:20180320-afw9aow
gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-cpu:20180320-afw9aow
```

Fixes #375

Fixes #467 (Multiple Jupyter images for different TF Versions).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/471)
<!-- Reviewable:end -->
