### PR TITLE
Fix the tensorflow version in prebuilt images for python 2.7.

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -164,6 +164,7 @@ RUN conda install --quiet --yes \
     conda clean -tipsy
 
 ARG TF_PACKAGE=tf-nightly
+ARG TF_PACKAGE_PY_27=tf-nightly
 RUN echo Installing $TF_PACKAGE && pip install --upgrade --quiet --no-cache-dir $TF_PACKAGE
 
 # Hack recommended in tf-serving-api to use it with py3. Remove when proper pip package is available.
@@ -207,21 +208,24 @@ ENV XDG_CACHE_HOME /home/$NB_USER/.cache/
 # that, we temporarily add a stub implementation of the CUDA library to the
 # library load path while we install and enable that extension.
 RUN conda_packages=$(conda list -e | cut -d '=' -f 1 | grep -v '#' | sort) && \
-    pip_packages=$(pip --no-cache-dir list --format=freeze | cut -d '=' -f 1 | grep -v '#' | sort) && \
+    pip_packages=$(pip --no-cache-dir list --format=freeze | cut -d '=' -f 1 | grep -v '#' | grep -v 'tensorflow' | sort) && \
     pip_only_packages=$(comm -23 <(echo "${pip_packages}") <(echo "${conda_packages}")) && \
     conda create -n ipykernel_py2 python=2 --file <(echo "${conda_packages}" | grep -v conda | grep -v python | grep -v jupyterhub) && \
     source activate ipykernel_py2 && \
     python -m ipykernel install --user && \
     echo "${pip_only_packages}" | xargs -n 1 -I "{}" /bin/bash -c 'pip install --no-cache-dir {} || true' && \
+    pip install --upgrade --quiet --no-cache-dir "${TF_PACKAGE_PY_27}" && \
     pip install --no-cache-dir tensorflow-transform && \
-    pip install --no-cache-dir tensorflow-model-analysis && \
     if [ -n "$(find /usr/local/ -name 'libcuda.so')" ]; then \
         export OLD_LD_LIBRARY_PATH="${LD_LIBRARY_PATH}" && \
         export LD_LIBRARY_PATH="$(dirname $(find /usr/local/ -name 'libcuda.so') ):${LD_LIBRARY_PATH}" && \
         ln -s "$(find /usr/local/ -name 'libcuda.so')" "$(find /usr/local/ -name 'libcuda.so').1"; \
     fi && \
-    jupyter nbextension install --py --symlink tensorflow_model_analysis --system && \
-    jupyter nbextension enable --py tensorflow_model_analysis --system && \
+    if [ ! "$(python -c 'import tensorflow; print(tensorflow.__version__)')" \< "1.6.0" ]; then \
+      pip install --no-cache-dir tensorflow-model-analysis && \
+      jupyter nbextension install --py --symlink tensorflow_model_analysis --system && \
+      jupyter nbextension enable --py tensorflow_model_analysis --system; \
+    fi && \
     if [ -n "${OLD_LD_LIBRARY_PATH}" ]; then \
       export LD_LIBRARY_PATH="${OLD_LD_LIBRARY_PATH}"; \
     fi && \

--- a/components/tensorflow-notebook-image/build_image.sh
+++ b/components/tensorflow-notebook-image/build_image.sh
@@ -16,6 +16,7 @@ TAG=$3
 IS_LATEST=$4
 BASE_IMAGE=${5:-"ubuntu:latest"}
 TF_PACKAGE=${6:-"tf-nightly"}
+TF_PACKAGE_PY_27=${7:-"tf-nightly"}
 
 # Wait for the Docker daemon to be available.
 until docker ps
@@ -25,6 +26,7 @@ done
 docker build --pull \
         --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
         --build-arg "TF_PACKAGE=${TF_PACKAGE}" \
+        --build-arg "TF_PACKAGE_PY_27=${TF_PACKAGE_PY_27}" \
         -t "${IMAGE}:${TAG}" \
 	-f ${DOCKERFILE} ${CONTEXT_DIR}
 

--- a/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
@@ -147,6 +147,14 @@
           "-" +
           tf_version +
           "-cp36-cp36m-linux_x86_64.whl",
+        local tf_package_py_27 =
+          "https://storage.googleapis.com/tensorflow/linux/" +
+          device +
+          "/tensorflow" +
+          (if device == "gpu" then "_gpu" else "") +
+          "-" +
+          tf_version +
+          "-cp27-none-linux_x86_64.whl",
         result:: buildTemplate(
           "build-" + workflow_name + "-" + device,
           [
@@ -160,7 +168,8 @@
             + tag + " "
             + std.toString(is_latest) + " "
             + base_image + " "
-            + tf_package,
+            + tf_package + " ",
+            + tf_package_py_27,
           ],
           [
             {


### PR DESCRIPTION
This fixes an issue that was recently uncovered for the prebuilt
images where the version of tensorflow used in the python 2.7
environment was not the one explicitly specified when building
the image.

When we set up the python 2.7 environment, the source of the
tensorflow package was getting dropped, so instead of installing
the specified version, we installed the latest version from
PyPI (which is currently 1.7).

This was uncovered when enabling the tensorflow_model_analysis
package for GPU images revealed that the installed version of
tensorflow relied on a different version of libcublas than the
one bundled in the base image.

However, this also revealed a potential issue where we were
installing tensorflow_model_analysis even if the specified
version of tensorflow did not support it. To prevent that,
we make the installation of tensorflow_model_analysis conditional
on the version of tensorflow installed in the python 2.7 environment.

Fixes #571

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/580)
<!-- Reviewable:end -->
