### PR TITLE
openmpi package doesn't work on kubernetes cluster having custom dns.

### DIFF
--- a/kubeflow/openmpi/assets.libsonnet
+++ b/kubeflow/openmpi/assets.libsonnet
@@ -21,7 +21,7 @@
   genHostfile(params)::
     std.lines(
       std.map(
-        function(index) "openmpi-worker-%(index)d.%(name)s.%(namespace)s.svc.cluster.local" % {
+        function(index) "openmpi-worker-%(index)d.%(name)s.%(namespace)s" % {
           index: index,
           name: params.name,
           namespace: params.namespace,


### PR DESCRIPTION
Hi, I'm really pleased kubeflow is going to support openmpi.  I'm also happy to contribute this openmpi package.  It is because I'm also developing very similar tool of [everpeace/kube-openmpi](https://github.com/everpeace/kube-openmpi/) by myself.  

## Problem this PR fixes
current openmpi package doesn't work well on kubernetes cluster having custom dns (other than `cluster.local`) because `hostfile` includes fixed `cluster.local` string.

## How this PR fixed the problem
This PR just removed `svc.cluster.local` from `genHostfile` function.  StatefulSets depends on Headless Service to create sub-domain, and sub-domain is always under `svc.<cluster-dns>`.   So, removing `svc` is safe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/676)
<!-- Reviewable:end -->
