### PR TITLE
sidecar for envoy pod to keep IAP up to date

### DIFF
--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -98,7 +98,7 @@ We can configure Jupyter to use the identity provided by IAP. This way users won
 
 ```
 ks param set ${CORE_NAME} jupyterHubAuthenticator iap
-ks apply ${ENV} -c ${CORE_NAME}
+ks apply ${ENVIRONMENT} -c ${CORE_NAME}
 # Restart JupyterHub so it picks up the updated config
 kubectl delete -n ${NAMESPACE} pods tf-hub-0
 ```

--- a/kubeflow/argo/prototypes/argo.jsonnet
+++ b/kubeflow/argo/prototypes/argo.jsonnet
@@ -11,7 +11,7 @@ local argo = import "kubeflow/argo/argo.libsonnet";
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 local namespace = updatedParams.namespace;
 

--- a/kubeflow/core/centraldashboard.libsonnet
+++ b/kubeflow/core/centraldashboard.libsonnet
@@ -2,7 +2,7 @@
   // TODO(https://github.com/ksonnet/ksonnet/issues/222): Taking namespace as an argument is a work around for the fact that ksonnet
   // doesn't support automatically piping in the namespace from the environment to prototypes.
 
-all(params):: [
+  all(params):: [
     $.parts(params.namespace).deployUi,
     $.parts(params.namespace).uiService,
     $.parts(params.namespace).uiServiceAccount,

--- a/kubeflow/core/cert-manager.libsonnet
+++ b/kubeflow/core/cert-manager.libsonnet
@@ -20,7 +20,7 @@
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",
       metadata: {
-        name: "certificates.certmanager.k8s.io"
+        name: "certificates.certmanager.k8s.io",
       },
       spec: {
         group: "certmanager.k8s.io",
@@ -39,7 +39,7 @@
       metadata: {
         name: "clusterissuers.certmanager.k8s.io",
       },
-        
+
       spec: {
         group: "certmanager.k8s.io",
         version: "v1alpha1",
@@ -55,7 +55,7 @@
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",
       metadata: {
-        name: "issuers.certmanager.k8s.io"
+        name: "issuers.certmanager.k8s.io",
       },
       spec: {
         group: "certmanager.k8s.io",
@@ -67,14 +67,14 @@
         scope: "Namespaced",
       },
     },
-    
+
     serviceAccount:: {
       apiVersion: "v1",
       kind: "ServiceAccount",
       metadata: {
         name: "cert-manager",
         namespace: namespace,
-      }
+      },
     },
 
     clusterRole:: {

--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -173,8 +173,8 @@
                 image: "google/cloud-sdk:alpine",
                 command: [
                   "sh",
-                  "/var/envoy-config/iap-init.sh"
-            ],
+                  "/var/envoy-config/iap-init.sh",
+                ],
                 env: [
                   {
                     name: "NAMESPACE",

--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -134,7 +134,7 @@
       volumeMounts: [
         {
           mountPath: "/etc/envoy",
-          name: "config-volume",
+          name: "shared",
         },
       ],
     },  // envoyContainer
@@ -156,14 +156,25 @@
           },
           spec: {
             serviceAccountName: "envoy",
-            initContainers: [
+            containers: [
+              $.parts(namespace).envoyContainer({
+                image: image,
+                name: "envoy",
+                // We use the admin port for the health, readiness check because the main port will require a valid JWT.
+                // healthPath: "/server_info",
+                healthPath: "/healthz",
+                healthPort: envoyPort,
+                configPath: "/etc/envoy/envoy-config.json",
+                baseId: "27000",
+                ports: [envoyPort, envoyAdminPort, envoyStatsPort],
+              }),
               {
                 name: "iap",
                 image: "google/cloud-sdk:alpine",
                 command: [
                   "sh",
-                  "/var/envoy-config/iap-init.sh",
-                ],
+                  "/var/envoy-config/iap-init.sh"
+            ],
                 env: [
                   {
                     name: "NAMESPACE",
@@ -191,26 +202,22 @@
                     name: "SERVICE",
                     value: "envoy",
                   },
+                  {
+                    name: "ENVOY_ADMIN",
+                    value: "http://localhost:" + envoyAdminPort,
+                  },
                 ],
                 volumeMounts: [
                   {
                     mountPath: "/var/envoy-config/",
                     name: "config-volume",
                   },
+                  {
+                    mountPath: "/var/shared/",
+                    name: "shared",
+                  },
                 ],
               },
-            ],
-            containers: [
-              $.parts(namespace).envoyContainer({
-                image: image,
-                name: "envoy",
-                // We use the admin port for the health, readiness check because the main port will require a valid JWT.
-                healthPath: "/server_info",
-                healthPort: envoyAdminPort,
-                configPath: "/etc/envoy/envoy-config.json",
-                baseId: "27000",
-                ports: [envoyPort, envoyAdminPort, envoyStatsPort],
-              }),
             ],
             restartPolicy: "Always",
             volumes: [
@@ -219,6 +226,12 @@
                   name: "envoy-config",
                 },
                 name: "config-volume",
+              },
+              {
+                emptyDir: {
+                  medium: "Memory",
+                },
+                name: "shared",
               },
             ],
           },
