### PR TITLE
Make GKE VM service account storage.objectViewer to have read access of gcr #1164

### DIFF
--- a/scripts/gke/deploy.sh
+++ b/scripts/gke/deploy.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+# This script creates a kubeflow deployment on GCP
+# It checks for kubectl, gcloud, ks
+# Uses default PROJECT, ZONE, EMAIL from gcloud config
+# Creates a deployment manager config copy and edits appropriate values
+# Adds user to the IAP role
+# Creates the deployment
+# Creates the ksonnet app, installs packages, components and then applies them
+
+set -xe
+
+KUBEFLOW_REPO=${KUBEFLOW_REPO:-"`pwd`/kubeflow_repo"}
+KUBEFLOW_VERSION=${KUBEFLOW_VERSION:-"master"}
+
+if [[ ! -d "${KUBEFLOW_REPO}" ]]; then
+  git clone https://github.com/kubeflow/kubeflow.git "${KUBEFLOW_REPO}"
+  cd "${KUBEFLOW_REPO}"
+  git checkout "${KUBEFLOW_VERSION}"
+  cd -
+fi
+
+source "${KUBEFLOW_REPO}/scripts/util.sh"
+
+check_install gcloud
+check_install kubectl
+# TODO(ankushagarwal): verify ks version is higher than 0.11.0
+check_install ks
+
+check_variable "${CLIENT_ID}" "CLIENT_ID"
+check_variable "${CLIENT_SECRET}" "CLIENT_SECRET"
+
+# Name of the deployment
+DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-"kubeflow"}
+
+# Kubeflow directories - Deployment Manager and Ksonnet App
+KUBEFLOW_DM_DIR=${KUBEFLOW_DM_DIR:-"`pwd`/${DEPLOYMENT_NAME}_deployment_manager_configs"}
+KUBEFLOW_KS_DIR=${KUBEFLOW_KS_DIR:-"`pwd`/${DEPLOYMENT_NAME}_ks_app"}
+# GCP Project
+PROJECT=${PROJECT:-$(gcloud config get-value project 2>/dev/null)}
+check_variable "${PROJECT}" "PROJECT"
+# GCP Zone
+ZONE=${ZONE:-$(gcloud config get-value compute/zone 2>/dev/null)}
+ZONE=${ZONE:-"us-central1-a"}
+# Email for cert manager
+EMAIL=${EMAIL:-$(gcloud config get-value account 2>/dev/null)}
+check_variable "${EMAIL}" "EMAIL"
+# GCP Static IP Name
+KUBEFLOW_IP_NAME=${KUBEFLOW_IP_NAME:-"${DEPLOYMENT_NAME}-ip"}
+# Name of the endpoint
+KUBEFLOW_ENDPOINT_NAME=${KUBEFLOW_ENDPOINT_NAME:-"${DEPLOYMENT_NAME}"}
+# Complete hostname
+KUBEFLOW_HOSTNAME=${KUBEFLOW_HOSTNAME:-"${KUBEFLOW_ENDPOINT_NAME}.endpoints.${PROJECT}.cloud.goog"}
+# Whether to setup the project. Set to false to skip setting up the project.
+SETUP_PROJECT=${SETUP_PROJECT:true}
+# Namespace where kubeflow is deployed
+K8S_NAMESPACE=${K8S_NAMESPACE:-"kubeflow"}
+CONFIG_FILE=${CONFIG_FILE:-"cluster-kubeflow.yaml"}
+PROJECT_NUMBER=`gcloud projects describe ${PROJECT} --format='value(project_number)'`
+ADMIN_EMAIL=${DEPLOYMENT_NAME}-admin@${PROJECT}.iam.gserviceaccount.com
+USER_EMAIL=${DEPLOYMENT_NAME}-user@${PROJECT}.iam.gserviceaccount.com
+
+if ${SETUP_PROJECT}; then
+  # Enable GCloud APIs
+  gcloud services enable deploymentmanager.googleapis.com \
+                         servicemanagement.googleapis.com \
+                         cloudresourcemanager.googleapis.com \
+                         endpoints.googleapis.com \
+                         iam.googleapis.com --project=${PROJECT}
+
+  # Set IAM Admin Policy
+  gcloud projects add-iam-policy-binding ${PROJECT} \
+     --member serviceAccount:${PROJECT_NUMBER}@cloudservices.gserviceaccount.com \
+     --role roles/resourcemanager.projectIamAdmin
+else
+  echo skipping project setup
+fi
+
+# Check if it already exists
+set +e
+gcloud deployment-manager --project=${PROJECT} deployments describe ${DEPLOYMENT_NAME}
+exists=$?
+set -e
+
+cp -r "${KUBEFLOW_REPO}/scripts/gke/deployment_manager_configs" "${KUBEFLOW_DM_DIR}"
+cd "${KUBEFLOW_DM_DIR}"
+# Set values in DM config file
+sed -i.bak "s/zone: us-central1-a/zone: ${ZONE}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+sed -i.bak "s/users:/users: [\"user:${EMAIL}\"]/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+sed -i.bak "s/ipName: kubeflow-ip/ipName: ${KUBEFLOW_IP_NAME}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+rm "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}.bak"
+
+if [ ${exists} -eq 0 ]; then
+  echo ${DEPLOYMENT_NAME} exists
+  gcloud deployment-manager --project=${PROJECT} deployments update ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}
+else
+  # Run Deployment Manager
+  gcloud deployment-manager --project=${PROJECT} deployments create ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}
+fi
+
+# TODO(jlewi): We should name the secrets more consistently based on the service account name.
+# We will need to update the component configs though
+gcloud --project=${PROJECT} iam service-accounts keys create ${ADMIN_EMAIL}.json --iam-account ${ADMIN_EMAIL}
+gcloud --project=${PROJECT} iam service-accounts keys create ${USER_EMAIL}.json --iam-account ${USER_EMAIL}
+
+# Set credentials for kubectl context
+gcloud --project=${PROJECT} container clusters get-credentials --zone=${ZONE} ${DEPLOYMENT_NAME}
+
+# Make yourself cluster admin
+kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --user=${EMAIL}
+
+kubectl create namespace ${K8S_NAMESPACE}
+
+# We want the secret name to be the same by default for all clusters so that users don't have to set it manually.
+kubectl create secret generic --namespace=${K8S_NAMESPACE} admin-gcp-sa --from-file=admin-gcp-sa.json=./${ADMIN_EMAIL}.json
+kubectl create secret generic --namespace=${K8S_NAMESPACE} user-gcp-sa --from-file=user-gcp-sa.json=./${USER_EMAIL}.json
+kubectl create secret generic --namespace=${K8S_NAMESPACE} kubeflow-oauth --from-literal=CLIENT_ID=${CLIENT_ID} --from-literal=CLIENT_SECRET=${CLIENT_SECRET}
+
+# Install the GPU driver. It has no effect on non-GPU nodes.
+kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+
+# Create the ksonnet app
+cd $(dirname "${KUBEFLOW_KS_DIR}")
+ks init $(basename "${KUBEFLOW_KS_DIR}")
+cd "${KUBEFLOW_KS_DIR}"
+
+ks env set default --namespace "${K8S_NAMESPACE}"
+# Add the local registry
+ks registry add kubeflow "${KUBEFLOW_REPO}/kubeflow"
+
+# Install all required packages
+ks pkg install kubeflow/core
+
+# Generate all required components
+ks generate kubeflow-core kubeflow-core --jupyterHubAuthenticator iap
+ks generate cloud-endpoints cloud-endpoints
+ks generate cert-manager cert-manager --acmeEmail=${EMAIL}
+ks generate iap-ingress iap-ingress --ipName=${KUBEFLOW_IP_NAME} --hostname=${KUBEFLOW_HOSTNAME}
+
+# Apply the components generated
+ks apply default -c kubeflow-core
+ks apply default -c cloud-endpoints
+ks apply default -c cert-manager
+ks apply default -c iap-ingress

