### PR TITLE
Give KF_USER_NAME service account roles/cloudbuild.builds.editor role

### DIFF
--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -177,6 +177,10 @@ resources:
           members:
             {# Deployment manager uses cloudservices account. #}
             - {{ 'serviceAccount:' + env['project_number'] + '@cloudservices.gserviceaccount.com' }}
+        {# Grant permissions needed to submit builds to Google Cloud Container Builder #}
+        - role: roles/cloudbuild.builds.editor
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
 
         {# Grant permissions needed to push the app to a cloud repository. #}
         - role: roles/source.admin
@@ -248,6 +252,11 @@ resources:
     policy: $(ref.get-iam-policy-delete)
     gcpIamPolicyPatch:
         remove:
+        {# Grant permissions needed to submit builds to Google Cloud Container Builder #}
+        - role: roles/cloudbuild.builds.editor
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
         {# Grant permissions needed to push the app to a cloud repository. #}
         - role: roles/source.admin
           members:


### PR DESCRIPTION
This allows us to submit docker builds to google cloud container builder

/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1163)
<!-- Reviewable:end -->
