### PR TITLE
Turn bootstrapper into an RPC server for ksonnet.

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,6 +1,6 @@
 # bootstrapper-builder contains the tool chain we need to build the image.
 # This primarily means glide.
-FROM gcr.io/kubeflow-images-public/bootstrapper-builder:v20180709-2ef5fe7a-dirty-39cf08 as builder
+FROM gcr.io/kubeflow-images-public/bootstrapper-builder:v20180712-4adef8c0 as builder
 
 RUN mkdir -p /opt/kubeflow
 
@@ -17,7 +17,7 @@ RUN cd $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/ && \
 
 RUN go build -i -o /opt/kubeflow/bootstrapper ${GOPATH}/src/github.com/kubeflow/kubeflow/bootstrap/cmd/bootstrap/main.go
 
-FROM golang:1.8.2
+FROM golang:1.10.3
 
 # We need gcloud to get gke credentials.
 RUN wget -q https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz && \

--- a/bootstrap/Dockerfile.Builder
+++ b/bootstrap/Dockerfile.Builder
@@ -1,5 +1,5 @@
 # Dockerfile to create an image suitable for building the bootstrapper.
-FROM golang:1.8.2 as builder
+FROM golang:1.10.3 as builder
 
 # Install glide. We need this in order to fetch dependencies.
 RUN curl https://glide.sh/get | sh

