### PR TITLE
IAP should route to central ui instead of jupyterhub

### DIFF
--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -491,24 +491,6 @@
                             ],
                           },
                         },
-                        // TODO(ankushagarwal): We should eventually
-                        // redirect to the central UI once its ready
-                        // See https://github.com/kubeflow/kubeflow/pull/146
-                        // Redirect to jupyterhub when visiting /
-                        {
-                          timeout_ms: 600000,
-                          path: "/",
-                          prefix_rewrite: "/hub",
-                          use_websocket: true,
-                          weighted_clusters: {
-                            clusters: [
-                              {
-                                name: "cluster_jupyterhub",
-                                weight: 100.0,
-                              },
-                            ],
-                          },
-                        },
                         {
                           // Route remaining traffic to Ambassador which supports dynamically adding
                           // routes based on service annotations.


### PR DESCRIPTION
Fixes #809 

- [x] Removed stanza in iap.libsonnet shown below

```
                        // TODO(ankushagarwal): We should eventually
                        // redirect to the central UI once its ready
                        // See https://github.com/kubeflow/kubeflow/pull/146
                        // Redirect to jupyterhub when visiting /
                        {
                          timeout_ms: 600000,
                          path: "/",
                          prefix_rewrite: "/hub",
                          use_websocket: true,
                          weighted_clusters: {
                            clusters: [
                              {
                                name: "cluster_jupyterhub",
                                weight: 100.0,
                              },
                            ],
                          },
                        },
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/827)
<!-- Reviewable:end -->
