### PR TITLE
Use dashes not underscores in junit file names.

### DIFF
--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -306,9 +306,14 @@ def wrap_test(args):
 
     test_util.wrap_test(run, test_case)
   finally:
-
+    # Test grid has problems with underscores in the name.
+    # https://github.com/kubeflow/kubeflow/issues/631
+    # TestGrid currently uses the regex junit_(^_)*.xml so we only
+    # want one underscore after junit.
+    junit_name = test_name.replace("_", "-")
     junit_path = os.path.join(args.artifacts_dir,
-                              "junit_kubeflow-deploy-{0}.xml".format(test_name))
+                              "junit_kubeflow-deploy-{0}.xml".format(
+                              junit_name))
     logging.info("Writing test results to %s", junit_path)
     test_util.create_junit_xml_file([test_case], junit_path)
 

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -351,7 +351,7 @@
               // Name is used for the test case name so it should be unique across
               // all E2E tests.
               "--params=name=simple-tfjob-" + platform + ",namespace=" + stepsNamespace,
-              "--junit_path=" + artifactsDir + "/junit_e2e_" + platform + ".xml",
+              "--junit_path=" + artifactsDir + "/junit_e2e-" + platform + ".xml",
             ]),  // run tests
           ],  // templates
         },


### PR DESCRIPTION
* TestGrid relies on the regex junit_[^_]*.xml. So we don't want
  any underscores other than the one after junit. This preventing
  appropriate rows from being created in test_grid.

* Fix #631

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/638)
<!-- Reviewable:end -->
