### PR TITLE
Update ambassador and statsd to 0.30.1 as part of 0.1 release

### DIFF
--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -10,7 +10,7 @@
   ],
 
   parts(namespace):: {
-    local ambassadorImage = "quay.io/datawire/ambassador:0.26.0",
+    local ambassadorImage = "quay.io/datawire/ambassador:0.30.1",
     service(serviceType):: {
       apiVersion: "v1",
       kind: "Service",
@@ -207,7 +207,7 @@
                 },
               },
               {
-                image: "quay.io/datawire/statsd:0.22.0",
+                image: "quay.io/datawire/statsd:0.30.1",
                 name: "statsd",
               },
             ],
@@ -218,7 +218,7 @@
       },
     },  // deploy
 
-    isDashboardTls(cloud):: 
+    isDashboardTls(cloud)::
       if cloud == "acsengine" || cloud == "aks" then
         "false"
       else

--- a/kubeflow/core/tests/ambassador_test.jsonnet
+++ b/kubeflow/core/tests/ambassador_test.jsonnet
@@ -182,7 +182,7 @@ ambassador.parts(params.namespace).deploy,
                         "value": "true"
                      }
                   ],
-                  "image": "quay.io/datawire/ambassador:0.26.0",
+                  "image": "quay.io/datawire/ambassador:0.30.1",
                   "livenessProbe": {
                      "httpGet": {
                         "path": "/ambassador/v0/check_alive",

--- a/kubeflow/core/tests/ambassador_test.jsonnet
+++ b/kubeflow/core/tests/ambassador_test.jsonnet
@@ -212,7 +212,7 @@ ambassador.parts(params.namespace).deploy,
                   }
                },
                {
-                  "image": "quay.io/datawire/statsd:0.22.0",
+                  "image": "quay.io/datawire/statsd:0.30.1",
                   "name": "statsd"
                }
             ],


### PR DESCRIPTION
Deployed kubeflow on a new cluster and tested new ambassador by
deploying an inception model and routing traffic through ambassador

Related to https://github.com/kubeflow/kubeflow/issues/506

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/513)
<!-- Reviewable:end -->
