### PR TITLE
[openmpi] Wait for nvidia driver to be installed before running MPI job

### DIFF
--- a/components/openmpi-controller/Makefile
+++ b/components/openmpi-controller/Makefile
@@ -1,11 +1,13 @@
 # TODO: move to kubeflow
 IMAGE=jiez/openmpi-controller
-TAG=latest
+TAG=0.0.1
+
+default: build push
 
 build:
 	docker build --pull -t ${IMAGE}:${TAG} .
 
-push: build
+push:
 	docker push ${IMAGE}:${TAG}
 
 .PHONY: build push

--- a/components/openmpi-controller/controller/controller.py
+++ b/components/openmpi-controller/controller/controller.py
@@ -1,27 +1,29 @@
 from pathlib import Path
-from time import sleep
 
 from kubernetes import client, config
-from kubernetes.client.rest import ApiException
 from kubernetes.config.config_exception import ConfigException
-from retrying import retry
+from util import log, api_retry, long_poll
 
 SIG_DIR = '.openmpi-controller'
-SIG_TERM = f'{SIG_DIR}/term.sig'
-POLL_STATUS_INTERVAL = 10
-TERMINATED_PHASES = ('Succeeded', 'Failed')
+SIGCONT = f'{SIG_DIR}/SIGCONT'
+SIGTERM = f'{SIG_DIR}/SIGTERM'
+PHASE_SUCCEEDED = 'Succeeded'
+PHASE_FAILED = 'Failed'
+NVIDIA_VERSION_PATH = '/proc/driver/nvidia/version'
 
 
 class Controller:
     """
     Controller is a sidecar container that extends the "main" container (openmpi-job).
     It communicates with the main container using a shared volume mounted at the working directory.
-    Right before it finishes its work, it creates a semaphore file "term.sig" to signal the main container to terminate.
+    It communicates with the master pod using kubernetes API.
     """
 
-    def __init__(self, namespace, master):
+    def __init__(self, namespace, master, num_gpus, timeout_secs):
         self.namespace = namespace
         self.master = master
+        self.num_gpus = num_gpus
+        self.timeout_secs = timeout_secs
         Path(SIG_DIR).mkdir()
 
     def __enter__(self):
@@ -36,24 +38,43 @@ class Controller:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         log('controller exited')
-        Path(SIG_TERM).touch()
+        Path(SIGTERM).touch()
 
-    def wait_master_terminated(self):
-        while True:
-            phase = self._get_master_phase()
-            log(f'{self.master} is in "{phase}" phase')
-            if phase in TERMINATED_PHASES:
-                break
+    def wait_ready(self):
+        if self.num_gpus > 0:
+            self._wait_nvidia_driver_present()
+        Path(SIGCONT).touch()
 
-            sleep(POLL_STATUS_INTERVAL)
+    def wait_done(self):
+        self._wait_master_terminated()
 
-    @retry(stop_max_attempt_number=5,
-           wait_exponential_multiplier=1000,
-           retry_on_exception=lambda e: isinstance(e, ApiException))
-    def _get_master_phase(self):
+    def _wait_nvidia_driver_present(self):
+        log('waiting for nvidia driver to be installed')
+        long_poll(self._poll_nvidia_driver_version, timeout_secs=self.timeout_secs)
+
+    def _wait_master_terminated(self):
+        log('waiting for master to terminate')
+        long_poll(self._poll_master_phase)
+
+    def _poll_nvidia_driver_version(self):
+        # Driver installer is expected to be installed externally.
+        # See https://cloud.google.com/kubernetes-engine/docs/concepts/gpus#installing_drivers for GCP instructions.
+        version_path = Path(NVIDIA_VERSION_PATH)
+        if not version_path.exists():
+            log(f'nvidia driver not found')
+            return None
+        version = version_path.read_text()
+        log(f'nvidia version: {version}')
+        return version
+
+    def _poll_master_phase(self):
+        phase = self._query_master_phase()
+        log(f'{self.master} is in "{phase}" phase')
+        if phase not in (PHASE_SUCCEEDED, PHASE_FAILED):
+            return None
+        return phase
+
+    @api_retry
+    def _query_master_phase(self):
         pod = self.api.read_namespaced_pod(self.master, self.namespace)
         return pod.status.phase
-
-
-def log(msg):
-    print(msg, flush=True)

--- a/components/openmpi-controller/controller/main.py
+++ b/components/openmpi-controller/controller/main.py
@@ -7,10 +7,16 @@ def main():
     parser = ArgumentParser()
     parser.add_argument('--namespace', type=str, required=True)
     parser.add_argument('--master', type=str, required=True)
+    parser.add_argument('--num-gpus', type=int, default=0)
+    parser.add_argument('--timeout-secs', type=int, default=300)
     args = parser.parse_args()
 
-    with Controller(args.namespace, args.master) as ctl:
-        ctl.wait_master_terminated()
+    with Controller(namespace=args.namespace,
+                    master=args.master,
+                    num_gpus=args.num_gpus,
+                    timeout_secs=args.timeout_secs) as ctl:
+        ctl.wait_ready()
+        ctl.wait_done()
 
 
 if __name__ == '__main__':

