### PR TITLE
Update tf jupter notebook images to include tfma (from #544)

### DIFF
--- a/kubeflow/core/jupyterhub_spawner.py
+++ b/kubeflow/core/jupyterhub_spawner.py
@@ -12,10 +12,10 @@ class KubeFormSpawner(KubeSpawner):
     <label for='image'>Image</label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     <input list="image" name="image" placeholder='repo/image:tag'>
     <datalist id="image">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-cpu:v20180402-10c4841">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-cpu:v20180327-6bb4058">
       <option value="gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-gpu:v20180327-6bb4058">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-cpu:v20180402-10c4841">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-gpu:v20180402-10c4841">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-cpu:v20180327-6bb4058">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-gpu:v20180327-6bb4058">
       <option value="gcr.io/kubeflow-images-staging/tensorflow-1.6.0-notebook-cpu:v20180402-10c4841">
       <option value="gcr.io/kubeflow-images-staging/tensorflow-1.6.0-notebook-gpu:v20180402-10c4841">
       <option value="gcr.io/kubeflow-images-staging/tensorflow-1.7.0-notebook-cpu:v20180402-10c4841">

--- a/kubeflow/core/jupyterhub_spawner.py
+++ b/kubeflow/core/jupyterhub_spawner.py
@@ -12,12 +12,14 @@ class KubeFormSpawner(KubeSpawner):
     <label for='image'>Image</label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     <input list="image" name="image" placeholder='repo/image:tag'>
     <datalist id="image">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-cpu:v20180327-6bb4058">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-cpu:v20180402-10c4841">
       <option value="gcr.io/kubeflow-images-staging/tensorflow-1.4.1-notebook-gpu:v20180327-6bb4058">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-cpu:v20180327-6bb4058">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-gpu:v20180327-6bb4058">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.6.0-notebook-cpu:v20180327-6bb4058">
-      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.6.0-notebook-gpu:v20180327-6bb4058">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-cpu:v20180402-10c4841">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.5.1-notebook-gpu:v20180402-10c4841">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.6.0-notebook-cpu:v20180402-10c4841">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.6.0-notebook-gpu:v20180402-10c4841">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.7.0-notebook-cpu:v20180402-10c4841">
+      <option value="gcr.io/kubeflow-images-staging/tensorflow-1.7.0-notebook-gpu:v20180402-10c4841">
     </datalist>
     <br/><br/>
 


### PR DESCRIPTION
tf1.4 gpu image has issues building with the latest tfma, so that's
not updated in this PR. Related  : https://github.com/kubeflow/kubeflow/issues/571

Also add tf1.7 images

/cc @jlewi
/cc @ojarjur

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/570)
<!-- Reviewable:end -->
