### PR TITLE
Order the kubeflow components correctly

### DIFF
--- a/components/gcp-click-to-deploy/src/configs/cluster-kubeflow.yaml
+++ b/components/gcp-click-to-deploy/src/configs/cluster-kubeflow.yaml
@@ -86,14 +86,14 @@ resources:
           - name: tf-serving
           - name: tf-job
         components:
-          - name: kubeflow-core
-            prototype: kubeflow-core
-          - name: cloud-endpoints
-            prototype: cloud-endpoints
           - name: cert-manager
             prototype: cert-manager
+          - name: cloud-endpoints
+            prototype: cloud-endpoints
           - name: iap-ingress
             prototype: iap-ingress
+          - name: kubeflow-core
+            prototype: kubeflow-core
         parameters:
           - component: cloud-endpoints
             name: secretName


### PR DESCRIPTION
Having them out of order can cause bootstrapper to fail

Related to https://github.com/kubeflow/kubeflow/issues/1006
/assign @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1007)
<!-- Reviewable:end -->
