### PR TITLE
Update README to reflect install experience

### DIFF
--- a/user_guide.md
+++ b/user_guide.md
@@ -35,6 +35,9 @@ For an end to end example illustrating in details how to deploy kubeflow and run
 ## Requirements
  * Kubernetes >= 1.8 [see here](https://github.com/kubeflow/tf-operator#requirements)
  * ksonnet version [0.9.2](https://ksonnet.io/#get-started). (See [below](#why-kubeflow-uses-ksonnet) for an explanation of why we use ksonnet)
+ * An existing kubernetes cluster:
+   * A minimum of 0.6 CPU in cluster (Reserved for 3 replicated ambassador pods and according to your need add additional CPUs)
+   * Node with storage >= 10 GB (Due to the ML libraries and third party packages being bundled in Kubeflow Docker images)
 
 ## Deploy Kubeflow
 


### PR DESCRIPTION
Hi,

I learned about kubeflow recently and gave it a run, but it occurred to me that:
1. If there aren't enough nodes in the cluster, then creating server in browser (tf-hub-0) will wait forever.
2. When kubeflow docker image is being installed, if node doesn't have enough storage, `kubectl port-forward tf-hub-0` process will have issue.

```
E0405 13:41:46.006868   61040 portforward.go:331] an error occurred forwarding 8000 -> 8000: error forwarding port 8000 to pod 237c9ddb56660461a4328110bdbb2624eea8ef4dc5055031bd00d0c6d393a831, uid : container not running (237c9ddb56660461a4328110bdbb2624eea8ef4dc5055031bd00d0c6d393a831)
```

This updates the user guide to get around the issues. At the same time I want to raise them if maybe they can be solved without updating the user guide (pre-check cluster size before deploying pod, potentially make kubeflow image smaller)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/617)
<!-- Reviewable:end -->
