### PR TITLE
controller bug fix

### DIFF
--- a/docs/gke/iap.md
+++ b/docs/gke/iap.md
@@ -116,7 +116,7 @@ to create a ksonnet app to deploy Kubeflow.
 [cert-manager](https://github.com/jetstack/cert-manager) is used to automatically request valid SSL certifiactes using the [ACME](https://en.wikipedia.org/wiki/Automated_Certificate_Management_Environment) issuer.
 
 ```
-ks generate cert-manager cert-manager --acmeEmail=${ACCOUNT}
+ks generate cert-manager cert-manager --namespace=${NAMESPACE} --acmeEmail=${ACCOUNT}
 ks apply ${ENVIRONMENT} -c cert-manager
 
 ks generate iap-ingress iap-ingress --namespace=${NAMESPACE} --ipName=${IP_NAME} --hostname=${FQDN}

--- a/kubeflow/core/cloud-endpoints.libsonnet
+++ b/kubeflow/core/cloud-endpoints.libsonnet
@@ -173,6 +173,7 @@
       kind: "Service",
       metadata: {
         name: "cloud-endpoints-controller",
+        namespace: namespace,
       },
       spec: {
         type: "ClusterIP",


### PR DESCRIPTION
fix https://github.com/kubeflow/kubeflow/issues/709

Original problem: 
1. Service ```cloud-endpoints-controller``` will always created with default namespace, which is not accessible by other resources when user specify their namespace.
2. When generate cert-manager, user should provide namespace as well, to make sure ```issuer``` is accessible by other resources.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/714)
<!-- Reviewable:end -->
