### PR TITLE
Restore openssh-client to NB images

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   graphviz \
   locales \
   lsb-release \
+  openssh-client \
   sudo \
   unzip \
   vim \


### PR DESCRIPTION
Fixes #850 

Re-enables git ssh push/pull within NB container.

/assign @ankushagarwal 
/cc @cwbeitel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/882)
<!-- Reviewable:end -->
