### PR TITLE
add bootstrapper to e2e test

### DIFF
--- a/bootstrap/build_image.sh
+++ b/bootstrap/build_image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# A simple script to build the Docker images.
+# This is intended to be invoked as a step in Argo to build the docker image.
+#
+# build_image.sh ${DOCKERFILE} ${IMAGE}
+set -ex
+
+DOCKERFILE=$1
+CONTEXT_DIR=$(dirname "$DOCKERFILE")
+IMAGE=$2
+
+# Wait for the Docker daemon to be available.
+until docker ps
+do sleep 3
+done
+
+docker build --pull -t ${IMAGE} \
+	-f ${DOCKERFILE} ${CONTEXT_DIR}
+
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+gcloud docker -- push ${IMAGE}

--- a/bootstrap/cmd/bootstrap/app/options/options.go
+++ b/bootstrap/cmd/bootstrap/app/options/options.go
@@ -30,6 +30,7 @@ type ServerOption struct {
 	Project       string
 	Email         string
 	IpName        string
+	RegistryUri	  string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -50,4 +51,5 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.Email, "email", "", "Your Email address for GCP account, if you are using GKE.")
 	fs.StringVar(&s.IpName, "ip-name", "kubeflow", "Name of the ip you reserved on GCP project")
 	fs.BoolVar(&s.InCluster, "in-cluster", false, "Whether bootstrapper is executed inside a pod")
+	fs.StringVar(&s.RegistryUri, "registry-uri", "/opt/kubeflow/kubeflow", "Location of kubeflow registry.")
 }

--- a/bootstrap/cmd/bootstrap/app/options/options.go
+++ b/bootstrap/cmd/bootstrap/app/options/options.go
@@ -23,15 +23,15 @@ type ServerOption struct {
 	Apply         bool
 	PrintVersion  bool
 	JsonLogFormat bool
-	InCluster	  bool
-	Testing	  	  bool
+	InCluster     bool
+	KeepAlive     bool
 	AppDir        string
 	KfVersion     string
 	NameSpace     string
 	Project       string
 	Email         string
 	IpName        string
-	RegistryUri	  string
+	RegistryUri   string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -53,5 +53,5 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.IpName, "ip-name", "kubeflow", "Name of the ip you reserved on GCP project")
 	fs.BoolVar(&s.InCluster, "in-cluster", false, "Whether bootstrapper is executed inside a pod")
 	fs.StringVar(&s.RegistryUri, "registry-uri", "/opt/kubeflow/kubeflow", "Location of kubeflow registry.")
-	fs.BoolVar(&s.Testing, "testing", false, "Whether bootstrapper is executed for e2e test.")
+	fs.BoolVar(&s.KeepAlive, "keep-alive", true, "Whether bootstrapper will stay alive after setup resources.")
 }

--- a/bootstrap/cmd/bootstrap/app/options/options.go
+++ b/bootstrap/cmd/bootstrap/app/options/options.go
@@ -24,6 +24,7 @@ type ServerOption struct {
 	PrintVersion  bool
 	JsonLogFormat bool
 	InCluster	  bool
+	Testing	  	  bool
 	AppDir        string
 	KfVersion     string
 	NameSpace     string
@@ -52,4 +53,5 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&s.IpName, "ip-name", "kubeflow", "Name of the ip you reserved on GCP project")
 	fs.BoolVar(&s.InCluster, "in-cluster", false, "Whether bootstrapper is executed inside a pod")
 	fs.StringVar(&s.RegistryUri, "registry-uri", "/opt/kubeflow/kubeflow", "Location of kubeflow registry.")
+	fs.BoolVar(&s.Testing, "testing", false, "Whether bootstrapper is executed for e2e test.")
 }

--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -486,7 +486,7 @@ func Run(opt *options.ServerOption) error {
 			log.Infof("Components applied: " + out.String())
 		}
 	}