--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -1,0 +1,555 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"os/exec"
+	"path"
+	"sync"
+
+	"path/filepath"
+
+	"github.com/go-kit/kit/endpoint"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/ksonnet/ksonnet/actions"
+	kApp "github.com/ksonnet/ksonnet/metadata/app"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/afero"
+	"golang.org/x/net/context"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// The name of the prototype for Jupyter.
+const JUPYTER_PROTOTYPE = "jupyterhub"
+
+// KsService defines an interface for working with ksonnet.
+type KsService interface {
+	// CreateApp creates a ksonnet application.
+	CreateApp(context.Context, CreateRequest) error
+}
+
+// appInfo keeps track of information about apps.
+type appInfo struct {
+	App kApp.App
+	mux sync.Mutex
+}
+
+// ksServer provides a server to wrap ksonnet.
+// This allows ksonnet applications to be managed remotely.
+type ksServer struct {
+	// appsDir is the directory where apps should be stored.
+	appsDir string
+	// knownRegistries is a list of known registries
+	// This can be used to map the name of a registry to info about the registry.
+	// This allows apps to specify a registry by name without having to know any
+	// other information about the regisry.
+	knownRegistries map[string]RegistryConfig
+
+	// Config used to talk to Kubernetes.
+	config *rest.Config
+
+	fs afero.Fs
+
+	apps    map[string]*appInfo
+	appsMux sync.Mutex
+}
+
+// NewServer constructs a ksServer.
+func NewServer(appsDir string, registries []RegistryConfig, config *rest.Config) (*ksServer, error) {
+	if appsDir == "" {
+		return nil, fmt.Errorf("appsDir can't be empty")
+	}
+
+	s := &ksServer{
+		appsDir:         appsDir,
+		apps:            make(map[string]*appInfo),
+		knownRegistries: make(map[string]RegistryConfig),
+		fs:              afero.NewOsFs(),
+		config:          config,
+	}
+
+	for _, r := range registries {
+		s.knownRegistries[r.Name] = r
+		if r.RegUri == "" {
+			return nil, fmt.Errorf("Known registry %v missing URI", r.Name)
+		}
+	}
+
+	info, err := s.fs.Stat(appsDir)
+
+	// TODO(jlewi): Should we create the directory if it doesn't exist?
+	if err != nil {
+		return nil, err
+	}
+
+	if !info.IsDir() {
+		return nil, fmt.Errorf("appsDir %v is not a directory", appsDir)
+	}
+
+	files, err := ioutil.ReadDir(appsDir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+
+		// Try loading the directory
+		appName := file.Name()
+		appDir := path.Join(appsDir, appName)
+		kfApp, err := kApp.Load(s.fs, appDir, true)
+
+		if err != nil {
+			// Keep going if there is a problem loading an existing app.
+			log.Errorf("There was a problem loading the app: %v", appsDir)
+			continue
+		}
+
+		s.apps[appName] = &appInfo{
+			App: kfApp,
+		}
+	}
+	return s, nil
+}
+
+// CreateRequest represents a request to create a ksonnet application.
+type CreateRequest struct {
+	// Name for the app.
+	Name string
+	// AppConfig is the config for the app.
+	AppConfig AppConfig
+
+	// Namespace for the app.
+	Namespace string
+
+	// Whether to try to autoconfigure the app.
+	AutoConfigure bool
+}
+
+// createRequest is the response to a createRequest
+type createResponse struct {
+	Err string `json:"err,omitempty"` // errors don't JSON-marshal, so we use a string
+}
+
+// Request to apply an app.
+type ApplyRequest struct {
+	// Name of the app to apply
+	Name string
+
+	// Environment is the environment to use.
+	Environment string
+
+	// Components is a list of the names of the components to apply.
+	Components []string
+
+	// Token is an authorization token to use to authorize to the K8s API Server.
+	// Leave blank to use the pods service account.
+	Token string
+}
+
+// CreateApp creates a ksonnet application based on the request.
+func (s *ksServer) CreateApp(ctx context.Context, request CreateRequest) error {
+	a, err := func() (*appInfo, error) {
+		s.appsMux.Lock()
+		defer s.appsMux.Unlock()
+
+		if request.Name == "" {
+			return nil, fmt.Errorf("Name must be a non empty string.")
+		}
+		info, ok := s.apps[request.Name]
+
+		if ok {
+			log.Infof("App %v exists", request.Name)
+			return info, nil
+		}
+
+		log.Infof("Creating app %v", request.Name)
+		log.Infof("Using K8s host %v", s.config.Host)
+		envName := "default"
+
+		appDir := path.Join(s.appsDir, request.Name)
+		_, err := s.fs.Stat(appDir)
+
+		if err != nil {
+			options := map[string]interface{}{
+				actions.OptionFs:       s.fs,
+				actions.OptionName:     "app",
+				actions.OptionEnvName:  envName,
+				actions.OptionRootPath: appDir,
+				actions.OptionServer:   s.config.Host,
+				// TODO(jlewi): What is the proper version to use? It shouldn't be a version like v1.9.0-gke as that
+				// will create an error because ksonnet will be unable to fetch a swagger spec.
+				actions.OptionSpecFlag:              "version:v1.7.0",
+				actions.OptionNamespace:             request.Namespace,
+				actions.OptionSkipDefaultRegistries: true,
+			}
+
+			err := actions.RunInit(options)
+			if err != nil {
+				return nil, fmt.Errorf("There was a problem initializing the app: %v", err)
+			}
+			log.Infof("Successfully initialized the app %v.", appDir)
+
+		} else {
+			log.Infof("Directory %v exists", appDir)
+		}
+
+		kfApp, err := kApp.Load(s.fs, appDir, true)
+
+		if err != nil {
+			log.Errorf("There was a problem loading app %v. Error: %v", request.Name, err)
+			return nil, err
+		}
+		s.apps[request.Name] = &appInfo{
+			App: kfApp,
+		}
+		return s.apps[request.Name], nil
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	// Add the registries to the app.
+	for idx, registry := range request.AppConfig.Registries {
+		if registry.RegUri == "" {
+			v, ok := s.knownRegistries[registry.Name]
+			if !ok {
+				return fmt.Errorf("App %v uses registry %v but no URI is specified and this is not a known registry", request.Name, registry.Name)
+			}
+			log.Infof("No URI provided for registry %v; setting URI to %v.", registry.Name, v.RegUri)
+			request.AppConfig.Registries[idx].RegUri = v.RegUri
+		}
+		log.Infof("App %v add registry %v URI %v", request.Name, registry.Name, registry.RegUri)
+		options := map[string]interface{}{
+			actions.OptionApp:  a.App,
+			actions.OptionName: registry.Name,
+			actions.OptionURI:  registry.RegUri,
+			// Version doesn't actually appear to be used by the add function.
+			actions.OptionVersion: "",
+			// Looks like override allows us to override existing registries; we shouldn't
+			// need to do that.
+			actions.OptionOverride: false,
+		}
+
+		registries, err := a.App.Registries()
+		if err != nil {
+			log.Fatal("There was a problem listing registries; %v", err)
+		}
+
+		if _, found := registries[registry.Name]; found {
+			log.Infof("App already has registry %v", registry.Name)
+		} else {
+
+			err = actions.RunRegistryAdd(options)
+			if err != nil {
+				return fmt.Errorf("There was a problem adding registry %v: %v", registry.Name, err)
+			}
+		}
+	}
+
+	s.appGenerate(a.App, &request.AppConfig)
+	if request.AutoConfigure {
+		return s.autoConfigureApp(&a.App, &request.AppConfig)
+	}
+
+	log.Infof("Created and initialized app at %v", a.App.Root())
+	return nil
+}
+
+// appGenerate installs packages and creates components.
+func (s *ksServer) appGenerate(kfApp kApp.App, appConfig *AppConfig) error {
+	libs, err := kfApp.Libraries()
+
+	if err != nil {
+		return fmt.Errorf("Could not list libraries for app; error %v", err)
+	}
+
+	// Install all packages within each registry
+	// TODO(jlewi): Why do we install packages in the registry? Is this
+	// a legacy of when we had fewer optional/non-default packages?
+	// I think the code implicitly assumes RegUri is a file URI
+	// otherwise registry.yaml won't be located at regFile.
+	// Installing all packages could still be useful in the case
+	// where we are using a file URI (e.g. fetching from a registry cloned
+	// into the docker image). Installing all packages copies the packages
+	// into vendor so that the ks app will contain a complete set of packages.
+	// This is beneficial because the file URI won't be valid if the app is copied
+	// to other machines.
+	// Should we add an option to install packages rather than doing it if
+	// registry.yaml exists?
+	for _, registry := range appConfig.Registries {
+		regFile := path.Join(registry.RegUri, "registry.yaml")
+		_, err = s.fs.Stat(regFile)
+		if err == nil {
+			log.Infof("processing registry file %v ", regFile)
+			var ksRegistry KsRegistry
+			if LoadConfig(regFile, &ksRegistry) == nil {
+				for pkgName, _ := range ksRegistry.Libraries {
+					_, err = s.fs.Stat(path.Join(registry.RegUri, pkgName))
+					if err != nil {
+						return fmt.Errorf("Package %v didn't exist in registry %v", pkgName, registry.RegUri)
+					}
+					full := fmt.Sprintf("%v/%v", registry.Name, pkgName)
+					log.Infof("Installing package %v", full)
+
+					if _, found := libs[pkgName]; found {
+						log.Infof("Package %v already exists", pkgName)
+						continue
+					}
+					err := actions.RunPkgInstall(map[string]interface{}{
+						actions.OptionApp:     kfApp,
+						actions.OptionLibName: full,
+						actions.OptionName:    pkgName,
+					})
+
+					if err != nil {
+						return fmt.Errorf("There was a problem installing package %v; error %v", full, err)
+					}
+				}
+			}
+		}
+	}
+
+	// Install packages.
+	for _, pkg := range appConfig.Packages {
+		full := fmt.Sprintf("%v/%v", pkg.Registry, pkg.Name)
+		log.Infof("Installing package %v", full)
+
+		if _, found := libs[pkg.Name]; found {
+			log.Infof("Package %v already exists", pkg.Name)
+			continue
+		}
+		err := actions.RunPkgInstall(map[string]interface{}{
+			actions.OptionApp:     kfApp,
+			actions.OptionLibName: full,
+			actions.OptionName:    pkg.Name,
+		})
+
+		if err != nil {
+			return fmt.Errorf("There was a problem installing package %v; error %v", full, err)
+		}
+	}
+
+	paramMapping := make(map[string][]string)
+	// Extract params for each component
+	for _, p := range appConfig.Parameters {
+		if val, ok := paramMapping[p.Component]; ok {
+			paramMapping[p.Component] = append(val, []string{"--" + p.Name, p.Value}...)
+		} else {
+			paramMapping[p.Component] = []string{"--" + p.Name, p.Value}
+		}
+	}
+
+	// Create Components
+	for _, c := range appConfig.Components {
+		params := []string{c.Prototype, c.Name}
+		if val, ok := paramMapping[c.Name]; ok {
+			params = append(params, val...)
+		}
+		if err = s.createComponent(kfApp, params); err != nil {
+			return err
+		}
+	}
+	// Apply Params
+	for _, p := range appConfig.Parameters {
+		err = actions.RunParamSet(map[string]interface{}{
+			actions.OptionApp:   kfApp,
+			actions.OptionName:  p.Component,
+			actions.OptionPath:  p.Name,
+			actions.OptionValue: p.Value,
+		})
+		if err != nil {
+			return fmt.Errorf("Error when setting Parameters %v for Component %v: %v", p.Name, p.Component, err)
+		}
+	}
+	return err
+}
+
+// createComponent generates a ksonnet component from a prototype in the specified app.
+func (s *ksServer) createComponent(kfApp kApp.App, args []string) error {
+	componentName := args[1]
+	componentPath := filepath.Join(kfApp.Root(), "components", componentName+".jsonnet")
+
+	if exists, _ := afero.Exists(s.fs, componentPath); !exists {
+		log.Infof("Creating Component: %v ...", componentName)
+		err := actions.RunPrototypeUse(map[string]interface{}{
+			actions.OptionApp:       kfApp,
+			actions.OptionArguments: args,
+		})
+		if err != nil {
+			return fmt.Errorf("There was a problem creating component %v: %v", componentName, err)
+		}
+	} else {
+		log.Infof("Component %v already exists", componentName)
+	}
+	return nil
+}
+
+// autoConfigureApp attempts to automatically optimize the Kubeflow application
+// based on the cluster setup.
+func (s *ksServer) autoConfigureApp(kfApp *kApp.App, appConfig *AppConfig) error {
+
+	kubeClient, err := clientset.NewForConfig(rest.AddUserAgent(s.config, "kubeflow-bootstrapper"))
+	if err != nil {
+		return err
+	}
+
+	clusterVersion, err := kubeClient.DiscoveryClient.ServerVersion()
+
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Cluster version: %v", clusterVersion.String())
+
+	storage := kubeClient.StorageV1()
+	sClasses, err := storage.StorageClasses().List(meta_v1.ListOptions{})
+
+	if err != nil {
+		return err
+	}
+
+	hasDefault := hasDefaultStorage(sClasses)
+
+	// Component customization
+	// TODO(jlewi): We depend on the original appConfig in order to optimize it.
+	// Could we avoid this dependency by looking at an existing app and seeing
+	// which components correspond to which prototypes? Would we have to parse
+	// the actual jsonnet files?
+	for _, component := range appConfig.Components {		
+		if component.Prototype == JUPYTER_PROTOTYPE {
+			pvcMount := ""
+			if hasDefault {
+				pvcMount = "/home/jovyan"
+			}
+
+			err = actions.RunParamSet(map[string]interface{}{
+				actions.OptionApp:   kfApp,
+				actions.OptionName:  component.Name,
+				actions.OptionPath:  "jupyterNotebookPVCMount",
+				actions.OptionValue: pvcMount,
+			})
+
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Apply runs apply on a ksonnet application.
+func (s *ksServer) Apply(ctx context.Context, req ApplyRequest) error {
+	a, err := func() (*appInfo, error) {
+		s.appsMux.Lock()
+		defer s.appsMux.Unlock()
+
+		info, ok := s.apps[req.Name]
+
+		if !ok {
+			return nil, fmt.Errorf("App %s doesn't exist", req.Name)
+		}
+		return info, nil
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	a.mux.Lock()
+	defer a.mux.Unlock()
+
+	// (05092018): we shell out to ks apply and don't use ksonnet apply function because
+	// ks runApply API expects clientcmd.ClientConfig, which has a soft dependency on existence of ~/.kube/config
+	// if we use k8s client-go API, would be quite verbose if we create all resources one by one.
+	// TODO: use API to create ks Components
+	if err := os.Chdir(a.App.Root()); err != nil {
+		return err
+	}
+
+	token := req.Token
+
+	if token == "" {
+		log.Infof("No token specified in request; defaulting to service account")
+		token = "$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)"
+	}
+	for _, component := range req.Components {
+		log.Infof("Apply kubeflow component %v", component)
+		rawCmd := fmt.Sprintf("ks apply %v -c %v --token=%v", req.Environment, component, token)
+		applyCmd := exec.Command("bash", "-c", rawCmd)
+
+		var out bytes.Buffer
+		var stderr bytes.Buffer
+		applyCmd.Stdout = &out
+		applyCmd.Stderr = &stderr
+		log.Infof("Run command: %v", rawCmd)
+		err := applyCmd.Run()
+		log.Info("Command: %v\nstdout:\n%vstderr:\n%v", rawCmd, out.String(), stderr.String())
+
+		if err != nil {
+			log.Errorf("Component %v apply failed; Error: %v", component, err)
+			return err
+		} else {
+			// ks apply output to stderr on success case as well
+			log.Infof("Component %v apply succeded", component)
+		}
+	}
+	return nil
+}
+
+func makeCreateAppEndpoint(svc KsService) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(CreateRequest)
+		err := svc.CreateApp(ctx, req)
+
+		r := &createResponse{}
+
+		if err != nil {
+			r.Err = err.Error()
+		}
+		return r, nil
+	}
+}
+
+func decodeCreateAppRequest(_ context.Context, r *http.Request) (interface{}, error) {
+	var request CreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+		return nil, err
+	}
+	return request, nil
+}
+
+// The same encoder can be used for all RPC responses.
+func encodeResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	return json.NewEncoder(w).Encode(response)
+}
+
+// StartHttp starts an HTTP server and blocks.
+func (s *ksServer) StartHttp(port int) {
+	if port <= 0 {
+		log.Fatal("port must be > 0.")
+	}
+	// ctx := context.Background()
+
+	createAppHandler := httptransport.NewServer(
+		makeCreateAppEndpoint(s),
+		decodeCreateAppRequest,
+		encodeResponse,
+	)
+
+	http.Handle("/apps/create", createAppHandler)
+	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", port), nil))
+}

--- a/bootstrap/cmd/bootstrap/app/options/options.go
+++ b/bootstrap/cmd/bootstrap/app/options/options.go
@@ -20,15 +20,17 @@ import (
 
 // ServerOption is the main context object for the controller manager.
 type ServerOption struct {
-	Apply         bool
-	PrintVersion  bool
-	JsonLogFormat bool
-	InCluster     bool
-	KeepAlive     bool
-	AppDir        string
-	Config        string
-	Email         string
-	NameSpace     string
+	Apply                bool
+	PrintVersion         bool
+	JsonLogFormat        bool
+	InCluster            bool
+	KeepAlive            bool
+	Port                 int
+	AppDir               string
+	Config               string
+	Email                string
+	NameSpace            string
+	RegistriesConfigFile string
 }
 
 // NewServerOption creates a new CMServer with a default config.
@@ -37,15 +39,25 @@ func NewServerOption() *ServerOption {
 	return &s
 }
 
+const RegistriesDefaultConfig = "/opt/kubeflow/image_registries.yaml"
+
 // AddFlags adds flags for a specific Server to the specified FlagSet
 func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.PrintVersion, "version", false, "Show version and quit")
 	fs.BoolVar(&s.JsonLogFormat, "json-log-format", true, "Set true to use json style log format. Set false to use plaintext style log format")
-	fs.StringVar(&s.AppDir, "app-dir", "/opt/bootstrap/default", "The directory for the ksonnet application.")
+	fs.IntVar(&s.Port, "port", 8080, "The port to use when running an http server.")
+	fs.StringVar(&s.AppDir, "app-dir", "/opt/bootstrap/default", "The directory for the ksonnet applications.")
 	fs.StringVar(&s.NameSpace, "namespace", "kubeflow", "The namespace where all resources for kubeflow will be created")
 	fs.BoolVar(&s.Apply, "apply", false, "Whether or not to apply the configuration.")
+
+	fs.StringVar(&s.RegistriesConfigFile, "registries-config-file", RegistriesDefaultConfig, "A file containing information about known ksonnet registries.")
+
+	// TODO(jlewi): Email is no longer used. We can remove it as soon as we verify no manifests are trying
+	// to set this command line argument.
 	fs.StringVar(&s.Email, "email", "", "Your Email address for GCP account, if you are using GKE.")
 	fs.BoolVar(&s.InCluster, "in-cluster", false, "Whether bootstrapper is executed inside a pod")
 	fs.BoolVar(&s.KeepAlive, "keep-alive", true, "Whether bootstrapper will stay alive after setup resources.")
-	fs.StringVar(&s.Config, "config", "/opt/kubeflow/default.yaml", "Path to bootstrapper components config.")
+	// TODO(jlewi): We should probably change the default to the empty string because running as a server
+	// will be far more common then doing a one off batch job based on a config file.
+	fs.StringVar(&s.Config, "config", "/opt/kubeflow/default.yaml", "Path to a YAML file describing an app to create on startup.")
 }

