### PR TITLE
Cherrypick #1194 to master - Fix deploy.sh moving the unpacked repo

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,10 +14,13 @@ if [[ ! -d "${KUBEFLOW_REPO}" ]]; then
 	TAG=${KUBEFLOW_VERSION}
   else
   	TAG=v${KUBEFLOW_VERSION}
-  fi
-  curl -L -o /tmp/kubeflow.${KUBEFLOW_VERSION}.tar.gz https://github.com/kubeflow/kubeflow/archive/${TAG}.tar.gz
-  tar -xzvf /tmp/kubeflow.${KUBEFLOW_VERSION}.tar.gz  -C /tmp
-  mv /tmp/kubeflow-${TAG} "${KUBEFLOW_REPO}"
+  fi  
+  TMPDIR=$(mktemp -d /tmp/tmp.kubeflow-repo-XXXX)
+  curl -L -o ${TMPDIR}/kubeflow.tar.gz https://github.com/kubeflow/kubeflow/archive/${TAG}.tar.gz
+  tar -xzvf ${TMPDIR}/kubeflow.tar.gz  -C ${TMPDIR}
+  # GitHub seems to strip out the v in the file name.
+  SOURCE_DIR=$(find ${TMPDIR} -maxdepth 1 -type d -name "kubeflow*")
+  mv ${SOURCE_DIR} "${KUBEFLOW_REPO}"
 fi
 
 source "${KUBEFLOW_REPO}/scripts/util.sh"

--- a/scripts/deploy_test.sh
+++ b/scripts/deploy_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# A simple and minimal test for deploy.sh
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TMPDIR=$(mktemp -d /tmp/tmp.deploy-test-XXXX)
+export KUBEFLOW_DEPLOY=false
+cd ${TMPDIR}
+${DIR}/deploy.sh
+
+EXPECTED_APP_DIR=${TMPDIR}/kubeflow_ks_app
+
+if [[ ! -d ${EXPECTED_APP_DIR} ]]; then
+  echo ${EXPECTED_APP_DIR} was not created
+  exit 1
+fi	

--- a/scripts/gke/deploy.sh
+++ b/scripts/gke/deploy.sh
@@ -11,6 +11,7 @@ set -xe
 
 KUBEFLOW_REPO=${KUBEFLOW_REPO:-"`pwd`/kubeflow_repo"}
 KUBEFLOW_VERSION=${KUBEFLOW_VERSION:-"master"}
+KUBEFLOW_DEPLOY=${KUBEFLOW_DEPLOY:-true}
 
 if [[ ! -d "${KUBEFLOW_REPO}" ]]; then
   if [ "${KUBEFLOW_VERSION}" == "master" ]; then
@@ -18,9 +19,12 @@ if [[ ! -d "${KUBEFLOW_REPO}" ]]; then
   else
     TAG=v${KUBEFLOW_VERSION}
   fi
-  curl -L -o /tmp/kubeflow.${KUBEFLOW_VERSION}.tar.gz https://github.com/kubeflow/kubeflow/archive/${TAG}.tar.gz
-  tar -xzvf /tmp/kubeflow.${KUBEFLOW_VERSION}.tar.gz  -C /tmp
-  mv /tmp/kubeflow-${TAG} "${KUBEFLOW_REPO}"
+  TMPDIR=$(mktemp -d /tmp/tmp.kubeflow-repo-XXXX)
+  curl -L -o ${TMPDIR}/kubeflow.tar.gz https://github.com/kubeflow/kubeflow/archive/${TAG}.tar.gz
+  tar -xzvf ${TMPDIR}/kubeflow.tar.gz  -C ${TMPDIR}
+  # GitHub seems to strip out the v in the file name.
+  SOURCE_DIR=$(find ${TMPDIR} -maxdepth 1 -type d -name "kubeflow*")
+  mv ${SOURCE_DIR} "${KUBEFLOW_REPO}"
 fi
 
 source "${KUBEFLOW_REPO}/scripts/util.sh"
@@ -60,7 +64,11 @@ SETUP_PROJECT=${SETUP_PROJECT:true}
 # Namespace where kubeflow is deployed
 K8S_NAMESPACE=${K8S_NAMESPACE:-"kubeflow"}
 CONFIG_FILE=${CONFIG_FILE:-"cluster-kubeflow.yaml"}
