### PR TITLE
fix envoy config volumeMount

### DIFF
--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -151,7 +151,7 @@
       volumeMounts: [
         {
           mountPath: "/etc/envoy",
-          name: "shared",
+          name: "config-volume",
         },
       ],
     },  // envoyContainer
@@ -386,7 +386,7 @@
 
           function checkIAP() {
             # created by init container.
-            . /var/shared/healthz.env 
+            . /var/shared/healthz.env
 
             # If node port or backend id change, so does the JWT audience.
             CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')


### PR DESCRIPTION
Envoy fails to start due to `/etc/envoy/envoy-config.json` not being mounted properly. This corrects the volumeMount name.