--- a/bootstrap/cmd/bootstrap/app/server_test.go
+++ b/bootstrap/cmd/bootstrap/app/server_test.go
@@ -15,16 +15,11 @@
 package app
 
 import (
-	"errors"
 	"reflect"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
-	core_v1 "k8s.io/api/core/v1"
 	"k8s.io/api/storage/v1"
-	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sVersion "k8s.io/apimachinery/pkg/version"
-	type_v1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -73,7 +68,7 @@ func TestModifyGcloudCommand(t *testing.T) {
 	}
 }
 
-func TestisGke(t *testing.T) {
+func TestIsGke(t *testing.T) {
 	type TestCase struct {
 		Input    k8sVersion.Info
 		Expected bool
@@ -141,48 +136,4 @@ func TestHasDefaultStorageClass(t *testing.T) {
 			t.Errorf("hasDefaultStorage(%v) not correct; got %v; want %v", c.Input, result, c.Expected)
 		}
 	}
-}
-
-type MockedNamespace struct {
-	mock.Mock
-	type_v1.NamespaceInterface
-}
-
-func (n *MockedNamespace) Get(name string, options meta_v1.GetOptions) (*core_v1.Namespace, error) {
-	if name == "existing" {
-		return &core_v1.Namespace{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "existing",
-			},
-		}, nil
-	}
-	return nil, errors.New("not found")
-}
-
-func (n *MockedNamespace) Create(ns *core_v1.Namespace) (*core_v1.Namespace, error) {
-	n.Called(ns)
-	// no consumer of return value, so return nil
-	return nil, nil
-}
-
-// Make sure setupNamespace will create namespace if and only if the namespace doesn't exist.
-func TestSetupNamespace(t *testing.T) {
-	// create an instance of our test object
-	mockedNamespace := new(MockedNamespace)
-
-	nsIns := &core_v1.Namespace{
-		ObjectMeta: meta_v1.ObjectMeta{
-			Name: "new",
-		},
-	}
-	mockedNamespace.On("Create", nsIns).Return(
-		nsIns, nil)
-
-	// "Create" should be called 0 times when namespace exists already
-	setupNamespace(mockedNamespace, "existing")
-	mockedNamespace.AssertNumberOfCalls(t, "Create", 0)
-
-	// "Create" should be called 1 times when namespace doesn't exist
-	setupNamespace(mockedNamespace, "new")
-	mockedNamespace.AssertNumberOfCalls(t, "Create", 1)
 }

