### PR TITLE
use ks apply in bootstrapper to avoid creation ordering issue

### DIFF
--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -535,7 +535,7 @@ func Run(opt *options.ServerOption) error {
 		// if use k8s client-go API, would be quite verbose if we create all resources one by one.
 		// TODO: use API to create ks Components
 		log.Infof("Apply kubeflow Components...")
-		rawCmd := "ks show default | kubectl apply -f -"
+		rawCmd := "ks apply default --token=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
 		applyCmd := exec.Command("bash", "-c", rawCmd)
 
 		var out bytes.Buffer

--- a/bootstrap/config/gcp_prototype.yaml
+++ b/bootstrap/config/gcp_prototype.yaml
@@ -4,8 +4,11 @@
 app:
   packages:
     - name: core
+      registry: kubeflow
     - name: tf-serving
+      registry: kubeflow
     - name: tf-job
+      registry: kubeflow
   components:
     - name: kubeflow-core
       prototype: kubeflow-core
@@ -18,19 +21,19 @@ app:
   parameters:
     - component: cloud-endpoints
       name: secretName
-      value: cloudep-sa
+      value: admin-gcp-sa
     - component: cert-manager
       name: acmeEmail
-      # todo: use your email for ssl cert
-      value: <email>
+      # TODO: use your email for ssl cert
+      value: johnDoe@acme.com
     - component: iap-ingress
       name: ipName
-      # todo: change ip name here
-      value: static-ip
+      # TODO: make sure value of ipName is the same as property <ipName>.
+      value: ipName
     - component: iap-ingress
       name: hostname
-      # todo: replace with name of gcp project where kubeflow will be installed
-      value: kubeflow.endpoints.<project>.cloud.goog
+      # TODO: replace with Name of GCP project. This is fully qualified domain name to use with ingress.
+      value: kubeflow.endpoints.<Project>.cloud.goog
     - component: kubeflow-core
       name: jupyterHubAuthenticator
       value: iap


### PR DESCRIPTION
1. fix https://github.com/kubeflow/kubeflow/issues/954:
```ks apply``` allow us to define CRDs and use them during same apply action,
while ```ks show | kubectl apply``` doesn't guarantee so.

2. edit gcp_prototype.yaml following new format to make sure it works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/976)
<!-- Reviewable:end -->
