### PR TITLE
[openmpi] Add more parameters for GPU training

### DIFF
--- a/kubeflow/openmpi/README.md
+++ b/kubeflow/openmpi/README.md
@@ -53,16 +53,19 @@ ks prototype describe openmpi
 COMPONENT=openmpi
 IMAGE=YOUR_IMAGE_HERE
 WORKERS=4
-GPUS=0
-EXEC="mpiexec -n 4 --hostfile /kubeflow/openmpi/assets/hostfile --allow-run-as-root --display-map --tag-output --timestamp-output sh -c 'echo hello world'"
-ks generate openmpi ${COMPONENT} --image ${IMAGE} --secret ${SECRET} --workers ${WORKERS} --gpus ${GPUS} --exec "${EXEC}" 
+GPU=0
+EXEC="mpiexec -n ${WORKERS} --hostfile /kubeflow/openmpi/assets/hostfile --allow-run-as-root --display-map --tag-output --timestamp-output sh -c 'echo hello world'"
+ks generate openmpi ${COMPONENT} --image ${IMAGE} --secret ${SECRET} --workers ${WORKERS} --gpu ${GPU} --exec "${EXEC}" 
 
 # Deploy to your cluster. 
 ks apply default
 
 # Inspect the pod status.
-kubectl get pod -n ${NAMESPACE}
+kubectl get pod -n ${NAMESPACE} -o wide
 kubectl logs -n ${NAMESPACE} -f ${COMPONENT}-master
+
+# Clean up.
+ks delete default
 ```
 
 ## Running Horovod
@@ -80,8 +83,8 @@ Horovod is a distributed training framework for TensorFlow. You may use this pac
 GPU=1
 
 # Run the MNIST example.
-EXEC="mpiexec -n 4 --hostfile /kubeflow/openmpi/assets/hostfile --allow-run-as-root --display-map --tag-output --timestamp-output sh -c 'python /examples/tensorflow_mnist.py'"
+EXEC="mpiexec -n ${WORKERS} --hostfile /kubeflow/openmpi/assets/hostfile --allow-run-as-root --display-map --tag-output --timestamp-output sh -c 'python /examples/tensorflow_mnist.py'"
 
 # If you're running Horovod in a cluster without GPUs, you may need to set LD_LIBRARY_PATH to use CUDA stub drivers.
-EXEC="mpiexec -n 4 --hostfile /kubeflow/openmpi/assets/hostfile --allow-run-as-root --display-map --tag-output --timestamp-output sh -c 'LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-9.0/targets/x86_64-linux/lib/stubs python /examples/tensorflow_mnist.py'"
+EXEC="mpiexec -n ${WORKERS} --hostfile /kubeflow/openmpi/assets/hostfile --allow-run-as-root --display-map --tag-output --timestamp-output sh -c 'LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/cuda-9.0/targets/x86_64-linux/lib/stubs python /examples/tensorflow_mnist.py'"
 ```

--- a/kubeflow/openmpi/assets.libsonnet
+++ b/kubeflow/openmpi/assets.libsonnet
@@ -31,7 +31,7 @@
           index: index,
           name: params.name,
           namespace: params.namespace,
-          slots: if params.gpus > 1 then params.gpus else 1,
+          slots: if params.gpu > 1 then params.gpu else 1,
         },
         std.range(0, params.workers - 1)
       )

--- a/kubeflow/openmpi/assets/mca-params.conf
+++ b/kubeflow/openmpi/assets/mca-params.conf
@@ -2,3 +2,4 @@ hwloc_base_binding_policy=none
 rmaps_base_mapping_policy=slot
 btl_tcp_if_exclude=lo,docker0
 orte_keep_fqdn_hostnames=t
+mca_base_env_list=LD_LIBRARY_PATH

--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -10,9 +10,13 @@
 // @optionalParam init string null Command to bootstrap the containers. Defaults to init.sh.
 // @optionalParam exec string null Command to execute in master after bootstrap is done. It sleeps indefinitely if not set.
 // @optionalParam imagePullPolicy string IfNotPresent Image pull policy (either IfNotPresent or Always).
-// @optionalParam gpus number 0 Number of GPUs per worker.
+// @optionalParam gpu number 0 Number of GPUs per worker.
+// @optionalParam cpu string null CPU limits per worker.
+// @optionalParam memory string null Memory limits per worker.
 // @optionalParam schedulerName string default-scheduler scheduler name to use for the components.
 // @optionalParam controllerImage string jiez/openmpi-controller:latest Docker image of the openmpi-controller.
+// @optionalParam initTimeout number 300 Timeout in seconds to abort the initialization.
+// @optionalParam nodeSelector string null Comma-delimited list of "key=value" pairs to select the worker nodes. e.g. "cloud.google.com/gke-accelerator=nvidia-tesla-k80"
 
 local k = import "k.libsonnet";
 local openmpi = import "kubeflow/openmpi/all.libsonnet";

--- a/kubeflow/openmpi/util.libsonnet
+++ b/kubeflow/openmpi/util.libsonnet
@@ -1,0 +1,17 @@
+{
+  // Convert a comma-delimited string to an array.
+  toArray(str)::
+    if std.type(str) == "string" && str != "null" && std.length(str) > 0 then
+      std.split(str, ",")
+    else [],
+
+  // Convert a comma-delimited string of "key=value" pairs into an object.
+  // For example,
+  //   "key=value" => {key: "value"}
+  //   "key1=value1,key2=value2" => {key1: "value1", key2: "value2"}
+  toObject(str)::
+    if std.type(str) == "string" && str != "null" && std.length(str) > 0 then {
+      [std.splitLimit(keyValue, "=", 1)[0]]: std.splitLimit(keyValue, "=", 1)[1]
+      for keyValue in $.toArray(str)
+    } else [],
+}


### PR DESCRIPTION
cpu: CPU limits per worker.
memory: Memory limits per worker.
initTimeout: Timeout in seconds to abort the initialization.
nodeSelector: Comma-delimited list of "key=value" pairs to select the worker nodes. e.g. "cloud.google.com/gke-accelerator=nvidia-tesla-k80"

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/754)
<!-- Reviewable:end -->