--- a/bootstrap/cmd/bootstrap/main.go
+++ b/bootstrap/cmd/bootstrap/main.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/kubeflow/kubeflow/bootstrap/cmd/bootstrap/app"
 	"github.com/kubeflow/kubeflow/bootstrap/cmd/bootstrap/app/options"
-	"time"
 )
 
 func init() {
@@ -44,14 +43,6 @@ func main() {
 	}
 
 	if err := app.Run(s); err != nil {
-		if s.InCluster && s.KeepAlive {
-			log.Errorf("Bootstrapper failed with error: %v\n", err)
-			log.Infof("Keeping pod alive so user can ssh in and check error status.")
-			for {
-				time.Sleep(time.Minute)
-			}
-		} else {
-			log.Fatalf("%v\n", err)
-		}
+		log.Fatalf("%v\n", err)
 	}
 }

--- a/bootstrap/glide.lock
+++ b/bootstrap/glide.lock
@@ -1,5 +1,5 @@
-hash: f9b98ee92edf64bacb84e736efc13f87ea69ae788161300c7a86d2ddd45ca783
-updated: 2018-04-12T19:11:57.909552-07:00
+hash: 2b8757afcc7c0ea61f24e5561283321c7b443b36e64035bedc68adb1e637f76f
+updated: 2018-07-07T18:44:50.277401711-07:00
 imports:
 - name: cloud.google.com/go
   version: 3b1ae45394a234c385be014e9a488f2bb6eef821
