### PR TITLE
Fix TFMA jupyter extensions.

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -121,8 +121,10 @@ RUN conda create -n py2 python=2 && \
     # tensorflow-model-analysis is only supported for TF 1.6 and above
     if [[ $INSTALL_TFMA == "yes" ]]; then \
       pip install --no-cache-dir tensorflow-model-analysis && \
-      jupyter nbextension install --py --symlink tensorflow_model_analysis && \
-      jupyter nbextension enable --py tensorflow_model_analysis ; \
+      # We use --system because if we don't the config is written to the home directory
+      # and the changes are lost when we mount a PV over them.
+      jupyter nbextension install --py --system --symlink tensorflow_model_analysis && \
+      jupyter nbextension enable --py --system tensorflow_model_analysis ; \
     fi \
     && \
     # Install jupyterlab-manager


### PR DESCRIPTION
* We need to install & enable the extensions system wide; otherwise the relevant
  config changes are stored in /home/jovyan and the changes are lost
  when we mount a PV in /home/jovyan.

* It doesn't look like we need to change the command

jupyter labextension install @jupyter-widgets/jupyterlab-manager

  * It doesn't take a --system flag and it looks like its already installed
    system wide.

jupyter labextension install @jupyter-widgets/jupyterlab-manager && \

* Related to #1130

/assign @pdmack 
/assign @ankushagarwal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1131)
<!-- Reviewable:end -->
