### PR TITLE
openmpi: fix failing installing redis-tools in init.sh

### DIFF
--- a/kubeflow/openmpi/assets/init.sh
+++ b/kubeflow/openmpi/assets/init.sh
@@ -58,7 +58,7 @@ cp /kubeflow/openmpi/secrets/authorized_keys /root/.ssh
 cp /kubeflow/openmpi/assets/ssh_config /root/.ssh/config
 
 # Install redis-cli
-apt-get install -y redis-tools
+apt-get update && apt-get install -y redis-tools
 
 # Start sshd in daemon mode
 /usr/sbin/sshd -e -f /kubeflow/openmpi/assets/sshd_config


### PR DESCRIPTION
@jiezhang Most docker images don't have apt cache (it was regularly cleaned up  in `Dockerfile`).  So we must `apt-get update` first.  I think `init.sh` should support it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/690)
<!-- Reviewable:end -->
