### PR TITLE
Create an examples package in kubeflow

### DIFF
--- a/kubeflow/examples/parts.yaml
+++ b/kubeflow/examples/parts.yaml
@@ -1,0 +1,22 @@
+{
+   "name": "kubeflow examples",
+   "apiVersion": "0.0.1",
+   "kind": "ksonnet.io/parts",
+   "description": "kubeflow examples.\n",
+   "author": "kubeflow-team <kubeflow-discuss@googlegroups.com>",
+   "contributors": [
+   ],
+   "repository": {
+      "type": "git",
+      "url": "https://github.com/kubeflow/kubeflow"
+   },
+   "bugs": {
+      "url": "https://github.com/kubeflow/kubeflow/issues"
+   },
+   "keywords": [
+      "kubernetes",
+      "kubeflow",
+      "machine learning"
+   ],
+   "license": "Apache 2.0",
+}

--- a/kubeflow/examples/prototypes/tf-job-simple.jsonnet
+++ b/kubeflow/examples/prototypes/tf-job-simple.jsonnet
@@ -1,0 +1,90 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.tf-job-simple
+// @description tf-job-simple
+// @shortDescription A simple TFJob to run CNN benchmark
+// @param name string Name to give to each of the components
+
+local k = import "k.libsonnet";
+
+local namespace = "default";
+local image = "gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3";
+
+local tfjob = {
+  apiVersion: "kubeflow.org/v1alpha1",
+  kind: "TFJob",
+  metadata: {
+    name: "mycnnjob",
+    namespace: namespace,
+  },
+  spec: {
+    replicaSpecs: [
+      {
+        replicas: 1,
+        template: {
+          spec: {
+            containers: [
+              {
+                args: [
+                  "python",
+                  "tf_cnn_benchmarks.py",
+                  "--batch_size=32",
+                  "--model=resnet50",
+                  "--variable_update=parameter_server",
+                  "--flush_stdout=true",
+                  "--num_gpus=1",
+                  "--local_parameter_device=cpu",
+                  "--device=cpu",
+                  "--data_format=NHWC",
+                ],
+                image: image,
+                name: "tensorflow",
+                workingDir: "/opt/tf-benchmarks/scripts/tf_cnn_benchmarks",
+              },
+            ],
+            restartPolicy: "OnFailure",
+          },
+        },
+        tfReplicaType: "WORKER",
+      },
+      {
+        replicas: 1,
+        template: {
+          spec: {
+            containers: [
+              {
+                args: [
+                  "python",
+                  "tf_cnn_benchmarks.py",
+                  "--batch_size=32",
+                  "--model=resnet50",
+                  "--variable_update=parameter_server",
+                  "--flush_stdout=true",
+                  "--num_gpus=1",
+                  "--local_parameter_device=cpu",
+                  "--device=cpu",
+                  "--data_format=NHWC",
+                ],
+                image: image,
+                name: "tensorflow",
+                workingDir: "/opt/tf-benchmarks/scripts/tf_cnn_benchmarks",
+              },
+            ],
+            restartPolicy: "OnFailure",
+          },
+        },
+        tfReplicaType: "PS",
+      },
+    ],
+    terminationPolicy: {
+      chief: {
+        replicaIndex: 0,
+        replicaName: "WORKER",
+      },
+    },
+    tfimage: image,
+  },
+};
+
+k.core.v1.list.new([
+  tfjob,
+])

