### PR TITLE
add 'numGpus' parameter to openmpi package

### DIFF
--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -7,6 +7,7 @@
 // @param secret string Name of secret containing ssh keys.
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 // @optionalParam workers number 4 Number of workers.
+// @optionalParam numGpus number 0 Number of Gpus(nvidia.com/gpu) for each worker
 
 local k = import "k.libsonnet";
 local openmpi = import "kubeflow/openmpi/all.libsonnet";

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -1,9 +1,15 @@
 {
-  master(params):: $.statefulSet(params, "master", 1),
+  master(params):: $.statefulSet(params, "master", 1, {}),
 
-  worker(params):: $.statefulSet(params, "worker", params.workers),
+  worker(params):: $.statefulSet(params, "worker", params.workers,
+    {
+      limits: {
+        "nvidia.com/gpu": params.numGpus
+      }
+    }
+  ),
 
-  statefulSet(params, role, replicas):: {
+  statefulSet(params, role, replicas, resources):: {
     kind: "StatefulSet",
     apiVersion: "apps/v1",
     metadata: {
@@ -82,6 +88,7 @@
             {
               name: "openmpi-%s" % role,
               image: params.image,
+              resources: resources,
               command: [
                 "sh",
                 "/kubeflow/openmpi/assets/init.sh",


### PR DESCRIPTION
It just simply add `numGpus` (like `tf-job`) parameter to openmpi package to support deep learning tasks using this prototype.

@jiezhang sorry for multiple pings.  I'm glad if you would check this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/684)
<!-- Reviewable:end -->