@@ -235,7 +248,7 @@
       },
       data: {
         "envoy-config.json": std.manifestJson($.parts(namespace).envoyConfig(disableJwt)),
-        // Script executed by init container to enable IAP. When finished, the configmap is patched with the JWT audience.
+        // Script executed by the iap container to configure IAP. When finished, the envoy config is created with the JWT audience.
         "iap-init.sh": |||
           [ -z ${CLIENT_ID} ] && echo Error CLIENT_ID must be set && exit 1
           [ -z ${CLIENT_SECRET} ] && echo Error CLIENT_SECRET must be set && exit 1
@@ -320,13 +333,38 @@
 
           JWT_AUDIENCE="/projects/${PROJECT_NUM}/global/backendServices/${BACKEND_ID}"
 
-          echo JWT_AUDIENCE=${JWT_AUDIENCE}
+          # For healthcheck compare.
+          echo "JWT_AUDIENCE=${JWT_AUDIENCE}" > /var/shared/healthz.env
+          echo "NODE_PORT=${NODE_PORT}" >> /var/shared/healthz.env
+          echo "BACKEND_ID=${BACKEND_ID}" >> /var/shared/healthz.env
 
-          kubectl get configmap -n ${NAMESPACE} envoy-config -o json | \
-            sed -e "s|{{JWT_AUDIENCE}}|${JWT_AUDIENCE}|g" | kubectl apply -f -
+          kubectl get configmap -n ${NAMESPACE} envoy-config -o jsonpath='{.data.envoy-config\.json}' | \
+            sed -e "s|{{JWT_AUDIENCE}}|${JWT_AUDIENCE}|g" > /var/shared/envoy-config.json
+
+          echo "Restarting envoy"
+          curl -s ${ENVOY_ADMIN}/quitquitquit
 
           echo "Clearing lock on service annotation"
           kubectl patch svc "${SERVICE}" -p "{\"metadata\": { \"annotations\": {\"iaplock\": \"\" }}}"
+
+          function checkIAP() {
+            # created by init container.
+            . /var/shared/healthz.env 
+
+            # If node port or backend id change, so does the JWT audience.
+            CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
+            CURR_BACKEND_ID=$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${CURR_NODE_PORT}- --format='value(id)')
+            [ "$BACKEND_ID" == "$CURR_BACKEND_ID" ]
+          }
+
+          # Verify IAP every 10 seconds.
+          while true; do
+            if ! checkIAP; then
+              echo "$(date) WARN: IAP check failed, restarting container."
+              exit 1
+            fi
+            sleep 10
+          done
         |||,
       },
     },

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -23,7 +23,7 @@ local all = import "kubeflow/core/all.libsonnet";
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 
 std.prune(k.core.v1.list.new(all.parts(updatedParams).all))

--- a/kubeflow/core/prototypes/cert-manager.jsonnet
+++ b/kubeflow/core/prototypes/cert-manager.jsonnet
@@ -13,14 +13,14 @@
 local k = import "k.libsonnet";
 local certManager = import "kubeflow/core/cert-manager.libsonnet";
 
-local name = import "param://name";
 local acmeEmail = import "param://acmeEmail";
 local acmeUrl = import "param://acmeUrl";
+local name = import "param://name";
 
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 
 certManager.parts(updatedParams.namespace).certManagerParts(acmeEmail, acmeUrl)

--- a/kubeflow/core/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/core/prototypes/iap-ingress.jsonnet
@@ -19,7 +19,7 @@ local util = import "kubeflow/core/util.libsonnet";
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 
 local name = import "param://name";

