### PR TITLE
add service monitor prototype for monitoring deployment status

### DIFF
--- a/kubeflow/core/metric-collector.libsonnet
+++ b/kubeflow/core/metric-collector.libsonnet
@@ -1,0 +1,66 @@
+{
+  all(params):: [
+    $.parts(params.namespace, params.metricImage, params.targetUrl, params.oauthSecretName).deploy,
+  ],
+
+  parts(namespace, image, targetUrl, oauthSecretName):: {
+    deploy:: {
+      apiVersion: "extensions/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: "metric-collector",
+        namespace: namespace,
+      },
+      spec: {
+        replicas: 2,
+        template: {
+          metadata: {
+            labels: {
+              service: "metric-collector",
+            },
+            namespace: namespace,
+          },
+          spec: {
+            containers: [
+              {
+                env: [
+                  {
+                    name: "GOOGLE_APPLICATION_CREDENTIALS",
+                    value: "/var/run/secrets/sa/admin-gcp-sa.json",
+                  },
+                  {
+                    name: "CLIENT_ID",
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: oauthSecretName,
+                        key: "CLIENT_ID",
+                      },
+                    },
+                  },
+                ],
+                command: [
+                  "python3",
+                  "/opt/kubeflow-readiness.py",
+                ],
+                args: [
+                  "--url=" + targetUrl,
+                  "--client_id=$(CLIENT_ID)",
+                ],
+                volumeMounts: [
+                  {
+                    name: "sa-key",
+                    readOnly: true,
+                    mountPath: "/var/run/secrets/sa",
+                  },
+                ],
+                image: image,
+                name: "exporter",
+              },
+            ],
+            restartPolicy: "Always",
+          },
+        },
+      },
+    },  // deploy
+  },  // parts
+}

--- a/kubeflow/core/metric-collector.libsonnet
+++ b/kubeflow/core/metric-collector.libsonnet
@@ -58,6 +58,14 @@
               },
             ],
             restartPolicy: "Always",
+            volumes: [
+              {
+                name: "sa-key",
+                secret: {
+                  secretName: "admin-gcp-sa",
+                },
+              },
+            ],
           },
         },
       },

--- a/kubeflow/core/prototypes/metric-collector.jsonnet
+++ b/kubeflow/core/prototypes/metric-collector.jsonnet
@@ -1,0 +1,20 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.metric-collector
+// @description Provides metric-collector prototypes for monitoring kubeflow availability on GCP.
+// @shortDescription Service monitor for kubeflow on GCP.
+// @param name string Name for the component
+// @param targetUrl string Https url of kubeflow service on GCP; target of monitoring.
+// @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
+// @optionalParam metricImage string gcr.io/kubeflow-images-public/metric-collector:latest Image for running metric exporter of kubeflow availability.
+// @optionalParam oauthSecretName string kubeflow-oauth The name of the secret containing the OAuth CLIENT_ID and CLIENT_SECRET.
+
+local k = import "k.libsonnet";
+local metricCollector = import "kubeflow/core/metric-collector.libsonnet";
+
+// updatedParams uses the environment namespace if
+// the namespace parameter is not explicitly set
+local updatedParams = params {
+  namespace: if params.namespace == "null" then env.namespace else params.namespace,
+};
+
+std.prune(k.core.v1.list.new(metricCollector.all(updatedParams)))

