### PR TITLE
import of cloud-endpoints component and support in iap-ingress component

### DIFF
--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -10,15 +10,58 @@ when using GKE.
 
 If you aren't familiar with IAP you might want to start by looking at those docs.
 
+The instructions below reference the following environment variables which you will need to set for your deployment
+
+  * **CORE_NAME** The name assigned to the core Kubeflow ksonnet components (this is the name chosen when you ran `ks generate...`).
+  * **ENVIRONMENT** The name of the ksonnet environment where you want to deploy Kubeflow.
+  * **FQDN** The fully qualified domain name to use for your Kubeflow deployment.
+  * **IP_NAME** The name of the GCP static IP that you created above and will be associated with **DOMAIN**.
+  * **NAMESPACE** The namespace where Kubeflow is deployed.
+  * **ACCOUNT** The email address for your ACME account where certificate expiration notifications will be sent.
+
 ### Preliminaries
 
-##### Create an external static IP address
+#### Create an external static IP address
 
 ```
+PROJECT=$(gcloud config get-value project)
 gcloud compute --project=${PROJECT} addresses create kubeflow --global
 ```
 
-Use your DNS provider (e.g. Google Domains) create a type A custom resource record that associates the host you want e.g "kubeflow"
+#### Configure DNS record
+
+[Cloud Endpoints](https://cloud.google.com/endpoints/docs/) can be used to automatically provision a free DNS record for Kubeflow in the form of: `NAME.endpoints.PROJECT.cloud.goog`. 
+
+Enable the following APIs:
+- [Google Cloud Endpoints](https://console.cloud.google.com/apis/library/endpoints.googleapis.com/?q=Cloud%20Endpoints)
+- [Google Service Management](https://console.cloud.google.com/apis/library/servicemanagement.googleapis.com/?q=Service%20Management)
+
+Create a service account an IAM bindings for the cloud-endpoints-controller:
+
+```
+gcloud iam service-accounts create cloud-endpoints-controller \
+    --display-name cloud-endpoints-controller
+export SA_EMAIL=$(gcloud iam service-accounts list \
+    --filter="displayName:cloud-endpoints-controller" \
+    --format='value(email)')
+gcloud projects add-iam-policy-binding \
+      $PROJECT --role roles/servicemanagement.admin --member serviceAccount:$SA_EMAIL
+
+gcloud iam service-accounts keys create cloudep-sa.json --iam-account $SA_EMAIL
+
+kubectl create secret generic --namespace=${NAMESPACE} cloudep-sa --from-file=./cloudep-sa.json
+```
+
+Install the `cloud-endpoints` controller and set the `FQDN` environment variable used later:
+
+```
+ks generate cloud-endpoints cloud-endpoints --namespace=${NAMESPACE} --secretName=cloudep-sa
+ks apply ${ENVIRONMENT} -c cloud-endpoints
+
+export FQDN="kubeflow.endpoints.$(gcloud config get-value project).cloud.goog"
+```
+
+Alternatively if you already have a DNS provider (e.g. Google Domains) create a type A custom resource record that associates the host you want e.g "kubeflow"
 with the IP address that you just reserved.
   * Instructions for [Google Domains](https://support.google.com/domains/answer/3290350?hl=en&_ga=2.237821440.1874220825.1516857441-1976053267.1499435562&_gac=1.82147044.1516857441.Cj0KCQiA-qDTBRD-ARIsAJ_10yKS7G1HPa1aoM8Mk_4VagV9wIi5uKkMp5UWJGDNejKxWPKUO_A6ri4aAsahEALw_wcB)
 
@@ -51,19 +94,7 @@ kubectl -n ${NAMESPACE} create secret generic kubeflow-oauth --from-literal=CLIE
 If you haven't already, follow the instructions in the [user_guide](https://github.com/kubeflow/kubeflow/blob/master/user_guide.md#deploy-kubeflow)
 to create a ksonnet app to deploy Kubeflow.
 
-Your GKE cluster permissions should include the `https://www.googleapis.com/auth/compute` scope and a service account with the `editor` or `compute.admin` IAM role. This is the default configuration for GKE clusters version 1.9.x and earlier.
-Follow [this guide](https://medium.com/google-cloud/updating-google-container-engine-vm-scopes-with-zero-downtime-50bff87e5f80) if you need to modify the scopes of your cluster and the [IAM docs](https://cloud.google.com/iam/docs/granting-changing-revoking-access) for details on how to apply roles.
-
 [cert-manager](https://github.com/jetstack/cert-manager) is used to automatically request valid SSL certifiactes using the [ACME](https://en.wikipedia.org/wiki/Automated_Certificate_Management_Environment) issuer.
-
-The instructions below reference the following environment variables which you will need to set for your deployment
-
-  * **CORE_NAME** The name assigned to the core Kubeflow ksonnet components (this is the name chosen when you ran `ks generate...`).
-  * **ENVIRONMENT** The name of the ksonnet environment where you want to deploy Kubeflow.
-  * **FQDN** The fully qualified domain name to use for your Kubeflow deployment.
-  * **IP_NAME** The name of the GCP static IP that you created above and will be associated with **DOMAIN**.
-  * **NAMESPACE** The namespace where Kubeflow is deployed.
-  * **ACCOUNT** The email address for your ACME account where certificate expiration notifications will be sent.
 
 ```
 ks generate cert-manager cert-manager --acmeEmail=${ACCOUNT}

--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -28,7 +28,7 @@ PROJECT=$(gcloud config get-value project)
 gcloud compute --project=${PROJECT} addresses create kubeflow --global
 ```
 
-#### Configure DNS record
+#### Configure DNS record with Cloud Endpoints
 
 [Cloud Endpoints](https://cloud.google.com/endpoints/docs/) can be used to automatically provision a free DNS record for Kubeflow in the form of: `NAME.endpoints.PROJECT.cloud.goog`. 
 
@@ -61,7 +61,9 @@ ks apply ${ENVIRONMENT} -c cloud-endpoints
 export FQDN="kubeflow.endpoints.$(gcloud config get-value project).cloud.goog"
 ```
 
-Alternatively if you already have a DNS provider (e.g. Google Domains) create a type A custom resource record that associates the host you want e.g "kubeflow"
+#### Configure an existing DNS record
+
+If you already have a DNS provider (e.g. Google Domains) create a type A custom resource record that associates the host you want e.g "kubeflow"
 with the IP address that you just reserved.
   * Instructions for [Google Domains](https://support.google.com/domains/answer/3290350?hl=en&_ga=2.237821440.1874220825.1516857441-1976053267.1499435562&_gac=1.82147044.1516857441.Cj0KCQiA-qDTBRD-ARIsAJ_10yKS7G1HPa1aoM8Mk_4VagV9wIi5uKkMp5UWJGDNejKxWPKUO_A6ri4aAsahEALw_wcB)
 

--- a/kubeflow/core/cert-manager.libsonnet
+++ b/kubeflow/core/cert-manager.libsonnet
@@ -1,8 +1,8 @@
 {
   parts(namespace):: {
     local k = import "k.libsonnet",
-    local certManagerImage = "quay.io/jetstack/cert-manager-controller:v0.2.3",
-    local certManagerIngressShimImage = "quay.io/jetstack/cert-manager-ingress-shim:v0.2.3",
+    local certManagerImage = "quay.io/jetstack/cert-manager-controller:v0.2.4",
+    local certManagerIngressShimImage = "quay.io/jetstack/cert-manager-ingress-shim:v0.2.4",
 
     // Note, not using std.prune to preserve required empty http01 map in the Issuer spec.
     certManagerParts(acmeEmail, acmeUrl):: k.core.v1.list.new([

--- a/kubeflow/core/cloud-endpoints.libsonnet
+++ b/kubeflow/core/cloud-endpoints.libsonnet
@@ -1,0 +1,331 @@
+{
+  parts(namespace):: {
+    local k = import "k.libsonnet",
+    local cloudEndpointsImage = "gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.1.1",
+    local metacontrollerImage = "gcr.io/enisoc-kubernetes/metacontroller@sha256:18561c63e1c5380ac5bbaabefa933e484bdb499f10b61071506f9a0070bc65f6",
+
+    cloudEndpointsParts(secretName, secretKey):: k.core.v1.list.new([
+      $.parts(namespace).metaServiceAccount,
+      $.parts(namespace).metaClusterRole,
+      $.parts(namespace).metaClusterRoleBinding,
+      $.parts(namespace).metaInitializerCRD,
+      $.parts(namespace).metaLambdaCRD,
+      $.parts(namespace).metaDeployment,
+      $.parts(namespace).endpointsCRD,
+      $.parts(namespace).endpointsService,
+      $.parts(namespace).endpointsServiceAccount,
+      $.parts(namespace).endpointsClusterRole,
+      $.parts(namespace).endpointsClusterRoleBinding,
+      $.parts(namespace).endpointsDeploy(secretName, secretKey),
+      $.parts(namespace).endpointsLambdaController,
+    ]),
+
+    metaServiceAccount:: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "kube-metacontroller",
+        namespace: namespace,
+      },
+    },  // metaServiceAccount
+
+    metaClusterRole:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRole",
+      metadata: {
+        name: "kube-metacontroller",
+      },
+      rules: [
+        {
+          apiGroups: ["*"],
+          resources: ["*"],
+          verbs: ["*"],
+        },
+      ],
+    },  // metaClusterRole
+
+    metaClusterRoleBinding:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRoleBinding",
+      metadata: {
+        name: "kube-metacontroller",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "kube-metacontroller",
+          namespace: namespace,
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "kube-metacontroller",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+    },  // metaClusterRoleBinding
+
+    metaInitializerCRD:: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "initializercontrollers.metacontroller.k8s.io",
+      },
+      spec: {
+        group: "metacontroller.k8s.io",
+        version: "v1alpha1",
+        scope: "Cluster",
+        names: {
+          plural: "initializercontrollers",
+          singular: "initializercontroller",
+          kind: "InitializerController",
+          shortNames: [
+            "ic",
+            "ictl",
+          ],
+        },
+      },
+    },  // metaInitializerCRD
+
+    metaLambdaCRD:: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "lambdacontrollers.metacontroller.k8s.io",
+      },
+      spec: {
+        group: "metacontroller.k8s.io",
+        version: "v1alpha1",
+        scope: "Cluster",
+        names: {
+          plural: "lambdacontrollers",
+          singular: "lambdacontroller",
+          kind: "LambdaController",
+          shortNames: [
+            "lc",
+            "lctl",
+          ],
+        },
+      },
+    },  // metaLambdaCRD
+
+    metaDeployment:: {
+      apiVersion: "apps/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: "kube-metacontroller",
+        namespace: namespace,
+        labels: {
+          app: "kube-metacontroller",
+        },
+      },
+      spec: {
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              app: "kube-metacontroller",
+            },
+          },
+          spec: {
+            serviceAccountName: "kube-metacontroller",
+            containers: [
+              {
+                name: "kube-metacontroller",
+                image: metacontrollerImage,
+                command: [
+                  "/usr/bin/metacontroller",
+                ],
+                args: [
+                  "--logtostderr",
+                ],
+                imagePullPolicy: "Always",
+              },
+            ],
+          },
+        },
+      },
+    },  // metaDeployment
+
+    endpointsCRD:: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "cloudendpoints.ctl.isla.solutions",
+      },
+      spec: {
+        group: "ctl.isla.solutions",
+        version: "v1",
+        scope: "Namespaced",
+        names: {
+          plural: "cloudendpoints",
+          singular: "cloudendpoint",
+          kind: "CloudEndpoint",
+          shortNames: [
+            "cloudep",
+            "ce",
+          ],
+        },
+      },
+    },  // endpointsCRD
+
+    endpointsService:: {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "cloud-endpoints-controller",
+      },
+      spec: {
+        type: "ClusterIP",
+        ports: [
+          {
+            name: "http",
+            port: 80,
+          },
+        ],
+        selector: {
+          app: "cloud-endpoints-controller",
+        },
+      },
+    },  // endpointsService
+
+    endpointsLambdaController:: {
+      apiVersion: "metacontroller.k8s.io/v1alpha1",
+      kind: "LambdaController",
+      metadata: {
+        name: "cloud-endpoints-controller",
+      },
+      spec: {
+        parentResource: {
+          apiVersion: "ctl.isla.solutions/v1",
+          resource: "cloudendpoints",
+        },
+        childResources: [],
+        clientConfig: {
+          service: {
+            name: "cloud-endpoints-controller",
+            namespace: namespace,
+            caBundle: "...",
+          },
+        },
+        hooks: {
+          sync: {
+            path: "/sync",
+          },
+        },
+        generateSelector: true,
+      },
+    },  // endpointsLambdaController
+
+    endpointsServiceAccount:: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "cloud-endpoints-controller",
+        namespace: namespace,
+      },
+    },  // endpointsServiceAccount
+
+    endpointsClusterRole:: {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      metadata: {
+        name: "cloud-endpoints-controller",
+        namespace: namespace,
+      },
+      rules: [
+        {
+          apiGroups: [""],
+          resources: ["services"],
+          verbs: ["get", "list"],
+        },
+        {
+          apiGroups: ["extensions"],
+          resources: ["ingresses"],
+          verbs: ["get", "list"],
+        },
+      ],
+    },  // endpointsClusterRole
+
+    endpointsClusterRoleBinding:: {
+      kind: "ClusterRoleBinding",
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      metadata: {
+        name: "cloud-endpoints-controller",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "cloud-endpoints-controller",
+          namespace: namespace,
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "cloud-endpoints-controller",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+    },  // endpointsClusterRoleBinding
+
+    endpointsDeploy(secretName, secretKey):: {
+      apiVersion: "apps/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: "cloud-endpoints-controller",
+        namespace: namespace,
+      },
+      spec: {
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              app: "cloud-endpoints-controller",
+            },
+          },
+          spec: {
+            serviceAccountName: "cloud-endpoints-controller",
+            terminationGracePeriodSeconds: 5,
+            containers: [
+              {
+                name: "cloud-endpoints-controller",
+                image: cloudEndpointsImage,
+                imagePullPolicy: "Always",
+                env: [
+                  {
+                    name: "GOOGLE_APPLICATION_CREDENTIALS",
+                    value: "/var/run/secrets/sa/" + secretKey,
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "sa-key",
+                    readOnly: true,
+                    mountPath: "/var/run/secrets/sa",
+                  },
+                ],
+                readinessProbe: {
+                  httpGet: {
+                    path: "/healthz",
+                    port: 80,
+                    scheme: "HTTP",
+                    periodSeconds: 5,
+                    timeoutSeconds: 5,
+                    successThreshold: 1,
+                    failureThreshold: 2,
+                  },
+                },
+              },
+            ],
+            volumes: [
+              {
+                name: "sa-key",
+                secret: {
+                  secretName: secretName,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },  // endpointsDeploy
+  },  // parts
+}

--- a/kubeflow/core/prototypes/cert-manager.jsonnet
+++ b/kubeflow/core/prototypes/cert-manager.jsonnet
@@ -7,9 +7,6 @@
 // @param acmeEmail string The Lets Encrypt account email address
 // @optionalParam acmeUrl string https://acme-v01.api.letsencrypt.org/directory The ACME server URL, set to https://acme-staging.api.letsencrypt.org/directory for staging API.
 
-// TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
-// because ksonnet doesn't support inheriting it from the environment yet.
-
 local k = import "k.libsonnet";
 local certManager = import "kubeflow/core/cert-manager.libsonnet";
 

--- a/kubeflow/core/prototypes/cloud-endpoints.jsonnet
+++ b/kubeflow/core/prototypes/cloud-endpoints.jsonnet
@@ -1,0 +1,25 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.cloud-endpoints
+// @description Provides cloud-endpoints prototypes for creating Cloud Endpoints services and DNS records.
+// @shortDescription Cloud Endpoint domain creation.
+// @param name string Name for the component
+// @param secretName string Name of secret containing the json service account key.
+// @optionalParam secretKey string cloudep-sa.json Name of the key in the secret containing the JSON service account key.
+// @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
+
+// TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
+// because ksonnet doesn't support inheriting it from the environment yet.
+
+local k = import "k.libsonnet";
+local cloudEndpoints = import "kubeflow/core/cloud-endpoints.libsonnet";
+
+local secretKey = import "param://secretKey";
+local secretName = import "param://secretName";
+
+// updatedParams uses the environment namespace if
+// the namespace parameter is not explicitly set
+local updatedParams = params {
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
+};
+
+cloudEndpoints.parts(updatedParams.namespace).cloudEndpointsParts(secretName, secretKey)

--- a/kubeflow/core/prototypes/cloud-endpoints.jsonnet
+++ b/kubeflow/core/prototypes/cloud-endpoints.jsonnet
@@ -7,9 +7,6 @@
 // @optionalParam secretKey string cloudep-sa.json Name of the key in the secret containing the JSON service account key.
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 
-// TODO(https://github.com/ksonnet/ksonnet/issues/222): We have to add namespace as an explicit parameter
-// because ksonnet doesn't support inheriting it from the environment yet.
-
 local k = import "k.libsonnet";
 local cloudEndpoints = import "kubeflow/core/cloud-endpoints.libsonnet";
 


### PR DESCRIPTION
Fixes #586 

- Import of cloud-endpoints CRD and controller. Depends on kube-metacontroller which is bundled with the component.
- Updated iap-ingress component to create the `CloudEndpoint` resource if the FQDN matches the form of `NAME.endpoints.PROJECT.cloud.goog`
- Updated the IAP doc with steps for using Cloud Endpoints.

/cc @kunmingg
/cc @ankushagarwal 
/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/605)
<!-- Reviewable:end -->
