### PR TITLE
Use PV for /home/jovyan by default

### DIFF
--- a/kubeflow/core/prototypes/all.jsonnet
+++ b/kubeflow/core/prototypes/all.jsonnet
@@ -15,7 +15,7 @@
 // @optionalParam jupyterHubServiceType string ClusterIP The service type for Jupyterhub.
 // @optionalParam jupyterHubImage string gcr.io/kubeflow/jupyterhub-k8s:v20180531-3bb991b1 The image to use for JupyterHub.
 // @optionalParam jupyterHubAuthenticator string null The authenticator to use
-// @optionalParam jupyterNotebookPVCMount string null Mount path for PVC. Set empty to disable PVC
+// @optionalParam jupyterNotebookPVCMount string /home/jovyan Mount path for PVC. Set empty to disable PVC
 // @optionalParam jupyterNotebookRegistry string gcr.io The docker image registry for JupyterNotebook.
 // @optionalParam jupyterNotebookRepoName string kubeflow-images-public The repoistory name for JupyterNotebook.
 // @optionalParam reportUsage string false Whether or not to report Kubeflow usage to kubeflow.org.


### PR DESCRIPTION
* PV is working reliably now and its a better default experience to have
  notebooks backed up. Users who don't have a default storage class can disable
  it.

Fix #1187

/assign @ankushagarwal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1191)
<!-- Reviewable:end -->
