### PR TITLE
Add a script to cleanup leaked kubeflow-ci ingress resources

### DIFF
--- a/scripts/cleanup_kubeflow_ci.sh
+++ b/scripts/cleanup_kubeflow_ci.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# This script cleans up ingress related compute engine resources like backend-services,
+# forwarding rules, health-checks, etc. from kubeflow-ci project which
+# do not belong to the kubeflow-testing cluster
+
+set -xe
+
+PROJECT="--project=kubeflow-ci"
+
+# This id comes from ingress objects in kubeflow-testing cluster
+# They use a common suffix for GCP resources
+KUBEFLOW_TESTING_ID=c3cb19bff97cde34
+
+function cleanup() {
+  gcloud compute ${1} list ${PROJECT} | grep -v ${KUBEFLOW_TESTING_ID} | awk '{print $1}' | tail -n +2 | xargs gcloud compute ${1} delete ${2} --quiet ${PROJECT}
+}
+
+cleanup forwarding-rules --global
+
+cleanup target-http-proxies
+
+cleanup target-https-proxies
+
+cleanup url-maps
+
+cleanup health-checks
+
+cleanup backend-services --global

--- a/scripts/cleanup_kubeflow_ci.sh
+++ b/scripts/cleanup_kubeflow_ci.sh
@@ -5,14 +5,18 @@
 
 set -xe
 
-PROJECT="--project=kubeflow-ci"
+PROJECT="kubeflow-ci"
 
 # This id comes from ingress objects in kubeflow-testing cluster
 # They use a common suffix for GCP resources
 KUBEFLOW_TESTING_ID=c3cb19bff97cde34
 
 function cleanup() {
-  gcloud compute ${1} list ${PROJECT} | grep -v ${KUBEFLOW_TESTING_ID} | awk '{print $1}' | tail -n +2 | xargs gcloud compute ${1} delete ${2} --quiet ${PROJECT}
+  gcloud compute ${1} list --project=${PROJECT} \
+  | grep -v ${KUBEFLOW_TESTING_ID} \
+  | awk '{print $1}' \
+  | tail -n +2 \
+  | xargs gcloud compute ${1} delete ${2} --quiet --project=${PROJECT}
 }
 
 cleanup forwarding-rules --global


### PR DESCRIPTION
This script cleans up ingress related compute engine resources like backend-services,
forwarding rules, health-checks, etc. from kubeflow-ci project which
do not belong to the kubeflow-testing cluster

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1199)
<!-- Reviewable:end -->
