### PR TITLE
Fix hard coded "name" variable in example prototypes

### DIFF
--- a/kubeflow/examples/prototypes/tf-job-simple.jsonnet
+++ b/kubeflow/examples/prototypes/tf-job-simple.jsonnet
@@ -6,6 +6,7 @@
 
 local k = import "k.libsonnet";
 
+local name = import "param://name";
 local namespace = "default";
 local image = "gcr.io/kubeflow/tf-benchmarks-cpu:v20171202-bdab599-dirty-284af3";
 
@@ -13,7 +14,7 @@ local tfjob = {
   apiVersion: "kubeflow.org/v1alpha1",
   kind: "TFJob",
   metadata: {
-    name: "mycnnjob",
+    name: name,
     namespace: namespace,
   },
   spec: {

--- a/kubeflow/examples/prototypes/tf-serving-simple.jsonnet
+++ b/kubeflow/examples/prototypes/tf-serving-simple.jsonnet
@@ -7,7 +7,7 @@
 local k = import "k.libsonnet";
 
 local namespace = "default";
-local appName = "tf-serving-simple";
+local appName = import "param://name";
 local modelBasePath = "gs://kubeflow-models/inception";
 local modelName = "inception";
 local image = "gcr.io/kubeflow-images-public/tf-model-server-cpu:v20180327-995786ec";

--- a/kubeflow/examples/prototypes/tf-serving-with-istio.jsonnet
+++ b/kubeflow/examples/prototypes/tf-serving-with-istio.jsonnet
@@ -7,7 +7,7 @@
 local k = import "k.libsonnet";
 
 local namespace = "default";
-local appName = "tf-serving-with-istio";
+local appName = import "param://name";
 local modelBasePath = "gs://kubeflow-models/inception";
 local modelName = "inception";
 local image = "gcr.io/kubeflow-images-public/tf-model-server-cpu:v20180327-995786ec";


### PR DESCRIPTION
This fixes the hard coded "name" variable in the example prototypes so that it can take the value from exposed parameters and be compatible with the user guide.

The other hard coded variables remain as-is to keep it simple. However they could also be modified in the same way, if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1013)
<!-- Reviewable:end -->
