### PR TITLE
Grant roles/viewer to kubeflow user service account

### DIFF
--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -181,6 +181,10 @@ resources:
         - role: roles/cloudbuild.builds.editor
           members:
             - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+        {# roles/viewer is required for viewing the logs of a GCB build #}
+        - role: roles/viewer
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
 
         {# Grant permissions needed to push the app to a cloud repository. #}
         - role: roles/source.admin
@@ -259,6 +263,10 @@ resources:
         remove:
         {# Grant permissions needed to submit builds to Google Cloud Container Builder #}
         - role: roles/cloudbuild.builds.editor
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+        {# roles/viewer is required for viewing the logs of a GCB build #}
+        - role: roles/viewer
           members:
             - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
 


### PR DESCRIPTION
roles/viewer is required for viewing the logs of a GCB build

/assign @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1185)
<!-- Reviewable:end -->
