### PR TITLE
Expanding argo permissions to enable creation of more objects

### DIFF
--- a/kubeflow/argo/argo.libsonnet
+++ b/kubeflow/argo/argo.libsonnet
@@ -275,6 +275,8 @@
           apiGroups: [""],
           resources: [
             "configmaps",
+            "serviceaccounts",
+            "secrets",
           ],
           verbs: [
             "get",
@@ -295,6 +297,38 @@
           ],
         },
         {
+          apiGroups: [""],
+          resources: [
+            "services",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+          ],
+        },
+        {
+          apiGroups: [
+            "apps",
+            "extensions",
+          ],
+          resources: [
+            "deployments",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+            "delete",
+          ],
+        },
+        {
           apiGroups: [
             "argoproj.io",
           ],
@@ -307,6 +341,23 @@
             "watch",
             "update",
             "patch",
+          ],
+        },
+        {
+          apiGroups: [
+            "kubeflow.org",
+          ],
+          resources: [
+            "tfjobs",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+            "delete",
           ],
         },
       ],


### PR DESCRIPTION
If argo's going to be used in ML worfklows, it may need extra permissions.

These are just to get the mnist example over the hump:

https://github.com/kubeflow/examples/pull/42#issuecomment-378322298

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/591)
<!-- Reviewable:end -->
