### PR TITLE
Initial set of deployment manager configs for creating a GKE cluster to run Kubeflow

### DIFF
--- a/docs/gke/configs/cluster-kubeflow.yaml
+++ b/docs/gke/configs/cluster-kubeflow.yaml
@@ -1,0 +1,33 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: cluster.jinja
+
+resources:
+- name: kubeflow
+  type: cluster.jinja
+  properties:
+    zone: us-east1-d
+    # We create a very small initial pool.
+    # Actual nodes will be managed as additional node pools.
+    initialNodeCount: 1
+    # An arbitrary string appending to name of nodepools
+    # bump this if you want to modify the node pools.
+    # This will cause existing node pools to be deleted and new ones to be created.
+    # Use prefix v so it will be treated as a string.
+    pool-version: v1
+    # Two is small enough to fit within default quota.
+    cpu-pool-initialNodeCount: 2
+    gpu-pool-initialNodeCount: 0    

--- a/docs/gke/configs/cluster.jinja
+++ b/docs/gke/configs/cluster.jinja
@@ -1,0 +1,146 @@
+{#
+Copyright 2016 Google Inc. All rights reserved.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+#}
+
+
+{% set NAME_PREFIX = env['deployment'] + '-' + env['name'] %}
+{% set CLUSTER_NAME = env['name'] %}
+{% set TYPE_NAME = NAME_PREFIX + '-type' %}
+{% set K8S_ENDPOINTS = {'': 'api/v1', '-v1beta1-extensions': 'apis/extensions/v1beta1'} %}
+{% set CPU_POOL = 'cpu-pool-' + properties['pool-version'] %}
+{% set GPU_POOL = 'gpu-pool-' + properties['pool-version'] %}
+
+resources:
+- name: {{ CLUSTER_NAME }}
+  type: container.v1.cluster
+  properties:
+    zone: {{ properties['zone'] }}
+    cluster:
+      name: {{ CLUSTER_NAME }}
+      # 
+      initialNodeCount: {{ properties['initialNodeCount'] }}
+      # We need 1.9 to support GPUs without requiring Alpha.
+      initialClusterVersion: 1.9.6-gke.1
+      nodeConfig:
+        oauthScopes:        
+        - https://www.googleapis.com/auth/compute
+        - https://www.googleapis.com/auth/devstorage.read_only
+        - https://www.googleapis.com/auth/logging.write
+        - https://www.googleapis.com/auth/monitoring
+
+# We manage the node pools as separate resources.
+# We do this so that if we want to make changes we can delete the existing resource and then recreate it.
+# Updating doesn't work so well because we are limited in what changes GKE's update method supports.
+
+- name: cpu-pool-{{ properties['pool-version'] }}
+  type: container.v1.nodePool
+  properties:
+    project: {{ properties['project'] }}
+    zone: {{ properties['zone'] }}
+    clusterId: {{ CLUSTER_NAME }}
+    nodePool:
+      name: cpu-pool      
+      initialNodeCount: {{ properties['cpu-pool-initialNodeCount'] }}
+      config:          
+        machineType: n1-standard-8
+        oauthScopes:
+          - https://www.googleapis.com/auth/compute
+          - https://www.googleapis.com/auth/devstorage.read_only
+          - https://www.googleapis.com/auth/logging.write
+          - https://www.googleapis.com/auth/monitoring
+
+  metadata:
+    dependsOn:
+    - {{ CLUSTER_NAME }}
+
+- name: {{ GPU_POOL }}
+  type: container.v1.nodePool
+  properties:
+    project: {{ properties['project'] }}
+    zone: {{ properties['zone'] }}
+    clusterId: {{ CLUSTER_NAME }}
+    nodePool:
+      name: gpu-pool      
+      initialNodeCount: {{ properties['gpu-pool-initialNodeCount'] }}
+      config:          
+        machineType: n1-standard-8
+        oauthScopes:
+        # Attaching cloud-platform scope to nodes is not good practice
+        # But it simplifies demos.
+          - https://www.googleapis.com/auth/cloud-platform
+          - https://www.googleapis.com/auth/compute
+          - https://www.googleapis.com/auth/devstorage.read_only
+          - https://www.googleapis.com/auth/logging.write
+          - https://www.googleapis.com/auth/monitoring
+        accelerators:
+          - acceleratorCount: 1
+            acceleratorType: nvidia-tesla-k80
+
+  metadata:
+    dependsOn:
+    # We can only create 1 node pool at a time.
+    - {{ CPU_POOL }}
+
+- name: static-ip
+  type: compute.v1.globalAddress
+  properties:
+    project: {{ properties['project'] }}
+    name: {{ CLUSTER_NAME }}
+    description: "Static IP for ingress."
+
+
+{#
+
+Define TypeProviders for different K8s endpoints. 
+https://cloud.google.com/deployment-manager/docs/configuration/type-providers/process-adding-api
+This allows K8s resources to be created using Deployment manager.
+We use this to create the minimal resources needed to startup and deploy Kubeflow via the bootstrapper;
+e.g. creating namespaces, service accounts, stateful set to run the bootstrapper.
+
+#}
+{% for typeSuffix, endpoint in K8S_ENDPOINTS.iteritems() %}
+- name: {{ TYPE_NAME }}{{ typeSuffix }}
+  type: deploymentmanager.v2beta.typeProvider
+  properties:
+    options:
+      validationOptions:
+        # Kubernetes API accepts ints, in fields they annotate with string.
+        # This validation will show as warning rather than failure for
+        # Deployment Manager.
+        # https://github.com/kubernetes/kubernetes/issues/2971
+        schemaValidation: IGNORE_WITH_WARNINGS
+      # According to kubernetes spec, the path parameter 'name'
+      # should be the value inside the metadata field
+      # https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md
+      # This mapping specifies that
+      inputMappings:
+      - fieldName: name
+        location: PATH
+        methodMatch: ^(GET|DELETE|PUT)$
+        value: $.ifNull($.resource.properties.metadata.name, $.resource.name)
+      - fieldName: metadata.name
+        location: BODY
+        methodMatch: ^(PUT|POST)$
+        value: $.ifNull($.resource.properties.metadata.name, $.resource.name)
+      - fieldName: Authorization
+        location: HEADER
+        value: >
+          $.concat("Bearer ", $.googleOauth2AccessToken())
+    descriptorUrl: https://$(ref.{{ CLUSTER_NAME }}.endpoint)/swaggerapi/{{ endpoint }}
+{% endfor %}
+
+outputs:
+{% for typeSuffix, endpoint in K8S_ENDPOINTS.iteritems() %}
+- name: clusterType{{ typeSuffix }}
+  value: {{ TYPE_NAME }}{{ typeSuffix }}
+{% endfor %}
+

--- a/docs/gke/configs/cluster.jinja.schema
+++ b/docs/gke/configs/cluster.jinja.schema
@@ -1,0 +1,42 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  title: GKE cluster
+  author: Google, Inc.
+  description: |
+    Creates a GKE cluster and associated type for use in DM. The type can be
+    used in other DM configurations in the following manner:
+
+    "type: <cluster-type>:/api/v1/namespaces/{namespace}/services"
+
+required:
+- zone
+
+properties:
+  zone:
+    type: string
+    description: Zone in which the cluster should run.
+  initialNodeCount:
+    type: integer
+    description: Initial number of nodes desired in the cluster.
+    default: 4
+
+outputs:
+  clusterType:
+    description: The name of the type provider which can create resources from the Kubernetes v1 API in your cluster.
+    type: string
+  clusterType-v1beta1-extensions:
+    description: The name of the type provider which can create resources from the Kubernetes v1beta1-extensions API in your cluster.
+    type: string

--- a/docs/gke/configs/env-kubeflow.sh
+++ b/docs/gke/configs/env-kubeflow.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# Script that defines various environment variables.
+# This is script defines values for all the variables used in
+# the instructions.
+
+# Bucket and project must be unique for each project 
+
+# Set PROJECT to the project you want to use with Kubeflow.
+export PROJECT=kubeflow
+
+# The name of the ip address as defined in cluster.jinja
+# We will reserve a GCP IP address to use for ingress to the cluster.
+export IP_NAME=static-ip
+
+# Set the namespace to the name of the namespace to deploy Kubeflow in.
+export NAMESPACE=kubeflow
+
+# Set config file to the YAML file defining your deployment manager configs.
+export CONFIG_FILE=cluster-${PROJECT}.yaml
+
+# ksonnet environment
+#export ENV=${PROJECT}
+
+# The fully qualified domain name to use with ingress.
+# You only need to set this if you want to use a custom domain
+# with ingress as opposed to an automatic domain for your project.
+# TODO(jlewi): What is the automatic domain name.
+#export FQDN=${PROJECT}.kubeflow.dev

--- a/docs/gke/gke_setup.md
+++ b/docs/gke/gke_setup.md
@@ -1,0 +1,60 @@
+# Deploying Kubeflow On GKE
+
+Instructions for optimizing Kubeflow for GKE.
+
+These instructions take advantage of [Google Cloud Deployment Manager](https://cloud.google.com/deployment-manager/docs/)
+to manage your GKE cluster and other GCP resources that you might want to use with Kubeflow.
+
+The instructions also take advantage of IAP to provide secure authenticated access web-apps running as part of Kubeflow.
+
+## To Setup the cluster
+
+### Create the Cluster
+1.  Make a copy of the `configs` directory
+
+	* Its a good idea to check this into source control to make it easy to version and rollback your configs.
+
+1. Modify `cluster-kubeflow.yaml`
+
+	* Set the zone for your cluster
+	* Change the initial number of nodes if desired
+
+		* If you want GPUs set a non-zero number for number of GPU nodes.
+
+1. Modify `env-kubeflow.sh`
+
+	* This file defines environment variables used in the commands below
+	* We recommend checking a modified version into source control so its easy to source and repeat the commands.
+
+1. Create the cluster
+
+```
+. env-kubeflow.sh
+gcloud deployment-manager --project=${PROJECT} deployments create ${PROJECT} --config=${CONFIG_FILE}
+```
+
+### Setup GPUs
+
+```
+kubectl create -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/k8s-1.9/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+```
+
+TODO(jlewi): This should be created by either the ksonnet APP or deployment manager.
+
+### Setup RBAC
+
+```
+gcloud --project=${PROJECT} container clusters get-credentials --zone=${ZONE} ${CLUSTER}
+kubectl create clusterrolebinding cluster-admin-binding-${USER} \
+--clusterrole cluster-admin --user $(gcloud config get-value account)
+```
+
+TODO(jlewi): Can we do this using deployment manager?
+
+### Prepare IAP
+
+TODO(jlewi): Pull in [instructions](https://github.com/kubeflow/kubeflow/blob/master/docs/gke/iap.md#create-oauth-client-credentials) to setup IAP. We should describe using a custom domain as well as using Cloud Endpoints provided domain.
+
+## Deploying Kubeflow
+
+TODO(jlewi): Add instructions about running the bootstrapper to create ksonnet app and deploy Kubeflow.

--- a/docs/gke/testing/deploy.sh
+++ b/docs/gke/testing/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# 
+# A simple script to create the GCP deployment config.

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -16,4 +16,7 @@ workflows:
   - app_dir: kubeflow/kubeflow/components/k8s-model-server/images/releaser
     component: workflows
     name: tf-serving-image
-
+  # Run GKE deploy tests
+  - app_dir: kubeflow/kubeflow/testing/workflows
+    component: gke_deploy
+    name: kubeflow-gke-deploy

--- a/testing/workflows/app.yaml
+++ b/testing/workflows/app.yaml
@@ -1,11 +1,11 @@
 apiVersion: 0.1.0
 environments:
-  kubeflow-ci:
+  kubeflow-testing:
     destination:
       namespace: kubeflow-test-infra
-      server: https://35.185.54.227
+      server: https://35.196.213.148
     k8sVersion: v1.7.0
-    path: kubeflow-ci
+    path: kubeflow-testing
   prow:
     destination:
       namespace: kubeflow-testing

--- a/testing/workflows/components/gke_deploy.jsonnet
+++ b/testing/workflows/components/gke_deploy.jsonnet
@@ -1,6 +1,6 @@
 // E2E test for deploying Kubeflow on GKE.
 // The test ensures we can probably setup GKE using deployment manager.
-local params = std.extVar("__ksonnet/params").components.workflows;
+local params = std.extVar("__ksonnet/params").components["gke_deploy"];
 
 local k = import "k.libsonnet";
 local gke_deploy = import "gke_deploy.libsonnet";

--- a/testing/workflows/components/gke_deploy.jsonnet
+++ b/testing/workflows/components/gke_deploy.jsonnet
@@ -1,6 +1,6 @@
 // E2E test for deploying Kubeflow on GKE.
 // The test ensures we can probably setup GKE using deployment manager.
-local params = std.extVar("__ksonnet/params").components["gke_deploy"];
+local params = std.extVar("__ksonnet/params").components.gke_deploy;
 
 local k = import "k.libsonnet";
 local gke_deploy = import "gke_deploy.libsonnet";

--- a/testing/workflows/components/gke_deploy.jsonnet
+++ b/testing/workflows/components/gke_deploy.jsonnet
@@ -1,0 +1,10 @@
+// E2E test for deploying Kubeflow on GKE.
+// The test ensures we can probably setup GKE using deployment manager.
+local params = std.extVar("__ksonnet/params").components.workflows;
+
+local k = import "k.libsonnet";
+local gke_deploy = import "gke_deploy.libsonnet";
+
+local prowEnv = gke_deploy.parseEnv(params.prow_env);
+local bucket = params.bucket;
+std.prune(k.core.v1.list.new([gke_deploy.parts(params).e2e(prowEnv, bucket, params.platform)]))

--- a/testing/workflows/components/gke_deploy.libsonnet
+++ b/testing/workflows/components/gke_deploy.libsonnet
@@ -20,20 +20,21 @@
     else [],
 
   listToDict:: function(v)
-    {      
+    {
       local name = v[0],
       // v[0]: v[1],
-      [ v[0] ]: v[1],
+      [v[0]]: v[1],
     },
 
   // parseEnvToMap takes a string "key1=value1,key2=value2,..."
   // and turns it into an object with keys key1, key2, ... and values value1,...,value2
-  parseEnvToMap::function(v)
+  parseEnvToMap:: function(v)
     local pieces = std.split(v, ",");
     if v != "" && std.length(pieces) > 0 then
       std.foldl(
         function(a, b) a + $.listToDict(std.split(b, "=")),
-        pieces, {}
+        pieces,
+        {}
       )
     else {},
 
@@ -89,11 +90,12 @@
 
       // Common commands that should be executed before running gcloud commands.
       local commonCommands = [
-              "set -x",
-              "&&",
-              "gcloud auth activate-service-account --key-file=/secret/gcp-credentials/key.json",
-              "&&",
-              "gcloud config list",];
+        "set -x",
+        "&&",
+        "gcloud auth activate-service-account --key-file=/secret/gcp-credentials/key.json",
+        "&&",
+        "gcloud config list",
+      ];
 
       // Build an Argo template to execute a particular command.
       // step_name: Name for the template
@@ -203,9 +205,9 @@
                     name: "create-deployment",
                     template: "create-deployment",
                     dependencies: [
-                          "checkout",
+                      "checkout",
                     ],
-                  },                  
+                  },
                 ]),  // tasks
               },  // dag
             },  // e2e template
