### PR TITLE
[openmpi] support non-root users run jobs (introducing `runAsUser`, `runAsGroup`, `supplementalGroups`)

### DIFF
--- a/components/openmpi-controller/Dockerfile
+++ b/components/openmpi-controller/Dockerfile
@@ -4,7 +4,8 @@ USER root
 
 ENV HOME /root
 
-ADD requirements.txt $HOME
-ADD controller $HOME/controller
+RUN mkdir -p /kubeflow/openmpi/openmpi-controller
+ADD requirements.txt /kubeflow/openmpi/openmpi-controller/requirements.txt
+ADD controller /kubeflow/openmpi/openmpi-controller/controller
 
-RUN pip3 install -r $HOME/requirements.txt
+RUN pip3 install -r /kubeflow/openmpi/openmpi-controller/requirements.txt

--- a/components/openmpi-controller/Makefile
+++ b/components/openmpi-controller/Makefile
@@ -1,6 +1,6 @@
 # TODO: move to kubeflow
 IMAGE=jiez/openmpi-controller
-TAG=0.0.2
+TAG=0.0.3
 
 default: build push
 

--- a/kubeflow/openmpi/assets/init.sh
+++ b/kubeflow/openmpi/assets/init.sh
@@ -1,9 +1,14 @@
 set -exv
 
 OPENMPI_DIR=/kubeflow/openmpi
+SSHD_CONFIG=${OPENMPI_DIR}/assets/sshd_config
 MPIEXEC_TIMEOUT_ON_WAIT_MPI_READY=10
 BACKOFF_SECS=10
 TIMEOUT_EXIT_CODE=124
