### PR TITLE
Some scripts to support retagging our images as part of our releases.

### DIFF
--- a/releasing/apply_image_tags.py
+++ b/releasing/apply_image_tags.py
@@ -1,0 +1,42 @@
+"""Apply the image tags as defined in image_tags.yaml"""
+
+import argparse
+import logging
+import yaml
+
+from kubeflow.testing import util
+
+def main(unparsed_args=None):  # pylint: disable=too-many-locals
+  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
+  # create the top-level parser
+  parser = argparse.ArgumentParser(
+    description="Apply tags to file")
+
+  parser.add_argument(
+    "--images_file",
+    default="image_tags.yaml",
+    type=str,
+    help="Yaml file containing the tags to attach.")
+
+  args = parser.parse_args()
+
+  with open(args.images_file) as hf:
+    config = yaml.load(hf)
+
+  for image in config["images"]:
+    for tag in image["tags"]:
+      # TODO(jlewi): This appears to be really slow even when we aren't
+      # moving the image. Much slower than doing it in the UI
+      util.run(["gcloud", "container", "images", "add-tag", "--quiet",
+                image["image"], tag])
+
+  logging.info("Done.")
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+  logging.getLogger().setLevel(logging.INFO)
+  main()

--- a/releasing/image_tags.yaml
+++ b/releasing/image_tags.yaml
@@ -1,0 +1,7 @@
+# This file is a map from images to tags that should be applied
+# to an image. The images should be referenced by sha so they are
+# immutable.
+images:
+  - image: gcr.io/kubeflow-images-public/tf_operator@sha256:4f20e349f79059a009ef75aea158ca0c555fcc4a22e7c80a7cb9bff54fbab6c1
+    tags: 
+      - gcr.io/kubeflow-images-public/tf_operator:v0.2.0


### PR DESCRIPTION
* See #1060
* Use a YAML file to keep track of a map from images referenced by sha
  to tags to apply

* Add a script to apply the tags as listed in the YAML file.

* This will make it easy to promote images as part of our release process.

* I think a next step is to create a script to automate updating image_tags.yaml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1061)
<!-- Reviewable:end -->