-	if opt.InCluster {
+	if opt.InCluster && (!opt.Testing) {
 		log.Infof("Keeping pod alive...")
 		for {
 			time.Sleep(time.Minute)

--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -322,14 +322,12 @@ func Run(opt *options.ServerOption) error {
 		log.Fatalf("There was a problem loading the app: %v", err)
 	}
 
-	registryUri := fmt.Sprintf("/opt/kubeflow/kubeflow")
-
 	registryName := "kubeflow"
 
 	options := map[string]interface{}{
 		actions.OptionApp:  kfApp,
 		actions.OptionName: registryName,
-		actions.OptionURI:  registryUri,
+		actions.OptionURI:  opt.RegistryUri,
 		// Version doesn't actually appear to be used by the add function.
 		actions.OptionVersion: "",
 		// Looks like override allows us to override existing registries; we shouldn't
@@ -360,11 +358,15 @@ func Run(opt *options.ServerOption) error {
 	}
 
 	// Install packages.
-	for _, p := range []string{"kubeflow/core", "kubeflow/tf-serving", "kubeflow/tf-job"} {
+	for _, p := range []string{"kubeflow/core", "kubeflow/tf-serving", "kubeflow/tf-job", "kubeflow/pytorch-job"} {
+		pieces := strings.Split(p, "/")
+		_, err = fs.Stat(path.Join(opt.RegistryUri, pieces[1]))
+		if err != nil {
+			continue
+		}
 		full := fmt.Sprintf("%v@%v", p, opt.KfVersion)
 		log.Infof("Installing package %v", full)
 
-		pieces := strings.Split(p, "/")
 		pkgName := pieces[1]
 
 		if _, found := libs[pkgName]; found {
@@ -385,6 +387,10 @@ func Run(opt *options.ServerOption) error {
 	// Create the Kubeflow component
 	kubeflowCoreName := "kubeflow-core"
 	createComponent(opt, &kfApp, &fs, []string{kubeflowCoreName, kubeflowCoreName})
+
+	// Create the pytorch-operator component
+	pytorchName := "pytorch-operator"
+	createComponent(opt, &kfApp, &fs, []string{pytorchName, pytorchName})
 
 	pvcMount := ""
 	if hasDefault {

--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -486,7 +486,7 @@ func Run(opt *options.ServerOption) error {
 			log.Infof("Components applied: " + out.String())
 		}
 	}
-	if opt.InCluster && (!opt.Testing) {
+	if opt.InCluster && opt.KeepAlive {
 		log.Infof("Keeping pod alive...")
 		for {
 			time.Sleep(time.Minute)

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -241,7 +241,7 @@
                       if platform == "minikube" then
                         "deploy-kubeflow"
                       else
-                        "bootstrap-kubeflow"
+                        "bootstrap-kubeflow",
                     ],
                   },
                   // Don't run argo test for gke since
@@ -263,7 +263,7 @@
                       if platform == "minikube" then
                         "deploy-kubeflow"
                       else
-                        "bootstrap-kubeflow"
+                        "bootstrap-kubeflow",
                     ],
                   },
                   {
@@ -467,6 +467,7 @@
               "--namespace=" + stepsNamespace,
               "--registry-uri=" + srcDir + "/kubeflow",
               "--app-dir=" + testDir + "/app",
+              "--testing",
             ]),  // bootstrap-kubeflow
           ],  // templates
         },

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -467,7 +467,7 @@
               "--namespace=" + stepsNamespace,
               "--registry-uri=" + srcDir + "/kubeflow",
               "--app-dir=" + testDir + "/app",
-              "--testing",
+              "--keep-alive=false",
             ]),  // bootstrap-kubeflow
           ],  // templates
         },

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -261,7 +261,7 @@
                     template: "tfjob-test",
                     dependencies: [
                       if platform == "minikube" then
-                        "deploy-kubeflo"
+                        "deploy-kubeflow"
                       else
                         "bootstrap-kubeflow"
                     ],
@@ -466,6 +466,7 @@
               "--apply",
               "--namespace=" + stepsNamespace,
               "--registry-uri=" + srcDir + "/kubeflow",
+              "--app-dir=" + testDir + "/app",
             ]),  // bootstrap-kubeflow
           ],  // templates
         },

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -79,13 +79,10 @@
         container: {
           command: command,
           image:
-            if step_name == "bootstrap-image-create" then
-              testing_image
+            if step_name == "bootstrap-kubeflow" then
+              bootstrapperImage
             else
-              if step_name == "bootstrap-kubeflow" then
-                bootstrapperImage
-              else
-                image,
+              image,
           imagePullPolicy: "Always",
           env: [
             {

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -239,7 +239,7 @@
                     template: "pytorchjob-deploy",
                     dependencies: [
                       if platform == "minikube" then
-                        "deploy-kubeflo"
+                        "deploy-kubeflow"
                       else
                         "bootstrap-kubeflow"
                     ],


### PR DESCRIPTION
Change e2e test on gke: now we use bootstrapper to setup test env & resources.
Each e2e test will build bootstrapper image from PR src so e2e test now takes more time (~5min) to run.
Good news is we cover bootstrapper logic in e2e test, and it should be more stable than env-setup scripts.

Cover https://github.com/kubeflow/kubeflow/issues/742.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/803)
<!-- Reviewable:end -->
