### PR TITLE
[openmpi] Introduce a sidecar container for inter-pod synchronization

### DIFF
--- a/components/openmpi-controller/.gitignore
+++ b/components/openmpi-controller/.gitignore
@@ -1,0 +1,2 @@
+.openmpi-controller
+env

--- a/components/openmpi-controller/Dockerfile
+++ b/components/openmpi-controller/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6
+
+USER root
+
+ENV HOME /root
+
+ADD requirements.txt $HOME
+ADD controller $HOME/controller
+
+RUN pip3 install -r $HOME/requirements.txt

--- a/components/openmpi-controller/Makefile
+++ b/components/openmpi-controller/Makefile
@@ -1,0 +1,11 @@
+# TODO: move to kubeflow
+IMAGE=jiez/openmpi-controller
+TAG=latest
+
+build:
+	docker build --pull -t ${IMAGE}:${TAG} .
+
+push: build
+	docker push ${IMAGE}:${TAG}
+
+.PHONY: build push

--- a/components/openmpi-controller/controller/controller.py
+++ b/components/openmpi-controller/controller/controller.py
@@ -1,0 +1,59 @@
+from pathlib import Path
+from time import sleep
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+from kubernetes.config.config_exception import ConfigException
+from retrying import retry
+
+SIG_DIR = '.openmpi-controller'
+SIG_TERM = f'{SIG_DIR}/term.sig'
+POLL_STATUS_INTERVAL = 10
+TERMINATED_PHASES = ('Succeeded', 'Failed')
+
+
+class Controller:
+    """
+    Controller is a sidecar container that extends the "main" container (openmpi-job).
+    It communicates with the main container using a shared volume mounted at the working directory.
+    Right before it finishes its work, it creates a semaphore file "term.sig" to signal the main container to terminate.
+    """
+
+    def __init__(self, namespace, master):
+        self.namespace = namespace
+        self.master = master
+        Path(SIG_DIR).mkdir()
+
+    def __enter__(self):
+        log('controller entered')
+        try:
+            config.load_incluster_config()
+        except ConfigException:
+            config.load_kube_config()
+
+        self.api = client.CoreV1Api()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        log('controller exited')
+        Path(SIG_TERM).touch()
+
+    def wait_master_terminated(self):
+        while True:
+            phase = self._get_master_phase()
+            log(f'{self.master} is in "{phase}" phase')
+            if phase in TERMINATED_PHASES:
+                break
+
+            sleep(POLL_STATUS_INTERVAL)
+
+    @retry(stop_max_attempt_number=5,
+           wait_exponential_multiplier=1000,
+           retry_on_exception=lambda e: isinstance(e, ApiException))
+    def _get_master_phase(self):
+        pod = self.api.read_namespaced_pod(self.master, self.namespace)
+        return pod.status.phase
+
+
+def log(msg):
+    print(msg, flush=True)

--- a/components/openmpi-controller/controller/main.py
+++ b/components/openmpi-controller/controller/main.py
@@ -1,0 +1,17 @@
+from argparse import ArgumentParser
+
+from controller import Controller
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument('--namespace', type=str, required=True)
+    parser.add_argument('--master', type=str, required=True)
+    args = parser.parse_args()
+
+    with Controller(args.namespace, args.master) as ctl:
+        ctl.wait_master_terminated()
+
+
+if __name__ == '__main__':
+    main()

--- a/components/openmpi-controller/requirements.txt
+++ b/components/openmpi-controller/requirements.txt
@@ -1,0 +1,2 @@
+kubernetes==6.0.0
+retrying==1.3.3

--- a/kubeflow/openmpi/README.md
+++ b/kubeflow/openmpi/README.md
@@ -62,7 +62,7 @@ ks apply default
 
 # Inspect the pod status.
 kubectl get pod -n ${NAMESPACE}
