### PR TITLE
[openmpi] Add custom resources support

### DIFF
--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -13,6 +13,7 @@
 // @optionalParam gpu number 0 Number of GPUs per worker.
 // @optionalParam cpu string null CPU limits per worker.
 // @optionalParam memory string null Memory limits per worker.
+// @optionalParam customResources string null Comma-delimited list of "resourceName=amount" pairs which you want to limit per worker.
 // @optionalParam serviceAccountName string null the service account name to run pods. The service account should have clusterRoleBinding for "view" ClusterRole.  If it was not set, service account and its role binding will be created automatically.
 // @optionalParam schedulerName string default-scheduler scheduler name to use for the components.
 // @optionalParam controllerImage string jiez/openmpi-controller:0.0.1 Docker image of the openmpi-controller.

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -99,7 +99,7 @@ local ROLE_WORKER = "worker";
       name: "openmpi-job",
       image: params.image,
       imagePullPolicy: params.imagePullPolicy,
-      resources: $.resources(params, role),
+      resources: std.mergePatch($.resources(params, role), $.customResources(params, role)),
       terminationMessagePath: "/dev/termination-log",
       terminationMessagePolicy: "File",
       workingDir: "/kubeflow/openmpi/data",
@@ -173,4 +173,9 @@ local ROLE_WORKER = "worker";
 
   nodeSelector(params, role)::
     if role == ROLE_WORKER then util.toObject(params.nodeSelector) else {},
+
+  customResources(params, role)::
+    if role == ROLE_WORKER then {
+      limits: util.toObject(params.customResources),
+    } else {},
 }


### PR DESCRIPTION
## Motivation
Machine learning tasks sometimes require special hardware.  Currently we operate several custom resources on our on-premise Kubernetes cluster to run distributed machine learning tasks (with openmpi package) which requires special hardware other than GPUs.  

## How

- introduce `customResources` parameter.   This specifies custom resources to assign `openmpi-job` containers in worker pods.
- The value should be comma separated list of `custom-resource-name=amount`.  

## Note
This feature doesn't break any backward compatibility.  So I would be very happy if it could be merged to the official repo.  But I'm not sure that such general custom resources feature should be supported in this package.  I am happy if I could have feedbacks.

Development of device plugin in kubernetes repository seems to be  very active now.  They would introduce special hardware support officially [in the near future](https://github.com/kubernetes/kubernetes/issues/53497).  For example, FPGA, Solarflare NICs, Infiniband, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/772)
<!-- Reviewable:end -->
