### PR TITLE
Pin and fix katib images.

### DIFF
--- a/hack/retag_katib_images.sh
+++ b/hack/retag_katib_images.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# One off script to retag Katib images for 0.2
+set -ex
+docker pull mitdbg/modeldb-backend:latest
+docker pull katib/katib-frontend:master
+docker pull katib/suggestion-random:master
+docker pull katib/suggestion-grid:master
+docker pull katib/vizier-core:master
+
+docker tag mitdbg/modeldb-backend:latest \
+	gcr.io/kubeflow-images-public/modeldb-backend:v0.2.0
+
+docker tag katib/katib-frontend:master \
+	gcr.io/kubeflow-images-public/katib-frontend:v0.2.0
+
+docker tag katib/suggestion-random:master \
+	gcr.io/kubeflow-images-public/katib-suggestion-random:v0.2.0
+
+docker tag katib/suggestion-grid:master \
+	gcr.io/kubeflow-images-public/katib-suggestion-grid:v0.2.0
+
+docker tag katib/vizier-core:master \
+	gcr.io/kubeflow-images-public/katib-vizier-core:v0.2.0
+
+gcloud docker -- push \
+	gcr.io/kubeflow-images-public/modeldb-backend:v0.2.0
+
+gcloud docker -- push \
+	gcr.io/kubeflow-images-public/katib-frontend:v0.2.0
+
+gcloud docker -- push \
+	gcr.io/kubeflow-images-public/katib-suggestion-random:v0.2.0
+
+gcloud docker -- push \
+	gcr.io/kubeflow-images-public/katib-suggestion-grid:v0.2.0
+
+gcloud docker -- push \
+	gcr.io/kubeflow-images-public/katib-vizier-core:v0.2.0

--- a/kubeflow/katib/modeldb.libsonnet
+++ b/kubeflow/katib/modeldb.libsonnet
@@ -218,7 +218,7 @@
                     value: "/katib",
                   },
                 ],
-                image: params.modeldbFrontendImage + ":" + params.katibImageTag,
+                image: params.modeldbFrontendImage,
                 imagePullPolicy: "IfNotPresent",
                 name: "modeldb-frontend",
                 ports: [

--- a/kubeflow/katib/prototypes/all.jsonnet
+++ b/kubeflow/katib/prototypes/all.jsonnet
@@ -3,13 +3,12 @@
 // @description Kubeflow hyperparameter tuning component
 // @shortDescription hp-tuning
 // @param name string Name to give to each of the components
-// @optionalParam katibImageTag string latest Image tag for katib images
-// @optionalParam modeldbImage string mitdbg/modeldb-backend:latest The image for modeldb
+// @optionalParam modeldbImage string gcr.io/kubeflow-images-public/modeldb-backend:v0.2.0 The image for modeldb
 // @optionalParam modeldbDatabaseImage string mongo:3.4 The image for modeldb database.
-// @optionalParam modeldbFrontendImage string katib/katib-frontend The image for modeldb frontend.
-// @optionalParam suggestionRandomImage string katib/suggestion-random The image for random suggestion.
-// @optionalParam suggestionGridImage string katib/suggestion-grid The image for grid suggestion.
-// @optionalParam vizierCoreImage string katib/vizier-core The image for vizier core.
+// @optionalParam modeldbFrontendImage string gcr.io/kubeflow-images-public/katib-frontend:v0.2.0 The image for modeldb frontend.
+// @optionalParam suggestionRandomImage string gcr.io/kubeflow-images-public/katib-suggestion-random:v0.2.0 The image for random suggestion.
+// @optionalParam suggestionGridImage string gcr.io/kubeflow-images-public/katib-suggestion-grid:v0.2.0 The image for grid suggestion.
+// @optionalParam vizierCoreImage string gcr.io/kubeflow-images-public/katib-vizier-core:v0.2.0 The image for vizier core.
 // @optionalParam vizierDbImage string mysql:8.0.3 The image for vizier db.
 
 local k = import "k.libsonnet";

--- a/kubeflow/katib/suggestion.libsonnet
+++ b/kubeflow/katib/suggestion.libsonnet
@@ -59,7 +59,7 @@
           spec: {
             containers: [
               {
-                image: params.suggestionRandomImage + ":" + params.katibImageTag,
+                image: params.suggestionRandomImage,
                 name: "vizier-suggestion-random",
                 ports: [
                   {
@@ -125,7 +125,7 @@
           spec: {
             containers: [
               {
-                image: params.suggestionGridImage + ":" + params.katibImageTag,
+                image: params.suggestionGridImage,
                 name: "vizier-suggestion-grid",
                 ports: [
                   {

--- a/kubeflow/katib/vizier.libsonnet
+++ b/kubeflow/katib/vizier.libsonnet
@@ -70,7 +70,7 @@
                   "-i",
                   "k-cluster.example.net",
                 ],
-                image: params.vizierCoreImage + ":" + params.katibImageTag,
+                image: params.vizierCoreImage,
                 name: "vizier-core",
                 ports: [
                   {


### PR DESCRIPTION
* The latest images are too old; we should be using the images with tag "master"

* For the 0.2 release we want to pin the images to specific images which
  we tag 0.2.0

* Delete the protoype parameter katibImagTag; image parameters should provide
  the full image reference including the tag. This makes it much easier
  to override certain images and is consistent with other components.

* Create a simple, oneoff script to retag the existing Katib images into
  the Kubeflow image repository

  * We most likely won't ever use this again but its good to leave a paper
    trail.

Related to:
  kubeflow/katib#133 Katib images in 0.2.0-rc.1 are too old
     * Will need to cherry pick this.

  Fix kubeflow/katib#132 Get rid of katibImageTag

  Fix kubeflow/katib#131 Katib prototype needs to pin docker images

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1113)
<!-- Reviewable:end -->
