### PR TITLE
A bunch of fixes to the DM configs for GCP to work with latest bootstrapper

### DIFF
--- a/bootstrap/.gitignore
+++ b/bootstrap/.gitignore
@@ -1,3 +1,4 @@
 /lib
 /.ksonnet/registries
 /app.override.yaml
+/reg_tmp/**

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -16,6 +16,18 @@ IMG = gcr.io/kubeflow-images-public/bootstrapper
 
 TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
 
+
+CHANGED_FILES := $(shell git diff-files)
+
+ifeq ($(strip $(CHANGED_FILES)),)
+# Changed files is empty; not dirty
+# Don't include --dirty because it could be dirty if files outside the ones we care
+# about changed.
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always)
+else
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
 all: build
 
 # To build without the cache set the environment variable

--- a/docs/gke/configs/cluster-kubeflow.yaml
+++ b/docs/gke/configs/cluster-kubeflow.yaml
@@ -65,7 +65,7 @@ resources:
       # - user:john@acme.com
       # - group:data-scientists@acme.com
     # Path for the bootstrapper image.
-    bootstrapperImage: gcr.io/kubeflow-images-public/bootstrapper:latest
+    bootstrapperImage: gcr.io/kubeflow-images-public/bootstrapper:v20180607-v0.1.1-109-g4867d01b-dirty-601834
     # This is the name of the GCP static ip address reserved for your domain.
     # Each Kubeflow deployment in your project should use one unique ipName among all configs.
     ipName: kubeflow-ip
@@ -83,12 +83,20 @@ resources:
     #                 deployment in your project
     #          Project - This is the name of your GCP provided project.
     bootstrapperConfig: |
-      # Apps only apply if on GKE
+      registries:
+        - name: kubeflow
+          repo: https://github.com/kubeflow/kubeflow.git
+          branch: master
+          # relative path to registry from git repo.
+          path: kubeflow
       app:
         packages:
           - name: core
+            registry: kubeflow
           - name: tf-serving
+            registry: kubeflow
           - name: tf-job
+            registry: kubeflow
         components:
           - name: kubeflow-core
             prototype: kubeflow-core
@@ -101,7 +109,7 @@ resources:
         parameters:
           - component: cloud-endpoints
             name: secretName
-            value: cloudep-sa
+            value: admin-gcp-sa
           - component: cert-manager
             name: acmeEmail
             # TODO: use your email for ssl cert

--- a/docs/gke/configs/cluster.jinja
+++ b/docs/gke/configs/cluster.jinja
@@ -50,15 +50,6 @@ limitations under the License.
 {% set KF_USER_NAME = NAME_PREFIX + '-user' %}
 {% set KF_VM_SA_NAME = NAME_PREFIX + '-vm' %}
 
-{# For most of the K8s resources we set the deletePolicy to abandon; otherwise deployment manager reports various errors.
-   Since we delete the cluster all the K8s resources will be deleted anyway.
-
-   We also set deletePolicy to ABANDON on the project APIs because otherwise it tries to deactivate them
-   which causes errors.
-
-   TODO(jlewi): I don't think this is needed. I think the bug was that we weren't using references in K8s types
-   so we weren't ensuring the type providers were deleted after the corresponding resources.
-#}
 resources:
 - name: {{ KF_ADMIN_NAME }}
   type: iam.v1.serviceAccount
@@ -341,11 +332,13 @@ TODO(jlewi): Do we need to serialize API activation
             - {{ 'serviceAccount:' + KF_VM_SA_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
 
         {% if 'users' in properties %}
+        {% if properties['users'] %}
         - role: roles/iap.httpsResourceAccessor
           members:
             {% for user in properties['users'] %}
             - {{ user }}
             {% endfor %}
+        {% endif %}
         {% endif %}
 
       remove: []

--- a/docs/gke/create_k8s_secrets.sh
+++ b/docs/gke/create_k8s_secrets.sh
@@ -2,7 +2,9 @@
 #
 # A simple helper script to download secrets for Kubeflow service
 # accounts and store them as K8s secrets.
-set -ex
+#
+# Ignore errors because if secret/namespace already exists just keep going.
+set -x
 export SA_EMAIL=${DEPLOYMENT_NAME}-admin@${PROJECT}.iam.gserviceaccount.com
 
 # TODO(jlewi): We should name the secrets more consistently based on the service account name.
@@ -10,6 +12,11 @@ export SA_EMAIL=${DEPLOYMENT_NAME}-admin@${PROJECT}.iam.gserviceaccount.com
 gcloud --project=${PROJECT} iam service-accounts keys create ${SA_EMAIL}.json --iam-account ${SA_EMAIL}
 
 kubectl create secret generic --namespace=kubeflow-admin admin-gcp-sa --from-file=admin-gcp-sa.json=./${SA_EMAIL}.json
+
+# The namespace kubeflow may not exist yet because the bootstrapper can't run until the admin-gcp-sa 
+# secret is created.
+kubectl create namespace kubeflow
+
 kubectl create secret generic --namespace=kubeflow admin-gcp-sa --from-file=admin-gcp-sa.json=./${SA_EMAIL}.json
 
 export USER_EMAIL=${DEPLOYMENT_NAME}-user@${PROJECT}.iam.gserviceaccount.com

--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -159,6 +159,17 @@ ks apply ${ENV} -c workflows
 Create a PR to update [kubeform_spawner.py](https://github.com/kubeflow/kubeflow/blob/master/kubeflow/core/kubeform_spawner.py#L15) 
 to point to the newly built Jupyter notebook images.
 
+## Update the bootstrapper
+
+Build and push a new bootstrapper image
+
+```
+cd bootstrap
+make push
+```
+
+Update [cluster-kubeflow.yaml](https://github.com/kubeflow/kubeflow/blob/master/docs/gke/configs/cluster-kubeflow.yaml) to point to the new image.
+
 ## Create a release branch (if necessary)
 
 If you aren't already working on a release branch (of the form `v${MAJOR}.${MINOR}-branch`, where `${MAJOR}.${MINOR}` is a major-minor version number), then create one.  Release branches serve several purposes:

--- a/kubeflow/core/configure_envoy_for_iap.sh
+++ b/kubeflow/core/configure_envoy_for_iap.sh
@@ -33,7 +33,7 @@ gcloud config list
 NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
 while [[ -z ${BACKEND_ID} ]];
 do BACKEND_ID=$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${NODE_PORT}- --format='value(id)');
-echo "Waiting for backend id PROJECT=${PROJECT} NAMESPACE=${NAMESPACE} SERVICE=${SERVICE}...";
+echo "Waiting for backend id PROJECT=${PROJECT} NAMESPACE=${NAMESPACE} SERVICE=${SERVICE} filter=name~k8s-be-${NODE_PORT}-...";
 sleep 2;
 done
 echo BACKEND_ID=${BACKEND_ID}

--- a/kubeflow/core/setup_iap.sh
+++ b/kubeflow/core/setup_iap.sh
@@ -60,7 +60,7 @@ gcloud config list
 NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
 while [[ -z ${BACKEND_ID} ]];
 do BACKEND_ID=$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${NODE_PORT}- --format='value(id)');
-echo "Waiting for backend id PROJECT=${PROJECT} NAMESPACE=${NAMESPACE} SERVICE=${SERVICE}...";
+echo "Waiting for backend id PROJECT=${PROJECT} NAMESPACE=${NAMESPACE} SERVICE=${SERVICE} filter=name~k8s-be-${NODE_PORT}- ...";
 sleep 2;
 done
 echo BACKEND_ID=${BACKEND_ID}


### PR DESCRIPTION
* docks/gke/configs/cluster-kubeflow.yaml was out of date and needed to
  be updated to work with the latest bootstrapper to image.
* Update the bootstrapper image so we pull in the latest registry configs.
* Make the instructions cleaner about what steps need to be performed to
  configure gcp.
* create_k8s_secrets.sh needs to create the kubeflow namespace because the
  namespace won't exist yet because the bootstrapper hasn't run because
  its blocked waiting for the GCP key.

* Don't include git tags in the image tag for the bootstrapper image.
* cluster-kubeflow.yaml is using the wrong name for the GCP service account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/956)
<!-- Reviewable:end -->