--- a/scripts/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/scripts/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -1,0 +1,70 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+imports:
+- path: cluster.jinja
+
+resources:
+  # Deployment manager doesn't support depends on references in template type.
+  # So the two possible work arounds are
+  # 1. Use a single template (.jinja file for all resources) or
+  # 2. Create two separate deployments and launch the boot strapper
+  # after the cluster is created.
+  #
+  # Two separate deployments doesn't make much sense; we could just use
+  # kubectl at that point. So we put all resources in a single deployment.
+- name: kubeflow
+  type: cluster.jinja
+  properties:
+    zone: us-central1-a
+    # Set this to v1beta1 to use beta features such as private clusters,
+    gkeApiVersion: v1
+    # An arbitrary string appending to name of nodepools
+    # bump this if you want to modify the node pools.
+    # This will cause existing node pools to be deleted and new ones to be created.
+    # Use prefix v so it will be treated as a string.
+    pool-version: v1
+    # Two is small enough to fit within default quota.
+    cpu-pool-initialNodeCount: 2
+    gpu-pool-initialNodeCount: 0
+    # Whether to deploy the new Stackdriver Kubernetes agents
+    stackdriver-kubernetes: false
+    securityConfig:
+      # Whether to use a cluster with private IPs
+      # Use v1beta1 api
+      privatecluster: false
+      # masterIpv4CidrBlock for private clusters, if enabled
+      # Use v1beta1 api
+      masterIpv4CidrBlock: 172.16.0.16/28
+      # Protect worker node metadata from pods
+      # Use v1beta1 api
+      secureNodeMetadata: false
+      # Whether to enable Pod Security Policy Admission Controller
+      # Use v1beta1 api
+      podSecurityPolicy: false
+      masterAuthorizedNetworksConfig:
+          cidrBlocks:
+          - cidrBlock: 1.2.3.4/32
+          - cidrBlock: 5.6.7.8/32
+          enabled: false
+    users:
+      # List users to grant appropriate GCP permissions to use Kubeflow.
+      # These can either be individual users (Google accounts) or Google
+      # Groups.
+      # - user:john@acme.com
+      # - group:data-scientists@acme.com
+    # Path for the bootstrapper image.
+    # This is the name of the GCP static ip address reserved for your domain.
+    # Each Kubeflow deployment in your project should use one unique ipName among all configs.
+    ipName: kubeflow-ip

