### PR TITLE
CP to v0.1-branch: Update http_timeout to 5 minutes in jupyterhub (#691)

### DIFF
--- a/kubeflow/core/jupyterhub_spawner.py
+++ b/kubeflow/core/jupyterhub_spawner.py
@@ -91,6 +91,8 @@ c.KubeSpawner.cmd = 'start-singleuser.sh'
 c.KubeSpawner.args = ['--allow-root']
 # gpu images are very large ~15GB. need a large timeout.
 c.KubeSpawner.start_timeout = 60 * 30
+# Increase timeout to 5 minutes to avoid HTTP 500 errors on JupyterHub
+c.KubeSpawner.http_timeout = 60 * 5
 
 ###################################################
 ### Persistent volume options


### PR DESCRIPTION
This is popping up as a noticeable wart in some virtualized environments. I feel that we should include this in the next 0.1 release since that may be what is used for demos at the upcoming conferences in May and June.