### PR TITLE
Add katib tag to images

### DIFF
--- a/kubeflow/katib/modeldb.libsonnet
+++ b/kubeflow/katib/modeldb.libsonnet
@@ -218,7 +218,7 @@
                     value: "/katib",
                   },
                 ],
-                image: params.modeldbFrontendImage,
+                image: params.modeldbFrontendImage + ":" + params.katibImageTag,
                 imagePullPolicy: "IfNotPresent",
                 name: "modeldb-frontend",
                 ports: [

--- a/kubeflow/katib/prototypes/all.jsonnet
+++ b/kubeflow/katib/prototypes/all.jsonnet
@@ -3,6 +3,7 @@
 // @description Kubeflow hyperparameter tuning component
 // @shortDescription hp-tuning
 // @param name string Name to give to each of the components
+// @optionalParam katibImageTag string latest Image tag for katib images
 // @optionalParam modeldbImage string mitdbg/modeldb-backend:latest The image for modeldb
 // @optionalParam modeldbDatabaseImage string mongo:3.4 The image for modeldb database.
 // @optionalParam modeldbFrontendImage string katib/katib-frontend The image for modeldb frontend.

--- a/kubeflow/katib/suggestion.libsonnet
+++ b/kubeflow/katib/suggestion.libsonnet
@@ -141,5 +141,4 @@
     },  // gridDeployment
 
   },  // parts
-
 }

--- a/kubeflow/katib/suggestion.libsonnet
+++ b/kubeflow/katib/suggestion.libsonnet
@@ -59,7 +59,7 @@
           spec: {
             containers: [
               {
-                image: params.suggestionRandomImage,
+                image: params.suggestionRandomImage + ":" + params.katibImageTag,
                 name: "vizier-suggestion-random",
                 ports: [
                   {
@@ -125,7 +125,7 @@
           spec: {
             containers: [
               {
-                image: params.suggestionGridImage,
+                image: params.suggestionGridImage + ":" + params.katibImageTag,
                 name: "vizier-suggestion-grid",
                 ports: [
                   {
@@ -141,4 +141,5 @@
     },  // gridDeployment
 
   },  // parts
+
 }

--- a/kubeflow/katib/vizier.libsonnet
+++ b/kubeflow/katib/vizier.libsonnet
@@ -70,7 +70,7 @@
                   "-i",
                   "k-cluster.example.net",
                 ],
-                image: params.vizierCoreImage,
+                image: params.vizierCoreImage + ":" + params.katibImageTag ,
                 name: "vizier-core",
                 ports: [
                   {

--- a/kubeflow/katib/vizier.libsonnet
+++ b/kubeflow/katib/vizier.libsonnet
@@ -70,7 +70,7 @@
                   "-i",
                   "k-cluster.example.net",
                 ],
-                image: params.vizierCoreImage + ":" + params.katibImageTag ,
+                image: params.vizierCoreImage + ":" + params.katibImageTag,
                 name: "vizier-core",
                 ports: [
                   {


### PR DESCRIPTION
This change will make easier to pin Katib to any version we have images
for. Once we tag images with 0.2.0 for Katib, we should pin this to
0.2.0 in Kubeflow branch as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1085)
<!-- Reviewable:end -->
