### PR TITLE
Make the deploy scripts more efficient and other fixes.

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -51,7 +51,12 @@ ks pkg install kubeflow/tf-serving
 # Generate all required components
 ks generate kubeflow-core kubeflow-core
 
+# Enable collection of anonymous usage metrics
+# Skip this step if you don't want to enable collection.
+ks param set kubeflow-core reportUsage true
+ks param set kubeflow-core usageId $(uuidgen)
+
 # Apply the components generated
 if ${KUBEFLOW_DEPLOY}; then
-ks apply default
+  ks apply default
 fi

--- a/scripts/gke/deploy.sh
+++ b/scripts/gke/deploy.sh
@@ -147,6 +147,11 @@ ks generate cloud-endpoints cloud-endpoints
 ks generate cert-manager cert-manager --acmeEmail=${EMAIL}
 ks generate iap-ingress iap-ingress --ipName=${KUBEFLOW_IP_NAME} --hostname=${KUBEFLOW_HOSTNAME}
 
+# Enable collection of anonymous usage metrics
+# Skip this step if you don't want to enable collection.
+ks param set kubeflow-core reportUsage true
+ks param set kubeflow-core usageId $(uuidgen)
+
 # Apply the components generated
 ks apply default -c kubeflow-core
 ks apply default -c cloud-endpoints

--- a/scripts/gke/deploy.sh
+++ b/scripts/gke/deploy.sh
@@ -13,10 +13,14 @@ KUBEFLOW_REPO=${KUBEFLOW_REPO:-"`pwd`/kubeflow_repo"}
 KUBEFLOW_VERSION=${KUBEFLOW_VERSION:-"master"}
 
 if [[ ! -d "${KUBEFLOW_REPO}" ]]; then
-  git clone https://github.com/kubeflow/kubeflow.git "${KUBEFLOW_REPO}"
-  cd "${KUBEFLOW_REPO}"
-  git checkout "${KUBEFLOW_VERSION}"
-  cd -
+  if [ "${KUBEFLOW_VERSION}" == "master" ]; then
+    TAG=${KUBEFLOW_VERSION}
+  else
+    TAG=v${KUBEFLOW_VERSION}
+  fi
+  curl -L -o /tmp/kubeflow.${KUBEFLOW_VERSION}.tar.gz https://github.com/kubeflow/kubeflow/archive/${TAG}.tar.gz
+  tar -xzvf /tmp/kubeflow.${KUBEFLOW_VERSION}.tar.gz  -C /tmp
+  mv /tmp/kubeflow-${TAG} "${KUBEFLOW_REPO}"
 fi
 
 source "${KUBEFLOW_REPO}/scripts/util.sh"
@@ -128,7 +132,14 @@ ks env set default --namespace "${K8S_NAMESPACE}"
 ks registry add kubeflow "${KUBEFLOW_REPO}/kubeflow"
 
 # Install all required packages
+ks pkg install kubeflow/argo
 ks pkg install kubeflow/core
+ks pkg install kubeflow/examples
+ks pkg install kubeflow/katib
+ks pkg install kubeflow/mpi-job
+ks pkg install kubeflow/pytorch-job
+ks pkg install kubeflow/seldon
+ks pkg install kubeflow/tf-serving
 
 # Generate all required components
 ks generate kubeflow-core kubeflow-core --jupyterHubAuthenticator iap


### PR DESCRIPTION
* Download tarballs of the repo; this avoids GITHUB API token limits
  and is much faster because it avoids GitHistory

* Install most of the packages into the app so that the user won't
  have to do that step to start using other packages.

* Move scripts/minikube/deploy.sh to scripts/deploy.sh - This script is generic and will work for any existing K8s cluster not just minikube.

Fix #1154

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1174)
<!-- Reviewable:end -->
