### PR TITLE
Set requests and limits for RAM and CPU in TF notebook image releaser.

### DIFF
--- a/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
@@ -79,7 +79,7 @@
       // Build an Argo template to execute a particular command.
       // step_name: Name for the template
       // command: List to pass as the container command.
-      local buildTemplate(step_name, command, env_vars=[], sidecars=[]) = {
+      local buildTemplate(step_name, command, env_vars=[], sidecars=[], resources=null) = {
         name: step_name,
         // The tensorflow notebook image builds are flaky because they are very
         // large builds and sometimes there are timeouts while downloading
@@ -110,6 +110,7 @@
               },
             },
           ] + prow_env + env_vars,
+          resources: resources,
           volumeMounts: [
             {
               name: dataVolume,
@@ -185,11 +186,33 @@
           [{
             name: "dind",
             image: "docker:17.10-dind",
+            resources: {
+              requests: {
+                memory: "1.5Gi",
+                cpu: "1",
+              },
+              limits: {
+                memory: "4Gi",
+                cpu: "4",
+              },
+            },
             securityContext: {
               privileged: true,
             },
             mirrorVolumeMounts: true,
           }],
+          // Resources to allocate to the build container.
+          // Is most of the resources used by the dind side car?
+          {
+            requests: {
+              memory: "500Mi",
+              cpu: "1",
+            },
+            limits: {
+              memory: "2Gi",
+              cpu: "4",
+            },
+          },
         ),  // buildImageTemplate
       }.result;
       {


### PR DESCRIPTION
* See if this makes the build more reliable and faster

* We should really be setting disk space because it looks like (see #1135)
  that is one resource that is under pressure. Need to figure out
  if that is easy to control with K8s.

Related to:
  #1135 Docker image building workflows are failing
  #1132 Building Jupyter images took over 4 hours.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1136)
<!-- Reviewable:end -->
