### PR TITLE
Set default version of TFJob operator to be v1alpha2

### DIFF
--- a/ack_guide.md
+++ b/ack_guide.md
@@ -34,7 +34,7 @@ ks generate kubeflow-core kubeflow-core
 ks param set kubeflow-core cloud ack
 
 ks param set kubeflow-core jupyterHubImage registry.aliyuncs.com/kubeflow-images-public/jupyterhub-k8s:1.0.2
-ks param set kubeflow-core tfJobImage registry.aliyuncs.com/kubeflow-images-public/tf_operator:v20180522-77375baf
+ks param set kubeflow-core tfJobImage registry.aliyuncs.com/kubeflow-images-public/tf_operator:v20180615-b2ac020
 ks param set kubeflow-core tfAmbassadorImage registry.aliyuncs.com/datawire/ambassador:0.34.0
 ks param set kubeflow-core tfStatsdImage registry.aliyuncs.com/datawire/statsd:0.34.0
 

--- a/bootstrap/bootstrapper.yaml
+++ b/bootstrap/bootstrapper.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: kubeflow-bootstrapper
-        image: gcr.io/kubeflow-images-public/bootstrapper:v20180614-052b002-dirty-f2d8e3
+        image: gcr.io/kubeflow-images-public/bootstrapper:v20180615-2453eb7
         workingDir: /opt/bootstrap
         command: [ "/opt/kubeflow/bootstrapper"]
         args: [

--- a/docs/gke/configs/cluster-kubeflow.yaml
+++ b/docs/gke/configs/cluster-kubeflow.yaml
@@ -65,7 +65,7 @@ resources:
       # - user:john@acme.com
       # - group:data-scientists@acme.com
     # Path for the bootstrapper image.
-    bootstrapperImage: gcr.io/kubeflow-images-public/bootstrapper:v20180611-0763055-dirty-993707
+    bootstrapperImage: gcr.io/kubeflow-images-public/bootstrapper:v20180615-2453eb7
     # This is the name of the GCP static ip address reserved for your domain.
     # Each Kubeflow deployment in your project should use one unique ipName among all configs.
     ipName: kubeflow-ip

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -20,7 +20,7 @@
 // @optionalParam jupyterNotebookRepoName string kubeflow-images-public The repoistory name for JupyterNotebook.
 // @optionalParam reportUsage string false Whether or not to report Kubeflow usage to kubeflow.org.
 // @optionalParam usageId string unknown_cluster Optional id to use when reporting usage to kubeflow.org
-// @optionalParam tfJobVersion string v1alpha1 which version of the TFJob operator to use
+// @optionalParam tfJobVersion string v1alpha2 which version of the TFJob operator to use
 
 local k = import "k.libsonnet";
 local all = import "kubeflow/core/all.libsonnet";

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -9,7 +9,7 @@
 // @optionalParam tfAmbassadorServiceType string ClusterIP The service type for the API Gateway.
 // @optionalParam tfAmbassadorImage string quay.io/datawire/ambassador:0.30.1 The image for the API Gateway.
 // @optionalParam tfStatsdImage string quay.io/datawire/statsd:0.30.1 The image for the Stats and Monitoring.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180615-b2ac020 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.

--- a/kubeflow/core/prototypes/tf-job-operator.jsonnet
+++ b/kubeflow/core/prototypes/tf-job-operator.jsonnet
@@ -6,7 +6,7 @@
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
 // @optionalParam tfAmbassadorServiceType string ClusterIP The service type for the API Gateway.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180615-b2ac020 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam tfJobVersion string v1alpha2 which version of the TFJob operator to use

--- a/kubeflow/core/prototypes/tf-job-operator.jsonnet
+++ b/kubeflow/core/prototypes/tf-job-operator.jsonnet
@@ -9,7 +9,7 @@
 // @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
-// @optionalParam tfJobVersion string v1alpha1 which version of the TFJob operator to use
+// @optionalParam tfJobVersion string v1alpha2 which version of the TFJob operator to use
 
 // TODO(https://github.com/ksonnet/ksonnet/issues/235): ks param set args won't work if the arg starts with "--".
 

--- a/testing/deploy_kubeflow.py
+++ b/testing/deploy_kubeflow.py
@@ -53,7 +53,9 @@ def deploy_kubeflow(test_case):
   util.run(
     [
       "ks", "generate", "core", "kubeflow-core", "--name=kubeflow-core",
-      "--namespace=" + namespace
+      "--namespace=" + namespace,
+      "--tfJobImage=gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf",
+      "--tfJobVersion=v1alpha1"
     ],
     cwd=app_dir)
 


### PR DESCRIPTION
Fix https://github.com/kubeflow/kubeflow/issues/977

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1012)
<!-- Reviewable:end -->
