### PR TITLE
Add google-cloud-storage package to jupyterhub notebook

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -113,6 +113,7 @@ CMD ["start-notebook.sh"]
 
 # Install CUDA Profile Tools and other python packages
 RUN pip --no-cache-dir install \
+    google-cloud-storage \
     Pillow \
     h5py \
     ipykernel \


### PR DESCRIPTION
This is the official python client library for GCS

It will be used to read/write to GCS

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/492)
<!-- Reviewable:end -->
