### PR TITLE
Cherypick: Tag the latest Jupyter images with v0.2.1 (#1144)

### DIFF
--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -217,6 +217,45 @@ If you aren't already working on a release branch (of the form `v${MAJOR}.${MINO
 2.  they allow sophisticated users to track the development of a release (by using the release branch as a `ksonnet` registry), and
 4.  they simplify backporting critical bugfixes to a patchlevel release particular release stream (e.g., producing a `v0.1.1` from `v0.1-branch`), when appropriate.
 
+## Updating ksonnet prototypes with docker image
+
+Here is the general process for how we update our Docker prototypes to point to
+the correct Docker image.
+
+1. Build a Docker image using whatever tagging schema you like 
+
+   * General convention is v${DATE}-${COMMIT}
+
+1. On the **release branch** update all references to images that will be updated as part
+   of the release to use the tag v${RELEASE} where ${RELEASE} will be the next release
+
+   * e.g if the next RC is v0.2.1-RC.0 then you would use tag v0.2.1
+   * You can modify and then run the script `releasing/update_ksonnet.sh` to update
+     the prototypes
+
+1. Update [image_tags.yaml](https://github.com/kubeflow/kubeflow/blob/master/releasing/image_tags.yaml) **on the master branch**
+   
+   * You can do this by updating and then running **update_image_tags.sh**
+      * This invokes some python scripts that use regexes to match
+        images and apply a tag to them
+      * You can use suitable regexes to get a group of images (e.g. all the 
+        notebook) images.
+   * There should be an entry for ever image you want to use referenced by the sha of the image
+   * If there was a previous release using an earlier image, remove the tag v${RELEASE}
+     from that entry   
+   * Run run_apply_image_tags.sh
+
+     * This script actually creates the tags in the GCR registry based on the data in image_tags.yaml
+
+     ```
+     IMAGE_PATTERN=".*tensorflow.*notebook.*:v0.2.1.*"
+     ./run_apply_image_tags.sh "${IMAGE_PATTERN}"
+
+     ```
+
+     * IMAGE_PATTERN should be a regex matching the images that you want to add the tag
+   * Create a PR checking **into master** the changes in image_tags.yaml
+
 ### Release branching policy
 
 A release branch should be substantially _feature complete_ with respect to the intended release.  Code that is committed to `master` may be merged or cherry-picked on to a release branch, but code that is directly committed to the release branch should be solely applicable to that release (and should not be committed back to master).  In general, unless you're committing code that only applies to the release stream (for example, temporary hotfixes, backported security fixes, or image hashes), you should commit to `master` and then merge or cherry-pick to the reelase branch.

--- a/kubeflow/core/kubeform_spawner.py
+++ b/kubeflow/core/kubeform_spawner.py
@@ -14,16 +14,16 @@ class KubeFormSpawner(KubeSpawner):
     <label for='image'>Image</label>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
     <input list="image" name="image" placeholder='repo/image:tag'>
     <datalist id="image">
-      <option value="{0}/{1}/tensorflow-1.4.1-notebook-cpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.4.1-notebook-gpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.5.1-notebook-cpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.5.1-notebook-gpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.6.0-notebook-cpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.6.0-notebook-gpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.7.0-notebook-cpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.7.0-notebook-gpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.8.0-notebook-cpu:v20180607-476e150e">
-      <option value="{0}/{1}/tensorflow-1.8.0-notebook-gpu:v20180607-476e150e">
+      <option value="{0}/{1}/tensorflow-1.4.1-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.4.1-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.5.1-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.5.1-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.6.0-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.6.0-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.7.0-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.7.0-notebook-gpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.8.0-notebook-cpu:v0.2.1">
+      <option value="{0}/{1}/tensorflow-1.8.0-notebook-gpu:v0.2.1">
     </datalist>
     <br/><br/>
 
@@ -57,7 +57,7 @@ class KubeFormSpawner(KubeSpawner):
         if cloud == 'ack':
             image = 'registry.aliyuncs.com/kubeflow-images-public/tensorflow-notebook-cpu'
         else:
-            image = 'gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v20180619-c79194b3'
+            image = 'gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v0.2.1'
         if self.user_options.get('image'):
             image = self.user_options['image']
         return image

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -1,0 +1,3 @@
+# Scripts for managing releases
+
+See instructions [here](https://github.com/kubeflow/kubeflow/blob/master/docs_dev/releasing.md)

--- a/releasing/apply_image_tags.py
+++ b/releasing/apply_image_tags.py
@@ -1,0 +1,63 @@
+"""Apply the image tags as defined in image_tags.yaml"""
+
+import argparse
+import logging
+import os
+import re
+import yaml
+
+from kubeflow.testing import util
+
+def main(unparsed_args=None):  # pylint: disable=too-many-locals
+  logging.getLogger().setLevel(logging.INFO) # pylint: disable=too-many-locals
+  # create the top-level parser
+  parser = argparse.ArgumentParser(
+    description="Apply tags to file")
+
+  parser.add_argument(
+    "--images_file",
+    default="image_tags.yaml",
+    type=str,
+    help="Yaml file containing the tags to attach.")
+
+  parser.add_argument(
+    "--pattern",
+    default="",
+    type=str,
+    help=("Regex pattern e.g. .*tensorflow.*notebook.*:v20180619.* "
+          "to select the images to apply."))
+  args = parser.parse_args()
+
+  if not os.path.exists(args.images_file):
+    raise ValueError("Missing image tags file: {0}".format(args.images_file))
+
+  with open(args.images_file) as hf:
+    config = yaml.load(hf)
+
+  name_pattern, tag_pattern = args.pattern.split(":")
+  name_re = re.compile(name_pattern)
+  tag_re = re.compile(tag_pattern)
+
+  for image in config["images"]:
+    name = image["name"]
+    if not name_re.match(name):
+      continue
+    for v in image["versions"]:
+      for tag in v["tags"]:
+        if not tag_re.match(tag):
+          continue
+        source = name + "@" + v["digest"]
+        dest = name + ":" + tag
+        util.run(["gcloud", "container", "images", "add-tag", "--quiet",
+                  source, dest])
+
+  logging.info("Done.")
+
+if __name__ == "__main__":
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+  logging.getLogger().setLevel(logging.INFO)
+  main()

--- a/releasing/image_tags.yaml
+++ b/releasing/image_tags.yaml
@@ -1,0 +1,292 @@
+images:
+- name: gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu
+  versions:
+  - digest: sha256:f7fbde2e30a81d87df8987efb55ffeb9d3eb8d8436e9f4e4179a5aaf1557a860
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:40:06-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 40
+      month: 6
+      second: 6
+      year: 2018
+  - digest: sha256:f4162d2f77648d170c9cc5b99df5e94d98786046ffaa12afb230b236ac60eea5
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:34:09-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 34
+      month: 7
+      second: 9
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu
+  versions:
+  - digest: sha256:25ffa1588551ddd452ed9f89725346d5c21770db88284b0195058f0fce20632e
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:28:07-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 28
+      month: 7
+      second: 7
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu
+  versions:
+  - digest: sha256:1c5d18d73b3ff06be24d961c815fd9d662d225b266b36ac5140a28a7beeac0a0
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:34:49-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 34
+      month: 7
+      second: 49
+      year: 2018
+  - digest: sha256:9bbd319374e73f7632e0ffe4d8b52c5280c2c8ea00032629c91e03121d1ab4c3
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:40:09-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 40
+      month: 6
+      second: 9
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu
+  versions:
+  - digest: sha256:eea72345728b29cfe77d859c3a4c7907fea2ccf71947f5580080592dc31a4017
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:08:08-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 8
+      month: 6
+      second: 8
+      year: 2018
+  - digest: sha256:8a601b729df6dab2ccd2c59a284ccce42dc2b035fae85d7354ecdc0c761f6da7
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:29:40-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 29
+      month: 7
+      second: 40
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu
+  versions:
+  - digest: sha256:ee61d16658d6baa0bb6f18ad0d456de66d3931b2f0484bbd185f4af96170f5d6
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:23:39-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 23
+      month: 7
+      second: 39
+      year: 2018
+  - digest: sha256:dadb6730d9aadb7b024e3ebe0c4c76ff46e4b56f0c12367db3afbd4c1a732550
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:13:37-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 13
+      month: 6
+      second: 37
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu
+  versions:
+  - digest: sha256:bc343131c6ef4bdf29f7e54b945438b756b969aab1d786e16553b5209ca4e4b8
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:26:14-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 26
+      month: 7
+      second: 14
+      year: 2018
+  - digest: sha256:e1ffb27e9b831f5ad7db447e5cb1b4b6ecc135a3b95cbf7b4226fcf8f184be3b
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:35:55-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 35
+      month: 6
+      second: 55
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu
+  versions:
+  - digest: sha256:01d4be10c25c9b44a3818eedb603eb97dcfbdb8368a1c6186780a142889e3687
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:12:10-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 12
+      month: 6
+      second: 10
+      year: 2018
+  - digest: sha256:ff71fc8c4581daa174cfcb2242499c7dd9b64bbe5740a9009e0549960507f728
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:34:38-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 34
+      month: 7
+      second: 38
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu
+  versions:
+  - digest: sha256:c51a7af0e48d553b8e39c6610b9761f30221f64d6c0b425d122d59f91dcd9e01
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:29:00-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 29
+      month: 7
+      second: 0
+      year: 2018
+  - digest: sha256:2495fd5a62e6e1746255d0973f455171f5d939655bcb839b203c38032bf1f3e2
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:45:14-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 45
+      month: 6
+      second: 14
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu
+  versions:
+  - digest: sha256:34be48e7c812f6fa68f6321587a90b571e8cd138614ab5ad4331e993f50beeae
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:11:42-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 11
+      month: 6
+      second: 42
+      year: 2018
+  - digest: sha256:3bc4339e04c5ab822e46bf5fcb1fd18c11ce0b2e8bd45a1cfb038d14bffa9a5b
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:25:06-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 25
+      month: 7
+      second: 6
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu
+  versions:
+  - digest: sha256:63b30b10b0b597a4d52701c8bb2cfa40826ce39f9b33d66a3648c30e2e0e28d3
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:29:53-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 29
+      month: 7
+      second: 53
+      year: 2018
+  - digest: sha256:6b928a95e2109eb45d078fce8a757c2218a2965f653a6ed1a492ee5cf497c012
+    tags:
+    - latest
+    - v20180619-c79194b3
+    - v0.2.0
+    timestamp:
+      datetime: '2018-06-19 10:46:20-07:00'
+      day: 19
+      hour: 10
+      microsecond: 0
+      minute: 46
+      month: 6
+      second: 20
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tf_operator
+  versions:
+  - digest: sha256:4f20e349f79059a009ef75aea158ca0c555fcc4a22e7c80a7cb9bff54fbab6c1
+    tags:
+    - v0.2.0

--- a/releasing/run_apply_image_tags.sh
+++ b/releasing/run_apply_image_tags.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Wrapper script for running apply_image_tags.py
+set -ex
+
+PATTERN=$1
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd ${DIR}/.. && pwd )"
+
+# We need to add kubeflow/testing to the python path.
+# We assume its checked out as git_kubeflow-testing
+export PYTHONPATH=${PYTHONPATH}:${ROOT_DIR}/../git_kubeflow-testing/py
+
+# Update the TFJob operator image
+python ${ROOT_DIR}/releasing/apply_image_tags.py \
+	--images_file=${ROOT_DIR}/releasing/image_tags.yaml \
+	--pattern=${PATTERN}

--- a/releasing/update_image_tags.sh
+++ b/releasing/update_image_tags.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# A script to automate updating the images to use in the ksonnet
+# components.
+# This script contains the most recent commands run.
+# You can update it to run the latest images.
+#
+# This won't actually update any tags on images. It will just update
+# image_tags.yaml
+#
+# If image_tags.yaml looks good invoke apply_tags.py
+set -ex
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd ${DIR}/.. && pwd )"
+
+IMAGES_FILE=${ROOT_DIR}/releasing/image_tags.yaml
+
+# Assume the testing repo is checkout in git_kubeflow_testing because 
+# we depend on the python code in that repo.
+export PYTHONPATH=${PYTHONPATH}:${ROOT_DIR}/../git_kubeflow-testing/py
+
+JUPYTER_TAG=v20180707-5a11c84d
+RELEASE=v0.2.1
+
+# Fetch shas for Jupyter images
+python ${ROOT_DIR}/releasing/add_image_shas.py --pattern=.*tensorflow.*1.*notebook.*:${JUPYTER_TAG} \
+	--images_file=${IMAGES_FILE}
+
+# Tag the Jupyter images we want with the desired relase tag.
+python ${ROOT_DIR}/releasing/add_image_tag.py --pattern=.*tensorflow.*1.*notebook.*:${JUPYTER_TAG} --tag=${RELEASE} \
+    --images_file=${IMAGES_FILE}

--- a/releasing/update_images.sh
+++ b/releasing/update_images.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# A script to automate updating the images to use in the ksonnet
+# components
+set -ex
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd ${DIR}/.. && pwd )"
+
+# Update the TFJob operator image
+python ${ROOT_DIR}/scripts/update_prototype.py \
+	--file=${ROOT_DIR}/kubeflow/core/prototypes/all.jsonnet \
+	--values=tfJobImage=gcr.io/kubeflow-images-public/tf_operator:v0.2.0

