### PR TITLE
Update the TFJob image in preparation for a new RC.

### DIFF
--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -7,7 +7,7 @@
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
 // @optionalParam tfAmbassadorServiceType string ClusterIP The service type for the API Gateway.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-staging/tf_operator:v20180326-6214e560 The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-staging/tf_operator:v20180329-a7511ff The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -180,7 +180,7 @@
               ["/usr/local/bin/checkout.sh", srcRootDir],
               [{
                 name: "EXTRA_REPOS",
-                value: "kubeflow/tf-operator@HEAD;kubeflow/testing@HEAD",
+                value: "kubeflow/tf-operator@v0.1.0;kubeflow/testing@HEAD",
               }],
               [], // no sidecars
             ),


### PR DESCRIPTION
* The updated TFJob includes the fix to delete pods when job finishes
  rather than leave them running.

* We need to pin the commit of the tf-operator in the extra repos so
  that we checkout the tests at the commit that matches the image.

Related to #506

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/533)
<!-- Reviewable:end -->
