### PR TITLE
A bunch of fixes for deploying with private ks registry

### DIFF
--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -292,8 +292,8 @@ func appGenerate(opt *options.ServerOption, kfApp *kApp.App, fs *afero.Fs, bootC
 		if err != nil {
 			return errors.New(fmt.Sprintf("Package %v didn't exist in registry %v", pkgName, regUris[p.Registry]))
 		}
-		full := fmt.Sprintf("kubeflow/%v", pkgName)
-		log.Infof("Installing package %v", full)
+		full := fmt.Sprintf("%v/%v", p.Registry, pkgName)
+                log.Infof("Installing package %v", full)
 
 		if _, found := libs[pkgName]; found {
 			log.Infof("Package %v already exists", pkgName)
@@ -323,9 +323,6 @@ func appGenerate(opt *options.ServerOption, kfApp *kApp.App, fs *afero.Fs, bootC
 	// Create Components
 	for _, c := range bootConfig.App.Components {
 		params := []string{c.Prototype, c.Name}
-		if val, ok := paramMapping[c.Name]; ok {
-			params = append(params, val...)
-		}
 		if err = createComponent(opt, kfApp, fs, params); err != nil {
 			return err
 		}

--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -293,7 +293,7 @@ func appGenerate(opt *options.ServerOption, kfApp *kApp.App, fs *afero.Fs, bootC
 			return errors.New(fmt.Sprintf("Package %v didn't exist in registry %v", pkgName, regUris[p.Registry]))
 		}
 		full := fmt.Sprintf("%v/%v", p.Registry, pkgName)
-                log.Infof("Installing package %v", full)
+		log.Infof("Installing package %v", full)
 
 		if _, found := libs[pkgName]; found {
 			log.Infof("Package %v already exists", pkgName)


### PR DESCRIPTION
- use package registry name instead of hard coded "kubeflow"
- Avoid passing component parameter when creating component. The subsequent step will instead pass it. 

Got following error otherwise
{"filename":"bootstrap/main.go:48","level":"error","msg":"Bootstrapper failed with error: There was a problem creating component FOO: parse preview args: unknown flag: --BAR\n","time":"2018-06-20T19:39:44Z"}