-kubectl logs -n ${NAMESPACE} -f openmpi-master
+kubectl logs -n ${NAMESPACE} -f ${COMPONENT}-master
 ```
 
 ## Running Horovod

--- a/kubeflow/openmpi/all.libsonnet
+++ b/kubeflow/openmpi/all.libsonnet
@@ -1,6 +1,6 @@
+local assets = import "kubeflow/openmpi/assets.libsonnet";
 local service = import "kubeflow/openmpi/service.libsonnet";
 local workloads = import "kubeflow/openmpi/workloads.libsonnet";
-local assets = import "kubeflow/openmpi/assets.libsonnet";
 
 {
   all(params, env):: $.parts(params, env).all,
@@ -16,7 +16,7 @@ local assets = import "kubeflow/openmpi/assets.libsonnet";
 
     all::
       assets.all(updatedParams)
-      + workloads.all(updatedParams)
       + service.all(updatedParams)
+      + workloads.all(updatedParams),
   },
 }

--- a/kubeflow/openmpi/assets.libsonnet
+++ b/kubeflow/openmpi/assets.libsonnet
@@ -27,11 +27,11 @@
   genHostfile(params)::
     std.lines(
       std.map(
-        function(index) "%(name)s-worker-%(index)d.%(name)s.%(namespace)s%(slots)s" % {
+        function(index) "%(name)s-worker-%(index)d.%(name)s.%(namespace)s slots=%(slots)d" % {
           index: index,
           name: params.name,
           namespace: params.namespace,
-          slots: if params.gpus > 0 then " slots=%d" % params.gpus else ""
+          slots: if params.gpus > 1 then params.gpus else 1,
         },
         std.range(0, params.workers - 1)
       )

--- a/kubeflow/openmpi/assets/init.sh
+++ b/kubeflow/openmpi/assets/init.sh
@@ -1,101 +1,57 @@
 set -exv
 
-SCRIPT_DIR=$(cd $(dirname $0);pwd)
-K8S_PODS_ENDPOINT="$KUBERNETES_SERVICE_HOST:$KUBERNETES_SERVICE_PORT/api/v1/namespaces/$(cat /var/run/secrets/kubernetes.io/serviceaccount/namespace)/pods"
+OPENMPI_DIR=/kubeflow/openmpi
 
-# TOKEN should not be printed.
-set +x
-TOKEN_HEADER="Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
-set -x
+wait_mpi_ready() {
+  local max_retries=$1
+  local retries=0
 
-if [ $# -ne 5 ]; then
+  until mpiexec -n ${workers} --hostfile ${OPENMPI_DIR}/assets/hostfile --allow-run-as-root -q sh -c 'echo $(hostname) is ready'; do
+    sleep 10
+
+    retries=$(expr ${retries} + 1)
+    if [ -n "${max_retries}" ] && [ ${retries} -ge ${max_retries} ]; then
+      exit 124
+    fi
+  done
+}
+
+wait_controller_term() {
+  until [ -f ${OPENMPI_DIR}/data/.openmpi-controller/term.sig ]; do
+    sleep 10
+  done
+}
+
+if [ $# -ne 3 ]; then
   echo "illegal number of parameters"
   exit 1
 fi
 
 role="$1"
 workers="$2"
-hostname="$3"
-exec="$4"
-master_pod="$5"
-
-phase_of(){
-  local pod_name=$1
-  # TOKEN should not be printed.
-  set +x
-  curl -sL --insecure --header "$TOKEN_HEADER" \
-    https://${K8S_PODS_ENDPOINT}/${pod_name} \
-    | jq -r '.status.phase' 2>/dev/null
-  set -x
-}
-
-wait_workers_running() {
-  local max_retries=$1
-  local retries=0
-  local num_runnning_worker=0
-
-  until [ ${num_runnning_worker} -eq ${workers} ]; do
-
-    local num_runnning_worker=0
-    for worker in $(cat ${SCRIPT_DIR}/hostfile | cut -f 1 -d' '); do
-      local worker_pod=${worker%%.*}
-      echo -n "worker pod ${worker_pod}: "
-      phase=$(phase_of ${worker_pod})
-      echo $phase
-      if [ "$phase" = "Running" ]; then
-        num_runnning_worker=$((${num_runnning_worker} + 1))
-      fi
-    done
-    echo the number of running worker: ${num_runnning_worker}/${workers}
-
-    if [ -n "${max_retries}" ] && [ ${retries} -ge ${max_retries} ]; then
-      exit 124
-    else
-      sleep 1
-    fi
-  done
-}
-
-wait_master_done() {
-    local max_retries=$1
-    local retries=0
-    until [ $(phase_of ${master_pod}) = "Succeeded" -o $(phase_of ${master_pod}) = "Failed" ]; do
-      sleep 10;
-      retries=$(expr ${retries} + 1)
-      if [ -n "${max_retries}" ] && [ ${retries} -ge ${max_retries} ]; then
-        exit 124
-      fi
-    done
-}
+exec="$3"
 
 # Set up openmpi
 mkdir -p /root/.openmpi
-cp /kubeflow/openmpi/assets/mca-params.conf /root/.openmpi
+cp ${OPENMPI_DIR}/assets/mca-params.conf /root/.openmpi
 
 # Set up ssh
 mkdir -p /root/.ssh
-cp /kubeflow/openmpi/secrets/id_rsa /root/.ssh
-cp /kubeflow/openmpi/secrets/id_rsa.pub /root/.ssh
-cp /kubeflow/openmpi/secrets/authorized_keys /root/.ssh
-cp /kubeflow/openmpi/assets/ssh_config /root/.ssh/config
-
-# Install curl and jq
-apt-get update && apt-get install -y curl jq
+cp ${OPENMPI_DIR}/secrets/id_rsa /root/.ssh
+cp ${OPENMPI_DIR}/secrets/id_rsa.pub /root/.ssh
+cp ${OPENMPI_DIR}/secrets/authorized_keys /root/.ssh
+cp ${OPENMPI_DIR}/assets/ssh_config /root/.ssh/config
 
 # Start sshd in daemon mode
-/usr/sbin/sshd -e -f /kubeflow/openmpi/assets/sshd_config
-sleep 10
-
-# Start running the workloads.
-echo running ${hostname}
+/usr/sbin/sshd -e -f ${OPENMPI_DIR}/assets/sshd_config
 
 exit_code=0
 if [ "${role}" = "master" ]; then
-  wait_workers_running 30
+  # Run the exec command in master
+  wait_mpi_ready 30
   sh -c "${exec}" || exit_code=$?
 else
-  wait_master_done
+  wait_controller_term
 fi
 
-echo shutting down ${hostname}
 exit ${exit_code}

--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -12,6 +12,7 @@
 // @optionalParam imagePullPolicy string IfNotPresent Image pull policy (either IfNotPresent or Always).
 // @optionalParam gpus number 0 Number of GPUs per worker.
 // @optionalParam schedulerName string default-scheduler scheduler name to use for the components.
+// @optionalParam controllerImage string jiez/openmpi-controller:latest Docker image of the openmpi-controller.
 
 local k = import "k.libsonnet";
 local openmpi = import "kubeflow/openmpi/all.libsonnet";

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -1,29 +1,33 @@
-local service = import "kubeflow/openmpi/service.libsonnet";
 local assets = import "kubeflow/openmpi/assets.libsonnet";
+local service = import "kubeflow/openmpi/service.libsonnet";
+
+local ROLE_MASTER = "master";
+local ROLE_WORKER = "worker";
 
 {
   all(params)::
     $.master(params) + $.worker(params),
 
-  masterHostname(params):: "%s-master" % params.name,
   master(params)::
-    [$.pod(params, "master", $.masterHostname(params))],
+    [$.pod(params, ROLE_MASTER, $.masterName(params))],
 
-  workerHostname(params, index):: "%(name)s-worker-%(index)d" % {
-    name: params.name,
-    index: index
-  },
+  masterName(params)::
+    "%s-%s" % [params.name, ROLE_MASTER],
+
   worker(params)::
     std.map(
-      function(index) $.pod(params, "worker", $.workerHostname(params, index)),
+      function(index) $.pod(params, ROLE_WORKER, $.workerName(params, index)),
       std.range(0, params.workers - 1)
     ),
 
-  pod(params, role, hostname):: {
+  workerName(params, index)::
+    "%s-%s-%d" % [params.name, ROLE_WORKER, index],
+
+  pod(params, role, podName):: {
     kind: "Pod",
     apiVersion: "v1",
     metadata: {
-      name: hostname,
+      name: podName,
       namespace: params.namespace,
       labels: {
         app: params.name,
@@ -31,93 +35,128 @@ local assets = import "kubeflow/openmpi/assets.libsonnet";
       },
     },
     spec: {
-      hostname: hostname,
+      hostname: podName,
       subdomain: service.name(params),
       restartPolicy: "Never",
       terminationGracePeriodSeconds: 30,
       dnsPolicy: "ClusterFirst",
       schedulerName: params.schedulerName,
-      volumes: [
-        {
-          name: "kubeflow-openmpi-secrets",
-          secret: {
-            secretName: params.secret,
-            defaultMode: 256,  // 0400
-          },
-        },
-        {
-          name: "kubeflow-openmpi-assets",
-          configMap: {
-            name: assets.name(params),
-            items: [
-              {
-                key: "init.sh",
-                path: "init.sh",
-                mode: 365,  // 0555
-              },
-              {
-                key: "mca-params.conf",
-                path: "mca-params.conf",
-              },
-              {
-                key: "sshd_config",
-                path: "sshd_config",
-              },
-              {
-                key: "ssh_config",
-                path: "ssh_config",
-              },
-              {
-                key: "hostfile",
-                path: "hostfile",
-              },
-            ],
-            defaultMode: 420  // 0644
-          },
-        },
-      ],
-      containers: [
-        {
-          name: "openmpi-%s" % role,
-          image: params.image,
-          imagePullPolicy: params.imagePullPolicy,
-          resources: $.getResources(role, params.gpus),
-          terminationMessagePath: "/dev/termination-log",
-          terminationMessagePolicy: "File",
-          command: [
-            "sh",
-            params.init,
-            role,
-            std.toString(params.workers),
-            hostname,
-            params.exec,
-            $.masterHostname(params)
-          ],
-          ports: [
-            {
-              containerPort: 2022,
-              protocol: "TCP",
-            },
-          ],
-          volumeMounts: [
-            {
-              name: "kubeflow-openmpi-assets",
-              mountPath: "/kubeflow/openmpi/assets",
-            },
-            {
-              name: "kubeflow-openmpi-secrets",
-              mountPath: "/kubeflow/openmpi/secrets",
-            },
-          ],
-        },
-      ],
+      volumes: $.volumes(params),
+      containers: $.containers(params, role),
     },
   },
 
-  getResources(role, gpus)::
-    if role == "worker" && gpus > 0 then {
+  volumes(params):: [
+    {
+      name: "kubeflow-openmpi-data",
+      emptyDir: {},
+    },
+    {
+      name: "kubeflow-openmpi-secrets",
+      secret: {
+        secretName: params.secret,
+        defaultMode: 256,  // 0400
+      },
+    },
+    {
+      name: "kubeflow-openmpi-assets",
+      configMap: {
+        name: assets.name(params),
+        items: [
+          {
+            key: "init.sh",
+            path: "init.sh",
+            mode: 365,  // 0555
+          },
+          {
+            key: "mca-params.conf",
+            path: "mca-params.conf",
+          },
+          {
+            key: "sshd_config",
+            path: "sshd_config",
+          },
+          {
+            key: "ssh_config",
+            path: "ssh_config",
+          },
+          {
+            key: "hostfile",
+            path: "hostfile",
+          },
+        ],
+        defaultMode: 420,  // 0644
+      },
+    },
+  ],
+
+  containers(params, role):: {
+    local job = {
+      name: "openmpi-job",
+      image: params.image,
+      imagePullPolicy: params.imagePullPolicy,
+      resources: $.resources(role, params.gpus),
+      terminationMessagePath: "/dev/termination-log",
+      terminationMessagePolicy: "File",
+      workingDir: "/kubeflow/openmpi/data",
+      command: [
+        "sh",
+        params.init,
+        role,
+        std.toString(params.workers),
+        params.exec,
+      ],
+      ports: [
+        {
+          containerPort: 2022,
+          protocol: "TCP",
+        },
+      ],
+      volumeMounts: [
+        {
+          name: "kubeflow-openmpi-data",
+          mountPath: "/kubeflow/openmpi/data",
+        },
+        {
+          name: "kubeflow-openmpi-assets",
+          mountPath: "/kubeflow/openmpi/assets",
+        },
+        {
+          name: "kubeflow-openmpi-secrets",
+          mountPath: "/kubeflow/openmpi/secrets",
+        },
+      ],
+    },
+    local controller = {
+      name: "openmpi-controller",
+      image: params.controllerImage,
+      imagePullPolicy: "Always",
+      terminationMessagePath: "/dev/termination-log",
+      terminationMessagePolicy: "File",
+      workingDir: "/kubeflow/openmpi/data",
+      command: [
+        "python",
+        "/root/controller/main.py",
+        "--namespace",
+        params.namespace,
+        "--master",
+        $.masterName(params),
+      ],
+      volumeMounts: [
+        {
+          name: "kubeflow-openmpi-data",
+          mountPath: "/kubeflow/openmpi/data",
+        },
+      ],
+    },
+
+    result:: if role == ROLE_MASTER then [job] else [job, controller],
+  }.result,
+
+  resources(role, gpus)::
+    if role == ROLE_WORKER && gpus > 0 then {
       limits: {
         "nvidia.com/gpu": gpus,
       },
-    } else {}
+    } else {},
 }


### PR DESCRIPTION
* openmpi-controller monitors the master pod's status and creates a semaphore file "term.sig" to signal openmpi-job to terminate
* openmpi-job is now decoupled from kubernetes
* openmpi-controller and openmpi-job shares a volume for inter-container communication
* openmpi-controller can be extended in the future to support data snapshot

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/704)
<!-- Reviewable:end -->