@@ -215,7 +217,7 @@
                 tasks: [
                   {
                     name: "teardown",
-                    template: "delete-deployment",                        
+                    template: "delete-deployment",
                   },
                   {
                     name: "copy-artifacts",
@@ -226,7 +228,7 @@
               },  // dag
             },  // exit-handler
             // TODO(jlewi): We need to modify cluster-kubeflow.yaml to set things like the project
-            // and cluster name. 
+            // and cluster name.
             buildTemplate(
               "checkout",
               ["/usr/local/bin/checkout.sh", srcRootDir],
@@ -237,35 +239,40 @@
               [],  // no sidecars
             ),
             buildTemplate("create-deployment", [
-              "bash", "-c",
+              "bash",
+              "-c",
               std.join(
-              " ",
-              commonCommands + [
-              "&&",
-              "gcloud", 
-              "deployment-manager",
-              "--project=" + project,
-              "deployments", 
-              "create",
-              deployName,
-              "--config=" + configDir + "/cluster-kubeflow.yaml",
-              ])
+                " ",
+                commonCommands + [
+                  "&&",
+                  "gcloud",
+                  "deployment-manager",
+                  "--project=" + project,
+                  "deployments",
+                  "create",
+                  deployName,
+                  "--config=" + configDir + "/cluster-kubeflow.yaml",
+                ]
+              ),
             ]),  // create-deployment
             // Setup and teardown using GKE.
             buildTemplate("delete-deployment", [
-              "bash", "-c",
+              "bash",
+              "-c",
               std.join(
-              " ",
-              commonCommands + [
-              "&&",
-              "gcloud", 
-              "deployment-manager",
-              "--project=" + project,
-              "--quiet",
-              "deployments", 
-              "delete",
-              deployName,
-            ])]),  // delete-deployment
+                " ",
+                commonCommands + [
+                  "&&",
+                  "gcloud",
+                  "deployment-manager",
+                  "--project=" + project,
+                  "--quiet",
+                  "deployments",
+                  "delete",
+                  deployName,
+                ]
+              ),
+            ]),  // delete-deployment
             buildTemplate("create-pr-symlink", [
               "python",
               "-m",

--- a/testing/workflows/components/gke_deploy.libsonnet
+++ b/testing/workflows/components/gke_deploy.libsonnet
@@ -1,0 +1,289 @@
+{
+  // TODO(https://github.com/ksonnet/ksonnet/issues/222): Taking namespace as an argument is a work around for the fact that ksonnet
+  // doesn't support automatically piping in the namespace from the environment to prototypes.
+
+  // convert a list of two items into a map representing an environment variable
+  listToMap:: function(v)
+    {
+      name: v[0],
+      value: v[1],
+    },
+
+  // Function to turn comma separated list of prow environment variables into a dictionary.
+  parseEnv:: function(v)
+    local pieces = std.split(v, ",");
+    if v != "" && std.length(pieces) > 0 then
+      std.map(
+        function(i) $.listToMap(std.split(i, "=")),
+        pieces
+      )
+    else [],
+
+  listToDict:: function(v)
+    {      
+      local name = v[0],
+      // v[0]: v[1],
+      [ v[0] ]: v[1],
+    },
+
+  // parseEnvToMap takes a string "key1=value1,key2=value2,..."
+  // and turns it into an object with keys key1, key2, ... and values value1,...,value2
+  parseEnvToMap::function(v)
+    local pieces = std.split(v, ",");
+    if v != "" && std.length(pieces) > 0 then
+      std.foldl(
+        function(a, b) a + $.listToDict(std.split(b, "=")),
+        pieces, {}
+      )
+    else {},
+
+
+  parts(params):: {
+    local namespace = params.namespace,
+    local name = params.name,
+
+    // We append a letter because it must start with a lowercase letter.
+    // We use a suffix because the suffix contains the random salt.
+    // Resource names in deployment manager need to be 61 characters at most.
+    // The deployment name is used as a prefix for various resources so we truncate it
+    // to 20 characters to make room for the other parts added by the schema.
+    local deployName = if std.length(name) > 20 then
+      "z" + std.substr(name, std.length(name) - 20, 20)
+    else
+      name,
+
+    local prowEnv = $.parseEnvToMap(params.prow_env),
+
+    // Workflow to run the e2e test.
+    e2e(prow_env, bucket, platform="minikube"):
+      // The name for the workflow to run the steps in
+      local stepsNamespace = name;
+      // mountPath is the directory where the volume to store the test data
+      // should be mounted.
+      local mountPath = "/mnt/" + "test-data-volume";
+      // testDir is the root directory for all data for a particular test run.
+      local testDir = mountPath + "/" + name;
+      // outputDir is the directory to sync to GCS to contain the output for this job.
+      local outputDir = testDir + "/output";
+      local artifactsDir = outputDir + "/artifacts";
+      // Source directory where all repos should be checked out
+      local srcRootDir = testDir + "/src";
+      // The directory containing the kubeflow/kubeflow repo
+      local srcDir = srcRootDir + "/" + prowEnv.REPO_OWNER + "/kubeflow";
+
+      // The directory containing the deployment manager configs.
+      local configDir = srcDir + "/docs/gke/configs";
+      local image = "gcr.io/kubeflow-ci/test-worker:latest";
+
+      // The name of the NFS volume claim to use for test files.
+      local nfsVolumeClaim = "nfs-external";
+      // The name to use for the volume to use to contain test data.
+      local dataVolume = "kubeflow-test-volume";
+      local kubeflowPy = srcDir;
+      // The directory within the kubeflow_testing submodule containing
+      // py scripts to use.
+      local kubeflowTestingPy = srcRootDir + "/kubeflow/testing/py";
+
+      local project = "kubeflow-ci";
+      local zone = "us-east1-d";
+
+      // Common commands that should be executed before running gcloud commands.
+      local commonCommands = [
+              "set -x",
+              "&&",
+              "gcloud auth activate-service-account --key-file=/secret/gcp-credentials/key.json",
+              "&&",
+              "gcloud config list",];
+
+      // Build an Argo template to execute a particular command.
+      // step_name: Name for the template
+      // command: List to pass as the container command.
+      local buildTemplate(step_name, command, env_vars=[], sidecars=[]) = {
+        name: step_name,
+        container: {
+          command: command,
+          image: image,
+          imagePullPolicy: "Always",
+          env: [
+            {
+              // Add the source directories to the python path.
+              name: "PYTHONPATH",
+              value: kubeflowPy + ":" + kubeflowTestingPy,
+            },
+            {
+              name: "GOOGLE_APPLICATION_CREDENTIALS",
+              value: "/secret/gcp-credentials/key.json",
+            },
+            {
+              name: "GITHUB_TOKEN",
+              valueFrom: {
+                secretKeyRef: {
+                  name: "github-token",
+                  key: "github_token",
+                },
+              },
+            },
+            // We use a directory in our NFS share to store our kube config.
+            // This way we can configure it on a single step and reuse it on subsequent steps.
+            {
+              name: "KUBECONFIG",
+              value: testDir + "/.kube/config",
+            },
+          ] + prow_env + env_vars,
+          volumeMounts: [
+            {
+              name: dataVolume,
+              mountPath: mountPath,
+            },
+            {
+              name: "github-token",
+              mountPath: "/secret/github-token",
+            },
+            {
+              name: "gcp-credentials",
+              mountPath: "/secret/gcp-credentials",
+            },
+          ],
+        },
+        sidecars: sidecars,
+      };  // buildTemplate
+      {
+        apiVersion: "argoproj.io/v1alpha1",
+        kind: "Workflow",
+        metadata: {
+          name: name,
+          namespace: namespace,
+          labels: {
+            org: "kubeflow",
+            repo: "kubeflow",
+            workflow: "e2e",
+            // TODO(jlewi): Add labels for PR number and commit. Need to write a function
+            // to convert list of environment variables to labels.
+          },
+        },
+        spec: {
+          entrypoint: "e2e",
+          volumes: [
+            {
+              name: "github-token",
+              secret: {
+                secretName: "github-token",
+              },
+            },
+            {
+              name: "gcp-credentials",
+              secret: {
+                secretName: "kubeflow-testing-credentials",
+              },
+            },
+            {
+              name: dataVolume,
+              persistentVolumeClaim: {
+                claimName: nfsVolumeClaim,
+              },
+            },
+          ],  // volumes
+          // onExit specifies the template that should always run when the workflow completes.
+          onExit: "exit-handler",
+          templates: [
+            {
+              name: "e2e",
+              dag: {
+                tasks: std.prune([
+                  {
+                    name: "checkout",
+                    template: "checkout",
+                  },
+                  {
+                    name: "create-pr-symlink",
+                    template: "create-pr-symlink",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "create-deployment",
+                    template: "create-deployment",
+                    dependencies: [
+                          "checkout",
+                    ],
+                  },                  
+                ]),  // tasks
+              },  // dag
+            },  // e2e template
+            {
+              name: "exit-handler",
+              dag: {
+                tasks: [
+                  {
+                    name: "teardown",
+                    template: "delete-deployment",                        
+                  },
+                  {
+                    name: "copy-artifacts",
+                    template: "copy-artifacts",
+                    dependencies: ["teardown"],
+                  },
+                ],
+              },  // dag
+            },  // exit-handler
+            // TODO(jlewi): We need to modify cluster-kubeflow.yaml to set things like the project
+            // and cluster name. 
+            buildTemplate(
+              "checkout",
+              ["/usr/local/bin/checkout.sh", srcRootDir],
+              [{
+                name: "EXTRA_REPOS",
+                value: "kubeflow/tf-operator@v0.1.0;kubeflow/testing@HEAD",
+              }],
+              [],  // no sidecars
+            ),
+            buildTemplate("create-deployment", [
+              "bash", "-c",
+              std.join(
+              " ",
+              commonCommands + [
+              "&&",
+              "gcloud", 
+              "deployment-manager",
+              "--project=" + project,
+              "deployments", 
+              "create",
+              deployName,
+              "--config=" + configDir + "/cluster-kubeflow.yaml",
+              ])
+            ]),  // create-deployment
+            // Setup and teardown using GKE.
+            buildTemplate("delete-deployment", [
+              "bash", "-c",
+              std.join(
+              " ",
+              commonCommands + [
+              "&&",
+              "gcloud", 
+              "deployment-manager",
+              "--project=" + project,
+              "--quiet",
+              "deployments", 
+              "delete",
+              deployName,
+            ])]),  // delete-deployment
+            buildTemplate("create-pr-symlink", [
+              "python",
+              "-m",
+              "kubeflow.testing.prow_artifacts",
+              "--artifacts_dir=" + outputDir,
+              "create_pr_symlink",
+              "--bucket=" + bucket,
+            ]),  // create-pr-symlink
+            buildTemplate("copy-artifacts", [
+              "python",
+              "-m",
+              "kubeflow.testing.prow_artifacts",
+              "--artifacts_dir=" + outputDir,
+              "copy_artifacts",
+              "--bucket=" + bucket,
+            ]),  // copy-artifacts
+          ],  // templates
+        },
+      },  // e2e
+  },  // parts
+}

--- a/testing/workflows/components/params.libsonnet
+++ b/testing/workflows/components/params.libsonnet
@@ -9,11 +9,11 @@
     workflows: {
       bucket: "kubeflow-ci_temp",
       mode: "minikube",
-      name: "jlewi-kubeflow-kubeflow-presubmit-test-473-290a",
+      name: "jlewi-kubeflow-gke-deploy-test-4-3a8b",
       namespace: "kubeflow-test-infra",
       platform: "minikube",
       prow: "JOB_NAME=kubeflow-presubmit-test,JOB_TYPE=presubmit,PULL_NUMBER=209,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=997a",
-      prow_env: "JOB_NAME=kubeflow-kubeflow-presubmit-test,JOB_TYPE=presubmit,PULL_NUMBER=473,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=290a",
+      prow_env: "JOB_NAME=kubeflow-gke-deploy-test,JOB_TYPE=presubmit,PULL_NUMBER=4,REPO_NAME=kubeflow,REPO_OWNER=jlewi,BUILD_NUMBER=3a8b",
     },
   },
 }