@@ -31,6 +31,14 @@ imports:
   version: 507f6050b8568533fb3f5504de8e5205fa62a114
 - name: github.com/ghodss/yaml
   version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
+- name: github.com/go-kit/kit
+  version: ca4112baa34cb55091301bdc13b1420a122b1b9e
+  subpackages:
+  - endpoint
+  - log
+  - transport/http
+- name: github.com/go-logfmt/logfmt
+  version: 390ab7935ee28ec6b286364bba9b4dd6410cb3d5
 - name: github.com/go-openapi/jsonpointer
   version: 46af16f9f7b149af66e5d1bd010e3574dc06de98
 - name: github.com/go-openapi/jsonreference
@@ -39,6 +47,8 @@ imports:
   version: 6aced65f8501fe1217321abf0749d354824ba2ff
 - name: github.com/go-openapi/swag
   version: 1d0bd113de87027671077d3c71eb3ac5d7dbba72
+- name: github.com/go-stack/stack
+  version: 259ab82a6cad3992b4e21ff5cac294ccb06474bc
 - name: github.com/gogo/protobuf
   version: c0656edd0d9eab7c66d1eb0c568f9039345796f7
   subpackages:
@@ -100,6 +110,8 @@ imports:
   version: 36b14963da70d11297d313183d7e6388c8510e1e
 - name: github.com/juju/ratelimit
   version: 5b9ff866471762aa2ab2dced63c9fb6f53921342
