### PR TITLE
Install jupyter widgets in tensorflow-notebook-image

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -208,6 +208,13 @@ RUN conda_packages=$(conda list -e | cut -d '=' -f 1 | grep -v '#' | sort) && \
     pip install --no-cache-dir tensorflow-transform && \
     source deactivate
 
+# install notebook and lab widgets
+RUN 	conda install -n root -c conda-forge widgetsnbextension && \
+	conda install -n ipykernel_py2 -c conda-forge widgetsnbextension && \
+	conda install -n root -c conda-forge ipywidgets && \
+	conda install -n ipykernel_py2 -c conda-forge ipywidgets && \
+	jupyter labextension install @jupyter-widgets/jupyterlab-manager
+
 # Add local files as late as possible to avoid cache busting
 COPY start.sh /usr/local/bin/
 COPY start-notebook.sh /usr/local/bin/


### PR DESCRIPTION
Fixes #489 

@jlewi Your instructions appear to be correct for py3. Not sure why it was failing in your env. I tested with [interact](http://ipywidgets.readthedocs.io/en/latest/examples/Using%20Interact.html) but maybe you have something else in mind.

![screen shot 2018-03-27 at 5 03 38 pm](https://user-images.githubusercontent.com/2380545/37994907-eaa689ac-31e0-11e8-8596-19f7c35c84ad.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/518)
<!-- Reviewable:end -->