--- a/metric-collector/Dockerfile
+++ b/metric-collector/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:xenial
+
+RUN set -ex \
+    && apt-get update -yqq \
+    && apt-get install -yqq --no-install-recommends \
+    curl \
+    wget \
+    python3-dev \
+    python3-setuptools \
+    python3-pip \
+    && python3 -V \
+    && apt-get clean \
+    && rm -rf \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/* \
+    /usr/share/man \
+    /usr/share/doc \
+    /usr/share/doc-base
+
+RUN pip3 install --upgrade wheel && \
+    pip3 install requests && \
+    pip3 install prometheus_client && \
+    pip3 install google-api-python-client
+
+COPY service-readiness/kubeflow-readiness.py /opt/

--- a/metric-collector/Makefile
+++ b/metric-collector/Makefile
@@ -1,0 +1,31 @@
+IMG = gcr.io/kubeflow-images-public/metric-collector
+
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
+
+CHANGED_FILES := $(shell git diff-files)
+
+ifeq ($(strip $(CHANGED_FILES)),)
+# Changed files is empty; not dirty
+# Don't include --dirty because it could be dirty if files outside the ones we care
+# about changed.
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always)
+else
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
+all: build
+
+# To edit which registries to add to bootstrapper, edit config (eg. config/default.yaml)
+build:
+	docker build --pull -t $(IMG):$(TAG) .
+	@echo Built $(IMG):$(TAG)
+
+# Build but don't attach the latest tag. This allows manual testing/inspection of the image
+# first.
+push: build
+	gcloud docker -- push $(IMG):$(TAG)
+	@echo Pushed $(IMG) with  :$(TAG) tags
+
+push-latest: push
+	gcloud container images add-tag --quiet $(IMG):$(TAG) $(IMG):latest --verbosity=info
+	echo created $(IMG):latest

--- a/metric-collector/service-readiness/kubeflow-readiness.py
+++ b/metric-collector/service-readiness/kubeflow-readiness.py
@@ -1,0 +1,140 @@
+import argparse
+from time import sleep, time
+
+import google.auth
+import google.auth.app_engine
+import google.auth.compute_engine.credentials
+import google.auth.iam
+from google.auth.transport.requests import Request
+import google.oauth2.credentials
+import google.oauth2.service_account
+from prometheus_client import start_http_server, Gauge
+import requests
+
+IAM_SCOPE = 'https://www.googleapis.com/auth/iam'
+OAUTH_TOKEN_URI = 'https://www.googleapis.com/oauth2/v4/token'
+METHOD = 'GET'
+KUBEFLOW_AVAILABILITY = Gauge('kubeflow_availability', 'Signal of whether IAP protected kubeflow is available')
+
+def metric_update(args, google_open_id_connect_token):
+  resp = requests.request(
+    METHOD, args.url,
+    headers={'Authorization': 'Bearer {}'.format(
+      google_open_id_connect_token)})
+  if resp.status_code == 200:
+    KUBEFLOW_AVAILABILITY.set(1)
+  else:
+    KUBEFLOW_AVAILABILITY.set(0)
+
+def main(unparsed_args=None):
+  parser = argparse.ArgumentParser(
+    description="Output signal of kubeflow service readiness.")
+
+  parser.add_argument(
+    "--url",
+    default="",
+    type=str,
+    help="kubeflow IAP-protected url")
+  parser.add_argument(
+    "--client_id",
+    default="",
+    type=str,
+    help="Service account json credential file")
+
+  args = parser.parse_args(args=unparsed_args)
+
+  if args.url == "":
+    sleep(2000)
+    return
+
+  # Figure out what environment we're running in and get some preliminary
+  # information about the service account.
+  bootstrap_credentials, _ = google.auth.default(
+    scopes=[IAM_SCOPE])
+  if isinstance(bootstrap_credentials,
+                google.oauth2.credentials.Credentials):
+    raise Exception('make_iap_request is only supported for service '
+                    'accounts.')
+
+  # For service account's using the Compute Engine metadata service,
+  # service_account_email isn't available until refresh is called.
+  bootstrap_credentials.refresh(Request())
+
+  signer_email = bootstrap_credentials.service_account_email
+  if isinstance(bootstrap_credentials,
+                google.auth.compute_engine.credentials.Credentials):
+    # Since the Compute Engine metadata service doesn't expose the service
+    # account key, we use the IAM signBlob API to sign instead.
+    # In order for this to work:
+    #
+    # 1. Your VM needs the https://www.googleapis.com/auth/iam scope.
+    #    You can specify this specific scope when creating a VM
+    #    through the API or gcloud. When using Cloud Console,
+    #    you'll need to specify the "full access to all Cloud APIs"
+    #    scope. A VM's scopes can only be specified at creation time.
+    #
+    # 2. The VM's default service account needs the "Service Account Actor"
+    #    role. This can be found under the "Project" category in Cloud
+    #    Console, or roles/iam.serviceAccountActor in gcloud.
+    signer = google.auth.iam.Signer(
+      Request(), bootstrap_credentials, signer_email)
+  else:
+    # A Signer object can sign a JWT using the service account's key.
+    signer = bootstrap_credentials.signer
+
+  # Construct OAuth 2.0 service account credentials using the signer
+  # and email acquired from the bootstrap credentials.
+  service_account_credentials = google.oauth2.service_account.Credentials(
+    signer, signer_email, token_uri=OAUTH_TOKEN_URI, additional_claims={
+      'target_audience': args.client_id
+    })
+
+  token_refresh_time = 0
+  while True:
+    if time() > token_refresh_time:
+      # service_account_credentials gives us a JWT signed by the service
+      # account. Next, we use that to obtain an OpenID Connect token,
+      # which is a JWT signed by Google.
+      google_open_id_connect_token = get_google_open_id_connect_token(
+        service_account_credentials)
+      token_refresh_time = time() + 1800
+    metric_update(args, google_open_id_connect_token)
+    # Update status every 10 sec
+    sleep(10)
+
+def get_google_open_id_connect_token(service_account_credentials):
+  """Get an OpenID Connect token issued by Google for the service account.
+
+  This function:
+
+    1. Generates a JWT signed with the service account's private key
+       containing a special "target_audience" claim.
+
+    2. Sends it to the OAUTH_TOKEN_URI endpoint. Because the JWT in #1
+       has a target_audience claim, that endpoint will respond with
+       an OpenID Connect token for the service account -- in other words,
+       a JWT signed by *Google*. The aud claim in this JWT will be
+       set to the value from the target_audience claim in #1.
+
+  For more information, see
+  https://developers.google.com/identity/protocols/OAuth2ServiceAccount .
+  The HTTP/REST example on that page describes the JWT structure and
+  demonstrates how to call the token endpoint. (The example on that page
+  shows how to get an OAuth2 access token; this code is using a
+  modified version of it to get an OpenID Connect token.)
+  """
+
+  service_account_jwt = (
+    service_account_credentials._make_authorization_grant_assertion())
+  request = google.auth.transport.requests.Request()
+  body = {
+    'assertion': service_account_jwt,
+    'grant_type': google.oauth2._client._JWT_GRANT_TYPE,
+  }
+  token_response = google.oauth2._client._token_endpoint_request(
+    request, OAUTH_TOKEN_URI, body)
+  return token_response['id_token']
+
+if __name__ == '__main__':
+  start_http_server(8000)
+  main()

--- a/metric-collector/service-readiness/kubeflow-readiness.py
+++ b/metric-collector/service-readiness/kubeflow-readiness.py
@@ -49,19 +49,19 @@ def main(unparsed_args=None):
 
   # Figure out what environment we're running in and get some preliminary
   # information about the service account.
-  bootstrap_credentials, _ = google.auth.default(
+  credentials, _ = google.auth.default(
     scopes=[IAM_SCOPE])
-  if isinstance(bootstrap_credentials,
+  if isinstance(credentials,
                 google.oauth2.credentials.Credentials):
     raise Exception('make_iap_request is only supported for service '
                     'accounts.')
 
   # For service account's using the Compute Engine metadata service,
   # service_account_email isn't available until refresh is called.
-  bootstrap_credentials.refresh(Request())
+  credentials.refresh(Request())
 
-  signer_email = bootstrap_credentials.service_account_email
-  if isinstance(bootstrap_credentials,
+  signer_email = credentials.service_account_email
+  if isinstance(credentials,
                 google.auth.compute_engine.credentials.Credentials):
     # Since the Compute Engine metadata service doesn't expose the service
     # account key, we use the IAM signBlob API to sign instead.
@@ -77,10 +77,10 @@ def main(unparsed_args=None):
     #    role. This can be found under the "Project" category in Cloud
     #    Console, or roles/iam.serviceAccountActor in gcloud.
     signer = google.auth.iam.Signer(
-      Request(), bootstrap_credentials, signer_email)
+      Request(), credentials, signer_email)
   else:
     # A Signer object can sign a JWT using the service account's key.
-    signer = bootstrap_credentials.signer
+    signer = credentials.signer
 
   # Construct OAuth 2.0 service account credentials using the signer
   # and email acquired from the bootstrap credentials.


### PR DESCRIPTION
fix https://github.com/kubeflow/kubeflow/issues/955

Provide stackdriver/prometheus compatible data exporter, monitoring kubeflow status after deployment: 
the signal ```kubeflow_availability==1``` means https url behind IAP can be logged in with credentials.

How to integrate:
1. directly access port 8000 on pod.
2. read through stackdriver (if beta feature turned on for cluster).
3. read through prometheus engine (if deployed in cluster).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1123)
<!-- Reviewable:end -->