--- a/kubeflow/core/tests/ambassador_test.jsonnet
+++ b/kubeflow/core/tests/ambassador_test.jsonnet
@@ -5,246 +5,253 @@ local params = {
 };
 
 std.assertEqual(
-ambassador.parts(params.namespace).service(params.tfAmbassadorServiceType),
-{
-   "apiVersion": "v1",
-   "kind": "Service",
-   "metadata": {
-      "labels": {
-         "service": "ambassador"
+  ambassador.parts(params.namespace).service(params.tfAmbassadorServiceType),
+  {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: {
+      labels: {
+        service: "ambassador",
       },
-      "name": "ambassador",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "ports": [
-         {
-            "name": "ambassador",
-            "port": 80,
-            "targetPort": 80
-         }
+      name: "ambassador",
+      namespace: "test-kf-001",
+    },
+    spec: {
+      ports: [
+        {
+          name: "ambassador",
+          port: 80,
+          targetPort: 80,
+        },
       ],
-      "selector": {
-         "service": "ambassador"
+      selector: {
+        service: "ambassador",
       },
-      "type": "ClusterIP"
-   }
-}) &&
+      type: "ClusterIP",
+    },
+  }
+) &&
 
 std.assertEqual(
-ambassador.parts(params.namespace).adminService,
-{
-   "apiVersion": "v1",
-   "kind": "Service",
-   "metadata": {
-      "labels": {
-         "service": "ambassador-admin"
+  ambassador.parts(params.namespace).adminService,
+  {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: {
+      labels: {
+        service: "ambassador-admin",
       },
-      "name": "ambassador-admin",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "ports": [
-         {
-            "name": "ambassador-admin",
-            "port": 8877,
-            "targetPort": 8877
-         }
+      name: "ambassador-admin",
+      namespace: "test-kf-001",
+    },
+    spec: {
+      ports: [
+        {
+          name: "ambassador-admin",
+          port: 8877,
+          targetPort: 8877,
+        },
       ],
-      "selector": {
-         "service": "ambassador"
+      selector: {
+        service: "ambassador",
       },
-      "type": "ClusterIP"
-   }
-}) &&
+      type: "ClusterIP",
+    },
+  }
+) &&
 
 std.assertEqual(
-ambassador.parts(params.namespace).role,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "Role",
-   "metadata": {
-      "name": "ambassador",
-      "namespace": "test-kf-001"
-   },
-   "rules": [
+  ambassador.parts(params.namespace).role,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "Role",
+    metadata: {
+      name: "ambassador",
+      namespace: "test-kf-001",
+    },
+    rules: [
       {
-         "apiGroups": [
-            ""
-         ],
-         "resources": [
-            "services"
-         ],
-         "verbs": [
-            "get",
-            "list",
-            "watch"
-         ]
-      },
-      {
-         "apiGroups": [
-            ""
-         ],
-         "resources": [
-            "configmaps"
-         ],
-         "verbs": [
-            "create",
-            "update",
-            "patch",
-            "get",
-            "list",
-            "watch"
-         ]
+        apiGroups: [
+          "",
+        ],
+        resources: [
+          "services",
+        ],
+        verbs: [
+          "get",
+          "list",
+          "watch",
+        ],
       },
       {
-         "apiGroups": [
-            ""
-         ],
-         "resources": [
-            "secrets"
-         ],
-         "verbs": [
-            "get",
-            "list",
-            "watch"
-         ]
-      }
-   ]
-}) &&
-
-std.assertEqual(
-ambassador.parts(params.namespace).serviceAccount,
-{
-   "apiVersion": "v1",
-   "kind": "ServiceAccount",
-   "metadata": {
-      "name": "ambassador",
-      "namespace": "test-kf-001"
-   }
-}) &&
-
-std.assertEqual(
-ambassador.parts(params.namespace).roleBinding,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "RoleBinding",
-   "metadata": {
-      "name": "ambassador",
-      "namespace": "test-kf-001"
-   },
-   "roleRef": {
-      "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "Role",
-      "name": "ambassador"
-   },
-   "subjects": [
+        apiGroups: [
+          "",
+        ],
+        resources: [
+          "configmaps",
+        ],
+        verbs: [
+          "create",
+          "update",
+          "patch",
+          "get",
+          "list",
+          "watch",
+        ],
+      },
       {
-         "kind": "ServiceAccount",
-         "name": "ambassador",
-         "namespace": "test-kf-001"
-      }
-   ]
-}) &&
+        apiGroups: [
+          "",
+        ],
+        resources: [
+          "secrets",
+        ],
+        verbs: [
+          "get",
+          "list",
+          "watch",
+        ],
+      },
+    ],
+  }
+) &&
 
 std.assertEqual(
-ambassador.parts(params.namespace).deploy,
-{
-   "apiVersion": "extensions/v1beta1",
-   "kind": "Deployment",
-   "metadata": {
-      "name": "ambassador",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "replicas": 3,
-      "template": {
-         "metadata": {
-            "labels": {
-               "service": "ambassador"
+  ambassador.parts(params.namespace).serviceAccount,
+  {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      name: "ambassador",
+      namespace: "test-kf-001",
+    },
+  }
+) &&
+
+std.assertEqual(
+  ambassador.parts(params.namespace).roleBinding,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "RoleBinding",
+    metadata: {
+      name: "ambassador",
+      namespace: "test-kf-001",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "Role",
+      name: "ambassador",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: "ambassador",
+        namespace: "test-kf-001",
+      },
+    ],
+  }
+) &&
+
+std.assertEqual(
+  ambassador.parts(params.namespace).deploy,
+  {
+    apiVersion: "extensions/v1beta1",
+    kind: "Deployment",
+    metadata: {
+      name: "ambassador",
+      namespace: "test-kf-001",
+    },
+    spec: {
+      replicas: 3,
+      template: {
+        metadata: {
+          labels: {
+            service: "ambassador",
+          },
+          namespace: "test-kf-001",
+        },
+        spec: {
+          containers: [
+            {
+              env: [
+                {
+                  name: "AMBASSADOR_NAMESPACE",
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: "metadata.namespace",
+                    },
+                  },
+                },
+                {
+                  name: "AMBASSADOR_SINGLE_NAMESPACE",
+                  value: "true",
+                },
+              ],
+              image: "quay.io/datawire/ambassador:0.30.1",
+              livenessProbe: {
+                httpGet: {
+                  path: "/ambassador/v0/check_alive",
+                  port: 8877,
+                },
+                initialDelaySeconds: 30,
+                periodSeconds: 30,
+              },
+              name: "ambassador",
+              readinessProbe: {
+                httpGet: {
+                  path: "/ambassador/v0/check_ready",
+                  port: 8877,
+                },
+                initialDelaySeconds: 30,
+                periodSeconds: 30,
+              },
+              resources: {
+                limits: {
+                  cpu: 1,
+                  memory: "400Mi",
+                },
+                requests: {
+                  cpu: "200m",
+                  memory: "100Mi",
+                },
+              },
             },
-            "namespace": "test-kf-001"
-         },
-         "spec": {
-            "containers": [
-               {
-                  "env": [
-                     {
-                        "name": "AMBASSADOR_NAMESPACE",
-                        "valueFrom": {
-                           "fieldRef": {
-                              "fieldPath": "metadata.namespace"
-                           }
-                        }
-                     },
-                     {
-                        "name": "AMBASSADOR_SINGLE_NAMESPACE",
-                        "value": "true"
-                     }
-                  ],
-                  "image": "quay.io/datawire/ambassador:0.30.1",
-                  "livenessProbe": {
-                     "httpGet": {
-                        "path": "/ambassador/v0/check_alive",
-                        "port": 8877
-                     },
-                     "initialDelaySeconds": 30,
-                     "periodSeconds": 30
-                  },
-                  "name": "ambassador",
-                  "readinessProbe": {
-                     "httpGet": {
-                        "path": "/ambassador/v0/check_ready",
-                        "port": 8877
-                     },
-                     "initialDelaySeconds": 30,
-                     "periodSeconds": 30
-                  },
-                  "resources": {
-                     "limits": {
-                        "cpu": 1,
-                        "memory": "400Mi"
-                     },
-                     "requests": {
-                        "cpu": "200m",
-                        "memory": "100Mi"
-                     }
-                  }
-               },
-               {
-                  "image": "quay.io/datawire/statsd:0.30.1",
-                  "name": "statsd"
-               }
-            ],
-            "restartPolicy": "Always",
-            "serviceAccountName": "ambassador"
-         }
-      }
-   }
-}) &&
+            {
+              image: "quay.io/datawire/statsd:0.30.1",
+              name: "statsd",
+            },
+          ],
+          restartPolicy: "Always",
+          serviceAccountName: "ambassador",
+        },
+      },
+    },
+  }
+) &&
 
 std.assertEqual(
-ambassador.parts(params.namespace).k8sDashboard("cloud"),
-{
-   "apiVersion": "v1",
-   "kind": "Service",
-   "metadata": {
-      "annotations": {
-         "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind:  Mapping\nname: k8s-dashboard-ui-mapping\nprefix: /k8s/ui/\nrewrite: /\ntls: true\nservice: kubernetes-dashboard.kube-system"
+  ambassador.parts(params.namespace).k8sDashboard("cloud"),
+  {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: {
+      annotations: {
+        "getambassador.io/config": "---\napiVersion: ambassador/v0\nkind:  Mapping\nname: k8s-dashboard-ui-mapping\nprefix: /k8s/ui/\nrewrite: /\ntls: true\nservice: kubernetes-dashboard.kube-system",
       },
-      "name": "k8s-dashboard",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "ports": [
-         {
-            "port": 443,
-            "targetPort": 8443
-         }
+      name: "k8s-dashboard",
+      namespace: "test-kf-001",
+    },
+    spec: {
+      ports: [
+        {
+          port: 443,
+          targetPort: 8443,
+        },
       ],
-      "selector": {
-         "k8s-app": "kubernetes-dashboard"
+      selector: {
+        "k8s-app": "kubernetes-dashboard",
       },
-      "type": "ClusterIP"
-   }
-})
+      type: "ClusterIP",
+    },
+  }
+)

--- a/kubeflow/core/tests/jupyterhub_test.jsonnet
+++ b/kubeflow/core/tests/jupyterhub_test.jsonnet
@@ -8,11 +8,11 @@ local params = {
   jupyterNotebookPVCMount: "/home/jovyan/work",
 };
 
-local baseSpawner= importstr "../jupyterhub_spawner.py";
+local baseSpawner = importstr "../jupyterhub_spawner.py";
 
 // TODO(jlewi): We should be able to use std.startsWidth in later versions of jsonnet.
 //
-local config = jupyterhub.parts(params.namespace).jupyterHubConfigMap(params.jupyterHubAuthenticator, params.disks)["data"]["jupyterhub_config.py"];
+local config = jupyterhub.parts(params.namespace).jupyterHubConfigMap(params.jupyterHubAuthenticator, params.disks).data["jupyterhub_config.py"];
 local configPrefix = std.substr(config, 0, std.length(baseSpawner));
 local configSuffix = std.substr(config, std.length(baseSpawner), std.length(config) - std.length(baseSpawner));
 local configSuffixLines = std.split(configSuffix, "\n");
@@ -20,20 +20,20 @@ local configSuffixLines = std.split(configSuffix, "\n");
 // This assertion varies the config map is the same after zeroing the actual data.
 // The data will be compared in subsequent steps.
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubConfigMap(params.jupyterHubAuthenticator, params.disks) + {
-   "data": {
-      "jupyterhub_config.py": "",
-   },
+  data: {
+    "jupyterhub_config.py": "",
+  },
 }
-, {
-   "apiVersion": "v1",
-   "data": {
-      "jupyterhub_config.py": "",
-   },
-   "kind": "ConfigMap",
-   "metadata": {
-      "name": "jupyterhub-config",
-      "namespace": "test-kf-001"
-   }
+                , {
+  apiVersion: "v1",
+  data: {
+    "jupyterhub_config.py": "",
+  },
+  kind: "ConfigMap",
+  metadata: {
+    name: "jupyterhub-config",
+    namespace: "test-kf-001",
+  },
 }) &&
 
 // This step verifies that the start of the spawner config is the raw file.
@@ -53,179 +53,179 @@ std.assertEqual(configSuffixLines[3], "###### Volumes #######")
 std.assertEqual(configSuffixLines[4], 'c.KubeSpawner.volumes = [{"name": "disk01", "persistentVolumeClaim": {"claimName": "disk01"}}, {"name": "disk02", "persistentVolumeClaim": {"claimName": "disk02"}}]')
 &&
 std.assertEqual(configSuffixLines[5], 'c.KubeSpawner.volume_mounts = [{"mountPath": "/mnt/disk01", "name": "disk01"}, {"mountPath": "/mnt/disk02", "name": "disk02"}]')
-&& 
+&&
 
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubService,
-{
-   "apiVersion": "v1",
-   "kind": "Service",
-   "metadata": {
-      "labels": {
-         "app": "tf-hub"
-      },
-      "name": "tf-hub-0",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "clusterIP": "None",
-      "ports": [
-         {
-            "name": "hub",
-            "port": 8000
-         }
-      ],
-      "selector": {
-         "app": "tf-hub"
-      }
-   }
-}) &&
+                {
+                  apiVersion: "v1",
+                  kind: "Service",
+                  metadata: {
+                    labels: {
+                      app: "tf-hub",
+                    },
+                    name: "tf-hub-0",
+                    namespace: "test-kf-001",
+                  },
+                  spec: {
+                    clusterIP: "None",
+                    ports: [
+                      {
+                        name: "hub",
+                        port: 8000,
+                      },
+                    ],
+                    selector: {
+                      app: "tf-hub",
+                    },
+                  },
+                }) &&
 
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubLoadBalancer(params.jupyterHubServiceType),
-{
-   "apiVersion": "v1",
-   "kind": "Service",
-   "metadata": {
-      "labels": {
-         "app": "tf-hub-lb"
-      },
-      "name": "tf-hub-lb",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "ports": [
-         {
-            "name": "hub",
-            "port": 80,
-            "targetPort": 8000
-         }
-      ],
-      "selector": {
-         "app": "tf-hub"
-      },
-      "type": "ClusterIP"
-   }
-}) &&
+                {
+                  apiVersion: "v1",
+                  kind: "Service",
+                  metadata: {
+                    labels: {
+                      app: "tf-hub-lb",
+                    },
+                    name: "tf-hub-lb",
+                    namespace: "test-kf-001",
+                  },
+                  spec: {
+                    ports: [
+                      {
+                        name: "hub",
+                        port: 80,
+                        targetPort: 8000,
+                      },
+                    ],
+                    selector: {
+                      app: "tf-hub",
+                    },
+                    type: "ClusterIP",
+                  },
+                }) &&
 
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHub(params.jupyterHubImage, params.jupyterNotebookPVCMount),
-{
-   "apiVersion": "apps/v1beta1",
-   "kind": "StatefulSet",
-   "metadata": {
-      "name": "tf-hub",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "replicas": 1,
-      "serviceName": "",
-      "template": {
-         "metadata": {
-            "labels": {
-               "app": "tf-hub"
-            }
-         },
-         "spec": {
-            "containers": [
-               {
-                  "command": [
-                     "jupyterhub",
-                     "-f",
-                     "/etc/config/jupyterhub_config.py"
-                  ],
-                  "env": [
-                     {
-                        "name": "NOTEBOOK_PVC_MOUNT",
-                        "value": params.jupyterNotebookPVCMount
-                     }
-                  ],
-                  "image": "gcr.io/kubeflow/jupyterhub-k8s:1.0.1",
-                  "name": "tf-hub",
-                  "ports": [
-                     {
-                        "containerPort": 8000
-                     },
-                     {
-                        "containerPort": 8081
-                     }
-                  ],
-                  "volumeMounts": [
-                     {
-                        "mountPath": "/etc/config",
-                        "name": "config-volume"
-                     }
-                  ]
-               }
-            ],
-            "serviceAccountName": "jupyter-hub",
-            "volumes": [
-               {
-                  "configMap": {
-                     "name": "jupyterhub-config"
+                {
+                  apiVersion: "apps/v1beta1",
+                  kind: "StatefulSet",
+                  metadata: {
+                    name: "tf-hub",
+                    namespace: "test-kf-001",
                   },
-                  "name": "config-volume"
-               }
-            ]
-         }
-      },
-      "updateStrategy": {
-         "type": "RollingUpdate"
-      }
-   }
-}) &&
+                  spec: {
+                    replicas: 1,
+                    serviceName: "",
+                    template: {
+                      metadata: {
+                        labels: {
+                          app: "tf-hub",
+                        },
+                      },
+                      spec: {
+                        containers: [
+                          {
+                            command: [
+                              "jupyterhub",
+                              "-f",
+                              "/etc/config/jupyterhub_config.py",
+                            ],
+                            env: [
+                              {
+                                name: "NOTEBOOK_PVC_MOUNT",
+                                value: params.jupyterNotebookPVCMount,
+                              },
+                            ],
+                            image: "gcr.io/kubeflow/jupyterhub-k8s:1.0.1",
+                            name: "tf-hub",
+                            ports: [
+                              {
+                                containerPort: 8000,
+                              },
+                              {
+                                containerPort: 8081,
+                              },
+                            ],
+                            volumeMounts: [
+                              {
+                                mountPath: "/etc/config",
+                                name: "config-volume",
+                              },
+                            ],
+                          },
+                        ],
+                        serviceAccountName: "jupyter-hub",
+                        volumes: [
+                          {
+                            configMap: {
+                              name: "jupyterhub-config",
+                            },
+                            name: "config-volume",
+                          },
+                        ],
+                      },
+                    },
+                    updateStrategy: {
+                      type: "RollingUpdate",
+                    },
+                  },
+                }) &&
 
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubRole,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "Role",
-   "metadata": {
-      "name": "jupyter-role",
-      "namespace": "test-kf-001"
-   },
-   "rules": [
-      {
-         "apiGroups": [
-            "*"
-         ],
-         "resources": [
-            "*"
-         ],
-         "verbs": [
-            "*"
-         ]
-      }
-   ]
-}) &&
+                {
+                  apiVersion: "rbac.authorization.k8s.io/v1beta1",
+                  kind: "Role",
+                  metadata: {
+                    name: "jupyter-role",
+                    namespace: "test-kf-001",
+                  },
+                  rules: [
+                    {
+                      apiGroups: [
+                        "*",
+                      ],
+                      resources: [
+                        "*",
+                      ],
+                      verbs: [
+                        "*",
+                      ],
+                    },
+                  ],
+                }) &&
 
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubServiceAccount,
-{
-   "apiVersion": "v1",
-   "kind": "ServiceAccount",
-   "metadata": {
-      "labels": {
-         "app": "jupyter-hub"
-      },
-      "name": "jupyter-hub",
-      "namespace": "test-kf-001"
-   }
-}) &&
+                {
+                  apiVersion: "v1",
+                  kind: "ServiceAccount",
+                  metadata: {
+                    labels: {
+                      app: "jupyter-hub",
+                    },
+                    name: "jupyter-hub",
+                    namespace: "test-kf-001",
+                  },
+                }) &&
 
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubRoleBinding,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "RoleBinding",
-   "metadata": {
-      "name": "jupyter-role",
-      "namespace": "test-kf-001"
-   },
-   "roleRef": {
-      "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "Role",
-      "name": "jupyter-role"
-   },
-   "subjects": [
-      {
-         "kind": "ServiceAccount",
-         "name": "jupyter-hub",
-         "namespace": "test-kf-001"
-      }
-   ]
-})
+                {
+                  apiVersion: "rbac.authorization.k8s.io/v1beta1",
+                  kind: "RoleBinding",
+                  metadata: {
+                    name: "jupyter-role",
+                    namespace: "test-kf-001",
+                  },
+                  roleRef: {
+                    apiGroup: "rbac.authorization.k8s.io",
+                    kind: "Role",
+                    name: "jupyter-role",
+                  },
+                  subjects: [
+                    {
+                      kind: "ServiceAccount",
+                      name: "jupyter-hub",
+                      namespace: "test-kf-001",
+                    },
+                  ],
+                })