--- a/components/openmpi-controller/controller/util.py
+++ b/components/openmpi-controller/controller/util.py
@@ -1,0 +1,25 @@
+from kubernetes.client.rest import ApiException
+from retrying import retry
+
+RETRY_MAX_ATTEMPTS = 5
+RETRY_BACKOFF_MS = 1000
+POLL_BACKOFF_MS = 10000
+
+api_retry = retry(stop_max_attempt_number=RETRY_MAX_ATTEMPTS,
+                  wait_exponential_multiplier=RETRY_BACKOFF_MS,
+                  retry_on_exception=lambda e: isinstance(e, ApiException))
+
+
+def log(msg):
+    print(msg, flush=True)
+
+
+def long_poll(poll_fn, timeout_secs=None):
+    @retry(stop_max_delay=timeout_secs * 1000 if timeout_secs else None,
+           wait_fixed=POLL_BACKOFF_MS,
+           retry_on_exception=lambda _: False,
+           retry_on_result=lambda result: not result)
+    def poll_wrapper():
+        return poll_fn()
+
+    return poll_wrapper()

--- a/kubeflow/openmpi/assets/init.sh
+++ b/kubeflow/openmpi/assets/init.sh
@@ -2,9 +2,11 @@ set -exv
 
 OPENMPI_DIR=/kubeflow/openmpi
 BACKOFF_SECS=10
+TIMEOUT_EXIT_CODE=124
 
 wait_mpi_ready() {
-  local max_retries=$1
+  local workers=$1
+  local max_retries=$2
   local retries=0
 
   until mpiexec -n ${workers} --hostfile ${OPENMPI_DIR}/assets/hostfile --allow-run-as-root -q sh -c 'echo $(hostname) is ready'; do
@@ -12,14 +14,23 @@ wait_mpi_ready() {
 
     retries=$(expr ${retries} + 1)
     if [ -n "${max_retries}" ] && [ ${retries} -ge ${max_retries} ]; then
-      exit 124
+      exit ${TIMEOUT_EXIT_CODE}
     fi
   done
 }
 
-wait_controller_term() {
-  until [ -f ${OPENMPI_DIR}/data/.openmpi-controller/term.sig ]; do
+wait_controller_signal() {
+  local signal=$1
+  local max_retries=$2
+  local retries=0
+
+  until [ -f ${OPENMPI_DIR}/data/.openmpi-controller/${signal} ]; do
     sleep ${BACKOFF_SECS}
+
+    retries=$(expr ${retries} + 1)
+    if [ -n "${max_retries}" ] && [ ${retries} -ge ${max_retries} ]; then
+      exit ${TIMEOUT_EXIT_CODE}
+    fi
   done
 }
 
@@ -32,7 +43,7 @@ role="$1"
 workers="$2"
 exec="$3"
 timeout_secs="$4"
-retries=$(expr ${timeout_secs} / ${BACKOFF_SECS})
+max_retries=$(expr ${timeout_secs} / ${BACKOFF_SECS})
 
 # Set up openmpi
 mkdir -p /root/.openmpi
@@ -45,16 +56,22 @@ cp ${OPENMPI_DIR}/secrets/id_rsa.pub /root/.ssh
 cp ${OPENMPI_DIR}/secrets/authorized_keys /root/.ssh
 cp ${OPENMPI_DIR}/assets/ssh_config /root/.ssh/config
 
-# Start sshd in daemon mode
-/usr/sbin/sshd -e -f ${OPENMPI_DIR}/assets/sshd_config
-
 exit_code=0
 if [ "${role}" = "master" ]; then
+  # Wait until workers are ready.
+  wait_mpi_ready ${workers} ${max_retries}
+
   # Run the exec command in master
-  wait_mpi_ready ${retries}
   sh -c "${exec}" || exit_code=$?
 else
-  wait_controller_term
+  # Wait until controller finishes initialization.
+  wait_controller_signal SIGCONT ${max_retries}
+
+  # Start sshd in daemon mode
+  /usr/sbin/sshd -e -f ${OPENMPI_DIR}/assets/sshd_config
+
+  # Block forever until controller terminates.
+  wait_controller_signal SIGTERM
 fi
 
 exit ${exit_code}

--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -14,7 +14,7 @@
 // @optionalParam cpu string null CPU limits per worker.
 // @optionalParam memory string null Memory limits per worker.
 // @optionalParam schedulerName string default-scheduler scheduler name to use for the components.
-// @optionalParam controllerImage string jiez/openmpi-controller:latest Docker image of the openmpi-controller.
+// @optionalParam controllerImage string jiez/openmpi-controller:0.0.1 Docker image of the openmpi-controller.
 // @optionalParam initTimeout number 300 Timeout in seconds to abort the initialization.
 // @optionalParam nodeSelector string null Comma-delimited list of "key=value" pairs to select the worker nodes. e.g. "cloud.google.com/gke-accelerator=nvidia-tesla-k80"
 

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -145,6 +145,10 @@ local ROLE_WORKER = "worker";
         params.namespace,
         "--master",
         $.masterName(params),
+        "--num-gpus",
+        std.toString(params.gpu),
+        "--timeout-secs",
+        std.toString(params.initTimeout),
       ],
       volumeMounts: [
         {


### PR DESCRIPTION
For auto-scaling GPU node pool, the nvidia driver will be installed by [nvidia-driver-installer](https://cloud.google.com/kubernetes-engine/docs/concepts/gpus#installing_drivers).
The MPI job should be kicked off after the driver is present in the container.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/761)
<!-- Reviewable:end -->
