### PR TITLE
seldon load model files from PVC

### DIFF
--- a/kubeflow/seldon/prototypes/serve-simple.jsonnet
+++ b/kubeflow/seldon/prototypes/serve-simple.jsonnet
@@ -24,13 +24,17 @@ local image = import "param://image";
 local namespace = updatedParams.namespace;
 local replicas = import "param://replicas";
 local endpoint = import "param://endpoint";
-local pvcname = import "param://pvcName";
+local pvcName = import "param://pvcName";
 
 local serveComponents = [
   serve.parts(namespace).serve(name, image, replicas, endpoint, pvcName),
-  if pvcName != "null" && pvcName != "" then [
-      serve.parts(namespace).createPVC(pvcName),
-  ],
 ];
 
-k.core.v1.list.new(serveComponents)
+local pvcComponent = [
+  serve.parts(namespace).createPVC(pvcName)
+];
+
+if pvcName != "null" && pvcName != "" then
+  k.core.v1.list.new(serveComponents + pvcComponent)
+else
+  k.core.v1.list.new(serveComponents)

--- a/kubeflow/seldon/prototypes/serve-simple.jsonnet
+++ b/kubeflow/seldon/prototypes/serve-simple.jsonnet
@@ -31,7 +31,7 @@ local serveComponents = [
 ];
 
 local pvcComponent = [
-  serve.parts(namespace).createPVC(pvcName)
+  serve.parts(namespace).createPVC(pvcName),
 ];
 
 if pvcName != "null" && pvcName != "" then

--- a/kubeflow/seldon/prototypes/serve-simple.jsonnet
+++ b/kubeflow/seldon/prototypes/serve-simple.jsonnet
@@ -7,6 +7,8 @@
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 // @optionalParam replicas number 1 Number of replicas
 // @optionalParam endpoint string REST The endpoint type: REST or GRPC
+// @optionalParam pvcName string null Name of PVC
+
 
 local k = import "k.libsonnet";
 local serve = import "kubeflow/seldon/serve-simple.libsonnet";
@@ -22,5 +24,13 @@ local image = import "param://image";
 local namespace = updatedParams.namespace;
 local replicas = import "param://replicas";
 local endpoint = import "param://endpoint";
+local pvcname = import "param://pvcName";
 
-k.core.v1.list.new(serve.parts(namespace).serve(name, image, replicas, endpoint))
+local serveComponents = [
+  serve.parts(namespace).serve(name, image, replicas, endpoint, pvcName),
+  if pvcName != "null" && pvcName != "" then [
+      serve.parts(namespace).createPVC(pvcName),
+  ],
+];
+
+k.core.v1.list.new(serveComponents)

--- a/kubeflow/seldon/serve-simple.libsonnet
+++ b/kubeflow/seldon/serve-simple.libsonnet
@@ -7,9 +7,14 @@
       metadata: {
         name: pvcName,
       },
-      resources:{
-        requests:{
-          storage: "10Gi",
+      spec:{
+        accessModes:[
+          "ReadWriteOnce",
+        ],
+        resources:{
+          requests:{
+            storage: "10Gi",
+          },
         },
       },
     }, // createPVC

--- a/kubeflow/seldon/serve-simple.libsonnet
+++ b/kubeflow/seldon/serve-simple.libsonnet
@@ -1,6 +1,20 @@
 {
   parts(namespace):: {
-    serve(name, image, replicas, endpoint):: {
+
+    createPVC(pvcName):: {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: pvcName,
+      },
+      resources:{
+        requests:{
+          storage: "10Gi",
+        },
+      },
+    }, // createPVC
+
+    serve(name, image, replicas, endpoint, pvcName):: {
       apiVersion: "machinelearning.seldon.io/v1alpha1",
       kind: "SeldonDeployment",
       metadata: {
@@ -28,9 +42,25 @@
                     image: image,
                     imagePullPolicy: "Always",
                     name: name,
+                    volumeMounts+: if pvcName != "null" && pvcName != "" then [
+                      {
+                        "mountPath": "/mnt",
+                        "name": "persistent-storage"
+                      }
+                    ]else[],
                   },
                 ],
                 terminationGracePeriodSeconds: 1,
+                volumes+: if pvcName != "null" && pvcName != "" then [
+                  {
+                    "name": "persistent-storage",
+				            "volumeSource" : {
+                      "persistentVolumeClaim": {
+					              "claimName": pvcName
+                      }
+			 	            }
+                  }
+                ]else[],
               },
             },
             graph: {

--- a/kubeflow/seldon/serve-simple.libsonnet
+++ b/kubeflow/seldon/serve-simple.libsonnet
@@ -7,17 +7,17 @@
       metadata: {
         name: pvcName,
       },
-      spec:{
-        accessModes:[
+      spec: {
+        accessModes: [
           "ReadWriteOnce",
         ],
-        resources:{
-          requests:{
+        resources: {
+          requests: {
             storage: "10Gi",
           },
         },
       },
-    }, // createPVC
+    },  // createPVC
 
     serve(name, image, replicas, endpoint, pvcName):: {
       apiVersion: "machinelearning.seldon.io/v1alpha1",
@@ -49,23 +49,23 @@
                     name: name,
                     volumeMounts+: if pvcName != "null" && pvcName != "" then [
                       {
-                        "mountPath": "/mnt",
-                        "name": "persistent-storage"
-                      }
-                    ]else[],
+                        mountPath: "/mnt",
+                        name: "persistent-storage",
+                      },
+                    ] else [],
                   },
                 ],
                 terminationGracePeriodSeconds: 1,
                 volumes+: if pvcName != "null" && pvcName != "" then [
                   {
-                    "name": "persistent-storage",
-				            "volumeSource" : {
-                      "persistentVolumeClaim": {
-					              "claimName": pvcName
-                      }
-			 	            }
-                  }
-                ]else[],
+                    name: "persistent-storage",
+                    volumeSource: {
+                      persistentVolumeClaim: {
+                        claimName: pvcName,
+                      },
+                    },
+                  },
+                ] else [],
               },
             },
             graph: {


### PR DESCRIPTION
This PR is related to #733 . 

As for now, `seldon/seldon-serve-simple` prototype only read model files in docker image. 
Actually, seldon-serve can read env variables to find model file in any place. 
In this PR, add one more params: `pvcName`. If `pvcName` is not "null" or "", a PVC will be created by default storage class, and is mounted in `/mnt`. 

User can put their model file in PV, and specify the model location  in predictions file (eg. [IssueSummarization.py](https://github.com/kubeflow/examples/blob/master/github_issue_summarization/notebooks/IssueSummarization.py#L20))  or in env variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/799)
<!-- Reviewable:end -->
