### PR TITLE
[Azure] Update nvidia driver volumes for AKS

### DIFF
--- a/kubeflow/core/tf-job.libsonnet
+++ b/kubeflow/core/tf-job.libsonnet
@@ -113,19 +113,9 @@
         "alpha.kubernetes.io/nvidia-gpu": {
           volumes: [
             {
-              name: "lib",
-              mountPath: "/usr/local/nvidia/lib64",
-              hostPath: "/usr/lib/nvidia-384",
-            },
-            {
-              name: "bin",
-              mountPath: "/usr/local/nvidia/bin",
-              hostPath: "/usr/lib/nvidia-384/bin",
-            },
-            {
-              name: "libcuda",
-              mountPath: "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
-              hostPath: "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
+              name: "nvidia",
+              mountPath: "/usr/local/nvidia",
+              hostPath: "/usr/local/nvidia",
             },
           ],
         },


### PR DESCRIPTION
Drivers installation was updated recently for AKS, this PR update our ks template to reflect that change.

I'm keeping the distinction between aks and acsengine even though they are identical today, because acs-engine is going to receive the update for device-plugin pretty soon.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/650)
<!-- Reviewable:end -->