--- a/kubeflow/examples/prototypes/tf-serving-simple.jsonnet
+++ b/kubeflow/examples/prototypes/tf-serving-simple.jsonnet
@@ -1,0 +1,94 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.tf-serving-simple
+// @description tf-serving-simple
+// @shortDescription tf-serving-simple
+// @param name string Name to give to each of the components
+
+local k = import "k.libsonnet";
+
+local namespace = "default";
+local appName = "tf-serving-simple";
+local modelBasePath = "gs://kubeflow-models/inception";
+local modelName = "inception";
+local image = "gcr.io/kubeflow-images-public/tf-model-server-cpu:v20180327-995786ec";
+
+local service = {
+  apiVersion: "v1",
+  kind: "Service",
+  metadata: {
+    labels: {
+      app: appName,
+    },
+    name: appName,
+    namespace: namespace,
+  },
+  spec: {
+    ports: [
+      {
+        name: "grpc-tf-serving",
+        port: 9000,
+        targetPort: 9000,
+      },
+    ],
+    selector: {
+      app: appName,
+    },
+    type: "ClusterIP",
+  },
+};
+
+local deployment = {
+  apiVersion: "extensions/v1beta1",
+  kind: "Deployment",
+  metadata: {
+    labels: {
+      app: appName,
+    },
+    name: appName,
+    namespace: namespace,
+  },
+  spec: {
+    template: {
+      metadata: {
+        labels: {
+          app: appName,
+        },
+      },
+      spec: {
+        containers: [
+          {
+            args: [
+              "/usr/bin/tensorflow_model_server",
+              "--port=9000",
+              "--model_name=" + modelName,
+              "--model_base_path=" + modelBasePath,
+            ],
+            image: image,
+            imagePullPolicy: "IfNotPresent",
+            name: "inception",
+            ports: [
+              {
+                containerPort: 9000,
+              },
+            ],
+            resources: {
+              limits: {
+                cpu: "4",
+                memory: "4Gi",
+              },
+              requests: {
+                cpu: "1",
+                memory: "1Gi",
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+k.core.v1.list.new([
+  service,
+  deployment,
+])

--- a/kubeflow/examples/prototypes/tf-serving-with-istio.jsonnet
+++ b/kubeflow/examples/prototypes/tf-serving-with-istio.jsonnet
@@ -102,6 +102,9 @@ local deployment = {
         labels: {
           app: appName,
         },
+        annotations: {
+          "sidecar.istio.io/inject": "true",
+        },
       },
       spec: {
         containers: [

--- a/kubeflow/examples/prototypes/tf-serving-with-istio.jsonnet
+++ b/kubeflow/examples/prototypes/tf-serving-with-istio.jsonnet
@@ -1,0 +1,176 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.tf-serving-with-istio
+// @description tf-serving-with-istio
+// @shortDescription tf-serving-with-istio
+// @param name string Name to give to each of the components
+
+local k = import "k.libsonnet";
+
+local namespace = "default";
+local appName = "tf-serving-with-istio";
+local modelBasePath = "gs://kubeflow-models/inception";
+local modelName = "inception";
+local image = "gcr.io/kubeflow-images-public/tf-model-server-cpu:v20180327-995786ec";
+local httpProxyImage = "gcr.io/kubeflow-images-public/tf-model-server-http-proxy:v20180327-995786ec";
+
+local routeRule = {
+  apiVersion: "config.istio.io/v1alpha2",
+  kind: "RouteRule",
+  metadata: {
+    name: appName,
+    namespace: namespace,
+  },
+  spec: {
+    destination: {
+      name: "tf-serving",
+    },
+    precedence: 0,
+    route: [
+      {
+        labels: {
+          version: "v1",
+        },
+      },
+    ],
+  },
+};
+
+local service = {
+  apiVersion: "v1",
+  kind: "Service",
+  metadata: {
+    annotations: {
+      "getambassador.io/config":
+        std.join("\n", [
+          "---",
+          "apiVersion: ambassador/v0",
+          "kind:  Mapping",
+          "name: tfserving-mapping-tf-serving-get",
+          "prefix: /models/tf-serving/",
+          "rewrite: /",
+          "method: GET",
+          "service: tf-serving." + namespace + ":8000",
+          "---",
+          "apiVersion: ambassador/v0",
+          "kind:  Mapping",
+          "name: tfserving-mapping-tf-serving-post",
+          "prefix: /models/tf-serving/",
+          "rewrite: /model/tf-serving:predict",
+          "method: POST",
+          "service: tf-serving." + namespace + ":8000",
+        ]),
+    },
+    labels: {
+      app: appName,
+    },
+    name: appName,
+    namespace: namespace,
+  },
+  spec: {
+    ports: [
+      {
+        name: "grpc-tf-serving",
+        port: 9000,
+        targetPort: 9000,
+      },
+      {
+        name: "http-tf-serving-proxy",
+        port: 8000,
+        targetPort: 8000,
+      },
+    ],
+    selector: {
+      app: appName,
+    },
+    type: "ClusterIP",
+  },
+};
+
+local deployment = {
+  apiVersion: "extensions/v1beta1",
+  kind: "Deployment",
+  metadata: {
+    labels: {
+      app: appName,
+    },
+    name: appName,
+    namespace: namespace,
+  },
+  spec: {
+    template: {
+      metadata: {
+        labels: {
+          app: appName,
+        },
+      },
+      spec: {
+        containers: [
+          {
+            args: [
+              "/usr/bin/tensorflow_model_server",
+              "--port=9000",
+              "--model_name=" + modelName,
+              "--model_base_path=" + modelBasePath,
+            ],
+            image: image,
+            imagePullPolicy: "IfNotPresent",
+            name: "inception",
+            ports: [
+              {
+                containerPort: 9000,
+              },
+            ],
+            resources: {
+              limits: {
+                cpu: "4",
+                memory: "4Gi",
+              },
+              requests: {
+                cpu: "1",
+                memory: "1Gi",
+              },
+            },
+          },
+          {
+            name: appName + "-http-proxy",
+            image: httpProxyImage,
+            imagePullPolicy: "IfNotPresent",
+            command: [
+              "python",
+              "/usr/src/app/server.py",
+              "--port=8000",
+              "--rpc_port=9000",
+              "--rpc_timeout=10.0",
+            ],
+            env: [],
+            ports: [
+              {
+                containerPort: 8000,
+              },
+            ],
+            resources: {
+              requests: {
+                memory: "1Gi",
+                cpu: "1",
+              },
+              limits: {
+                memory: "4Gi",
+                cpu: "4",
+              },
+            },
+            securityContext: {
+              runAsUser: 1000,
+              fsGroup: 1000,
+            },
+          },
+        ],
+      },
+    },
+  },
+};
+
+k.core.v1.list.new([
+  routeRule,
+  service,
+  deployment,
+])


### PR DESCRIPTION
examples package is intended to contain self-contained prototypes for
deploying tf-job, tf-serving, etc.

The idea is that users should be able to fully customize and extend
these prototypes by modifying the jsonnet

Fixes https://github.com/kubeflow/kubeflow/issues/564

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/768)
<!-- Reviewable:end -->
