### PR TITLE
Changing defaults in Pytorch-job

### DIFF
--- a/kubeflow/pytorch-job/prototypes/pytorch-job.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-job.jsonnet
@@ -8,8 +8,7 @@
 // @optionalParam image string null The docker image to use for the job.
 // @optionalParam image_gpu string null The docker image to use when using GPUs.
 // @optionalParam num_masters number 1 The number of masters to use
-// @optionalParam num_ps number 0 The number of ps to use
-// @optionalParam num_workers number 0 The number of workers to use
+// @optionalParam num_workers number 1 The number of workers to use
 // @optionalParam num_gpus number 0 The number of GPUs to attach to workers.
 
 local k = import "k.libsonnet";


### PR DESCRIPTION
1. Kept default workers to 1 which is needed for distributed training. 
2. Removed num_ps parameter which is unused incase of pytorch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1040)
<!-- Reviewable:end -->
