### PR TITLE
Make bootstrapper support multi ks registry, including private ones

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -34,8 +34,8 @@ RUN git clone https://github.com/ksonnet/ksonnet.git /opt/ksonnet && \
 	cd /opt/ksonnet && \
 	git checkout v0.10.0-alpha.3
 
-ARG kubeflowversion=v0.1.3
-RUN git clone --depth 1 --branch $kubeflowversion https://github.com/kubeflow/kubeflow.git /opt/kubeflow
+ARG registries
+COPY $registries /opt/registries
 
 # TODO(jlewi): bootstrap is using an early dev version of ks (0.10) so we need
 # to build ks at the same commit because the generated app won't work with

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -20,8 +20,10 @@ all: build
 
 # To build without the cache set the environment variable
 # export DOCKER_BUILD_OPTS=--no-cache
+
+# To edit which registries to add to bootstrapper, edit config (eg. config/default.yaml)
 build:
-	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) . --build-arg kubeflowversion=master
+	python build.py --image=$(IMG):$(TAG) --build_opts=$(DOCKER_BUILD_OPTS) --config=config/default.yaml
 	docker tag $(IMG):$(TAG) $(IMG):latest
 	@echo Built $(IMG):latest
 	@echo Built $(IMG):$(TAG)

--- a/bootstrap/build.py
+++ b/bootstrap/build.py
@@ -1,0 +1,51 @@
+# Script to build bootstrapper image
+import argparse
+import os
+import shutil
+import yaml
+
+FILE_PATH = os.path.dirname(os.path.abspath(__file__))
+REG_FOLDER = "reg_tmp"
+
+# Clone repos to tmp folder and build docker images
+def main(unparsed_args=None):
+  parser = argparse.ArgumentParser(
+    description="Build bootstrapper image with ksonnet registries specified in config.")
+
+  parser.add_argument(
+    "--image",
+    default="",
+    type=str,
+    help="Image name.")
+  parser.add_argument(
+    "--build_opts",
+    default="",
+    type=str,
+    help="Docker build opts.")
+  parser.add_argument(
+    "--config",
+    default="config/default.yaml",
+    type=str,
+    help="Relative path to bootstrapper config file specify which registries to include.")
+
+  args = parser.parse_args(args=unparsed_args)
+  tmp_dir = os.path.join(FILE_PATH, REG_FOLDER)
+
+  # Make local dir, clone repos into it and Docker build will copy whole folder.
+  if os.path.exists(tmp_dir):
+    shutil.rmtree(tmp_dir)
+  os.mkdir(tmp_dir)
+  with open(os.path.join(FILE_PATH, args.config), 'r') as conf_input:
+    conf = yaml.load(conf_input)
+
+  for reg in conf['registries']:
+    if "repo" in reg and "branch" in reg:
+      reg_path = os.path.join(tmp_dir, reg["name"])
+      print("Adding registry %s from %s %s" % (reg["name"], reg["repo"], reg["branch"]))
+      os.system("git clone --depth 1 --branch %s %s %s" % (reg["branch"], reg["repo"], reg_path))
+
+  os.system("docker build %s -t %s %s --build-arg registries=%s" %
+            (args.build_opts, args.image, FILE_PATH, REG_FOLDER))
+
+if __name__ == '__main__':
+  main()

--- a/bootstrap/build_image.sh
+++ b/bootstrap/build_image.sh
@@ -3,20 +3,19 @@
 # A simple script to build the Docker images.
 # This is intended to be invoked as a step in Argo to build the docker image.
 #
-# build_image.sh ${DOCKERFILE} ${IMAGE}
+# build_image.sh ${BUILDDIR} ${IMAGE} ${CONFIG}
 set -ex
 
-DOCKERFILE=$1
-CONTEXT_DIR=$(dirname "$DOCKERFILE")
+BUILDDIR=$1
 IMAGE=$2
+CONFIG=$3
 
 # Wait for the Docker daemon to be available.
 until docker ps
 do sleep 3
 done
 
-docker build --pull -t ${IMAGE} \
-	-f ${DOCKERFILE} ${CONTEXT_DIR}
+python ${BUILDDIR}/build.py --image=${IMAGE} --build_opts="--pull" --config=${CONFIG}
 
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 gcloud docker -- push ${IMAGE}

--- a/bootstrap/cmd/bootstrap/app/options/options.go
+++ b/bootstrap/cmd/bootstrap/app/options/options.go
@@ -29,6 +29,7 @@ type ServerOption struct {
 	Config        string
 	Email         string
 	NameSpace     string
+	RegistryName   string
 	RegistryUri   string
 }
 
