### PR TITLE
Add katib to the centralUI

### DIFF
--- a/components/centraldashboard/frontend/index/index.html
+++ b/components/centraldashboard/frontend/index/index.html
@@ -25,6 +25,7 @@
         <a href="/hub/" class="mdl-layout__tab is-active mdl-color-text--white">JupyterHub</a>
         <a href="/tfjobs/ui/" class="mdl-layout__tab mdl-color-text--white">TFJob Dashboard</a>
         <a href="/k8s/ui/" class="mdl-layout__tab mdl-color-text--white">k8s Dashboard</a>
+        <a href="/katib/" class="mdl-layout__tab mdl-color-text--white">katib</a>
       </div>  
     </header>
     <br>


### PR DESCRIPTION
Addresses: https://github.com/kubeflow/katib/issues/128.
For now this PR assumes that Katib is always deployed. Upcoming PR's will address this better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1179)
<!-- Reviewable:end -->
