### PR TITLE
Argo Ksonnet package - Add Docker image Tag

### DIFF
--- a/kubeflow/argo/argo.libsonnet
+++ b/kubeflow/argo/argo.libsonnet
@@ -168,7 +168,7 @@
                     value: "true",
                   },
                 ],
-                image: "argoproj/argoui:v2.0.0-beta1",
+                image: "argoproj/argoui:"+imageTag,
                 imagePullPolicy: "IfNotPresent",
                 name: "argo-ui",
                 resources: {},

--- a/kubeflow/argo/argo.libsonnet
+++ b/kubeflow/argo/argo.libsonnet
@@ -2,19 +2,19 @@
   // TODO(jlewi): Do we need to add parts corresponding to a service account and cluster binding role?
   // see https://github.com/argoproj/argo/blob/master/cmd/argo/commands/install.go
 
-  parts(namespace):: {
+  parts(namespace, imageTag):: {
     all:: [
-      $.parts(namespace).crd,
-      $.parts(namespace).config,
-      $.parts(namespace).deploy,
-      $.parts(namespace).deployUi,
-      $.parts(namespace).uiService,
-      $.parts(namespace).serviceAccount,
-      $.parts(namespace).role,
-      $.parts(namespace).roleBinding,
-      $.parts(namespace).uiServiceAccount,
-      $.parts(namespace).uiRole,
-      $.parts(namespace).uiRoleBinding,
+      $.parts(namespace, imageTag).crd,
+      $.parts(namespace, imageTag).config,
+      $.parts(namespace, imageTag).deploy,
+      $.parts(namespace, imageTag).deployUi,
+      $.parts(namespace, imageTag).uiService,
+      $.parts(namespace, imageTag).serviceAccount,
+      $.parts(namespace, imageTag).role,
+      $.parts(namespace, imageTag).roleBinding,
+      $.parts(namespace, imageTag).uiServiceAccount,
+      $.parts(namespace, imageTag).uiRole,
+      $.parts(namespace, imageTag).uiRoleBinding,
     ],
 
     // CRD's are not namespace scoped; see
@@ -96,7 +96,7 @@
                     },
                   },
                 ],
-                image: "argoproj/workflow-controller:v2.0.0-beta1",
+                image: "argoproj/workflow-controller:"+imageTag,
                 imagePullPolicy: "IfNotPresent",
                 name: "workflow-controller",
                 resources: {},
@@ -222,7 +222,7 @@
     config: {
       apiVersion: "v1",
       data: {
-        config: @"executorImage: argoproj/argoexec:v2.0.0-beta1",
+        config: @"executorImage: argoproj/argoexec:"+imageTag,
       },
       kind: "ConfigMap",
       metadata: {

--- a/kubeflow/argo/prototypes/argo.jsonnet
+++ b/kubeflow/argo/prototypes/argo.jsonnet
@@ -4,6 +4,7 @@
 // @shortDescription Argo workflow engine
 // @param name string Name to give to the component
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
+// @optionalParam imageTag string latest Docker image tag to use. It is automatically inherited from the environment if not set.
 
 local k = import "k.libsonnet";
 local argo = import "kubeflow/argo/argo.libsonnet";
@@ -12,7 +13,9 @@ local argo = import "kubeflow/argo/argo.libsonnet";
 // the namespace parameter is not explicitly set
 local updatedParams = params {
   namespace: if params.namespace == "null" then env.namespace else params.namespace,
-};
+  };
+  
 local namespace = updatedParams.namespace;
+local imageTag = import "param://imageTag";
 
-std.prune(k.core.v1.list.new(argo.parts(namespace).all))
+std.prune(k.core.v1.list.new(argo.parts(namespace, imageTag).all))


### PR DESCRIPTION
This will allow to use a specific docker image tag for the `exec` and `controller` image.

For example, I hit an issue trying: https://github.com/kubeflow/examples/tree/master/mnist I fixed it using the `v2.1.0-beta2` tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/728)
<!-- Reviewable:end -->
