### PR TITLE
Upgrade jupyterhub and kube_spawner

### DIFF
--- a/components/jupyterhub/docker/Dockerfile
+++ b/components/jupyterhub/docker/Dockerfile
@@ -12,18 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM python:3.6
+FROM jupyterhub/jupyterhub:0.9
 
-RUN apt-get update && \
-    apt-get install -y npm nodejs-legacy
-
-RUN npm install -g configurable-http-proxy && \
-    pip3 install --no-cache-dir \
-                 notebook \
-                 jupyterhub==0.8.1 \
-                 jupyterhub-kubespawner==0.7.1 \
+RUN pip3 install --no-cache-dir \                 
+                 jupyterhub-kubespawner==0.8.1 \
                  jupyterhub-dummyauthenticator \
                  jhub_remote_user_authenticator \
                  oauthenticator
-
-ENTRYPOINT jupyterhub

--- a/components/jupyterhub/docker/Makefile
+++ b/components/jupyterhub/docker/Makefile
@@ -12,7 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-VERSION=1.0.1
+# List any changed  files. We only include files in the  image directory.
+# because that is the code in the docker image.
+CHANGED_FILES := $(shell git diff-files --relative=components/jupyterhub)
+
+ifeq ($(strip $(CHANGED_FILES)),)
+# Changed files is empty; not dirty
+# Don't include --dirty because it could be dirty if files outside the ones we care
+# about changed.
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --always)
+else
+VERSION := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
+
 PROJECT_ID=kubeflow
 GCR_PROJECT=gcr.io/${PROJECT_ID}
 DOCKERHUB_PROJECT=hub.docker.com/r/${PROJECT_ID}

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -11,8 +11,7 @@
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
-// @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:v20180531-3bb991b1
- The image to use for JupyterHub.
+// @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:v20180531-3bb991b1 The image to use for JupyterHub.
 // @optionalParam jupyterHubAuthenticator string null The authenticator to use
 // @optionalParam jupyterNotebookPVCMount string null Mount path for PVC. Set empty to disable PVC
 // @optionalParam reportUsage string false Whether or not to report Kubeflow usage to kubeflow.org.

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -11,7 +11,8 @@
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
-// @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:1.0.1 The image to use for JupyterHub.
+// @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:v20180531-3bb991b1
+ The image to use for JupyterHub.
 // @optionalParam jupyterHubAuthenticator string null The authenticator to use
 // @optionalParam jupyterNotebookPVCMount string null Mount path for PVC. Set empty to disable PVC
 // @optionalParam reportUsage string false Whether or not to report Kubeflow usage to kubeflow.org.


### PR DESCRIPTION
* JupyterHub 0.9 is now available and 0.8 for Kubespawner.
* These updates include improvements that should help with UX when spawning
  notebooks by providing more information about progress.

* As part of this change we switch to using the JupyterHub image as our
  base image and only installing the additional modules that we care about.

* It looks like the original image was manually intalling nodejs presumably
  to support the javascript proxy inside JupyterHub. If nodejs is needed
  by jupyterhub then I expect it to be included in the official image
  so we shouldn't need to manually install it.

* I verified this manually by spinning up a new JupyterHub instance using this image
     * The spawner provides a much greater UI
     * The UI shows K8s events e.g. "notebook spawned"
     * It also has a status bar showing progress. I'm guessing the progress is a total fabrication but it will probably make users feel better.
   
Fix #479

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/905)
<!-- Reviewable:end -->
