### PR TITLE
[tf-job] support image pull secrets

### DIFF
--- a/kubeflow/tf-job/tf-job.libsonnet
+++ b/kubeflow/tf-job/tf-job.libsonnet
@@ -1,8 +1,9 @@
 local k = import "k.libsonnet";
+local util = import "util.libsonnet";
 
 {
   parts:: {
-    tfJobReplica(replicaType, number, args, image, numGpus=0)::
+    tfJobReplica(replicaType, number, args, image, imagePullSecrets=[], numGpus=0)::
       local baseContainer = {
         image: image,
         name: "tensorflow",
@@ -24,6 +25,7 @@ local k = import "k.libsonnet";
           replicas: number,
           template: {
             spec: {
+              imagePullSecrets: [{ name: secret } for secret in util.toArray(imagePullSecrets)],
               containers: [
                 baseContainer + containerArgs + resources,
               ],

--- a/kubeflow/tf-job/util.libsonnet
+++ b/kubeflow/tf-job/util.libsonnet
@@ -1,0 +1,7 @@
+{
+  // Convert a comma-delimited string to an array.
+  toArray(str)::
+    if std.type(str) == "string" && str != "null" && std.length(str) > 0 then
+      std.split(str, ",")
+    else [],
+}


### PR DESCRIPTION
as @inc0 proposed in https://github.com/kubeflow/kubeflow/pull/771#pullrequestreview-118363134

This PR adds the support of `imagePullSecrets` (parameter name is actually in snake case) to two prototypes(`io.ksonnet.pkg.tf-job`, `io.ksonnet.pkg.tf-cnn`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/785)
<!-- Reviewable:end -->