@@ -47,7 +48,8 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.Apply, "apply", false, "Whether or not to apply the configuration.")
 	fs.StringVar(&s.Email, "email", "", "Your Email address for GCP account, if you are using GKE.")
 	fs.BoolVar(&s.InCluster, "in-cluster", false, "Whether bootstrapper is executed inside a pod")
-	fs.StringVar(&s.RegistryUri, "registry-uri", "/opt/kubeflow/kubeflow", "Location of kubeflow registry.")
+	fs.StringVar(&s.RegistryName, "registry-name", "", "Name of e2e test target registry.")
+	fs.StringVar(&s.RegistryUri, "registry-uri", "", "Location of e2e test target registry.")
 	fs.BoolVar(&s.KeepAlive, "keep-alive", true, "Whether bootstrapper will stay alive after setup resources.")
 	fs.StringVar(&s.Config, "config", "/opt/kubeflow/default.yaml", "Path to bootstrapper components config.")
 }

--- a/bootstrap/config/default.yaml
+++ b/bootstrap/config/default.yaml
@@ -1,11 +1,21 @@
-# Default config for kubeflow bootstrapper, included in bootstrapper image
+# Default kubeflow config for bootstrapper, included in bootstrapper image.
+# This config is shared by docker image build and bootstrapper execution.
 ---
-# App that always apply
+# Image build is when pulling registry happens, so make sure to include registries you want for image build
+registries:
+  - name: kubeflow
+    repo: https://github.com/kubeflow/kubeflow.git
+    branch: master
+    # relative path to registry from git repo.
+    path: kubeflow
 app:
   packages:
     - name: core
+      registry: kubeflow
     - name: tf-serving
+      registry: kubeflow
     - name: tf-job
+      registry: kubeflow
   components:
     - name: kubeflow-core
       prototype: kubeflow-core

--- a/bootstrap/config/gcp_prototype.yaml
+++ b/bootstrap/config/gcp_prototype.yaml
@@ -1,6 +1,12 @@
 # Sample config for kubeflow bootstrapper
 ---
 # App only apply if on GKE
+registries:
+  - name: kubeflow
+    repo: https://github.com/kubeflow/kubeflow.git
+    branch: master
+    # relative path to registry from git repo.
+    path: kubeflow
 app:
   packages:
     - name: core

--- a/testing/e2e_env.yaml
+++ b/testing/e2e_env.yaml
@@ -7,9 +7,13 @@ registries:
 app:
   packages:
     - name: core
+      registry: kubeflow
     - name: tf-serving
+      registry: kubeflow
     - name: tf-job
+      registry: kubeflow
     - name: pytorch-job
+      registry: kubeflow
   components:
     - name: kubeflow-core
       prototype: kubeflow-core

--- a/testing/e2e_env.yaml
+++ b/testing/e2e_env.yaml
@@ -1,4 +1,9 @@
-# App for e2e test
+# Bootstrap config for kubeflow e2e test
+registries:
+  # For e2e test we won't use registry in boostrapper image,
+  # Instead we use PR code attached to container by volumn. (specify registry path in parameters.)
+  # So don't need to provide repo here.
+  - name: kubeflow
 app:
   packages:
     - name: core

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -442,8 +442,9 @@
                 "/bin/bash",
                 "-c",
                 bootstrapDir + "/build_image.sh "
-                + bootstrapDir + "/Dockerfile" + " "
-                + bootstrapperImage,
+                + bootstrapDir + " "
+                + bootstrapperImage + " "
+                + "../testing/e2e_env.yaml",
               ],
               [
                 {
@@ -466,6 +467,7 @@
               "--apply",
               "--namespace=" + stepsNamespace,
               "--registry-uri=" + srcDir + "/kubeflow",
+              "--registry-name=kubeflow"
               "--app-dir=" + testDir + "/app",
               "--config=" + srcDir + "/testing/e2e_env.yaml",
               "--keep-alive=false",

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -467,7 +467,7 @@
               "--apply",
               "--namespace=" + stepsNamespace,
               "--registry-uri=" + srcDir + "/kubeflow",
-              "--registry-name=kubeflow"
+              "--registry-name=kubeflow",
               "--app-dir=" + testDir + "/app",
               "--config=" + srcDir + "/testing/e2e_env.yaml",
               "--keep-alive=false",


### PR DESCRIPTION
For https://github.com/kubeflow/kubeflow/issues/880
Bootstrapper now can apply and update ksonnet apps from multi repos.
Users now can one-command-deploy any custom ksonnet apps set through bootstrapper. 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/900)
<!-- Reviewable:end -->
