### PR TITLE
Merge PVC from spawner and provisioners

### DIFF
--- a/components/tensorflow-notebook-image/pvc-check.sh
+++ b/components/tensorflow-notebook-image/pvc-check.sh
@@ -21,7 +21,7 @@ CONF_DIR=$HOME/.jupyter
 
 echo "checking if $HOME volume needs init..."
 
-if [ "$(ls -A $HOME)" ]; then
+if [ "$(ls --ignore=lost+found -A $HOME)" ]; then
     # assume we are working with an existing volume via a PVC
     echo "...$HOME already has content..."
 else

--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -56,11 +56,13 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
 
         options::
           if std.length(volumeClaims) > 0 then
+            // we need to merge the PVC from the spawner config
+            // with any added by a provisioner
             std.join("\n",
                      [
                        "###### Volumes #######",
-                       "c.KubeSpawner.volumes = " + std.manifestPython(volumes),
-                       "c.KubeSpawner.volume_mounts = " + std.manifestPython(volumeMounts),
+                       "c.KubeSpawner.volumes.extend(" + std.manifestPython(volumes) + ")",
+                       "c.KubeSpawner.volume_mounts.extend(" + std.manifestPython(volumeMounts) + ")",
                      ])
           else "",
 

--- a/kubeflow/core/tests/jupyterhub_test.jsonnet
+++ b/kubeflow/core/tests/jupyterhub_test.jsonnet
@@ -51,9 +51,9 @@ std.assertEqual(configSuffixLines[2], "c.JupyterHub.authenticator_class = 'dummy
 &&
 std.assertEqual(configSuffixLines[3], "###### Volumes #######")
 &&
-std.assertEqual(configSuffixLines[4], 'c.KubeSpawner.volumes = [{"name": "disk01", "persistentVolumeClaim": {"claimName": "disk01"}}, {"name": "disk02", "persistentVolumeClaim": {"claimName": "disk02"}}]')
+std.assertEqual(configSuffixLines[4], 'c.KubeSpawner.volumes.extend([{"name": "disk01", "persistentVolumeClaim": {"claimName": "disk01"}}, {"name": "disk02", "persistentVolumeClaim": {"claimName": "disk02"}}])')
 &&
-std.assertEqual(configSuffixLines[5], 'c.KubeSpawner.volume_mounts = [{"mountPath": "/mnt/disk01", "name": "disk01"}, {"mountPath": "/mnt/disk02", "name": "disk02"}]')
+std.assertEqual(configSuffixLines[5], 'c.KubeSpawner.volume_mounts.extend([{"mountPath": "/mnt/disk01", "name": "disk01"}, {"mountPath": "/mnt/disk02", "name": "disk02"}])')
 &&
 
 std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubService,


### PR DESCRIPTION
Fixes kubeflow/testing#144 and more generally merges PVC from the spawner config and any provisioner. Tested in dev.kubeflow.org.

/cc @jlewi 
/cc @ankushagarwal 
/cc @inc0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/892)
<!-- Reviewable:end -->
