### PR TITLE
Delete test directory after test completes

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -285,6 +285,12 @@
                         else
                           "",
                   },
+                  if platform == "gke" then
+                    {
+                      name: "test-dir-delete",
+                      template: "test-dir-delete",
+                      dependencies: ["copy-artifacts"],
+                    },
                   {
                     name: "copy-artifacts",
                     template: "copy-artifacts",
@@ -302,6 +308,12 @@
               }],
               [],  // no sidecars
             ),
+            buildTemplate("test-dir-delete", [
+              "bash",
+              "-c",
+              "rm -rf " + testDir,
+            ]),  // test-dir-delete
+
             buildTemplate("wait-for-kubeflow-deployment", [
               "python",
               "-m",


### PR DESCRIPTION
Since we copy test artifacts to GCS, it should be safe to delete the test directory. Otherwise it keeps growing and runs out of disk.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/926)
<!-- Reviewable:end -->
