### PR TITLE
Disable PVC by default (#577)

### DIFF
--- a/kubeflow/core/jupyterhub_spawner.py
+++ b/kubeflow/core/jupyterhub_spawner.py
@@ -97,21 +97,23 @@ c.KubeSpawner.start_timeout = 60 * 30
 # TODO(jlewi): Verify this works on minikube.
 # TODO(jlewi): Should we set c.KubeSpawner.singleuser_fs_gid = 1000
 # see https://github.com/kubeflow/kubeflow/pull/22#issuecomment-350500944
-c.KubeSpawner.user_storage_pvc_ensure = True
-# How much disk space do we want?
-c.KubeSpawner.user_storage_capacity = '10Gi'
-c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
-c.KubeSpawner.volumes = [
-  {
-    'name': 'volume-{username}{servername}',
-    'persistentVolumeClaim': {
-      'claimName': 'claim-{username}{servername}'
-    }
-  }
-]
-c.KubeSpawner.volume_mounts = [
-  {
-    'mountPath': '/home/jovyan/work',
-    'name': 'volume-{username}{servername}'
-  }
-]
+pvc_mount = os.environ.get('NOTEBOOK_PVC_MOUNT')
+if pvc_mount and pvc_mount != 'null':
+    c.KubeSpawner.user_storage_pvc_ensure = True
+    # How much disk space do we want?
+    c.KubeSpawner.user_storage_capacity = '10Gi'
+    c.KubeSpawner.pvc_name_template = 'claim-{username}{servername}'
+    c.KubeSpawner.volumes = [
+      {
+        'name': 'volume-{username}{servername}',
+        'persistentVolumeClaim': {
+          'claimName': 'claim-{username}{servername}'
+        }
+      }
+    ]
+    c.KubeSpawner.volume_mounts = [
+      {
+        'mountPath': pvc_mount,
+        'name': 'volume-{username}{servername}'
+      }
+    ]

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -13,6 +13,7 @@
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
 // @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:1.0.1 The image to use for JupyterHub.
 // @optionalParam jupyterHubAuthenticator string null The authenticator to use
+// @optionalParam jupyterNotebookPVCMount string null Mount path for PVC. Set empty to disable PVC
 // @optionalParam reportUsage string false Whether or not to report Kubeflow usage to kubeflow.org.
 // @optionalParam usageId string unknown_cluster Optional id to use when reporting usage to kubeflow.org
 

--- a/user_guide.md
+++ b/user_guide.md
@@ -82,6 +82,11 @@ Now let's set `${KF_ENV}` to `cloud` or `nocloud` to reflect our environment for
 $ KF_ENV=cloud|nocloud
 ```
 
+By default Kubeflow does not persist any work that is done within the Jupyter notebook. That means if the container is destroyed or recreated, all of its contents, including users working notebooks and other files are going to be deleted. To enable the persistence of such files, the user will need to have a default StorageClass defined for [persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). If that is defined, persistence can be enabled by setting jupyterNotebookPVCMount to the available volume mount.
+```
+ks param set kubeflow-core jupyterNotebookPVCMount /home/jovyan/work
+```
+
 Create a namespace for your deployment and set it as part of the environment. Feel free to change the namespace to a value that better suits your kubernetes cluster.
 
 ```


### PR DESCRIPTION
Per discussion, we think default should be as easy to setup as possible,
and dependency on StorageClass makes it less straightforward to start
working with kubeflow. Change this default to remove need for persistent
storage.

* Related to #506 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/582)
<!-- Reviewable:end -->
