### PR TITLE
Fix user guide for the refactored tf-cnn example

### DIFF
--- a/user_guide.md
+++ b/user_guide.md
@@ -435,7 +435,7 @@ CNN_JOB_NAME=mycnnjob
 ks registry add kubeflow-git github.com/kubeflow/kubeflow/tree/${VERSION}/kubeflow
 ks pkg install kubeflow-git/examples
 
-ks generate tf-job-simple ${CNN_JOB_NAME} --name=${CNN_JOB_NAME} --namespace=${NAMEPSACE}
+ks generate tf-job-simple ${CNN_JOB_NAME} --name=${CNN_JOB_NAME}
 ```
 
 Submit it
@@ -444,7 +444,7 @@ Submit it
 ks apply ${KF_ENV} -c ${CNN_JOB_NAME}
 ```
 
-Monitor it (Noted that tf-cnn job is also a tfjobs. Please refer to the [TfJob docs](https://github.com/kubeflow/tf-operator#monitoring-your-job))
+Monitor it (Please refer to the [TfJob docs](https://github.com/kubeflow/tf-operator#monitoring-your-job))
 
 ```
 kubectl get -o yaml tfjobs ${CNN_JOB_NAME}
@@ -456,11 +456,6 @@ Delete it
 ks delete ${KF_ENV} -c ${CNN_JOB_NAME}
 ```
 
-The prototype provides a bunch of parameters to control how the job runs (e.g. use GPUs run distributed etc...). To see a list of paramets
-
-```
-ks prototype describe tf-cnn
-```
 
 ### Submitting a PyTorch training job
 


### PR DESCRIPTION
This fixes the user guide so that it works with the refactored tf-cnn
exampe in the examples package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/995)
<!-- Reviewable:end -->
