### PR TITLE
Disable the v1alpha2 test because it is failing because mnist data can't be downloaded.

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -270,7 +270,10 @@
                   },
                   if platform == "gke" then {
                     name: "tfjob-test" + v1alpha2Suffix,
-                    template: "tfjob-test" + v1alpha2Suffix,
+                    // TODO(https://github.com/kubeflow/kubeflow/issues/974): Reneable this test once
+                    // its fixed.
+                    // template: "tfjob-test" + v1alpha2Suffix,
+                    template: "skip-step",
                     dependencies: ["wait-for-kubeflow" + v1alpha2Suffix],
                   },
                   if platform == "gke" then {
@@ -343,6 +346,16 @@
               "-c",
               "rm -rf " + testDir,
             ]),  // test-dir-delete
+
+
+            // A simple step that can be used to replace a test that we want to temporarily
+            // disable. Changing the template of the step to use this simplifies things
+            // because then we don't need to mess with dependencies.
+            buildTemplate("skip-step", [
+              "echo",
+              "skipping",
+              "step",
+            ]),  // skip step
 
             buildTemplate("wait-for-kubeflow", [
               "python",


### PR DESCRIPTION
* The v1alpha2 test probably shouldn't be using MNIST anyway; we should be
  running a smoke test as in v1alpha1.

Related to #974

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/975)
<!-- Reviewable:end -->
