### PR TITLE
tf-serving support model on NFS

### DIFF
--- a/components/k8s-model-server/Serve a local model using Tensorflow Serving.md
+++ b/components/k8s-model-server/Serve a local model using Tensorflow Serving.md
@@ -1,0 +1,97 @@
+# Serve a local model using Tensorflow Serving
+
+- Build NFS Server and allow your k8s machine to access. (more detail in [Setup an NFS Server](https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nfs-mount-on-ubuntu-16-04)). Assume `/var/nfs/general` folder has exported now.
+
+- Put your model into NFS. In this tutorial, we also use inception model. So first download the whole model from [here](https://console.cloud.google.com/storage/browser/kubeflow-models/inception). Assume your model is located on `/var/nfs/general/inception`.
+
+- Install NFS Client Components on your k8s machine
+
+```
+$ sudo apt-get update
+$ sudo apt-get install nfs-common
+```
+
+- Check if model is available *(Optional)*
+
+```
+$ sudo mkdir -p /nfs/general
+$ sudo mount NFS_SERVER_IP:/var/nfs/general /nfs/general
+$ ls /nfs/general
+inception
+```
+
+- Create Persistent Volume(PV) and Persistent Volume Claim(PVC) *[learn more](https://github.com/kubernetes/examples/tree/master/staging/volumes/nfs)*
+
+	- Create PV. You need to modify `NFS_SERVER_IP` to yours
+
+	
+	```
+	$ cat nfs-pv.yaml
+	apiVersion: v1
+	kind: PersistentVolume
+	metadata:
+	  name: nfs
+	spec:
+	  capacity:
+	    storage: 1Mi
+	  accessModes:
+	    - ReadWriteMany
+	  nfs:
+	    server: NFS_SERVER_IP
+	    path: "/"
+	    
+	$ kubectl create -f nfs-pv.yaml
+	```
+	
+	- Create PVC
+
+	```
+	$ cat nfs-pvc.yaml
+	apiVersion: v1
+	kind: PersistentVolumeClaim
+	metadata:
+	  name: nfs
+	spec:
+	  accessModes:
+	    - ReadWriteMany
+	  storageClassName: ""
+	  resources:
+	    requests:
+	      storage: 1Mi
+	
+	$ kubectl create -f nfs-pvc.yaml
+	```
+	
+	- Check PV and PVC *(Optional)*
+
+	```
+	$ kubectl get pv
+	NAME      CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS    CLAIM         STORAGECLASS   REASON    AGE
+	nfs       1Mi        RWX            Retain           Bound     default/nfs                            20h
+	
+	$kubectl get pvc
+	NAME      STATUS    VOLUME    CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+	nfs       Bound     nfs       1Mi        RWX                           20h
+	```
+	
+- Create a Component for your model. You need to add `/mnt` before model path
+
+```
+$ MODEL_COMPONENT=serveInceptionNFS
+$ MODEL_NAME=inception-nfs
+$ MODEL_PATH=/mnt/var/nfs/general/inception
+$ MODEL_LOCATE=nfs
+$ NFS_PVC_NAME=nfs
+$ ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
+$ ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
+$ ks param set ${MODEL_COMPONENT} modelLocate ${MODEL_LOCATE}
+$ ks param set ${MODEL_COMPONENT} nfsPVC ${NFS_PVC_NAME}
+```
+
+- Deploy the model component. Ksonnet will pick up existing parameters for your environment (e.g. cloud, nocloud) and customize the resulting deployment appropriately
+
+```
+$ ks apply ${KF_ENV} -c ${MODEL_COMPONENT}
+```
+
+- Use the served model see [here](https://github.com/kubeflow/kubeflow/tree/master/components/k8s-model-server#use-the-served-model)

--- a/components/k8s-model-server/Serve a local model using Tensorflow Serving.md
+++ b/components/k8s-model-server/Serve a local model using Tensorflow Serving.md
@@ -80,11 +80,11 @@ inception
 $ MODEL_COMPONENT=serveInceptionNFS
 $ MODEL_NAME=inception-nfs
 $ MODEL_PATH=/mnt/var/nfs/general/inception
-$ MODEL_LOCATE=nfs
+$ MODEL_STORAGE_TYPE=nfs
 $ NFS_PVC_NAME=nfs
 $ ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
 $ ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
-$ ks param set ${MODEL_COMPONENT} modelLocate ${MODEL_LOCATE}
+$ ks param set ${MODEL_COMPONENT} modelStorageType ${MODEL_STORAGE_TYPE}
 $ ks param set ${MODEL_COMPONENT} nfsPVC ${NFS_PVC_NAME}
 ```
 

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -147,10 +147,12 @@
         runAsUser: 1000,
         fsGroup: 1000,
       },
-      volumeMounts+: if $.params.modelStorageType == "nfs" then [{
-        name: "nfs",
-        mountPath: "/mnt",
-      }]
+      volumeMounts+: if 'modelStorageType' om $.params then
+        if $.params.modelStorageType == "nfs" then [{
+          name: "nfs",
+          mountPath: "/mnt",
+        }]
+        else []
       else [],
     },  // tfServingContainer
 
@@ -222,13 +224,15 @@
               if $.util.toBool($.params.deployHttpProxy) then
                 $.parts.httpProxyContainer,
             ],
-            volumes+: if $.params.modelStorageType == "nfs" then 
-            [{
-              name: "nfs",
-              persistentVolumeClaim: {
-                claimName: $.params.nfsPVC,
-              }
-            }]
+            volumes+: if 'modelStorageType' in $.params then 
+              if $.params.modelStorageType == "nfs" then 
+              [{
+                name: "nfs",
+                persistentVolumeClaim: {
+                  claimName: $.params.nfsPVC,
+                }
+              }]
+              else []
             else [],
           },
         },

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -147,7 +147,7 @@
         runAsUser: 1000,
         fsGroup: 1000,
       },
-      volumeMounts+: if 'modelStorageType' om $.params then
+      volumeMounts+: if 'modelStorageType' in $.params then
         if $.params.modelStorageType == "nfs" then [{
           name: "nfs",
           mountPath: "/mnt",

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -147,6 +147,11 @@
         runAsUser: 1000,
         fsGroup: 1000,
       },
+      volumeMounts+: if $.params.modelLocate == "nfs" then [{
+        name: "nfs",
+        mountPath: "/mnt",
+      }]
+      else [],
     },  // tfServingContainer
 
     tfServingContainer+: $.parts.tfServingContainerBase +
@@ -217,6 +222,14 @@
               if $.util.toBool($.params.deployHttpProxy) then
                 $.parts.httpProxyContainer,
             ],
+            volumes+: if $.params.modelLocate == "nfs" then 
+            [{
+              name: "nfs",
+              persistentVolumeClaim: {
+                claimName: $.params.nfsPVC,
+              }
+            }]
+            else [],
           },
         },
       },

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -147,7 +147,7 @@
         runAsUser: 1000,
         fsGroup: 1000,
       },
-      volumeMounts+: if $.params.modelLocate == "nfs" then [{
+      volumeMounts+: if $.params.modelStorageType == "nfs" then [{
         name: "nfs",
         mountPath: "/mnt",
       }]
@@ -222,7 +222,7 @@
               if $.util.toBool($.params.deployHttpProxy) then
                 $.parts.httpProxyContainer,
             ],
-            volumes+: if $.params.modelLocate == "nfs" then 
+            volumes+: if $.params.modelStorageType == "nfs" then 
             [{
               name: "nfs",
               persistentVolumeClaim: {

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -10,6 +10,10 @@
     },
     modelName: $.params.name,
     modelPath: null,
+    storageType: if "modelStorageType" in $.params then
+      $.params.modelStorageType
+    else
+      "cloud",
 
     version: "v1",
     firstVersion: true,
@@ -147,12 +151,10 @@
         runAsUser: 1000,
         fsGroup: 1000,
       },
-      volumeMounts+: if 'modelStorageType' in $.params then
-        if $.params.modelStorageType == "nfs" then [{
-          name: "nfs",
-          mountPath: "/mnt",
-        }]
-        else []
+      volumeMounts+: if $.params.storageType == "nfs" then [{
+        name: "nfs",
+        mountPath: "/mnt",
+      }]
       else [],
     },  // tfServingContainer
 
@@ -224,15 +226,13 @@
               if $.util.toBool($.params.deployHttpProxy) then
                 $.parts.httpProxyContainer,
             ],
-            volumes+: if 'modelStorageType' in $.params then 
-              if $.params.modelStorageType == "nfs" then 
-              [{
-                name: "nfs",
-                persistentVolumeClaim: {
-                  claimName: $.params.nfsPVC,
-                }
-              }]
-              else []
+            volumes+: if $.params.storageType == "nfs" then 
+            [{
+              name: "nfs",
+              persistentVolumeClaim: {
+                claimName: $.params.nfsPVC,
+              }
+            }]
             else [],
           },
         },

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -10,10 +10,7 @@
     },
     modelName: $.params.name,
     modelPath: null,
-    storageType: if "modelStorageType" in $.params then
-      $.params.modelStorageType
-    else
-      "cloud",
+    modelStorageType: "cloud",
 
     version: "v1",
     firstVersion: true,
@@ -151,7 +148,7 @@
         runAsUser: 1000,
         fsGroup: 1000,
       },
-      volumeMounts+: if $.params.storageType == "nfs" then [{
+      volumeMounts+: if $.params.modelStorageType == "nfs" then [{
         name: "nfs",
         mountPath: "/mnt",
       }]
@@ -226,7 +223,7 @@
               if $.util.toBool($.params.deployHttpProxy) then
                 $.parts.httpProxyContainer,
             ],
-            volumes+: if $.params.storageType == "nfs" then 
+            volumes+: if $.params.modelStorageType == "nfs" then 
             [{
               name: "nfs",
               persistentVolumeClaim: {

--- a/user_guide.md
+++ b/user_guide.md
@@ -302,10 +302,8 @@ Create a component for your model located on cloud
 MODEL_COMPONENT=serveInception
 MODEL_NAME=inception
 MODEL_PATH=gs://kubeflow-models/inception
-MODEL_STORAGE_TYPE=cloud
 ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
 ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
-ks param set ${MODEL_COMPONENT} modelStorageType ${MODEL_STORAGE_TYPE}
 ```
 
 *(Or)* create a  component for your model located on nfs, learn more from `components/k8s-model-server`

--- a/user_guide.md
+++ b/user_guide.md
@@ -302,24 +302,24 @@ Create a component for your model located on cloud
 MODEL_COMPONENT=serveInception
 MODEL_NAME=inception
 MODEL_PATH=gs://kubeflow-models/inception
-MODEL_LOCATE=cloud
+MODEL_STORAGE_TYPE=cloud
 ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
 ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
-ks param set ${MODEL_COMPONENT} modelLocate ${MODEL_LOCATE}
+ks param set ${MODEL_COMPONENT} modelStorageType ${MODEL_STORAGE_TYPE}
 ```
 
 *(Or)* create a  component for your model located on nfs, learn more from `components/k8s-model-server`
 
 ```
-$ MODEL_COMPONENT=serveInceptionNFS
-$ MODEL_NAME=inception-nfs
-$ MODEL_PATH=/mnt/var/nfs/general/inception
-$ MODEL_LOCATE=nfs
-$ NFS_PVC_NAME=nfs
-$ ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
-$ ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
-$ ks param set ${MODEL_COMPONENT} modelLocate ${MODEL_LOCATE}
-$ ks param set ${MODEL_COMPONENT} nfsPVC ${NFS_PVC_NAME}
+MODEL_COMPONENT=serveInceptionNFS
+MODEL_NAME=inception-nfs
+MODEL_PATH=/mnt/var/nfs/general/inception
+MODEL_STORAGE_TYPE=nfs
+NFS_PVC_NAME=nfs
+ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
+ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
+ks param set ${MODEL_COMPONENT} modelStorageType ${MODEL_STORAGE_TYPE}
+ks param set ${MODEL_COMPONENT} nfsPVC ${NFS_PVC_NAME}
 ```
 
 Deploy the model component. Ksonnet will pick up existing parameters for your environment (e.g. cloud, nocloud) and customize the resulting deployment appropriately

--- a/user_guide.md
+++ b/user_guide.md
@@ -296,14 +296,30 @@ unsecured endpoint by default. For a production deployment with SSL and authenti
 
 We treat each deployed model as a [component](https://ksonnet.io/docs/tutorial#2-generate-and-deploy-an-app-component) in your APP.
 
-Create a component for your model
+Create a component for your model located on cloud
 
 ```
 MODEL_COMPONENT=serveInception
 MODEL_NAME=inception
 MODEL_PATH=gs://kubeflow-models/inception
+MODEL_LOCATE=cloud
 ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
 ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
+ks param set ${MODEL_COMPONENT} modelLocate ${MODEL_LOCATE}
+```
+
+*(Or)* create a  component for your model located on nfs, learn more from `components/k8s-model-server`
+
+```
+$ MODEL_COMPONENT=serveInceptionNFS
+$ MODEL_NAME=inception-nfs
+$ MODEL_PATH=/mnt/var/nfs/general/inception
+$ MODEL_LOCATE=nfs
+$ NFS_PVC_NAME=nfs
+$ ks generate tf-serving ${MODEL_COMPONENT} --name=${MODEL_NAME}
+$ ks param set ${MODEL_COMPONENT} modelPath ${MODEL_PATH}
+$ ks param set ${MODEL_COMPONENT} modelLocate ${MODEL_LOCATE}
+$ ks param set ${MODEL_COMPONENT} nfsPVC ${NFS_PVC_NAME}
 ```
 
 Deploy the model component. Ksonnet will pick up existing parameters for your environment (e.g. cloud, nocloud) and customize the resulting deployment appropriately


### PR DESCRIPTION
As for now, tf-serving can only support model located on cloud. I changed `tf-serving.libsonnet` file, add 2 more params: `modelStorageType` and `nfsPVC`. For now, `modelStorageType` can only detect if it's `nfs`. If so, container will mount a persistentVolumeClaim(PVC) specified by `nfcPVC`. We can support more choices in the future.
A guideline for running nfs-based model is put on `components/k8s-model-server` folder.
As a new param is added, I changed `user_guide.md`, `Serve a model using Tensorflow Serving` section, and add `ks param set ${MODEL_COMPONENT} modelLocate ${MODEL_STORAGE_TYPE}`. Also give a quick guideline of `Create a component for your model located on nfs` following `Create a component for your model located on cloud`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/688)
<!-- Reviewable:end -->