+- name: github.com/kr/logfmt
+  version: b84e30acd515aadc4b783ad4ff83aff3299bdfe0
 - name: github.com/ksonnet/ksonnet
   version: 68d8f751791db6b0e0798c34f0d72bda24926d8d
   subpackages:
@@ -174,7 +186,7 @@ imports:
 - name: github.com/spf13/pflag
   version: 1ce0cc6db4029d97571db82f85092fccedb572ce
 - name: github.com/stretchr/testify
-  version: 12b6f73e6084dad08a7c6e575284b177ecafbc71
+  version: f35b8ab0b5a2cef36673838d662e249dd9c94686
   subpackages:
   - assert
   - mock

--- a/bootstrap/glide.yaml
+++ b/bootstrap/glide.yaml
@@ -9,3 +9,7 @@ import:
   version: ^1.0.5
 - package: github.com/stretchr/testify
   version: ^1.2.0
+- package: github.com/go-kit/kit
+  version: ^0.7.0
+  subpackages:
+  - endpoint

--- a/bootstrap/hack/send_ks_request.py
+++ b/bootstrap/hack/send_ks_request.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python
+"""A script for manual testing and experimenting with the ks server.
+
+
+TODO(jlewi): Should we use this as the basis for doing
+E2E integration testing? We can run the server in a subprocess.
+Send requests to it and then run various checks on the results.
+"""
+import argparse
+import datetime
+import logging
+import requests
+
+def main():
+  parser = argparse.ArgumentParser(
+    description="Script to test sending requests to the ksonnet server.")
+
+  parser.add_argument(
+    "--endpoint",
+    default="http://localhost:8080",
+    type=str,
+    help="The endpoint of the server")
+
+  args = parser.parse_args()
+
+  create_endpoint = args.endpoint + "/apps/create"
+
+  now = datetime.datetime.now()
+
+  data = {
+    "Name": "test-app-" + now.strftime("%Y%m%d-%H%M%S"),
+    "AppConfig": {
+      "Registries": [
+        {
+          "Name": "kubeflow",
+          "RegUri": "/home/jlewi/git_kubeflow/kubeflow",
+        },
+      ],
+      "Packages": [
+        {
+          "Name": "core",
+          "Registry": "kubeflow",
+        }
+      ],
+    },
+    "Namespace": "kubeflow",
+    "AutoConfigure": False,
+  }
+  r = requests.post(create_endpoint, json=data)
+  if r.status_code != requests.codes.OK:
+    logging.error("Request failed: status_code: %s", r.status_code)
+
+  logging.info("Result Body: %s", r.content)
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+  logging.getLogger().setLevel(logging.INFO)
+  main()

