### PR TITLE
Fix Serving metadata

### DIFF
--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -211,12 +211,7 @@
       },
       spec: {
         template: {
-          metadata: {
-            labels: $.params.labels + { version: $.params.version, },
-            annotations: {
-              "sidecar.istio.io/inject": if $.util.toBool($.params.deployIstio) then "true",
-            },
-          },
+          metadata: $.parts.tfServingMetadata,
           spec: {
             containers: [
               $.parts.tfServingContainer,

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -84,7 +84,7 @@
       // Default routing rule for the first version of model.
       if $.util.toBool($.params.deployIstio) && $.util.toBool($.params.firstVersion) then
         $.parts.defaultRouteRule,
-    ] + 
+    ] +
       // TODO(jlewi): It would be better to structure s3 as a mixin.
       // As an example it would be great to allow S3 and GCS parameters
       // to be enabled simultaneously. This should be doable because
@@ -160,6 +160,12 @@
                            }
                          else {},
 
+    tfServingMetadata+: {
+      labels: $.params.labels + { version: $.params.version, },
+      annotations: {
+        "sidecar.istio.io/inject": if $.util.toBool($.params.deployIstio) then "true",
+      },
+    },
 
     httpProxyContainer:: {
       name: $.params.name + "-http-proxy",
@@ -310,7 +316,7 @@
     tfDeployment: $.parts.tfDeployment {
       spec: +{
         template: +{
-
+          metadata: $.parts.tfServingMetadata,
           spec: +{
             containers: [
               $.s3parts.tfServingContainer,
@@ -344,14 +350,13 @@
     tfDeployment: $.parts.tfDeployment {
       spec+: {
         template+: {
-
+          metadata: $.parts.tfServingMetadata,
           spec+: {
             containers: [
               $.gcpParts.tfServingContainer,
               if $.util.toBool($.params.deployHttpProxy) then
                 $.parts.httpProxyContainer,
             ],
-
             volumes: [
               if $.gcpParams.gcpCredentialSecretName != "" then
                 {


### PR DESCRIPTION
Was getting the following error when applying Serving template using S3 enabled:

```
ERROR handle object: can't update deployments serving.mnist-v1: Deployment.apps "mnist-v1" is invalid: [spec.selector: Required value, spec.template.metadata.labels: Invalid value: map[string]string(nil): `selector` does not match template `labels`]
```

Looks like for GCP and S3 parts, metadata is not getting inserted. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/741)
<!-- Reviewable:end -->
