### PR TITLE
openmpi: namespaced resource names should be prefixed with component name

### DIFF
--- a/kubeflow/openmpi/assets.libsonnet
+++ b/kubeflow/openmpi/assets.libsonnet
@@ -3,11 +3,13 @@
     $.configMap(params),
   ],
 
+  name(params):: "%s-assets" % params.name,
+
   configMap(params):: {
     kind: "ConfigMap",
     apiVersion: "v1",
     metadata: {
-      name: "openmpi-assets",
+      name: $.name(params),
       namespace: params.namespace,
       labels: {
         app: params.name,
@@ -25,7 +27,7 @@
   genHostfile(params)::
     std.lines(
       std.map(
-        function(index) "openmpi-worker-%(index)d.%(name)s.%(namespace)s%(slots)s" % {
+        function(index) "%(name)s-worker-%(index)d.%(name)s.%(namespace)s%(slots)s" % {
           index: index,
           name: params.name,
           namespace: params.namespace,

--- a/kubeflow/openmpi/service.libsonnet
+++ b/kubeflow/openmpi/service.libsonnet
@@ -3,11 +3,13 @@
     $.service(params),
   ],
 
+  name(params):: params.name,
+
   service(params):: {
     kind: "Service",
     apiVersion: "v1",
     metadata: {
-      name: params.name,
+      name: $.name(params),
       namespace: params.namespace,
       labels: {
         app: params.name,


### PR DESCRIPTION
openmpi package currently creates __fixed named__ pods which are `openmpi-master`, `openmpi-worker-n`, and `openmpi-assets`.  This prevents users from creating multiple openmpi components in one namespace.  

I think prefixing component name to namespaced resource names would be preferred.

```
$ COMPONENT=c1
$ ks generate openmpi ${COMPONENT} --image ${IMAGE} --secret ${SECRET} --workers ${WORKERS} --gpus ${GPUS} --exec "${EXEC}"
$ COMPONENT=c2
$ ks generate openmpi ${COMPONENT} --image ${IMAGE} --secret ${SECRET} --workers ${WORKERS} --gpus ${GPUS} --exec "${EXEC}"
$ ks apply default
...

$ k get po,svc,cm --show-all 
NAME             READY     STATUS    RESTARTS   AGE
po/c1-master     1/1       Running   0          12s
po/c1-worker-0   1/1       Running   0          11s
po/c1-worker-1   1/1       Running   0          11s
po/c2-master     1/1       Running   0          12s
po/c2-worker-0   1/1       Running   0          12s
po/c2-worker-1   1/1       Running   0          11s
NAME      TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)     AGE
svc/c1    ClusterIP   None         <none>        12345/TCP   13s
svc/c2    ClusterIP   None         <none>        12345/TCP   13s
NAME           DATA      AGE
cm/c1-assets   5         13s
cm/c2-assets   5         13s
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/698)
<!-- Reviewable:end -->