--- a/bootstrap/start.sh
+++ b/bootstrap/start.sh
@@ -5,6 +5,11 @@
 # with the same id as the user on the host system to
 # that we can read the user's home directory on the host
 # so that we can uss kubeconfig, gcloud config and other things.
+#
+# TODO(jlewi): Do we still need this script? I think
+# switching the user to match the host system is a remnant
+# of the original idea of running it on the host system.
+# That's no longer a supported approach.
 set -x
 
 # If it's run by deployment job, don't switch users

--- a/scripts/run_gofmt.sh
+++ b/scripts/run_gofmt.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+ALL_FILES=false
+
+function usage()
+{
+    echo "run_gofmt [--all]"
+    echo ""
+    echo "Autoformats .go files tracked by git."
+    echo "By default only files relative that are modified to origin/master are formatted"
+    echo ""
+    echo "Options:"
+    echo "    --all : Formats all .go files"
+}
+
+# Checkout versions of the code that shouldn't be overwritten
+raw=`git remote`
+readarray -t remotes <<< "$raw"
+
+repo_name=''
+for r in "${remotes[@]}"
+do
+   url=`git remote get-url ${r}`
+   # Period is in brackets because its a special character.
+   if [[ ${url} =~ git@github[.]com:kubeflow/.* ]]; then
+      repo_name=${r}
+   fi
+done
+
+echo using ${repo_name}
+if [ -z "$repo_name" ]; then
+    echo "Could not find remote repository pointing at git@github.com:kubeflow/kubeflow.git"
+    exit 1
+fi
+
+
+while [ "$1" != "" ]; do
+    PARAM=`echo $1 | awk -F= '{print $1}'`
+    case $PARAM in 
+        -h | --help)
+            usage
+            exit
+            ;;
+        --all)
+            ALL_FILES=true
+            ;;
+        *)
+            echo "ERROR: unknown parameter \"$PARAM\""
+            usage
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if $ALL_FILES; then
+    fmt_files=($(git ls-files -- '*.go')) 
+else 
+    fmt_files=($(git diff --name-only ${repo_name}/master -- '*.go'))
+fi
+
+# 2 spaces vertical indentation
+# Use double quotes for strings
+# Use // for comments
+for f in "${fmt_files[@]}"
+do
+  if [[ "${f}" =~ "/vendor/" ]]; then
+  	continue
+  fi  
+  gofmt -w "$f"
+  goimports -w "$f"
+  echo "Autoformatted $f"
+done


