### PR TITLE
Clarify authentication requirements in release process

### DIFF
--- a/releasing.md
+++ b/releasing.md
@@ -4,10 +4,10 @@ Some preliminary instructions for how to cut a release.
 
 ## Authenticate to GCP
 
-If you're new to using GKE or are new to the release team, you'll need to authenticate to GCP first.  [Install the `gcloud` tool](https://cloud.google.com/sdk/gcloud/) and then execute the following commands, substituting your release team account for `your-team-account@kubeflow.org`:
+If you're new to using GKE or are new to the release team, you'll need to authenticate to GCP first.  [Install the `gcloud` tool](https://cloud.google.com/sdk/gcloud/) and then execute the following commands, substituting your Kubeflow release team account for `your-account@yourdomain.org` (if you aren't a member of `release-team@kubeflow.org`, ask to be added):
 
 ```
-gcloud config set account your-team-account@kubeflow.org
+gcloud config set account your-account@yourdomain.org
 gcloud auth 
 ```
 


### PR DESCRIPTION
This commit clarifies that a `kubeflow.org` account is not necessary to authenticate to GCP as part of cutting a Kubeflow release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/520)
<!-- Reviewable:end -->
