### PR TITLE
Delete kubeflow namespace before deleting the cluster

### DIFF
--- a/testing/teardown_kubeflow_gcp.sh
+++ b/testing/teardown_kubeflow_gcp.sh
@@ -13,8 +13,8 @@ fi
 
 # Delete kubeflow namespace - this deletes all the ingress objects
 # in the namespace which deletes the associated GCP resources
-kubectl delete ns/kubeflow
 set +e
+kubectl delete ns/kubeflow
 while kubectl get ns/kubeflow; do
   echo "kubeflow namespace not yet deleted. sleeping 10 seconds..."
   sleep 10

--- a/testing/teardown_kubeflow_gcp.sh
+++ b/testing/teardown_kubeflow_gcp.sh
@@ -11,6 +11,16 @@ if [[ -n "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
   gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 fi
 
+# Delete kubeflow namespace - this deletes all the ingress objects
+# in the namespace which deletes the associated GCP resources
+kubectl delete ns/kubeflow
+set +e
+while kubectl get ns/kubeflow; do
+  echo "kubeflow namespace not yet deleted. sleeping 10 seconds..."
+  sleep 10
+done
+echo "kubeflow namespace successfully deleted."
+set -e
 # Add a jitter to reduce the chance of deployments updating at the same time
 # since tests are run in parallel
 sleep $((${RANDOM} % 30))

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -581,7 +581,7 @@
               deploymentName + v1alpha2Suffix,
               srcDir + "/docs/gke/configs-" + deploymentName + v1alpha2Suffix + "/cluster-kubeflow.yaml",
               project,
-            ]),  // teardown-kubeflow-gcp
+            ], kubeConfig="v1alpha2"),  // teardown-kubeflow-gcp
           ],  // templates
         },
       },  // e2e


### PR DESCRIPTION
Deleting the namespace deletes ingress objects which deletes the GCP
resources associated with it like backends, instance groups,
healthchecks, etc.

This PR should help with resource leaks in the kubeflow-ci project and quota issues

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1167)
<!-- Reviewable:end -->
