### PR TITLE
Use ks version 0.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ If you want to use GPUs, be sure to follow the Kubernetes [instructions for enab
 
 ### Requirements
 
-  * ksonnet version [0.9.1](https://ksonnet.io/#get-started) or later.
+  * ksonnet version [0.9.2](https://ksonnet.io/#get-started) or later.
   * Kubernetes >= 1.8 [see here](https://github.com/kubeflow/tf-operator#requirements)
 
 ### Steps

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -59,9 +59,9 @@ RUN wget --quiet https://github.com/krallin/tini/releases/download/v0.10.0/tini 
     chmod +x /usr/local/bin/tini
 
 # Install ksonnet
-RUN wget --quiet https://github.com/ksonnet/ksonnet/releases/download/v0.9.1/ks_0.9.1_linux_amd64.tar.gz && \
-    tar -zvxf ks_0.9.1_linux_amd64.tar.gz && \
-    mv ks_0.9.1_linux_amd64/ks /usr/local/bin/ks && \
+RUN wget --quiet https://github.com/ksonnet/ksonnet/releases/download/v0.9.2/ks_0.9.2_linux_amd64.tar.gz && \
+    tar -zvxf ks_0.9.2_linux_amd64.tar.gz && \
+    mv ks_0.9.2_linux_amd64/ks /usr/local/bin/ks && \
     chmod +x /usr/local/bin/ks
 
 # Configure environment

--- a/user_guide.md
+++ b/user_guide.md
@@ -8,7 +8,7 @@ This guide will walk you through the basics of deploying and interacting with Ku
 
 ## Requirements
  * Kubernetes >= 1.8 [see here](https://github.com/kubeflow/tf-operator#requirements)
- * ksonnet version [0.9.1](https://ksonnet.io/#get-started) or later. (See [below](#why-kubeflow-uses-ksonnet) for an explanation of why we use ksonnet)
+ * ksonnet version [0.9.2](https://ksonnet.io/#get-started) or later. (See [below](#why-kubeflow-uses-ksonnet) for an explanation of why we use ksonnet)
 
 ## Deploy Kubeflow
 


### PR DESCRIPTION
ks 0.9.1 had a bug in which ks env set default --namespace=kubeflow doesn't change the namespace 

This is fixed in ks 0.9.2 so we need to update to 0.9.2.

Fixes https://github.com/kubeflow/kubeflow/issues/477

Related to #506 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/515)
<!-- Reviewable:end -->
