### PR TITLE
Troubleshooting note on cluster-admin privileges for tf-job-operator

### DIFF
--- a/user_guide.md
+++ b/user_guide.md
@@ -449,8 +449,7 @@ oc adm policy add-scc-to-user anyuid -z jupyter-hub
 ```
 Once the anyuid policy has been set, you must delete the failing pods and allow them to be recreated in the project deployment.
 
-You will also need to adjust the privileges of the tf-job-operator service account for TFJobs to run. Do this in the project
-where you are running TFJobs:
+You will also need to adjust the privileges of the tf-job-operator service account for TFJobs to run. Do this in the project where you are running TFJobs:
 
 ```commandline
 oc adm policy add-role-to-user cluster-admin -z tf-job-operator


### PR DESCRIPTION
The tf-job-operator service account can't successfully start TFJobs
in OpenShift unless it has privileges granted for the project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/641)
<!-- Reviewable:end -->
