### PR TITLE
update tf_operator image to point to tag v0.2.0

### DIFF
--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -9,7 +9,7 @@
 // @optionalParam AmbassadorServiceType string ClusterIP The service type for the API Gateway.
 // @optionalParam AmbassadorImage string quay.io/datawire/ambassador:0.30.1 The image for the API Gateway.
 // @optionalParam StatsdImage string quay.io/datawire/statsd:0.30.1 The image for the Stats and Monitoring.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180615-b2ac020 The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v0.2.0 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.

--- a/kubeflow/core/prototypes/tf-job-operator.jsonnet
+++ b/kubeflow/core/prototypes/tf-job-operator.jsonnet
@@ -6,7 +6,7 @@
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
 // @optionalParam tfAmbassadorServiceType string ClusterIP The service type for the API Gateway.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v20180615-b2ac020 The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v0.2.0 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam tfJobVersion string v1alpha2 which version of the TFJob operator to use


### PR DESCRIPTION
Want to cherry-pick to new rc.

Now tf_operator:v0.2.0 contains fixes in: https://github.com/kubeflow/kubeflow/issues/1024#issuecomment-399111025