### PR TITLE
test-dir-delete should depend upon teardown to complete

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -313,8 +313,12 @@
                     {
                       name: "test-dir-delete",
                       template: "test-dir-delete",
-                      dependencies: ["copy-artifacts"],
-                    },
+                      dependencies: ["copy-artifacts", "teardown-kubeflow-gcp" + v1alpha2Suffix],
+                    } else {
+                    name: "test-dir-delete",
+                    template: "test-dir-delete",
+                    dependencies: ["copy-artifacts"],
+                  },
                   {
                     name: "copy-artifacts",
                     template: "copy-artifacts",


### PR DESCRIPTION
If test directory gets deleted, teardown won't work, so we need to
ensure that test-dir-delete happens only after teardown steps

Add test-dir-delete for minikube workflow as well

/assign @lluunn 