### PR TITLE
openmpi: slots clause should be generated when gpus '> 0'

### DIFF
--- a/kubeflow/openmpi/assets.libsonnet
+++ b/kubeflow/openmpi/assets.libsonnet
@@ -29,7 +29,7 @@
           index: index,
           name: params.name,
           namespace: params.namespace,
-          slots: if params.gpus > 1 then " slots=%d" % params.gpus else ""
+          slots: if params.gpus > 0 then " slots=%d" % params.gpus else ""
         },
         std.range(0, params.workers - 1)
       )


### PR DESCRIPTION
@jiezhang It's really tiny fix.  could you review it??  We should generate `slots=` clause even when `gpus==1`.