### PR TITLE
Use relative directory path so that build_image.py can be called from another dir

### DIFF
--- a/components/build_image.py
+++ b/components/build_image.py
@@ -78,7 +78,8 @@ def get_config(context_dir, version):
   return config
 
 def build_tf_serving(args):
-  context_dir = os.path.join(os.getcwd(), "k8s-model-server/images")
+  dir_path = os.path.dirname(os.path.realpath(__file__))
+  context_dir = os.path.join(dir_path, "k8s-model-server/images")
   version = args.tf_version if args.platform == "cpu" else args.tf_version + "gpu"
 
   config = get_config(context_dir, version)
@@ -93,7 +94,8 @@ def build_tf_serving(args):
   run(command, cwd=context_dir)
 
 def build_tf_notebook(args):
-  context_dir = os.path.join(os.getcwd(), "tensorflow-notebook-image")
+  dir_path = os.path.dirname(os.path.realpath(__file__))
+  context_dir = os.path.join(dir_path, "tensorflow-notebook-image")
   version = args.tf_version if args.platform == "cpu" else args.tf_version + "gpu"
 
   config = get_config(context_dir, version)

--- a/components/build_image.py
+++ b/components/build_image.py
@@ -93,7 +93,7 @@ def build_tf_serving(args):
   run(command, cwd=context_dir)
 
 def build_tf_notebook(args):
-  context_dir = "tensorflow-notebook-image"
+  context_dir = os.path.join(os.getcwd(), "tensorflow-notebook-image")
   version = args.tf_version if args.platform == "cpu" else args.tf_version + "gpu"
 
   config = get_config(context_dir, version)

--- a/components/build_image.py
+++ b/components/build_image.py
@@ -78,7 +78,7 @@ def get_config(context_dir, version):
   return config
 
 def build_tf_serving(args):
-  context_dir = "k8s-model-server/images"
+  context_dir = os.path.join(os.getcwd(), "k8s-model-server/images")
   version = args.tf_version if args.platform == "cpu" else args.tf_version + "gpu"
 
   config = get_config(context_dir, version)


### PR DESCRIPTION
This is for usomg build_image.py in the release workflow

/cc @ankushagarwal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/840)
<!-- Reviewable:end -->
