### PR TITLE
Update TF serving 1.7 gpu image to use cuda 9.0

### DIFF
--- a/components/k8s-model-server/images/versions/1.7gpu/version-config.json
+++ b/components/k8s-model-server/images/versions/1.7gpu/version-config.json
@@ -1,9 +1,9 @@
 {
-  "base_image": "nvidia/cuda:9.1-cudnn7-devel-ubuntu16.04",
+  "base_image": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
   "tf_version": "1.7.0",
-  "cuda_version": "9.1",
+  "cuda_version": "9.0",
   "cudnn_version": "7",
-  "bazel_version": "0.11.1",
+  "bazel_version": "0.10.0",
   "tf_cuda_compatibility": "3.5,5.2,6.1,7.0",
-  "cuda_config_version": "9-1",
+  "cuda_config_version": "9-0",
 }

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -32,7 +32,7 @@
     // Users can also override modelServerImage in which case the user supplied value will always be used
     // regardless of numGpus.
     defaultCpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.7:v20180604-0da89b8a",
-    defaultGpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.6gpu:v20180604-0da89b8a",
+    defaultGpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.7gpu:latest",
     modelServerImage: if $.params.numGpus == 0 then
       $.params.defaultCpuImage
     else

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -32,7 +32,7 @@
     // Users can also override modelServerImage in which case the user supplied value will always be used
     // regardless of numGpus.
     defaultCpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.7:v20180604-0da89b8a",
-    defaultGpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.7gpu:latest",
+    defaultGpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.6gpu:v20180604-0da89b8a",
     modelServerImage: if $.params.numGpus == 0 then
       $.params.defaultCpuImage
     else


### PR DESCRIPTION
9.1 is not supported by driver now.

Fix #1009 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1030)
<!-- Reviewable:end -->
