### PR TITLE
Run v1alpha1 and v1alpha2 TfJob tests in GKE workflow

### DIFF
--- a/testing/deploy_kubeflow_gcp.py
+++ b/testing/deploy_kubeflow_gcp.py
@@ -30,6 +30,10 @@ def parse_args():
     help="The bootstrapper image for deployment.")
 
   parser.add_argument(
+    "--tfjob_version", required=True, type=str,
+    help="The tfjob version to deploy.")
+
+  parser.add_argument(
     "--config", required=True, type=str, 
     help="The path to the YAML file for the deployment config to use.")
   
@@ -40,6 +44,13 @@ def parse_args():
   
   args, _ = parser.parse_known_args()
   return args
+
+def update_tfjob_version(config, tfjob_version):
+  bootstrapper_config = yaml.load(config['resources'][0]['properties']['bootstrapperConfig'])
+  for param in bootstrapper_config['app']['parameters']:
+    if param['name'] == 'tfJobVersion':
+      param['value'] = tfjob_version
+  config['resources'][0]['properties']['bootstrapperConfig'] = yaml.dump(bootstrapper_config)
 
 def deploy_kubeflow_gcp(_):
   """Deploy Kubeflow."""
@@ -62,6 +73,7 @@ def deploy_kubeflow_gcp(_):
     content = hf.read()
     content_yaml = yaml.load(content)
 
+  update_tfjob_version(content_yaml, args.tfjob_version)
   if args.bootstrapper_image:
     content_yaml['resources'][0]['properties']['bootstrapperImage'] = args.bootstrapper_image
 

--- a/testing/dm_configs/cluster-kubeflow.yaml
+++ b/testing/dm_configs/cluster-kubeflow.yaml
@@ -44,3 +44,7 @@ resources:
             prototype: kubeflow-core
           - name: pytorch-operator
             prototype: pytorch-operator
+        parameters:
+          - component: kubeflow-core
+            name: tfJobVersion
+            value: v1alpha2


### PR DESCRIPTION
* Update deploy_kubeflow_gcp to add tfjob_version flag
* In GKE Testing workflow, bring up two k8s clusters - one to test v1alpha1 and other to test v1alpha2
* Deploy kubeflow on both clusters using bootstrapper - set tfjob_version different for both clusters
* Using different kubeConfig for both clusters
* Teardown both clusters at the end

Fixes https://github.com/kubeflow/kubeflow/issues/852

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/918)
<!-- Reviewable:end -->
