### PR TITLE
Update tf-job-operator.libsonnet

### DIFF
--- a/kubeflow/core/tests/tf-job_test.jsonnet
+++ b/kubeflow/core/tests/tf-job_test.jsonnet
@@ -190,6 +190,17 @@ std.assertEqual(
           "*",
         ],
       },
+      {
+        apiGroups: [
+          "policy",
+        ],
+        resources: [
+          "poddisruptionbudgets",
+        ],
+        verbs: [
+          "*",
+        ],
+      },
     ],
   }
 ) &&

--- a/kubeflow/core/tf-job-operator.libsonnet
+++ b/kubeflow/core/tf-job-operator.libsonnet
@@ -386,6 +386,17 @@
             "*",
           ],
         },
+        {
+          apiGroups: [
+            "policy",
+          ],
+          resources: [
+            "poddisruptionbudgets",
+          ],
+          verbs: [
+            "*",
+          ],
+        },
       ],
     },  // operator-role
 


### PR DESCRIPTION
when tf-operator enable-gang-scheduler, tf-job-operator ClusterRole need the corresponding poddisruptionbudgets.policy, otherwise tf-operator will get/create pdb object failed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1216)
<!-- Reviewable:end -->
