### PR TITLE
DM config should allow setting users/groups to grant IAP access to.

### DIFF
--- a/docs/gke/configs/cluster-kubeflow.yaml
+++ b/docs/gke/configs/cluster-kubeflow.yaml
@@ -58,6 +58,12 @@ resources:
           - cidrBlock: 1.2.3.4/32
           - cidrBlock: 5.6.7.8/32
           enabled: false
+    users: 
+      # List users to grant appropriate GCP permissions to use Kubeflow.
+      # These can either be individual users (Google accounts) or Google
+      # Groups.
+      # - user:john@acme.com
+      # - group:data-scientists@acme.com
     # Path for the bootstrapper image.
     bootstrapperImage: gcr.io/kubeflow-images-public/bootstrapper:latest
     # This is the name of the GCP static ip address to reserve for your domain.

--- a/docs/gke/configs/cluster.jinja
+++ b/docs/gke/configs/cluster.jinja
@@ -75,7 +75,7 @@ resources:
 - name: {{ KF_VM_SA_NAME }}
   type: iam.v1.serviceAccount
   properties:
-    accountId: {{ properties['vmServiceAccountName'] }}
+    accountId: {{ KF_VM_SA_NAME }}
     displayName: GCP Service Account to use as VM Service Account for Kubeflow Cluster VMs
 
 - name: {{ CLUSTER_NAME }}
@@ -154,7 +154,7 @@ resources:
           nodeMetadata: SECURE
         {% endif %}
         machineType: n1-standard-8
-        serviceAccount: {{ properties['vmServiceAccountName'] }}@{{ env['project'] }}.iam.gserviceaccount.com
+        serviceAccount: {{ KF_VM_SA_NAME }}@{{ env['project'] }}.iam.gserviceaccount.com
         oauthScopes: {{ VM_OAUTH_SCOPES }}
   metadata:
     dependsOn:
@@ -334,6 +334,14 @@ TODO(jlewi): Do we need to serialize API activation
           members:
             {# VM service account is used to write monitoring data. #}
             - {{ 'serviceAccount:' + KF_VM_SA_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        {% if 'users' in properties %}
+        - role: roles/iap.httpsResourceAccessor
+          members:
+            {% for user in properties['users'] %}
+            - {{ user }}
+            {% endfor %}
+        {% endif %}
 
       remove: []
 

--- a/docs/gke/gke_setup.md
+++ b/docs/gke/gke_setup.md
@@ -24,6 +24,14 @@ The instructions also take advantage of IAP to provide secure authenticated acce
 
 		* If you want GPUs set a non-zero number for number of GPU nodes.
 
+   1. List any users (Google Accounts) or Google groups that should be able to access Kubeflow in the **users** section; e.g.
+
+      ```
+      users: 
+       - user:john@acme.com
+       - group:data-scientists@acme.com
+      ```
+
 1. Modify `env-kubeflow.sh`
 
 	* This file defines environment variables used in the commands below.
@@ -70,7 +78,8 @@ Create an OAuth Client ID to be used to identify IAP when requesting acces to us
   * Click Save.
 
 1.  On the [Credentials](https://console.cloud.google.com/apis/credentials) Click Create credentials, and then click OAuth client ID.
-  * Under Application type, select Web application. In the Name box enter a name, and in the Authorized redirect URIs box, enter
+  
+   * Under Application type, select Web application. In the Name box enter a name, and in the Authorized redirect URIs box, enter
 
    ```
    https://${FQDN}/_gcp_gatekeeper/authenticate
@@ -87,11 +96,22 @@ Create an OAuth Client ID to be used to identify IAP when requesting acces to us
 
 1. Grant users IAP access
 
-   ```
-   gcloud projects add-iam-policy-binding $PROJECT \
-    --role roles/iap.httpsResourceAccessor \
-    --member user:${USER_EMAIL}
-   ```
+  * Users/Google groups listed in **users:** in the ${CONFIG_FILE} will be granted IAP access
+  * To additional users
+
+    1. Update ${CONFIG_FILE} and issue an update
+
+       ```
+       gcloud deployment-manager --project=${PROJECT} deployments create ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}
+       ```
+
+    1.  Use gcloud to grant users access
+
+       ```
+       gcloud projects add-iam-policy-binding $PROJECT \
+        --role roles/iap.httpsResourceAccessor \
+        --member user:${USER_EMAIL}
+       ```
 
 1. Kubeflow will be available at
 


### PR DESCRIPTION
* Tested this works if users isn't specified or if users is specified.

* For the VM service account we should be using KF_VM_SA_NAME
* We want to use unique service accounts for each deployment. This creates
  fewer problems/interference between deployments.

Fix #883

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/928)
<!-- Reviewable:end -->