--- a/testing/workflows/environments/kubeflow-testing/main.jsonnet
+++ b/testing/workflows/environments/kubeflow-testing/main.jsonnet
@@ -1,7 +1,7 @@
 local base = import "base.libsonnet";
 local k = import "k.libsonnet";
 
-base + {
+base {
   // Insert user-specified overrides here. For example if a component is named "nginx-deployment", you might have something like:
   //   "nginx-deployment"+: k.deployment.mixin.metadata.labels({foo: "bar"})
 }

--- a/testing/workflows/environments/kubeflow-testing/main.jsonnet
+++ b/testing/workflows/environments/kubeflow-testing/main.jsonnet
@@ -1,7 +1,7 @@
 local base = import "base.libsonnet";
 local k = import "k.libsonnet";
 
-base {
+base + {
   // Insert user-specified overrides here. For example if a component is named "nginx-deployment", you might have something like:
   //   "nginx-deployment"+: k.deployment.mixin.metadata.labels({foo: "bar"})
 }

--- a/testing/workflows/environments/kubeflow-testing/params.libsonnet
+++ b/testing/workflows/environments/kubeflow-testing/params.libsonnet
@@ -1,6 +1,6 @@
 local params = import "../../components/params.libsonnet";
-params + {
-  components +: {
+params {
+  components+: {
     // Insert component parameter overrides here. Ex:
     // guestbook +: {
     //   name: "guestbook-dev",

--- a/testing/workflows/environments/kubeflow-testing/params.libsonnet
+++ b/testing/workflows/environments/kubeflow-testing/params.libsonnet
@@ -1,6 +1,6 @@
 local params = import "../../components/params.libsonnet";
-params {
-  components+: {
+params + {
+  components +: {
     // Insert component parameter overrides here. Ex:
     // guestbook +: {
     //   name: "guestbook-dev",


### PR DESCRIPTION
* The config just creates the GKE cluster we still have a lot of work to do
  to get a complete solution for deploying Kubeflow.

* The goal is to provide a complete declarative solution that makes it easy to
get started with Kubeflow. The idea is the configs should provide sensible
defaults (e.g. n1-standard-8) so people can just copy it to create a good
initial setup.

* For more advanced setup users can customize the config. For example, they
  might configure VPC networks as part of their deployment.

* The current thinking is that deployment manager should create the K8s cluster
  and other resources (service accounts, namespaces, etc...) to run the
  bootstrapper.

* Deployment manager could then kick off the bootstrapper which would create
  a ksonnet app to deploy Kubeflow and then deploy Kubeflow.

* Create an E2E test to provide a smoke test of the configs.

Related to:
  #757 Use Deployment manager
  #241 Recommended setup for GKE - The idea is to encode the recommended setup as a deployment manager config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/787)
<!-- Reviewable:end -->
