### PR TITLE
openmpi: master should wait until worker pods are really ready.

### DIFF
--- a/kubeflow/openmpi/assets/init.sh
+++ b/kubeflow/openmpi/assets/init.sh
@@ -37,12 +37,8 @@ wait_workers_running() {
   until [ ${num_runnning_worker} -eq ${workers} ]; do
 
     local num_runnning_worker=0
-    for worker in $(cat ${SCRIPT_DIR}/hostfile | cut -f 1 -d' '); do
-      local worker_pod=${worker%%.*}
-      echo -n "worker pod ${worker_pod}: "
-      phase=$(phase_of ${worker_pod})
-      echo $phase
-      if [ "$phase" = "Running" ]; then
+    for worker in $(cat ${SCRIPT_DIR}/hostfile); do
+      if ssh $worker echo hello >/dev/null 2>&1 ; then
         num_runnning_worker=$((${num_runnning_worker} + 1))
       fi
     done


### PR DESCRIPTION
As @jiezhang pointed out [#696](https://github.com/kubeflow/kubeflow/pull/696#issuecomment-383176969), once worker reaches "Running" state, bunch of initilization remains on workers and of cource sshd might not ready on workers.  So, user's command executed on master can fail. So, master should wait until it can 'ssh' to all workers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/701)
<!-- Reviewable:end -->
