### PR TITLE
Skip project setup during deployment.

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -101,6 +101,13 @@
               },
             },
             {
+              // The deploy script doesn't need to setup the project; e.g. enable APIs; they should already
+              // be enabled. This slows down setup and leads to test flakiness.
+              // If need be we can have a separate test for the new project case.
+              name: "SETUP_PROJECT",
+              value: "false",
+            },
+            {
               // We use a directory in our NFS share to store our kube config.
               // This way we can configure it on a single step and reuse it on subsequent steps.
               name: "KUBECONFIG",


### PR DESCRIPTION
* Project should already be setup (e.g. APIs enabled). The project
  setup tests just lead to test flakiness.

Fix #1158

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1162)
<!-- Reviewable:end -->
