### PR TITLE
Upgrade ambassador to 0.34.0 and delete statsd

### DIFF
--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -5,7 +5,7 @@
     $.parts(params.namespace, params.AmbassadorImage).role,
     $.parts(params.namespace, params.AmbassadorImage).serviceAccount,
     $.parts(params.namespace, params.AmbassadorImage).roleBinding,
-    $.parts(params.namespace, params.AmbassadorImage).deploy(params.StatsdImage),
+    $.parts(params.namespace, params.AmbassadorImage).deploy(),
     $.parts(params.namespace, params.AmbassadorImage).k8sDashboard(params.cloud),
   ],
 
@@ -143,7 +143,7 @@
       ],
     },  // roleBinding
 
-    deploy(statsdImage):: {
+    deploy():: {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
       metadata: {
@@ -204,10 +204,6 @@
                     memory: "100Mi",
                   },
                 },
-              },
-              {
-                image: statsdImage,
-                name: "statsd",
               },
             ],
             restartPolicy: "Always",

--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -7,8 +7,7 @@
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
 // @optionalParam AmbassadorServiceType string ClusterIP The service type for the API Gateway.
-// @optionalParam AmbassadorImage string quay.io/datawire/ambassador:0.30.1 The image for the API Gateway.
-// @optionalParam StatsdImage string quay.io/datawire/statsd:0.30.1 The image for the Stats and Monitoring.
+// @optionalParam AmbassadorImage string quay.io/datawire/ambassador:0.34.0 The image for the API Gateway.
 // @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v0.2.0 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.

--- a/kubeflow/core/tests/ambassador_test.jsonnet
+++ b/kubeflow/core/tests/ambassador_test.jsonnet
@@ -3,7 +3,6 @@ local params = {
   namespace:: "test-kf-001",
   tfAmbassadorServiceType:: "ClusterIP",
   tfAmbassadorImage:: "quay.io/datawire/ambassador:0.34.0",
-  tfStatsdImage:: "quay.io/datawire/statsd:0.34.0",
 };
 
 std.assertEqual(
@@ -155,7 +154,7 @@ std.assertEqual(
 ) &&
 
 std.assertEqual(
-  ambassador.parts(params.namespace, params.tfAmbassadorImage).deploy(params.tfStatsdImage),
+  ambassador.parts(params.namespace, params.tfAmbassadorImage).deploy(),
   {
     apiVersion: "extensions/v1beta1",
     kind: "Deployment",
@@ -217,10 +216,6 @@ std.assertEqual(
                   memory: "100Mi",
                 },
               },
-            },
-            {
-              image: "quay.io/datawire/statsd:0.34.0",
-              name: "statsd",
             },
           ],
           restartPolicy: "Always",


### PR DESCRIPTION
statsd container had a bug which caused elevated cpu
usage for kube-dns. statsd is not really used right now
so we can drop it
Fixes https://github.com/kubeflow/kubeflow/issues/945

/cc @kflynn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1096)
<!-- Reviewable:end -->