+
+run_by_non_root() {
+  [ "$(id -u)" != "0" ]
+}
 
 wait_mpi_ready() {
   local workers=$1
@@ -47,15 +52,29 @@ timeout_secs="$4"
 max_retries=$(expr ${timeout_secs} / ${BACKOFF_SECS})
 
 # Set up openmpi
-mkdir -p /root/.openmpi
-cp ${OPENMPI_DIR}/assets/mca-params.conf /root/.openmpi
+mkdir -p ${HOME}/.openmpi
+cp ${OPENMPI_DIR}/assets/mca-params.conf ${HOME}/.openmpi
 
 # Set up ssh
-mkdir -p /root/.ssh
-cp ${OPENMPI_DIR}/secrets/id_rsa /root/.ssh
-cp ${OPENMPI_DIR}/secrets/id_rsa.pub /root/.ssh
-cp ${OPENMPI_DIR}/secrets/authorized_keys /root/.ssh
-cp ${OPENMPI_DIR}/assets/ssh_config /root/.ssh/config
+mkdir -p ${HOME}/.ssh
+cp ${OPENMPI_DIR}/secrets/id_rsa ${HOME}/.ssh
+chmod 400 ${HOME}/.ssh/id_rsa
+cp ${OPENMPI_DIR}/secrets/id_rsa.pub ${HOME}/.ssh
+cp ${OPENMPI_DIR}/secrets/authorized_keys ${HOME}/.ssh
+cp ${OPENMPI_DIR}/assets/ssh_config ${HOME}/.ssh/config
+
+# when this runs by non-root user.
+# we have to create ephemeral hostkeys
+if run_by_non_root ; then
+  mkdir -p ${HOME}/.sshd
+  cp ${OPENMPI_DIR}/assets/sshd_config ${HOME}/.sshd/sshd_config
+  SSHD_CONFIG=${HOME}/.sshd/sshd_config
+
+  ssh-keygen -f ${HOME}/.sshd/host_rsa_key -C '' -N '' -t rsa
+  ssh-keygen -f ${HOME}/.sshd/host_dsa_key -C '' -N '' -t dsa
+  echo "HostKey ${HOME}/.sshd/host_rsa_key" >> ${SSHD_CONFIG}
+  echo "HostKey ${HOME}/.sshd/host_dsa_key" >> ${SSHD_CONFIG}
+fi
 
 exit_code=0
 if [ "${role}" = "master" ]; then
@@ -69,7 +88,7 @@ else
   wait_controller_signal SIGCONT ${max_retries}
 
   # Start sshd in daemon mode
-  /usr/sbin/sshd -e -f ${OPENMPI_DIR}/assets/sshd_config
+  /usr/sbin/sshd -e -f ${SSHD_CONFIG}
 
   # Block forever until controller terminates.
   wait_controller_signal SIGTERM

--- a/kubeflow/openmpi/assets/ssh_config
+++ b/kubeflow/openmpi/assets/ssh_config
@@ -1,4 +1,3 @@
 StrictHostKeyChecking no
-IdentityFile /root/.ssh/id_rsa
 Port 2022
 UserKnownHostsFile=/dev/null

--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -25,6 +25,9 @@
 // @optionalParam downloadDataTo string null Local path where data are downloaded to.
 // @optionalParam uploadDataFrom string null Local path where data are uploaded from.
 // @optionalParam uploadDataTo string null URI where data are uploaded to. Namespace, name, and pod will be appended to the URI. Only S3 bucket is supported at the moment.
+// @optionalParam runAsUser string null uid of the first process of containers in master/worker pods. If not set, this will be default value of your cluster configuration.
+// @optionalParam runAsGroup string null Primary gid of the first process of containers in master/worker pods. If not set, this will be default value of your cluster configuration.
+// @optionalParam supplementalGroups string null Comma-delimited list of supplemental group ids to put the user of the first process of containers in master/worker pods.
 
 local k = import "k.libsonnet";
 local openmpi = import "kubeflow/openmpi/all.libsonnet";

--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -17,7 +17,7 @@
 // @optionalParam customResources string null Comma-delimited list of "resourceName=amount" pairs which you want to limit per worker.
 // @optionalParam serviceAccountName string null the service account name to run pods. The service account should have clusterRoleBinding for "view" ClusterRole.  If it was not set, service account and its role binding will be created automatically.
 // @optionalParam schedulerName string default-scheduler scheduler name to use for the components.
-// @optionalParam controllerImage string jiez/openmpi-controller:0.0.2 Docker image of the openmpi-controller.
+// @optionalParam controllerImage string jiez/openmpi-controller:0.0.3 Docker image of the openmpi-controller.
 // @optionalParam initTimeout number 300 Timeout in seconds to abort the initialization.
 // @optionalParam nodeSelector string null Comma-delimited list of "key=value" pairs to select the worker nodes. e.g. "cloud.google.com/gke-accelerator=nvidia-tesla-k80"
 // @optionalParam s3Secret string null Name of secret containing s3 credentials (AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY).

--- a/kubeflow/openmpi/util.libsonnet
+++ b/kubeflow/openmpi/util.libsonnet
@@ -13,5 +13,5 @@
     if std.type(str) == "string" && str != "null" && std.length(str) > 0 then {
       [std.splitLimit(keyValue, "=", 1)[0]]: std.splitLimit(keyValue, "=", 1)[1]
       for keyValue in $.toArray(str)
-    } else [],
+    } else {},
 }

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -48,6 +48,7 @@ local ROLE_WORKER = "worker";
       imagePullSecrets: [{ name: secret } for secret in util.toArray(params.imagePullSecrets)],
       serviceAccountName: serviceaccount.name(params),
       nodeSelector: $.nodeSelector(params, role),
+      securityContext: $.securityContext(params),
     },
   },
 
@@ -222,4 +223,11 @@ local ROLE_WORKER = "worker";
         },
       },
     ] else [],
+
+  securityContext(params):: {
+    runAsUser: if params.runAsUser != "null" then params.runAsUser else {},
+    runAsGroup: if params.runAsGroup != "null" then params.runAsGroup else {},
+    supplementalGroups: [std.parseInt(g) for g in util.toArray(std.toString(params.supplementalGroups))],
+    fsGroup: if params.runAsGroup != "null" then params.runAsGroup else {},
+  },
 }

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -173,7 +173,7 @@ local ROLE_WORKER = "worker";
   controllerCommand(params, podName):: {
     local common = [
       "python",
-      "/root/controller/main.py",
+      "/kubeflow/openmpi/openmpi-controller/controller/main.py",
       "--namespace",
       params.namespace,
       "--master",


### PR DESCRIPTION
Fixes #793 

# Changes
- introduce `runAsUser`, `runAsGroup`, `supplementalGroups` parameters.
- If these parameters set, this package will put `securityContext` to the master/worker pods.
- changed `init.sh` to support non-root users can spawn sshd servers.
- changed openmpi-controller path from `/root` to `/openmpi-controller` so that non-root users can execute the controller
  - this bump version of openmpi-controller docker image.

# Note
__new openmpi-controller's docker image needs to be published before merging this__.

@jiezhang I need your assistance.  Could you build and publish `jiezhang/openmpi-controller:0.0.3` before this pr is approved 🙇  ??

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/820)
<!-- Reviewable:end -->
