### PR TITLE
fix tf-job-dashboard fails to show logs

### DIFF
--- a/kubeflow/core/tf-job-operator.libsonnet
+++ b/kubeflow/core/tf-job-operator.libsonnet
@@ -564,6 +564,7 @@
           resources: [
             "configmaps",
             "pods",
+            "pods/log",
             "services",
             "endpoints",
             "persistentvolumeclaims",


### PR DESCRIPTION
Fix [Unable to check logs in TFJob ui for v1apha2](https://github.com/kubeflow/tf-operator/issues/723)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1210)
<!-- Reviewable:end -->