--- a/kubeflow/core/tests/nfs_test.jsonnet
+++ b/kubeflow/core/tests/nfs_test.jsonnet
@@ -5,85 +5,89 @@ local params = {
 };
 
 std.assertEqual(
-nfs.parts(params.namespace, params.name).serviceAccount,
-{
-   "apiVersion": "v1",
-   "kind": "ServiceAccount",
-   "metadata": {
-      "labels": {
-         "app": "nfsnfs-provisioner"
+  nfs.parts(params.namespace, params.name).serviceAccount,
+  {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      labels: {
+        app: "nfsnfs-provisioner",
       },
-      "name": "nfs",
-      "namespace": "test-kf-001"
-   }
-}) &&
+      name: "nfs",
+      namespace: "test-kf-001",
+    },
+  }
+) &&
 
 std.assertEqual(
-nfs.parts(params.namespace, params.name).role,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "Role",
-   "metadata": {
-      "name": "nfs",
-      "namespace": "test-kf-001"
-   },
-   "rules": [
+  nfs.parts(params.namespace, params.name).role,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "Role",
+    metadata: {
+      name: "nfs",
+      namespace: "test-kf-001",
+    },
+    rules: [
       {
-         "apiGroups": [
-            "*"
-         ],
-         "resources": [
-            "*"
-         ],
-         "verbs": [
-            "*"
-         ]
-      }
-   ]
-}) &&
+        apiGroups: [
+          "*",
+        ],
+        resources: [
+          "*",
+        ],
+        verbs: [
+          "*",
+        ],
+      },
+    ],
+  }
+) &&
 
 std.assertEqual(
-nfs.parts(params.namespace, params.name).roleBinding,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "RoleBinding",
-   "metadata": {
-      "name": "nfs-nfs-role",
-      "namespace": "test-kf-001"
-   },
-   "roleRef": {
-      "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "Role",
-      "name": "nfs"
-   },
-   "subjects": [
+  nfs.parts(params.namespace, params.name).roleBinding,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "RoleBinding",
+    metadata: {
+      name: "nfs-nfs-role",
+      namespace: "test-kf-001",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "Role",
+      name: "nfs",
+    },
+    subjects: [
       {
-         "kind": "ServiceAccount",
-         "name": "nfs",
-         "namespace": "test-kf-001"
-      }
-   ]
-}) &&
+        kind: "ServiceAccount",
+        name: "nfs",
+        namespace: "test-kf-001",
+      },
+    ],
+  }
+) &&
 
 std.assertEqual(
-nfs.parts(params.namespace, params.name).clusterRoleBinding,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "ClusterRoleBinding",
-   "metadata": {
-      "name": "nfs-nfs-role",
-      "namespace": "test-kf-001"
-   },
-   "roleRef": {
-      "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "ClusterRole",
-      "name": "system:persistent-volume-provisioner"
-   },
-   "subjects": [
+  nfs.parts(params.namespace, params.name).clusterRoleBinding,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRoleBinding",
+    metadata: {
+      name: "nfs-nfs-role",
+      namespace: "test-kf-001",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "system:persistent-volume-provisioner",
+    },
+    subjects: [
       {
-         "kind": "ServiceAccount",
-         "name": "nfs",
-         "namespace": "test-kf-001"
-      }
-   ]
-})
+        kind: "ServiceAccount",
+        name: "nfs",
+        namespace: "test-kf-001",
+      },
+    ],
+  }
+)

