### PR TITLE
[openmpi] support `imagePullSecrets`

### DIFF
--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -10,6 +10,7 @@
 // @optionalParam init string null Command to bootstrap the containers. Defaults to init.sh.
 // @optionalParam exec string null Command to execute in master after bootstrap is done. It sleeps indefinitely if not set.
 // @optionalParam imagePullPolicy string IfNotPresent Image pull policy (either IfNotPresent or Always).
+// @optionalParam imagePullSecrets string null Comma-delimited list of secret names to use credentials in pulling your docker images.
 // @optionalParam gpu number 0 Number of GPUs per worker.
 // @optionalParam cpu string null CPU limits per worker.
 // @optionalParam memory string null Memory limits per worker.

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -45,6 +45,7 @@ local ROLE_WORKER = "worker";
       schedulerName: params.schedulerName,
       volumes: $.volumes(params),
       containers: $.containers(params, role),
+      imagePullSecrets: [{ name: secret } for secret in util.toArray(params.imagePullSecrets)],
       serviceAccountName: serviceaccount.name(params),
       nodeSelector: $.nodeSelector(params, role),
     },


### PR DESCRIPTION
## What is the problem?

When using openmpi package, end users often build their own docker images which would contain some their custom code and these images are possibly published to private repositories.

But, openmpi package doesn't support `imagePullSecrets` section so users can not pull from private repositories.  

## How the PR fixes it
In Kubernetes, I think there are two ways to pull private images.

- [Add ImagePullSecrets to a service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#add-imagepullsecrets-to-a-service-account)
- [Create a Pod that uses your Secret](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/#create-a-pod-that-uses-your-secret)

The first one(add secrets to service accounts) would need a strong permission, that is `edit` for `serviceaccoutns` resources.  This operation would be kind of administrative operaiotns.  Thus, end users would not have such permission.  So, I prefer to support the second one.

So, the PR 

- introduce `imagePullSecrets` parameter.  This should be comma separated secret names to pull private imags.  The parameter will be expanded to `imagePullSecrets` secition to pods definition.
- If not set (`=="null"`),   no secret would be fed to pods

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/771)
<!-- Reviewable:end -->