-PROJECT_NUMBER=`gcloud projects describe ${PROJECT} --format='value(project_number)'`
+
+if [ -z "${PROJECT_NUMBER}" ]; then
+  PROJECT_NUMBER=`gcloud projects describe ${PROJECT} --format='value(project_number)'`
+fi
+
 ADMIN_EMAIL=${DEPLOYMENT_NAME}-admin@${PROJECT}.iam.gserviceaccount.com
 USER_EMAIL=${DEPLOYMENT_NAME}-user@${PROJECT}.iam.gserviceaccount.com
 
@@ -82,48 +90,56 @@ else
   echo skipping project setup
 fi
 
-# Check if it already exists
-set +e
-gcloud deployment-manager --project=${PROJECT} deployments describe ${DEPLOYMENT_NAME}
-exists=$?
-set -e
-
-cp -r "${KUBEFLOW_REPO}/scripts/gke/deployment_manager_configs" "${KUBEFLOW_DM_DIR}"
-cd "${KUBEFLOW_DM_DIR}"
-# Set values in DM config file
-sed -i.bak "s/zone: us-central1-a/zone: ${ZONE}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
-sed -i.bak "s/users:/users: [\"user:${EMAIL}\"]/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
-sed -i.bak "s/ipName: kubeflow-ip/ipName: ${KUBEFLOW_IP_NAME}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
-rm "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}.bak"
-
-if [ ${exists} -eq 0 ]; then
-  echo ${DEPLOYMENT_NAME} exists
-  gcloud deployment-manager --project=${PROJECT} deployments update ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}
+# Create the DM configs if they don't exists
+if [ ! -d "${KUBEFLOW_DM_DIR}" ]; then
+  echo creating Deployment Manager configs in directory "${KUBEFLOW_DM_DIR}"
+  cp -r "${KUBEFLOW_REPO}/scripts/gke/deployment_manager_configs" "${KUBEFLOW_DM_DIR}"
+  cd "${KUBEFLOW_DM_DIR}"
+  # Set values in DM config file
+  sed -i.bak "s/zone: us-central1-a/zone: ${ZONE}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+  sed -i.bak "s/users:/users: [\"user:${EMAIL}\"]/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+  sed -i.bak "s/ipName: kubeflow-ip/ipName: ${KUBEFLOW_IP_NAME}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+  rm "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}.bak"
 else
-  # Run Deployment Manager
-  gcloud deployment-manager --project=${PROJECT} deployments create ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}
+  echo Deployment Manager configs already exist in directory "${KUBEFLOW_DM_DIR}"
 fi
 
-# TODO(jlewi): We should name the secrets more consistently based on the service account name.
-# We will need to update the component configs though
-gcloud --project=${PROJECT} iam service-accounts keys create ${ADMIN_EMAIL}.json --iam-account ${ADMIN_EMAIL}
-gcloud --project=${PROJECT} iam service-accounts keys create ${USER_EMAIL}.json --iam-account ${USER_EMAIL}
+if ${KUBEFLOW_DEPLOY}; then
+  # Check if it already exists
+  set +e
+  gcloud deployment-manager --project=${PROJECT} deployments describe ${DEPLOYMENT_NAME}
+  exists=$?
+  set -e
 
-# Set credentials for kubectl context
-gcloud --project=${PROJECT} container clusters get-credentials --zone=${ZONE} ${DEPLOYMENT_NAME}
+  if [ ${exists} -eq 0 ]; then
+    echo ${DEPLOYMENT_NAME} exists
+    gcloud deployment-manager --project=${PROJECT} deployments update ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}
+  else
+    # Run Deployment Manager
+    gcloud deployment-manager --project=${PROJECT} deployments create ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}
+  fi
 
-# Make yourself cluster admin
-kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --user=${EMAIL}
+  # TODO(jlewi): We should name the secrets more consistently based on the service account name.
+  # We will need to update the component configs though
+  gcloud --project=${PROJECT} iam service-accounts keys create ${ADMIN_EMAIL}.json --iam-account ${ADMIN_EMAIL}
+  gcloud --project=${PROJECT} iam service-accounts keys create ${USER_EMAIL}.json --iam-account ${USER_EMAIL}
 
-kubectl create namespace ${K8S_NAMESPACE}
+  # Set credentials for kubectl context
+  gcloud --project=${PROJECT} container clusters get-credentials --zone=${ZONE} ${DEPLOYMENT_NAME}
 
