### PR TITLE
fix for file_cache is unavailable when using oauth2client >= 4.0.0

### DIFF
--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -349,7 +349,7 @@ def deploy_minikube(args):
   """Create a VM and setup minikube."""
 
   credentials = GoogleCredentials.get_application_default()
-  gce = discovery.build("compute", "v1", credentials=credentials)
+  gce = discovery.build("compute", "v1", credentials=credentials, cache_discovery=False)
   instances = gce.instances()
   body = {
     "name":


### PR DESCRIPTION
Fixes https://github.com/kubeflow/tf-operator/issues/696
The error appears when building tf-operator but the fix applies to testing/test_deploy.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1084)
<!-- Reviewable:end -->
