### PR TITLE
openmpi: make 'schedulerName'  configurable to use custom schedulers.

### DIFF
--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -11,6 +11,7 @@
 // @optionalParam exec string null Command to execute in master after bootstrap is done. It sleeps indefinitely if not set.
 // @optionalParam imagePullPolicy string IfNotPresent Image pull policy (either IfNotPresent or Always).
 // @optionalParam gpus number 0 Number of GPUs per worker.
+// @optionalParam schedulerName string default-scheduler scheduler name to use for the components.
 
 local k = import "k.libsonnet";
 local openmpi = import "kubeflow/openmpi/all.libsonnet";

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -28,7 +28,7 @@
       restartPolicy: "Never",
       terminationGracePeriodSeconds: 30,
       dnsPolicy: "ClusterFirst",
-      schedulerName: "default-scheduler",
+      schedulerName: params.schedulerName,
       volumes: [
         {
           name: "kubeflow-openmpi-secrets",


### PR DESCRIPTION
## What the PR changes
introducing `schedulerName` parameter in openmpi prototype.

## Why we need this?
In Kubernetes default scheduler, scheduling multiple openmpi prototypes will sometimes lead deadlocks as discussed https://github.com/kubeflow/tf-operator/issues/165 .  Please imagine the case 2 openmpi prototypes with 100 workers were scheduled simultaneously. 

In that case,  users would want to do _gang-scheduling_ (scheduling a group of pods all-together).  Currently, [kube-arbitrator](https://github.com/kubernetes-incubator/kube-arbitrator/blob/master/doc/usage/batchd_tutorial.md#3-create-poddisruptionbudget-for-application)  can achieve such scheduling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/683)
<!-- Reviewable:end -->