--- a/releasing/update_ksonnet.sh
+++ b/releasing/update_ksonnet.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# A script to automate updating the images to use in the ksonnet
+# components.
+# This script contains the most recent commands run.
+# You can update it to run the latest images.
+#
+# This won't actually update any tags on images. It will just update
+# image_tags.yaml
+#
+# If image_tags.yaml looks good invoke apply_tags.py
+set -ex
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd ${DIR}/.. && pwd )"
+
+IMAGES_FILE=${ROOT_DIR}/releasing/image_tags.yaml
+
+# Assume the testing repo is checkout in git_kubeflow_testing because 
+# we depend on the python code in that repo.
+export PYTHONPATH=${PYTHONPATH}:${ROOT_DIR}/../git_kubeflow-testing/py
+
+RELEASE=v0.2.0
+
+OLD_NOTEBOOK_RELEASE=v0.2.0
+NOTEBOOK_RELEASE=v0.2.1
+
+# Update the Jupyter Images
+sed -i "s/tensorflow-\([0-9\.]*\)-notebook-\(.*\):${OLD_NOTEBOOK_RELEASE}/tensorflow-\1-notebook-\2:${NOTEBOOK_RELEASE}/" \
+	kubeflow/core/kubeform_spawner.py 
+
+# Update the TFJob operator image
+python scripts/update_prototype.py \
+	--file=${ROOT_DIR}/kubeflow/core/prototypes/all.jsonnet \
+	--values=tfJobImage=gcr.io/kubeflow-images-public/tf_operator:${RELEASE}


### PR DESCRIPTION
* These images includes fixes to TFMA in the Jupyter images.

* Related to #1129 - Upgrade images for 0.2.1

* Related to #1130 - Fix TFMA

* Upgrade the images in the ksonnet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1170)
<!-- Reviewable:end -->
