### PR TITLE
update bootstrapper image to use tfJobsVersion v1alpha2 as default

### DIFF
--- a/bootstrap/bootstrapper.yaml
+++ b/bootstrap/bootstrapper.yaml
@@ -52,7 +52,7 @@ spec:
     spec:
       containers:
       - name: kubeflow-bootstrapper
-        image: gcr.io/kubeflow-images-public/bootstrapper:v20180615-2453eb7
+        image: gcr.io/kubeflow-images-public/bootstrapper:v20180618-715aafc
         workingDir: /opt/bootstrap
         command: [ "/opt/kubeflow/bootstrapper"]
         args: [

--- a/docs/gke/configs/cluster-kubeflow.yaml
+++ b/docs/gke/configs/cluster-kubeflow.yaml
@@ -65,7 +65,7 @@ resources:
       # - user:john@acme.com
       # - group:data-scientists@acme.com
     # Path for the bootstrapper image.
-    bootstrapperImage: gcr.io/kubeflow-images-public/bootstrapper:v20180615-2453eb7
+    bootstrapperImage: gcr.io/kubeflow-images-public/bootstrapper:v20180618-715aafc
     # This is the name of the GCP static ip address reserved for your domain.
     # Each Kubeflow deployment in your project should use one unique ipName among all configs.
     ipName: kubeflow-ip


### PR DESCRIPTION
fix https://github.com/kubeflow/kubeflow/issues/1018.
Will cherry pick to ```v0.2-branch```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1021)
<!-- Reviewable:end -->