--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -21,25 +21,8 @@ limitations under the License.
    that will be created to represent Kubernetes objects.
    There is type corresponding to each API endpoint.
 #}
-{% set TYPE_NAME = NAME_PREFIX + '-type' %}
-{% set RBAC_TYPE_NAME = TYPE_NAME + '-rbac-v1' %}
-{% set APPS_TYPE_NAME = TYPE_NAME + '-apps-v1' %}
-
 {% set VM_OAUTH_SCOPES = ['https://www.googleapis.com/auth/logging.write', 'https://www.googleapis.com/auth/monitoring'] %}
 
-{# A dictionary mapping type name suffixes to the corresponding
-   Kubernetes API endpoint.
-#}
-{% set K8S_ENDPOINTS = {'': 'api/v1', '-v1beta1-extensions': 'apis/extensions/v1beta1', '-rbac-v1': 'apis/rbac.authorization.k8s.io/v1', '-apps-v1': 'apis/apps/v1/'}  %}
-
-{% set COLLECTION_PREFIX = '/api/v1/namespaces/{namespace}/' %}
-{% set NAMESPACE_COLLECTION = '/api/v1/namespaces' %}
-{% set CM_COLLECTION = COLLECTION_PREFIX + 'configmaps' %}
-{% set RC_COLLECTION = COLLECTION_PREFIX + 'replicationcontrollers' %}
-{% set SERVICE_COLLECTION = COLLECTION_PREFIX + 'services' %}
-{% set PVC_COLLECTION = COLLECTION_PREFIX + 'persistentvolumeclaims' %}
-{% set STATEFULSETS_COLLECTION = '/apis/apps/v1/namespaces/{namespace}/statefulsets' %}
-{% set CLUSTER_ROLE_BINDING_COLLECTION = '/apis/rbac.authorization.k8s.io/v1/clusterrolebindings' %}
 
 {# Names for service accounts.
    -admin is to be used for admin tasks
@@ -82,7 +65,7 @@ resources:
       name: {{ CLUSTER_NAME }}
       # Create a very small minimal pool. Actual nodes will be managed
       # as additional node pools. This makes it easier to
-      initialNodeCount: 1
+      initialNodeCount: {{ properties['cpu-pool-initialNodeCount'] }}
       {% if properties['stackdriver-kubernetes'] %}
       # TODO: remove alpha when 10.2 is public.
       # https://github.com/kubeflow/kubeflow/issues/821
@@ -110,7 +93,7 @@ resources:
       masterAuthorizedNetworksConfig: {{ properties['securityConfig']['masterAuthorizedNetworksConfig'] }}
       {% endif %}
       nodeConfig:
-        machineType: n1-standard-1
+        machineType: n1-standard-8
         serviceAccount: {{ KF_VM_SA_NAME }}@{{ env['project'] }}.iam.gserviceaccount.com
         {% if properties['securityConfig']['secureNodeMetadata'] %}
         workloadMetadataConfig:
@@ -124,32 +107,6 @@ resources:
 # We manage the node pools as separate resources.
 # We do this so that if we want to make changes we can delete the existing resource and then recreate it.
 # Updating doesn't work so well because we are limited in what changes GKE's update method supports.
-
-- name: {{ CPU_POOL }}
-  {% if properties['gkeApiVersion'] == 'v1beta1' %}
-  type: gcp-types/container-v1beta1:projects.locations.clusters.nodePools
-  {% else %}
-  type: container.v1.nodePool
-  {% endif %}
-  properties:
-    parent: projects/{{ env['project'] }}/locations/{{ properties['zone'] }}/clusters/{{ CLUSTER_NAME }}
-    project: {{ properties['project'] }}
-    zone: {{ properties['zone'] }}
-    clusterId: {{ CLUSTER_NAME }}
-    nodePool:
-      name: cpu-pool
-      initialNodeCount: {{ properties['cpu-pool-initialNodeCount'] }}
-      config:
-        {% if properties['securityConfig']['secureNodeMetadata'] %}
-        workloadMetadataConfig:
-          nodeMetadata: SECURE
-        {% endif %}
-        machineType: n1-standard-8
-        serviceAccount: {{ KF_VM_SA_NAME }}@{{ env['project'] }}.iam.gserviceaccount.com
-        oauthScopes: {{ VM_OAUTH_SCOPES }}
-  metadata:
-    dependsOn:
-    - {{ CLUSTER_NAME }}
 
 - name: {{ GPU_POOL }}
   {% if properties['gkeApiVersion'] == 'v1beta1' %}
@@ -180,7 +137,7 @@ resources:
   metadata:
     dependsOn:
     # We can only create 1 node pool at a time.
-    - {{ CPU_POOL }}
+    - {{ CLUSTER_NAME }}
 
 {# Project defaults to the project of the deployment. #}
 - name: {{ properties['ipName']  }}
@@ -188,89 +145,15 @@ resources:
   properties:
     description: "Static IP for Kubeflow ingress."
 
-{#
-
-Define TypeProviders for different K8s endpoints.
-https://cloud.google.com/deployment-manager/docs/configuration/type-providers/process-adding-api
-This allows K8s resources to be created using Deployment manager.
-We use this to create the minimal resources needed to startup and deploy Kubeflow via the bootstrapper;
-e.g. creating namespaces, service accounts, stateful set to run the bootstrapper.
-
-#}
-{% for typeSuffix, endpoint in K8S_ENDPOINTS.iteritems() %}
-- name: {{ TYPE_NAME }}{{ typeSuffix }}
-  type: deploymentmanager.v2beta.typeProvider
-  properties:
-    options:
-      validationOptions:
-        # Kubernetes API accepts ints, in fields they annotate with string.
-        # This validation will show as warning rather than failure for
-        # Deployment Manager.
-        # https://github.com/kubernetes/kubernetes/issues/2971
-        schemaValidation: IGNORE_WITH_WARNINGS
-      # According to kubernetes spec, the path parameter 'name'
-      # should be the value inside the metadata field
-      # https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md
-      # This mapping specifies that
-      inputMappings:
-      - fieldName: name
-        location: PATH
-        methodMatch: ^(GET|DELETE|PUT)$
-        value: $.ifNull($.resource.properties.metadata.name, $.resource.name)
-      - fieldName: metadata.name
-        location: BODY
-        methodMatch: ^(PUT|POST)$
-        value: $.ifNull($.resource.properties.metadata.name, $.resource.name)
-      - fieldName: Authorization
-        location: HEADER
-        value: >
-          $.concat("Bearer ", $.googleOauth2AccessToken())
-    descriptorUrl: https://$(ref.{{ CLUSTER_NAME }}.endpoint)/swaggerapi/{{ endpoint }}
-
-{% endfor %}
-
-{# Enable the resource manager API. This is needed below to get IAM policy.
- If activating multiple APIs you might want to serialize them.
-
- We use an action and not the type deploymentmanager.v2.virtual.enableService
- because we only want to create it; we don't want to delete it.
- Deleting the service corresponds to deactivating the API and that causes problems.
- #}
-- name: resource-manager-api
-  action: 'gcp-types/servicemanagement-v1:servicemanagement.services.enable'
-  properties:
-    consumerId: {{ 'project:' + env['project'] }}
-    serviceName: cloudresourcemanager.googleapis.com
-
-{# Enable cloud endpoints. This is used to provision DNS names.
-
-TODO(jlewi): Do we need to serialize API activation
-#}
-- name: endpoints-api
-  action: 'gcp-types/servicemanagement-v1:servicemanagement.services.enable'
-  properties:
-    consumerId: {{ 'project:' + env['project'] }}
-    serviceName: endpoints.googleapis.com
-
-- name: iam-api
-  action: 'gcp-types/servicemanagement-v1:servicemanagement.services.enable'
-  properties:
-    consumerId: {{ 'project:' + env['project'] }}
-    serviceName: iam.googleapis.com
 
 {# Get the IAM policy first so that we do not remove any existing bindings. #}
-- name: get-iam-policy
+- name: get-iam-policy-add
   action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.getIamPolicy
-  properties:
-    resource: {{ env['project'] }}
-
   metadata:
-    dependsOn:
-      - resource-manager-api
-      - iam-api
-    runtimePolicy:
-      - UPDATE_ALWAYS
-
+      runtimePolicy:
+        - UPDATE_ALWAYS
+  properties:
+      resource: {{ env["project"] }}
 {# Set the IAM policy patching the existing policy with what ever is currently in the
   config.
 
@@ -280,13 +163,16 @@ TODO(jlewi): Do we need to serialize API activation
   Note: This will fail if the cloudservices account doesn't have IamProjectAdmin
   permissions.
 #}
-- name: patch-iam-policy
+- name: set-iam-policy-add
   action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy
+  metadata:
+      runtimePolicy:
+        - UPDATE_ON_CHANGE
   properties:
-    resource: {{ env['project'] }}
-    policy: $(ref.get-iam-policy)
+    resource: {{ env["project"] }}
+    policy: $(ref.get-iam-policy-add)
     gcpIamPolicyPatch:
-      add:
+        add:
         - role: roles/container.admin
           members:
             {# Deployment manager uses cloudservices account. #}
@@ -347,31 +233,26 @@ TODO(jlewi): Do we need to serialize API activation
             {% endfor %}
         {% endif %}
         {% endif %}
-
-      remove: []
-
+# Use a second get-set IAM policy pair to have a fresh etag.
+- name: get-iam-policy-delete
+  action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.getIamPolicy
   metadata:
-    dependsOn:
-      - get-iam-policy
-      - iam-api
-      - {{ KF_ADMIN_NAME }}
-      - {{ KF_USER_NAME }}
-    runtimePolicy:
-      - CREATE
-
-{# Remove IAM role binding when delete deployment.
-
-  TODO: This delete might be too aggresive (delete roles not created by deployment manager)
-#}
-- name: remove-iam-policy
-  action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy
+      dependsOn:
+       - set-iam-policy-add
+      runtimePolicy:
+        - UPDATE_ALWAYS
   properties:
-    resource: {{ env['project'] }}
-    policy: $(ref.patch-iam-policy)
+      resource: {{ env["project"] }}
+- name: set-iam-policy-delete
+  action: gcp-types/cloudresourcemanager-v1:cloudresourcemanager.projects.setIamPolicy
+  metadata:
+      runtimePolicy:
+        - DELETE
+  properties:
+    resource: {{ env["project"] }}
+    policy: $(ref.get-iam-policy-delete)
     gcpIamPolicyPatch:
-      add: []
-
-      remove:
+        remove:
         {# Grant permissions needed to push the app to a cloud repository. #}
         - role: roles/source.admin
           members:
@@ -427,181 +308,5 @@ TODO(jlewi): Do we need to serialize API activation
             {% endfor %}
         {% endif %}
         {% endif %}
-  metadata:
-    dependsOn:
-      - patch-iam-policy
-    runtimePolicy:
-      - DELETE
-
-{# A note about K8s resources.
-The type value should be defined using a reference to the corresponding type provider.
-Using references will ensure the K8s resource has
-an explicit dependency on the type provider. This will ensure resources aren't created
-until their type provider is created and that the resources are deleted before
-the corresponding type provider.
-#}
-
-{#  Namespace for bootstrapper. #}
-- name: admin-namespace
-  type: {{ env['project'] }}/$(ref.{{ TYPE_NAME }}.name):{{ NAMESPACE_COLLECTION }}
-  properties:
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: kubeflow-admin
-    spec:
-
-{# The deployment manager uses the cloudservices account. We need to create
-   a cluster role binding making the cloudservices account cluster admin
-   so that we can then create other cluster role bindings.
-#}
-- name: dm-rbac
-  type: {{ env['project'] }}/$(ref.{{ RBAC_TYPE_NAME }}.name):{{ CLUSTER_ROLE_BINDING_COLLECTION }}
-  properties:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: cloud-services-cluster-admin
-    subjects:
-      - kind: User
-        name: {{ env['project_number'] + '@cloudservices.gserviceaccount.com' }}
-    roleRef:
-      kind: ClusterRole
-      name: cluster-admin
-      apiGroup: rbac.authorization.k8s.io
-  metadata:
-    dependsOn:
-      - admin-namespace
-
-{# Make the default service account in the kubeflow-admin namespace a cluster admin.
-   Cluster admin priveleges are needed by the bootstrapper.
-#}
-- name: bootstrap-rbac
-  type: {{ env['project'] }}/$(ref.{{ RBAC_TYPE_NAME }}.name):{{ CLUSTER_ROLE_BINDING_COLLECTION }}
-  properties:
-    apiVersion: rbac.authorization.k8s.io/v1
-    kind: ClusterRoleBinding
-    metadata:
-      name: kubeflow-cluster-admin
-    subjects:
-      - kind: ServiceAccount
-        name: default
-        namespace: kubeflow-admin
-    roleRef:
-      kind: ClusterRole
-      name: cluster-admin
-      apiGroup: rbac.authorization.k8s.io
-  metadata:
-    dependsOn:
-      - admin-namespace
-      - dm-rbac
-
-{# Create a persistent volume to store the ksonnet app.
-#}
-- name: bootstrap-pvc
-  type: {{ env['project'] }}/$(ref.{{ TYPE_NAME }}.name):{{ PVC_COLLECTION }}
-  properties:
-    apiVersion: v1
-    kind: PersistentVolumeClaim
-    {# Namespace is a property because its used by deployment manager in
-       the URL #}
-    namespace: kubeflow-admin
-    metadata:
-      name: kubeflow-ksonnet-pvc
-      labels:
-        app: kubeflow-ksonnet
-    spec:
-      accessModes:
-      - ReadWriteOnce
-      resources:
-        requests:
-          storage: 5Gi
-
-  metadata:
-    dependsOn:
-      - admin-namespace
-
-{# ConfigMap for the bootstrapper #}
-- name: bootstrap-configmap
-  type: {{ env['project'] }}/$(ref.{{ TYPE_NAME }}.name):{{ CM_COLLECTION }}
-  properties:
-    apiVersion: v1
-    {# Namespace is a property because its used bye deployment manager in
-       the URL #}
-    kind: ConfigMap
-    namespace: kubeflow-admin
-    metadata:
-      name: kubeflow-bootstrapper
-      namespace: kubeflow-admin
-    data:
-      {# We need to escape newlines so that they get preserved in the configmap. #}
-      config.yaml: "{{ properties["bootstrapperConfig"]|replace("\n", "\\n") }}"
-
-  metadata:
-      dependsOn:
-        - admin-namespace
-
-{# Stateful set for the bootstrapper #}
-- name: bootstrap-statefulset
-  type: {{ env['project'] }}/$(ref.{{ APPS_TYPE_NAME }}.name):{{ STATEFULSETS_COLLECTION }}
-  properties:
-    apiVersion: apps/v1
-    {# Namespace is a property because its used bye deployment manager in
-       the URL #}
-    kind: StatefulSet
-    namespace: kubeflow-admin
-    metadata:
-      name: kubeflow-bootstrapper
-      namespace: kubeflow-admin
-    spec:
-      selector:
-        matchLabels:
-          app: kubeflow-bootstrapper
-      serviceName: kubeflow-bootstrapper
-      template:
-        metadata:
-          name: kubeflow-bootstrapper
-          labels:
-            app: kubeflow-bootstrapper
-        spec:
-          containers:
-          - name: kubeflow-bootstrapper
-            image: {{ properties["bootstrapperImage"] }}
-            workingDir: /opt/bootstrap
-            command:
-              - /opt/kubeflow/bootstrapper
-              - --in-cluster=true
-              - --apply=true
-              - --namespace=kubeflow
-              - --config=/etc/kubeflow/config.yaml
-            env:
-              - name: GOOGLE_APPLICATION_CREDENTIALS
-                value: /var/run/secrets/sa/admin-gcp-sa.json
-            volumeMounts:
-            - name: kubeflow-ksonnet-pvc
-              mountPath: /opt/bootstrap
-            - name: kubeflow-bootstrapper
-              mountPath: /etc/kubeflow
-            - name: kubeflow-admin-sa
-              readOnly: true
-              mountPath: /var/run/secrets/sa
-          volumes:
-          - name: kubeflow-ksonnet-pvc
-            persistentVolumeClaim:
-              claimName: kubeflow-ksonnet-pvc
-          - name: kubeflow-bootstrapper
-            configMap:
-              name: kubeflow-bootstrapper
-          - name: kubeflow-admin-sa              
-            secret:
-              secretName: admin-gcp-sa
-                
-  metadata:
-    dependsOn:
-      - admin-namespace
-
-outputs:
-{% for typeSuffix, endpoint in K8S_ENDPOINTS.iteritems() %}
-- name: clusterType{{ typeSuffix }}
-  value: {{ TYPE_NAME }}{{ typeSuffix }}
-{% endfor %}
+    {# This changes every time to ensure a fresh etag is obtained. #}
+    quotaUser: {{ env["current_time"] }}

--- a/scripts/gke/deployment_manager_configs/cluster.jinja.schema
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja.schema
@@ -1,0 +1,34 @@
+# Copyright 2016 Google Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+info:
+  title: GKE cluster
+  author: Google, Inc.
+  description: |
+    Creates a GKE cluster and associated type for use in DM. The type can be
+    used in other DM configurations in the following manner:
+
+    "type: <cluster-type>:/api/v1/namespaces/{namespace}/services"
+
+required:
+- zone
+
+properties:
+  zone:
+    type: string
+    description: Zone in which the cluster should run.
+  initialNodeCount:
+    type: integer
+    description: Initial number of nodes desired in the cluster.
+    default: 4

--- a/scripts/gke/teardown.sh
+++ b/scripts/gke/teardown.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -xe
+
+DEPLOYMENT_NAME=${DEPLOYMENT_NAME:-"kubeflow"}
+CONFIG_FILE=${CONFIG_FILE:-"cluster-kubeflow.yaml"}
+PROJECT=${PROJECT:-$(gcloud config get-value project 2>/dev/null)}
+KUBEFLOW_DM_DIR=${KUBEFLOW_DM_DIR:-"`pwd`/${DEPLOYMENT_NAME}_deployment_manager_configs"}
+
+cd "${KUBEFLOW_DM_DIR}"
+# We need to run an update because for deleting IAM roles,
+# we need to obtain a fresh copy of the IAM policy. A stale
+# copy of IAM policy causes issues during deletion.
+gcloud deployment-manager deployments update \
+ ${DEPLOYMENT_NAME} --config=${CONFIG_FILE} --project=${PROJECT}
+
+gcloud deployment-manager deployments delete --quiet \
+ ${DEPLOYMENT_NAME} --project=${PROJECT}


### PR DESCRIPTION
Cherry pick #1164

* Sync the contents of scripts/gke to what's on upstream/master because
  we want to use the new deploy.sh script with v0.2. This doesn't depdend
  on the bootstrapper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1172)
<!-- Reviewable:end -->