### PR DESCRIPTION
We have two use cases.

We want to create a click to deploy web app. This will be a client side
javascript app. This app needs a way to run ksonnet. We will do that
by deploying the bootstrapper on the K8s cluster and then sending RPCs.

Using RPCs will allow the web app to send a bearer token containing user
credentials to do authorization so that we don't need to give the RPC
elevated permissions.

We also want a microservice to do ksonnet substitution that can be used
with hyperparameter tuning to fill in the hyperparamters into a template.

Fix #962 handle file and http registries in a consistent manner.

  * The AppConfig can now specify registries consisting of a (name, URI)
    pair. URI can be anything ks registry add supports (e.g. file or git link).

  * Registries that have been prefetched to local directories are specified
    separately

  * In AppConfig if a registry doesn't specify a URI, the server will
    try to match that registry to one of the known regstries based on
    the name. This allows us to avoid needing a GitHub token
    by using prefetched repositories.

* Delete the code to create the namespace and RBAC roles.

  * This is a legacy of when bootstrapper was running locally in
    a docker container.

    * The code to create the RBAC role was only invoked when running locally
      and not in cluster; if its running in cluster some process would
      have had to deploy the bootstrapper on the cluster and that
      process presumably already has credentials to deploy it.

  * Kubeflow setup now has two modes

    1. Running a deploy.sh script locally; the namespace and rbac
       roles should be created by the deploy script

       The deploy scripts most likely won't use the bootstrapper; there's
       not much reason to.

    2. Click to deploy

      * We use bootstrapper as a ksonnet server since the webapp can't
        otherwise run ksonnet.

      * The webapp however can create the minimal K8s resources needed
        to run the bootstrapper e.g. RBAC roles, namespace etc...

* Add a script to manually test sending requests to the server.

* Add script to run gofmt and goimports on all files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1151)
<!-- Reviewable:end -->
