### PR TITLE
Include the TF 1.8 image in kubeform_spawner.

### DIFF
--- a/kubeflow/core/kubeform_spawner.py
+++ b/kubeflow/core/kubeform_spawner.py
@@ -22,6 +22,8 @@ class KubeFormSpawner(KubeSpawner):
       <option value="{0}/{1}/tensorflow-1.6.0-notebook-gpu:v20180607-476e150e">
       <option value="{0}/{1}/tensorflow-1.7.0-notebook-cpu:v20180607-476e150e">
       <option value="{0}/{1}/tensorflow-1.7.0-notebook-gpu:v20180607-476e150e">
+      <option value="{0}/{1}/tensorflow-1.8.0-notebook-cpu:v20180607-476e150e">
+      <option value="{0}/{1}/tensorflow-1.8.0-notebook-gpu:v20180607-476e150e">
     </datalist>
     <br/><br/>
 


### PR DESCRIPTION
* There's no reason to upgrade to a more recent Jupyter image because it
looks like the last change to the images was #907 on 06/05.

Fix #1014

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1015)
<!-- Reviewable:end -->
