### PR TITLE
Use deployment name as the NAME_PREFIX and CLUSTER_NAME

### DIFF
--- a/docs/gke/configs/cluster.jinja
+++ b/docs/gke/configs/cluster.jinja
@@ -12,7 +12,7 @@ limitations under the License.
 #}
 
 
-{% set NAME_PREFIX = env['deployment'] + '-' + env['name'] %}
+{% set NAME_PREFIX = env['deployment'] %}
 {% set CLUSTER_NAME = NAME_PREFIX %}
 {% set CPU_POOL = NAME_PREFIX + '-cpu-pool-' + properties['pool-version'] %}
 {% set GPU_POOL = NAME_PREFIX + '-gpu-pool-' + properties['pool-version'] %}


### PR DESCRIPTION
Having longer names leads to errors with objects which have limits on
their names. Deployment name is concise enough to name objects.

/assign @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/893)
<!-- Reviewable:end -->