--- a/kubeflow/core/tests/spartakus_test.jsonnet
+++ b/kubeflow/core/tests/spartakus_test.jsonnet
@@ -5,102 +5,106 @@ local params = {
 };
 
 std.assertEqual(
-spartakus.parts(params.namespace).role,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "ClusterRole",
-   "metadata": {
-      "labels": {
-         "app": "spartakus"
+  spartakus.parts(params.namespace).role,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRole",
+    metadata: {
+      labels: {
+        app: "spartakus",
       },
-      "name": "spartakus"
-   },
-   "rules": [
+      name: "spartakus",
+    },
+    rules: [
       {
-         "apiGroups": [
-            ""
-         ],
-         "resources": [
-            "nodes"
-         ],
-         "verbs": [
-            "get",
-            "list"
-         ]
-      }
-   ]
-}) &&
+        apiGroups: [
+          "",
+        ],
+        resources: [
+          "nodes",
+        ],
+        verbs: [
+          "get",
+          "list",
+        ],
+      },
+    ],
+  }
+) &&
 
 std.assertEqual(
-spartakus.parts(params.namespace).roleBinding,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "ClusterRoleBinding",
-   "metadata": {
-      "labels": {
-         "app": "spartakus"
+  spartakus.parts(params.namespace).roleBinding,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRoleBinding",
+    metadata: {
+      labels: {
+        app: "spartakus",
       },
-      "name": "spartakus"
-   },
-   "roleRef": {
-      "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "ClusterRole",
-      "name": "spartakus"
-   },
-   "subjects": [
+      name: "spartakus",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "spartakus",
+    },
+    subjects: [
       {
-         "kind": "ServiceAccount",
-         "name": "spartakus",
-         "namespace": "test-kf-001"
-      }
-   ]
-}) &&
-
-std.assertEqual(
-spartakus.parts(params.namespace).serviceAccount,
-{
-   "apiVersion": "v1",
-   "kind": "ServiceAccount",
-   "metadata": {
-      "labels": {
-         "app": "spartakus"
+        kind: "ServiceAccount",
+        name: "spartakus",
+        namespace: "test-kf-001",
       },
-      "name": "spartakus",
-      "namespace": "test-kf-001"
-   }
-}) &&
+    ],
+  }
+) &&
 
 std.assertEqual(
-spartakus.parts(params.namespace).deployment(params.usageId),
-{
-   "apiVersion": "extensions/v1beta1",
-   "kind": "Deployment",
-   "metadata": {
-      "name": "spartakus-volunteer",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "replicas": 1,
-      "template": {
-         "metadata": {
-            "labels": {
-               "app": "spartakus-volunteer"
-            }
-         },
-         "spec": {
-            "containers": [
-               {
-                  "args": [
-                     "volunteer",
-                     "--cluster-id=unknown_cluster",
-                     "--database=https://stats-collector.kubeflow.org"
-                  ],
-                  "image": "gcr.io/google_containers/spartakus-amd64:v1.0.0",
-                  "name": "volunteer"
-               }
-            ],
-            "serviceAccountName": "spartakus"
-         }
-      }
-   }
-})
+  spartakus.parts(params.namespace).serviceAccount,
+  {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      labels: {
+        app: "spartakus",
+      },
+      name: "spartakus",
+      namespace: "test-kf-001",
+    },
+  }
+) &&
+
+std.assertEqual(
+  spartakus.parts(params.namespace).deployment(params.usageId),
+  {
+    apiVersion: "extensions/v1beta1",
+    kind: "Deployment",
+    metadata: {
+      name: "spartakus-volunteer",
+      namespace: "test-kf-001",
+    },
+    spec: {
+      replicas: 1,
+      template: {
+        metadata: {
+          labels: {
+            app: "spartakus-volunteer",
+          },
+        },
+        spec: {
+          containers: [
+            {
+              args: [
+                "volunteer",
+                "--cluster-id=unknown_cluster",
+                "--database=https://stats-collector.kubeflow.org",
+              ],
+              image: "gcr.io/google_containers/spartakus-amd64:v1.0.0",
+              name: "volunteer",
+            },
+          ],
+          serviceAccountName: "spartakus",
+        },
+      },
+    },
+  }
+)