-# We want the secret name to be the same by default for all clusters so that users don't have to set it manually.
-kubectl create secret generic --namespace=${K8S_NAMESPACE} admin-gcp-sa --from-file=admin-gcp-sa.json=./${ADMIN_EMAIL}.json
-kubectl create secret generic --namespace=${K8S_NAMESPACE} user-gcp-sa --from-file=user-gcp-sa.json=./${USER_EMAIL}.json
-kubectl create secret generic --namespace=${K8S_NAMESPACE} kubeflow-oauth --from-literal=CLIENT_ID=${CLIENT_ID} --from-literal=CLIENT_SECRET=${CLIENT_SECRET}
+  # Make yourself cluster admin
+  kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --user=${EMAIL}
 
-# Install the GPU driver. It has no effect on non-GPU nodes.
-kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+  kubectl create namespace ${K8S_NAMESPACE}
+
+  # We want the secret name to be the same by default for all clusters so that users don't have to set it manually.
+  kubectl create secret generic --namespace=${K8S_NAMESPACE} admin-gcp-sa --from-file=admin-gcp-sa.json=./${ADMIN_EMAIL}.json
+  kubectl create secret generic --namespace=${K8S_NAMESPACE} user-gcp-sa --from-file=user-gcp-sa.json=./${USER_EMAIL}.json
+  kubectl create secret generic --namespace=${K8S_NAMESPACE} kubeflow-oauth --from-literal=CLIENT_ID=${CLIENT_ID} --from-literal=CLIENT_SECRET=${CLIENT_SECRET}
+
+  # Install the GPU driver. It has no effect on non-GPU nodes.
+  kubectl apply -f https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml
+fi
 
 # Create GCFS Instance
 gcloud beta filestore instances create ${GCFS_INSTANCE} \
@@ -171,8 +187,10 @@ ks param set kubeflow-core reportUsage true
 ks param set kubeflow-core usageId $(uuidgen)
 
 # Apply the components generated
-ks apply default -c google-cloud-filestore-pv
-ks apply default -c kubeflow-core
-ks apply default -c cloud-endpoints
-ks apply default -c cert-manager
-ks apply default -c iap-ingress
+if ${KUBEFLOW_DEPLOY}; then
+  ks apply default -c google-cloud-filestore-pv
+  ks apply default -c kubeflow-core
+  ks apply default -c cloud-endpoints
+  ks apply default -c cert-manager
+  ks apply default -c iap-ingress
+fi

--- a/scripts/gke/deploy_test.sh
+++ b/scripts/gke/deploy_test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# A simple and minimal test for deploy.sh
+# This only verifies the configs are created it doesn't try to deploy them.
+set -ex
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+TMPDIR=$(mktemp -d /tmp/tmp.deploy-gke-test-XXXX)
+export KUBEFLOW_DEPLOY=false
+export SETUP_PROJECT=false
+export PROJECT=fakeproject
+export PROJECT_NUMBER=1234
+export CLIENT_ID=fake_id
+export CLIENT_SECRET=fake_secret
+
+cd ${TMPDIR}
+${DIR}/deploy.sh
+
+EXPECTED_DM_DIR=${TMPDIR}/kubeflow_deployment_manager_configs
+
+if [[ ! -d ${EXPECTED_DM_DIR} ]]; then
+  echo ${EXPECTED_DM_DIR} was not created
+  exit 1
+fi	
+
+EXPECTED_APP_DIR=${TMPDIR}/kubeflow_ks_app
+
+if [[ ! -d ${EXPECTED_APP_DIR} ]]; then
+  echo ${EXPECTED_APP_DIR} was not created
+  exit 1
+fi	


### PR DESCRIPTION
* Fix deploy.sh moving the unpacked repo.

* It looks like GitHub is stripping out the v in the name of the top level
  directory.

Make the scripts less brittle by not assuming the top level directory
will be named a certain way.
Related to 1193.

* Fix indent.

* * Add simple test scripts to verify that the configs are created
* Add an option to gke/deploy.sh to skip deployment to facilitate testing
* Add an option to gke/deploy.sh to not recreate the DM configs if they
  already exist; the sed commands assume we are starting from scratch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1196)
<!-- Reviewable:end -->
