### PR TITLE
Parameterize extra_repos and build_image_path in automation release app

### DIFF
--- a/kubeflow/automation/prototypes/release.jsonnet
+++ b/kubeflow/automation/prototypes/release.jsonnet
@@ -15,6 +15,8 @@
 // @optionalParam bucket string kubeflow-releasing-artifacts GCS bucket storing artifacts.
 // @optionalParam prow_env string REPO_OWNER=kubeflow,REPO_NAME=kubeflow,PULL_BASE_SHA=master Self explanatory.
 // @optionalParam versionTag string latest Tag for released image.
+// @optionalParam build_image_path string Path to your build_image.sh folder
+// @optionalParam extra_repos string Extra repos to be cloned for build_image.sh
 // @optionalParam extra_args string Extra args for your build_image.sh
 
 local k = import "k.libsonnet";

--- a/kubeflow/automation/release.libsonnet
+++ b/kubeflow/automation/release.libsonnet
@@ -84,10 +84,10 @@
 
       //Extra Repos must be semicolon delimited string. See testing checkout.sh file
       local repos =
-          if extra_repos == "null" then
-           "kubeflow/testing@HEAD"
-          else
-           extra_repos + ";" + "kubeflow/testing@HEAD";
+        if extra_repos == "null" then
+          "kubeflow/testing@HEAD"
+        else
+          extra_repos + ";" + "kubeflow/testing@HEAD";
 
       // Build an Argo template to execute a particular command.
       // step_name: Name for the template

--- a/kubeflow/katib/prototypes/all.jsonnet
+++ b/kubeflow/katib/prototypes/all.jsonnet
@@ -13,9 +13,9 @@
 
 local k = import "k.libsonnet";
 
-local vizier = import "kubeflow/katib/vizier.libsonnet";
 local modeldb = import "kubeflow/katib/modeldb.libsonnet";
 local suggestion = import "kubeflow/katib/suggestion.libsonnet";
+local vizier = import "kubeflow/katib/vizier.libsonnet";
 
 local namespace = env.namespace;
 


### PR DESCRIPTION
Fixes #970 

Two extra parameters are added.
1. extra_repos - semicolon delimited string of repos that is passed to checkout.sh
2. build_image_path - Location of build_image.sh folder eg: kubeflow/pytorch-operator

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/988)
<!-- Reviewable:end -->
