### PR TITLE
ksonnet changes to support deploying the v1alpha2 TFJob operator.

### DIFF
--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -7,7 +7,7 @@
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
 // @optionalParam tfAmbassadorServiceType string ClusterIP The service type for the API Gateway.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180329-a7511ff The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
@@ -16,6 +16,7 @@
 // @optionalParam jupyterNotebookPVCMount string null Mount path for PVC. Set empty to disable PVC
 // @optionalParam reportUsage string false Whether or not to report Kubeflow usage to kubeflow.org.
 // @optionalParam usageId string unknown_cluster Optional id to use when reporting usage to kubeflow.org
+// @optionalParam tfJobVersion string v1alpha1 which version of the TFJob operator to use
 
 local k = import "k.libsonnet";
 local all = import "kubeflow/core/all.libsonnet";

--- a/kubeflow/core/prototypes/tf-job-operator.jsonnet
+++ b/kubeflow/core/prototypes/tf-job-operator.jsonnet
@@ -6,9 +6,10 @@
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
 // @optionalParam tfAmbassadorServiceType string ClusterIP The service type for the API Gateway.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180329-a7511ff The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
+// @optionalParam tfJobVersion string v1alpha1 which version of the TFJob operator to use
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/235): ks param set args won't work if the arg starts with "--".
 

--- a/kubeflow/core/tf-job-operator.libsonnet
+++ b/kubeflow/core/tf-job-operator.libsonnet
@@ -1,26 +1,27 @@
 {
   all(params):: [
-    
-    $.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
-    $.parts(params.namespace).serviceAccount,
-    $.parts(params.namespace).operatorRole,
-    $.parts(params.namespace).operatorRoleBinding,    
-    $.parts(params.namespace).uiRole,
-    $.parts(params.namespace).uiRoleBinding,
-    $.parts(params.namespace).uiService(params.tfJobUiServiceType),
-    $.parts(params.namespace).uiServiceAccount,
-    $.parts(params.namespace).ui(params.tfJobImage),
-  ] + 
 
-  if params.tfJobVersion == "v1alpha2" then
-  [ $.parts(params.namespace).crdv1alpha2, 
-    $.parts(params.namespace).tfJobDeployV1Alpha2(params.tfJobImage),
-  ]
-  else
-  [
-    $.parts(params.namespace).crd, 
-    $.parts(params.namespace).tfJobDeploy(params.tfJobImage),  
-  ],
+                  $.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
+                  $.parts(params.namespace).serviceAccount,
+                  $.parts(params.namespace).operatorRole,
+                  $.parts(params.namespace).operatorRoleBinding,
+                  $.parts(params.namespace).uiRole,
+                  $.parts(params.namespace).uiRoleBinding,
+                  $.parts(params.namespace).uiService(params.tfJobUiServiceType),
+                  $.parts(params.namespace).uiServiceAccount,
+                  $.parts(params.namespace).ui(params.tfJobImage),
+                ] +
+
+                if params.tfJobVersion == "v1alpha2" then
+                  [
+                    $.parts(params.namespace).crdv1alpha2,
+                    $.parts(params.namespace).tfJobDeployV1Alpha2(params.tfJobImage),
+                  ]
+                else
+                  [
+                    $.parts(params.namespace).crd,
+                    $.parts(params.namespace).tfJobDeploy(params.tfJobImage),
+                  ],
 
   parts(namespace):: {
     crd: {

--- a/kubeflow/core/tf-job-operator.libsonnet
+++ b/kubeflow/core/tf-job-operator.libsonnet
@@ -1,16 +1,25 @@
 {
   all(params):: [
-    $.parts(params.namespace).tfJobDeploy(params.tfJobImage),
+    
     $.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
     $.parts(params.namespace).serviceAccount,
     $.parts(params.namespace).operatorRole,
-    $.parts(params.namespace).operatorRoleBinding,
-    $.parts(params.namespace).crd,
+    $.parts(params.namespace).operatorRoleBinding,    
     $.parts(params.namespace).uiRole,
     $.parts(params.namespace).uiRoleBinding,
     $.parts(params.namespace).uiService(params.tfJobUiServiceType),
     $.parts(params.namespace).uiServiceAccount,
     $.parts(params.namespace).ui(params.tfJobImage),
+  ] + 
+
+  if params.tfJobVersion == "v1alpha2" then
+  [ $.parts(params.namespace).crdv1alpha2, 
+    $.parts(params.namespace).tfJobDeployV1Alpha2(params.tfJobImage),
+  ]
+  else
+  [
+    $.parts(params.namespace).crd, 
+    $.parts(params.namespace).tfJobDeploy(params.tfJobImage),  
   ],
 
   parts(namespace):: {
@@ -23,6 +32,23 @@
       spec: {
         group: "kubeflow.org",
         version: "v1alpha1",
+        names: {
+          kind: "TFJob",
+          singular: "tfjob",
+          plural: "tfjobs",
+        },
+      },
+    },
+
+    crdv1alpha2: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "tfjobs.kubeflow.org",
+      },
+      spec: {
+        group: "kubeflow.org",
+        version: "v1alpha2",
         names: {
           kind: "TFJob",
           singular: "tfjob",
@@ -52,6 +78,71 @@
                 command: [
                   "/opt/mlkube/tf-operator",
                   "--controller-config-file=/etc/config/controller_config_file.yaml",
+                  "--alsologtostderr",
+                  "-v=1",
+                ],
+                env: [
+                  {
+                    name: "MY_POD_NAMESPACE",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.namespace",
+                      },
+                    },
+                  },
+                  {
+                    name: "MY_POD_NAME",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.name",
+                      },
+                    },
+                  },
+                ],
+                image: image,
+                name: "tf-job-operator",
+                volumeMounts: [
+                  {
+                    mountPath: "/etc/config",
+                    name: "config-volume",
+                  },
+                ],
+              },
+            ],
+            serviceAccountName: "tf-job-operator",
+            volumes: [
+              {
+                configMap: {
+                  name: "tf-job-operator-config",
+                },
+                name: "config-volume",
+              },
+            ],
+          },
+        },
+      },
+    },  // tfJobDeploy
+
+    tfJobDeployV1Alpha2(image): {
+      apiVersion: "extensions/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: "tf-job-operator-v1alpha2",
+        namespace: namespace,
+      },
+      spec: {
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              name: "tf-job-operator",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                command: [
+                  "/opt/kubeflow/tf-operator.v2",
                   "--alsologtostderr",
                   "-v=1",
                 ],


### PR DESCRIPTION
* K8s doesn't support installing multiple versions of a CRD in the same cluster.
* So we add an option to choose which version to support.
* We don't add an E2E test in this PR because its not straightforward.
  Currently the E2E test deploys Kubeflow in a different namespace but not
  a different cluster. This won't allow us to simulatenously test both
  versions.

* So to test multiple versions we will need to spin up a separate GKE cluster.

Related to: kubeflow/tf-operator#599

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/851)
<!-- Reviewable:end -->
