### PR TITLE
Install graphviz in tensorflow notebook image

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
     fonts-liberation \
     g++ \
     git \
+    graphviz \
     inkscape \
     jed \
     libav-tools \


### PR DESCRIPTION
This is required for pydot to work. It was accidentally removed in
https://github.com/kubeflow/kubeflow/pull/471

/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/583)
<!-- Reviewable:end -->