--- a/kubeflow/core/tests/tf-job_test.jsonnet
+++ b/kubeflow/core/tests/tf-job_test.jsonnet
@@ -7,229 +7,235 @@ local params = {
 };
 
 std.assertEqual(
-tfjob.parts(params.namespace).tfJobDeploy(params.tfJobImage),
-{
-   "apiVersion": "extensions/v1beta1",
-   "kind": "Deployment",
-   "metadata": {
-      "name": "tf-job-operator",
-      "namespace": "test-kf-001"
-   },
-   "spec": {
-      "replicas": 1,
-      "template": {
-         "metadata": {
-            "labels": {
-               "name": "tf-job-operator"
-            }
-         },
-         "spec": {
-            "containers": [
-               {
-                  "command": [
-                     "/opt/mlkube/tf-operator",
-                     "--controller-config-file=/etc/config/controller_config_file.yaml",
-                     "--alsologtostderr",
-                     "-v=1"
-                  ],
-                  "env": [
-                     {
-                        "name": "MY_POD_NAMESPACE",
-                        "valueFrom": {
-                           "fieldRef": {
-                              "fieldPath": "metadata.namespace"
-                           }
-                        }
-                     },
-                     {
-                        "name": "MY_POD_NAME",
-                        "valueFrom": {
-                           "fieldRef": {
-                              "fieldPath": "metadata.name"
-                           }
-                        }
-                     }
-                  ],
-                  "image": "gcr.io/kubeflow-images-staging/tf_operator:v20180226-403",
-                  "name": "tf-job-operator",
-                  "volumeMounts": [
-                     {
-                        "mountPath": "/etc/config",
-                        "name": "config-volume"
-                     }
-                  ]
-               }
-            ],
-            "serviceAccountName": "tf-job-operator",
-            "volumes": [
-               {
-                  "configMap": {
-                     "name": "tf-job-operator-config"
+  tfjob.parts(params.namespace).tfJobDeploy(params.tfJobImage),
+  {
+    apiVersion: "extensions/v1beta1",
+    kind: "Deployment",
+    metadata: {
+      name: "tf-job-operator",
+      namespace: "test-kf-001",
+    },
+    spec: {
+      replicas: 1,
+      template: {
+        metadata: {
+          labels: {
+            name: "tf-job-operator",
+          },
+        },
+        spec: {
+          containers: [
+            {
+              command: [
+                "/opt/mlkube/tf-operator",
+                "--controller-config-file=/etc/config/controller_config_file.yaml",
+                "--alsologtostderr",
+                "-v=1",
+              ],
+              env: [
+                {
+                  name: "MY_POD_NAMESPACE",
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: "metadata.namespace",
+                    },
                   },
-                  "name": "config-volume"
-               }
-            ]
-         }
-      }
-   }
-}) &&
+                },
+                {
+                  name: "MY_POD_NAME",
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: "metadata.name",
+                    },
+                  },
+                },
+              ],
+              image: "gcr.io/kubeflow-images-staging/tf_operator:v20180226-403",
+              name: "tf-job-operator",
+              volumeMounts: [
+                {
+                  mountPath: "/etc/config",
+                  name: "config-volume",
+                },
+              ],
+            },
+          ],
+          serviceAccountName: "tf-job-operator",
+          volumes: [
+            {
+              configMap: {
+                name: "tf-job-operator-config",
+              },
+              name: "config-volume",
+            },
+          ],
+        },
+      },
+    },
+  }
+) &&
 
 std.assertEqual(
-tfjob.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
-{
-   "apiVersion": "v1",
-   "data": {
-      "controller_config_file.yaml": "{\n    \"grpcServerFilePath\": \"/opt/mlkube/grpc_tensorflow_server/grpc_tensorflow_server.py\"\n}"
-   },
-   "kind": "ConfigMap",
-   "metadata": {
-      "name": "tf-job-operator-config",
-      "namespace": "test-kf-001"
-   }
-}) &&
+  tfjob.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
+  {
+    apiVersion: "v1",
+    data: {
+      "controller_config_file.yaml": '{\n    "grpcServerFilePath": "/opt/mlkube/grpc_tensorflow_server/grpc_tensorflow_server.py"\n}',
+    },
+    kind: "ConfigMap",
+    metadata: {
+      name: "tf-job-operator-config",
+      namespace: "test-kf-001",
+    },
+  }
+) &&
 
 std.assertEqual(
-tfjob.parts(params.namespace).serviceAccount,
-{
-   "apiVersion": "v1",
-   "kind": "ServiceAccount",
-   "metadata": {
-      "labels": {
-         "app": "tf-job-operator"
+  tfjob.parts(params.namespace).serviceAccount,
+  {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      labels: {
+        app: "tf-job-operator",
       },
-      "name": "tf-job-operator",
-      "namespace": "test-kf-001"
-   }
-}) &&
+      name: "tf-job-operator",
+      namespace: "test-kf-001",
+    },
+  }
+) &&
 
 std.assertEqual(
-tfjob.parts(params.namespace).operatorRole,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "ClusterRole",
-   "metadata": {
-      "labels": {
-         "app": "tf-job-operator"
+  tfjob.parts(params.namespace).operatorRole,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRole",
+    metadata: {
+      labels: {
+        app: "tf-job-operator",
       },
-      "name": "tf-job-operator"
-   },
-   "rules": [
+      name: "tf-job-operator",
+    },
+    rules: [
       {
-         "apiGroups": [
-            "tensorflow.org",
-            "kubeflow.org"
-         ],
-         "resources": [
-            "tfjobs"
-         ],
-         "verbs": [
-            "*"
-         ]
-      },
-      {
-         "apiGroups": [
-            "apiextensions.k8s.io"
-         ],
-         "resources": [
-            "customresourcedefinitions"
-         ],
-         "verbs": [
-            "*"
-         ]
+        apiGroups: [
+          "tensorflow.org",
+          "kubeflow.org",
+        ],
+        resources: [
+          "tfjobs",
+        ],
+        verbs: [
+          "*",
+        ],
       },
       {
-         "apiGroups": [
-            "storage.k8s.io"
-         ],
-         "resources": [
-            "storageclasses"
-         ],
-         "verbs": [
-            "*"
-         ]
+        apiGroups: [
+          "apiextensions.k8s.io",
+        ],
+        resources: [
+          "customresourcedefinitions",
+        ],
+        verbs: [
+          "*",
+        ],
       },
       {
-         "apiGroups": [
-            "batch"
-         ],
-         "resources": [
-            "jobs"
-         ],
-         "verbs": [
-            "*"
-         ]
+        apiGroups: [
+          "storage.k8s.io",
+        ],
+        resources: [
+          "storageclasses",
+        ],
+        verbs: [
+          "*",
+        ],
       },
       {
-         "apiGroups": [
-            ""
-         ],
-         "resources": [
-            "configmaps",
-            "pods",
-            "services",
-            "endpoints",
-            "persistentvolumeclaims",
-            "events"
-         ],
-         "verbs": [
-            "*"
-         ]
+        apiGroups: [
+          "batch",
+        ],
+        resources: [
+          "jobs",
+        ],
+        verbs: [
+          "*",
+        ],
       },
       {
-         "apiGroups": [
-            "apps",
-            "extensions"
-         ],
-         "resources": [
-            "deployments"
-         ],
-         "verbs": [
-            "*"
-         ]
-      }
-   ]
-}) &&
+        apiGroups: [
+          "",
+        ],
+        resources: [
+          "configmaps",
+          "pods",
+          "services",
+          "endpoints",
+          "persistentvolumeclaims",
+          "events",
+        ],
+        verbs: [
+          "*",
+        ],
+      },
+      {
+        apiGroups: [
+          "apps",
+          "extensions",
+        ],
+        resources: [
+          "deployments",
+        ],
+        verbs: [
+          "*",
+        ],
+      },
+    ],
+  }
+) &&
 
 std.assertEqual(
-tfjob.parts(params.namespace).operatorRoleBinding,
-{
-   "apiVersion": "rbac.authorization.k8s.io/v1beta1",
-   "kind": "ClusterRoleBinding",
-   "metadata": {
-      "labels": {
-         "app": "tf-job-operator"
+  tfjob.parts(params.namespace).operatorRoleBinding,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRoleBinding",
+    metadata: {
+      labels: {
+        app: "tf-job-operator",
       },
-      "name": "tf-job-operator"
-   },
-   "roleRef": {
-      "apiGroup": "rbac.authorization.k8s.io",
-      "kind": "ClusterRole",
-      "name": "tf-job-operator"
-   },
-   "subjects": [
+      name: "tf-job-operator",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "tf-job-operator",
+    },
+    subjects: [
       {
-         "kind": "ServiceAccount",
-         "name": "tf-job-operator",
-         "namespace": "test-kf-001"
-      }
-   ]
-}) &&
+        kind: "ServiceAccount",
+        name: "tf-job-operator",
+        namespace: "test-kf-001",
+      },
+    ],
+  }
+) &&
 
 std.assertEqual(
-tfjob.parts(params.namespace).crd,
-{
-   "apiVersion": "apiextensions.k8s.io/v1beta1",
-   "kind": "CustomResourceDefinition",
-   "metadata": {
-      "name": "tfjobs.kubeflow.org"
-   },
-   "spec": {
-      "group": "kubeflow.org",
-      "names": {
-         "kind": "TFJob",
-         "plural": "tfjobs",
-         "singular": "tfjob"
+  tfjob.parts(params.namespace).crd,
+  {
+    apiVersion: "apiextensions.k8s.io/v1beta1",
+    kind: "CustomResourceDefinition",
+    metadata: {
+      name: "tfjobs.kubeflow.org",
+    },
+    spec: {
+      group: "kubeflow.org",
+      names: {
+        kind: "TFJob",
+        plural: "tfjobs",
+        singular: "tfjob",
       },
-      "version": "v1alpha1"
-   }
-})
+      version: "v1alpha1",
+    },
+  }
+)

