### PR TITLE
Add TfJob dashboard to ksonnet (#548)

### DIFF
--- a/kubeflow/core/tf-job.libsonnet
+++ b/kubeflow/core/tf-job.libsonnet
@@ -6,6 +6,11 @@
     $.parts(params.namespace).operatorRole,
     $.parts(params.namespace).operatorRoleBinding,
     $.parts(params.namespace).crd,
+    $.parts(params.namespace).uiRole,
+    $.parts(params.namespace).uiRoleBinding,
+    $.parts(params.namespace).uiService(params.tfJobUiServiceType),
+    $.parts(params.namespace).uiServiceAccount,
+    $.parts(params.namespace).ui(params.tfJobImage)
   ],
 
   parts(namespace):: {


### PR DESCRIPTION
Cherry pick #548 into the 0.1 release branch.

* This fix adds the UI components to the Kubeflow deployment.