### PR TITLE
Python script to build TF notebook images

### DIFF
--- a/components/README.md
+++ b/components/README.md
@@ -5,8 +5,8 @@ This allows us to use `build_image.py` to build all images.
 
 For example
 ```
-python build_image.py tf_serving --tf_version=1.6 --platform=gpu
-python build_image.py tf_serving --tf_version=1.7  // default is cpu image
+python build_image.py --tf_version=1.6 --platform=gpu tf_serving
+python build_image.py --tf_version=1.4.1 tf_notebook
 ```
 
 See `build_image.py` for details.
@@ -16,3 +16,7 @@ See `build_image.py` for details.
 ### TF Serving
 - CPU: 1.4, 1.5, 1.6, 1.7
 - GPU: 1.6, 1.7
+
+### TF notebook
+- CPU: 1.4.1, 1.5.1, 1.6.0, 1.7.0
+- GPU: 1.4.1, 1.5.1, 1.6.0, 1.7.0

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   curl \
   g++ \
   git \
+  gnupg \
   graphviz \
   locales \
   lsb-release \

--- a/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "ubuntu:latest",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "no"
+}

--- a/components/tensorflow-notebook-image/versions/1.4.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.4.1gpu/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.4.1-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.4.1-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "no"
+}

--- a/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "ubuntu:latest",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "no"
+}

--- a/components/tensorflow-notebook-image/versions/1.5.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.5.1gpu/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.1-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "no"
+}

--- a/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "ubuntu:latest",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "yes"
+}

--- a/components/tensorflow-notebook-image/versions/1.6.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.6.0gpu/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.6.0-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.6.0-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "yes"
+}

--- a/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "ubuntu:latest",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "yes"
+}

--- a/components/tensorflow-notebook-image/versions/1.7.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.7.0gpu/version-config.json
@@ -1,0 +1,6 @@
+{
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.7.0-cp36-cp36m-linux_x86_64.whl",
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.7.0-cp27-none-linux_x86_64.whl",
+  "INSTALL_TFMA": "yes"
+}


### PR DESCRIPTION
- share the same python script to build TF notebook and TF serving (and can extend to other components)
- add gnupg to Dockerfile, otherwise got `E: gnupg, gnupg2 and gnupg1 do not seem to be installed, but one of them is required for this operation`

Still verifying all versions work.
/hold

/cc @ankushagarwal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/791)
<!-- Reviewable:end -->
