### PR TITLE
Fix setup/teardown of VM for minikube.

### DIFF
--- a/testing/vm_util.py
+++ b/testing/vm_util.py
@@ -11,6 +11,48 @@ from kubeflow.testing import util
 
 # TODO(jlewi): Should we move this to kubeflow/testing
 
+def wait_for_operation(client,
+                       project,
+                       zone,
+                       op_id,
+                       timeout=datetime.timedelta(hours=1),
+                       polling_interval=datetime.timedelta(seconds=5)):
+  """Wait for the specified operation to complete.
+
+  Args:
+    client: Client for the API that owns the operation.
+    project: project
+    zone: Zone. Set to none if its a global operation
+    op_id: Operation id/name.
+    timeout: A datetime.timedelta expressing the amount of time to wait before
+      giving up.
+    polling_interval: A datetime.timedelta to represent the amount of time to
+      wait between requests polling for the operation status.
+
+  Returns:
+    op: The final operation.
+
+  Raises:
+    TimeoutError: if we timeout waiting for the operation to complete.
+  """
+  endtime = datetime.datetime.now() + timeout
+  while True:
+    if zone:
+      op = client.zoneOperations().get(
+        project=project, zone=zone, operation=op_id).execute()
+    else:
+      op = client.globalOperations().get(project=project,
+                                         operation=op_id).execute()
+
+    status = op.get("status", "")
+    # Need to handle other status's
+    if status == "DONE":
+      return op
+    if datetime.datetime.now() > endtime:
+      raise TimeoutError("Timed out waiting for op: {0} to complete.".format(
+        op_id))
+    time.sleep(polling_interval.total_seconds())
+
 def wait_for_vm(project, zone, vm, timeout=datetime.timedelta(minutes=5),
                 polling_interval=datetime.timedelta(seconds=10)):
   """Wait for the VM to be ready. This is measured by trying to ssh into the VM.
@@ -34,7 +76,8 @@ def wait_for_vm(project, zone, vm, timeout=datetime.timedelta(minutes=5),
     
     if datetime.datetime.now() > endtime:
       raise util.TimeoutError(
-        "Timed out waiting for op: {0} to complete.".format(op_id))
+        ("Timed out waiting for VM to %s be sshable. Check firewall rules "
+         "aren't blocking ssh.").format(vm))
     time.sleep(polling_interval.total_seconds())
      
 def execute(project, zone, vm, commands):


### PR DESCRIPTION
* deploy step should wait for VM to be created and report any errors
if the VM can't be created; e.g. because of insufficient quota.

* teardown step should ensure the VM's disk is deleted so that we don't
  leak disks.

* Fix a bug in wait for VM; there is no op_id since we are trying to
ssh into the VM and not executing a GCE operation.

Related to #618

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/620)
<!-- Reviewable:end -->
