### PR TITLE
Correct typo for param defaultHttpProxyImage (#556)

### DIFF
--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -13,7 +13,7 @@
     defaultHttpProxyImage: "gcr.io/kubeflow-images-staging/tf-model-server-http-proxy:v20180327-995786ec",
     httpProxyImage: "",
     httpProxyImageToUse: if $.params.httpProxyImage == "" then
-      $.params.defualtHttpProxyImage
+      $.params.defaultHttpProxyImage
     else
       $.params.httpProxyImage,
 


### PR DESCRIPTION
* CP #556 into the 0.1 release branch.

Related to #506

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/584)
<!-- Reviewable:end -->
