### PR TITLE
Improve user guide wrt exposing notebook in non-cloud setup

### DIFF
--- a/user_guide.md
+++ b/user_guide.md
@@ -170,9 +170,23 @@ tf-hub-lb          ClusterIP      10.11.245.94    <none>        80/TCP         1
 ...
 ```
 
-By default we are using ClusterIPs for the JupyterHub UI. This can be changed to a LoadBalancer by issuing `ks param set kubeflow-core jupyterHubServiceType LoadBalancer`, however this will leave your Jupyter Notebook open to the Internet.
+By default we are using ClusterIPs for the JupyterHub UI. This can be changed to one of the followings:
 
-To connect to your [Jupyter Notebook](http://jupyter.org/index.html):
+- NodePort (for non-cloud) by issuing
+  ```
+  ks param set kubeflow-core jupyterHubServiceType NodePort
+  ks apply ${KF_ENV}
+  ```
+
+- LoadBalancer (for cloud) by issuing
+  ```
+  ks param set kubeflow-core jupyterHubServiceType LoadBalancer
+  ks apply ${KF_ENV}
+  ```
+
+however this will leave your Jupyter Notebook open to the Internet.
+
+To connect to your [Jupyter Notebook](http://jupyter.org/index.html) locally:
 
 ```
 PODNAME=`kubectl get pods --namespace=${NAMESPACE} --selector="app=tf-hub" --output=template --template="{{with index .items 0}}{{.metadata.name}}{{end}}"`

--- a/user_guide.md
+++ b/user_guide.md
@@ -170,7 +170,7 @@ tf-hub-lb          ClusterIP      10.11.245.94    <none>        80/TCP         1
 ...
 ```
 
-By default we are using ClusterIPs for the JupyterHub UI. This can be changed to one of the followings:
+By default we are using ClusterIPs for the JupyterHub UI. This can be changed to one of the following:
 
 - NodePort (for non-cloud) by issuing
   ```
@@ -184,7 +184,7 @@ By default we are using ClusterIPs for the JupyterHub UI. This can be changed to
   ks apply ${KF_ENV}
   ```
 
-however this will leave your Jupyter Notebook open to the Internet.
+however this will leave your Jupyter notebook open to the Internet.
 
 To connect to your [Jupyter Notebook](http://jupyter.org/index.html) locally:
 


### PR DESCRIPTION
This makes it more clear how to expose the Jupyter notebook if you are
on a standalone, non-cloud node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/625)
<!-- Reviewable:end -->
