### PR TITLE
fix iam role delete for deployment manager

### DIFF
--- a/docs/gke/configs/cluster.jinja
+++ b/docs/gke/configs/cluster.jinja
@@ -367,11 +367,6 @@ TODO(jlewi): Do we need to serialize API activation
       add: []
 
       remove:
-        - role: roles/container.admin
-          members:
-            {# Deployment manager uses cloudservices account. #}
-            - {{ 'serviceAccount:' + env['project_number'] + '@cloudservices.gserviceaccount.com' }}
-
         {# Grant permissions needed to push the app to a cloud repository. #}
         - role: roles/source.admin
           members:

--- a/docs/gke/configs/cluster.jinja
+++ b/docs/gke/configs/cluster.jinja
@@ -352,7 +352,81 @@ TODO(jlewi): Do we need to serialize API activation
       - {{ KF_ADMIN_NAME }}
       - {{ KF_USER_NAME }}
     runtimePolicy:
-      - UPDATE_ALWAYS
+      - CREATE
+
+{# Remove IAM role binding when delete deployment.
+
+  TODO: This delete might be too aggresive (delete roles not created by deployment manager)
+#}
+- name: remove-iam-policy
+  action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy
+  properties:
+    resource: {{ env['project'] }}
+    policy: $(ref.patch-iam-policy)
+    gcpIamPolicyPatch:
+      add: []
+
+      remove:
+        - role: roles/container.admin
+          members:
+            {# Deployment manager uses cloudservices account. #}
+            - {{ 'serviceAccount:' + env['project_number'] + '@cloudservices.gserviceaccount.com' }}
+
+        {# Grant permissions needed to push the app to a cloud repository. #}
+        - role: roles/source.admin
+          members:
+            - {{ 'serviceAccount:' + KF_ADMIN_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        {# servicemanagement.admin is needed by CloudEndpoints controller
+           so we can create a service to get a hostname.
+         #}
+        - role: roles/servicemanagement.admin
+          members:
+            - {{ 'serviceAccount:' + KF_ADMIN_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+        {# Network admin is needed to enable IAP and configure network settings
+           like backend timeouts and health checks.
+        #}
+        - role: roles/compute.networkAdmin
+          members:
+            - {{ 'serviceAccount:' + KF_ADMIN_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        - role: roles/storage.admin
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        - role: roles/bigquery.admin
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        - role: roles/dataflow.admin
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        - role: roles/logging.logWriter
+          members:
+            {# VM service account is used to write logs. #}
+            - {{ 'serviceAccount:' + KF_VM_SA_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        - role: roles/monitoring.metricWriter
+          members:
+            {# VM service account is used to write monitoring data. #}
+            - {{ 'serviceAccount:' + KF_VM_SA_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        {% if 'users' in properties %}
+        {% if properties['users'] %}
+        - role: roles/iap.httpsResourceAccessor
+          members:
+            {% for user in properties['users'] %}
+            - {{ user }}
+            {% endfor %}
+        {% endif %}
+        {% endif %}
+  metadata:
+    dependsOn:
+      - patch-iam-policy
+    runtimePolicy:
+      - DELETE
 
 {# A note about K8s resources.
 The type value should be defined using a reference to the corresponding type provider.


### PR DESCRIPTION
Fix https://github.com/kubeflow/kubeflow/issues/910.
Fix https://github.com/kubeflow/kubeflow/issues/953.

Deploy manager iam role works similar to k8s multi-pod locks: one version can only have one consumer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1001)
<!-- Reviewable:end -->
