### PR TITLE
Fix permissions for jupyter-role

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -249,7 +249,7 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
       rules: [
         {
           apiGroups: [
-            "*",
+            "",
           ],
           resources: [
             "pods",
@@ -265,7 +265,7 @@ c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'",
         },
         {
           apiGroups: [
-            "*",
+            "",
           ],
           resources: [
             "events",

--- a/kubeflow/core/tests/jupyterhub_test.jsonnet
+++ b/kubeflow/core/tests/jupyterhub_test.jsonnet
@@ -219,7 +219,7 @@ std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubRole,
                   rules: [
                     {
                       apiGroups: [
-                        "*",
+                        "",
                       ],
                       resources: [
                         "pods",
@@ -235,7 +235,7 @@ std.assertEqual(jupyterhub.parts(params.namespace).jupyterHubRole,
                     },
                     {
                       apiGroups: [
-                        "*",
+                        "",
                       ],
                       resources: [
                         "events",


### PR DESCRIPTION
The permissions handed out in the jupyter-role were allowing "*" in the
apiGroups, in stead of "". This means that it gives permissions to all
different kinds of apiGroups, in stead of the default one, which is
actually sufficient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/978)
<!-- Reviewable:end -->
