### PR TITLE
Install py2 to global conda env

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -117,12 +117,12 @@ RUN conda create -n py2 python=2 && \
     tensorflow-serving-api \
     # ipykernel for python 2 jupyter notebook kernel
     && \
-    python -m ipykernel install --user && \
+    python -m ipykernel install && \
     # tensorflow-model-analysis is only supported for TF 1.6 and above
     if [[ $INSTALL_TFMA == "yes" ]]; then \
       pip install --no-cache-dir tensorflow-model-analysis && \
-      jupyter nbextension install --py --symlink tensorflow_model_analysis --user && \
-      jupyter nbextension enable --py tensorflow_model_analysis --user; \
+      jupyter nbextension install --py --symlink tensorflow_model_analysis && \
+      jupyter nbextension enable --py tensorflow_model_analysis ; \
     fi \
     && \
     # Install jupyterlab-manager


### PR DESCRIPTION
Fixes #906 

PTAL
/cc @jlewi 
/cc @ankushagarwal 

Are we good with just dropping the `--user` py2 install and letting it get installed to `/opt/conda/envs`? Are there some other tests I should try?

Also, should we install the Beam pkg @jlewi was referring to in #906 while we're here?

<img width="173" alt="screen shot 2018-06-01 at 11 47 20 am" src="https://user-images.githubusercontent.com/2380545/40850207-0d9ef298-6592-11e8-8958-88ae4e60d867.png">
<img width="534" alt="screen shot 2018-06-01 at 1 01 54 pm" src="https://user-images.githubusercontent.com/2380545/40853449-164f8e5c-659c-11e8-8ae4-4ffb70840aae.png">

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/907)
<!-- Reviewable:end -->