--- a/kubeflow/core/tf-job.libsonnet
+++ b/kubeflow/core/tf-job.libsonnet
@@ -10,7 +10,7 @@
     $.parts(params.namespace).uiRoleBinding,
     $.parts(params.namespace).uiService(params.tfJobUiServiceType),
     $.parts(params.namespace).uiServiceAccount,
-    $.parts(params.namespace).ui(params.tfJobImage)
+    $.parts(params.namespace).ui(params.tfJobImage),
   ],
 
   parts(namespace):: {

--- a/kubeflow/seldon/crd.libsonnet
+++ b/kubeflow/seldon/crd.libsonnet
@@ -1,5 +1,5 @@
-local k = import "k.libsonnet";
 local podTemplateValidation = import "json/pod-template-spec-validation.json";
+local k = import "k.libsonnet";
 
 {
   crd()::

--- a/kubeflow/seldon/prototypes/core.jsonnet
+++ b/kubeflow/seldon/prototypes/core.jsonnet
@@ -19,7 +19,7 @@ local core = import "kubeflow/seldon/core.libsonnet";
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 
 local name = import "param://name";

--- a/kubeflow/seldon/prototypes/serve-simple.jsonnet
+++ b/kubeflow/seldon/prototypes/serve-simple.jsonnet
@@ -14,7 +14,7 @@ local serve = import "kubeflow/seldon/serve-simple.libsonnet";
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 
 local name = import "param://name";

--- a/kubeflow/tf-job/prototypes/tf-cnn-benchmarks.jsonnet
+++ b/kubeflow/tf-job/prototypes/tf-cnn-benchmarks.jsonnet
@@ -24,7 +24,7 @@ local podTemplate = k.extensions.v1beta1.podTemplate;
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 
 local tfJob = import "kubeflow/tf-job/tf-job.libsonnet";

--- a/kubeflow/tf-job/prototypes/tf-job.jsonnet
+++ b/kubeflow/tf-job/prototypes/tf-job.jsonnet
@@ -19,7 +19,7 @@ local tfJob = import "kubeflow/tf-job/tf-job.libsonnet";
 // updatedParams uses the environment namespace if
 // the namespace parameter is not explicitly set
 local updatedParams = params {
-  namespace: if params.namespace == "null" then env.namespace else params.namespace
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
 };
 
 local name = import "param://name";
@@ -50,10 +50,14 @@ else
   tfJob.parts.tfJobReplica("WORKER", numWorkers, args, image);
 
 std.prune(k.core.v1.list.new([
-  tfJob.parts.tfJob(name, namespace, [
-    tfJob.parts.tfJobReplica("MASTER", numMasters, args, image),
-    workerSpec,
-    tfJob.parts.tfJobReplica("PS", numPs, args, image),],
+  tfJob.parts.tfJob(
+    name,
+    namespace,
+    [
+      tfJob.parts.tfJobReplica("MASTER", numMasters, args, image),
+      workerSpec,
+      tfJob.parts.tfJobReplica("PS", numPs, args, image),
+    ],
     terminationPolicy
   ),
 ]))

--- a/kubeflow/tf-job/tf-job.libsonnet
+++ b/kubeflow/tf-job/tf-job.libsonnet
@@ -36,8 +36,8 @@ local k = import "k.libsonnet";
 
     tfJobTerminationPolicy(replicaName, replicaIndex):: {
       chief: {
-          replicaName: replicaName,
-          replicaIndex: replicaIndex,
+        replicaName: replicaName,
+        replicaIndex: replicaIndex,
       },
     },
 


### PR DESCRIPTION
Converts the IAP initContainer to a sidecar that configures IAP and monitors for changes to the backend service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/552)
<!-- Reviewable:end -->
