### PR TITLE
[openmpi] make RBAC be optional

### DIFF
--- a/kubeflow/openmpi/all.libsonnet
+++ b/kubeflow/openmpi/all.libsonnet
@@ -1,5 +1,6 @@
 local assets = import "kubeflow/openmpi/assets.libsonnet";
 local service = import "kubeflow/openmpi/service.libsonnet";
+local serviceaccount = import "kubeflow/openmpi/serviceaccount.libsonnet";
 local workloads = import "kubeflow/openmpi/workloads.libsonnet";
 
 {
@@ -17,6 +18,7 @@ local workloads = import "kubeflow/openmpi/workloads.libsonnet";
     all::
       assets.all(updatedParams)
       + service.all(updatedParams)
+      + serviceaccount.all(updatedParams)
       + workloads.all(updatedParams),
   },
 }

--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -13,6 +13,7 @@
 // @optionalParam gpu number 0 Number of GPUs per worker.
 // @optionalParam cpu string null CPU limits per worker.
 // @optionalParam memory string null Memory limits per worker.
+// @optionalParam serviceAccountName string null the service account name to run pods. The service account should have clusterRoleBinding for "view" ClusterRole.  If it was not set, service account and its role binding will be created automatically.
 // @optionalParam schedulerName string default-scheduler scheduler name to use for the components.
 // @optionalParam controllerImage string jiez/openmpi-controller:0.0.1 Docker image of the openmpi-controller.
 // @optionalParam initTimeout number 300 Timeout in seconds to abort the initialization.

--- a/kubeflow/openmpi/service.libsonnet
+++ b/kubeflow/openmpi/service.libsonnet
@@ -1,8 +1,6 @@
 {
   all(params):: [
     $.service(params),
-    $.serviceAccount(params),
-    $.clusterRoleBinding(params),
   ],
 
   name(params):: params.name,
@@ -30,41 +28,5 @@
       },
       clusterIP: "None",
     },
-  },
-
-  serviceAccount(params):: {
-    kind: "ServiceAccount",
-    apiVersion: "v1",
-    metadata: {
-      name: $.name(params),
-      namespace: params.namespace,
-      labels: {
-        app: params.name,
-      },
-    },
-  },
-
-  clusterRoleBinding(params):: {
-    kind: "ClusterRoleBinding",
-    apiVersion: "rbac.authorization.k8s.io/v1",
-    metadata: {
-      name: $.name(params),
-      namespace: params.namespace,
-      labels: {
-        app: params.name,
-      },
-    },
-    roleRef: {
-      apiGroup: "rbac.authorization.k8s.io",
-      kind: "ClusterRole",
-      name: "view",
-    },
-    subjects: [
-      {
-        kind: "ServiceAccount",
-        name: $.name(params),
-        namespace: params.namespace,
-      },
-    ],
   },
 }

--- a/kubeflow/openmpi/serviceaccount.libsonnet
+++ b/kubeflow/openmpi/serviceaccount.libsonnet
@@ -1,0 +1,46 @@
+local service = import "kubeflow/openmpi/service.libsonnet";
+
+{
+  all(params):: if params.serviceAccountName == "null" then [
+    $.serviceAccount(params),
+    $.clusterRoleBinding(params),
+  ] else [],
+
+  name(params):: if params.serviceAccountName == "null" then service.name(params) else params.serviceAccountName,
+
+  serviceAccount(params):: {
+    kind: "ServiceAccount",
+    apiVersion: "v1",
+    metadata: {
+      name: $.name(params),
+      namespace: params.namespace,
+      labels: {
+        app: params.name,
+      },
+    },
+  },
+
+  clusterRoleBinding(params):: {
+    kind: "ClusterRoleBinding",
+    apiVersion: "rbac.authorization.k8s.io/v1",
+    metadata: {
+      name: $.name(params),
+      namespace: params.namespace,
+      labels: {
+        app: params.name,
+      },
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "view",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: $.name(params),
+        namespace: params.namespace,
+      },
+    ],
+  },
+}

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -1,5 +1,6 @@
 local assets = import "kubeflow/openmpi/assets.libsonnet";
 local service = import "kubeflow/openmpi/service.libsonnet";
+local serviceaccount = import "kubeflow/openmpi/serviceaccount.libsonnet";
 local util = import "kubeflow/openmpi/util.libsonnet";
 
 local ROLE_MASTER = "master";
@@ -44,7 +45,7 @@ local ROLE_WORKER = "worker";
       schedulerName: params.schedulerName,
       volumes: $.volumes(params),
       containers: $.containers(params, role),
-      serviceAccountName: service.name(params),
+      serviceAccountName: serviceaccount.name(params),
       nodeSelector: $.nodeSelector(params, role),
     },
   },


### PR DESCRIPTION
## What is the problem?
openmpi package _always_ creates a `ServiceAccount` and its `ClusterRoleBinding`.

However, end users who run this in batch mode sometimes are NOT allowed to create them by cluster administrator because the permission, granting `create` `ServcieAccount` and `ClusterRoleBinding`, is too strong.  Particularly, granting `create` for `ClusterRoleBinding` resources to some users nearly equal to give cluster admin rights to them. 

_NOTE: Actually openmpi prototype can work correctly if its service account can at least `get` for `pods` resources.  However I would like to handle this issue with another PR._

## How the PR fixes the problem

- introduce `serviceAccountName` paramter to openmpi prototype.  Users can specify service account name which would be provisioned by cluster administrators.  its default value is `"null"` (similar to other params).
- if it is not set ( `== "null"`), `ServiceAccount` and its `ClusterRoleBinding` will be create automatically.
- `serviceaccount.libsonnet` was introduced to define `ServiceAccount` and its `ClusterRoleBinding` because RBAC related entities is not related to `Service`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/764)
<!-- Reviewable:end -->
