### PR TITLE
Cherrypick #526 and #533 into v0.1-branch (#540)

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     fonts-liberation \
     g++ \
     git \
+    graphviz \
     inkscape \
     jed \
     libav-tools \


### PR DESCRIPTION
* Fix typos in tensorflow notebook images in spawner

* Update the TFJob image in preparation for a new RC. (#533)

* The updated TFJob includes the fix to delete pods when job finishes
  rather than leave them running.

* We need to pin the commit of the tf-operator in the extra repos so
  that we checkout the tests at the commit that matches the image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/581)
<!-- Reviewable:end -->
