### PR TITLE
[gcp-deployer] Enable required GCP services before deploying

### DIFF
--- a/components/gcp-click-to-deploy/public/index.html
+++ b/components/gcp-click-to-deploy/public/index.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#000000">
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
   <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:300,400|Open+Sans:300,400">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro|Google+Sans">
   <script type="text/javascript">
     var gapiPromise = (() => {
       return new Promise((resolve, reject) => {

--- a/components/gcp-click-to-deploy/src/App.tsx
+++ b/components/gcp-click-to-deploy/src/App.tsx
@@ -19,6 +19,7 @@ const styles: { [p: string]: React.CSSProperties } = {
     backgroundColor: '#3b78e7',
     display: 'flex',
     flexFlow: 'column',
+    fontFamily: '"google sans", Helvetica',
     height: '100%',
     width: '100%',
   },

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -10,7 +10,7 @@ import glamorous from 'glamorous';
 import * as jsYaml from 'js-yaml';
 import * as React from 'react';
 import Gapi from './Gapi';
-import { flattenDeploymentOperationError, log } from './Utils';
+import { flattenDeploymentOperationError, log, wait } from './Utils';
 
 // TODO(jlewi): Can we fetch these directly from GitHub so we always get the latest value?
 // When I tried using fetch API to do that I ran into errors that I interpreted as chrome blocking
@@ -49,6 +49,7 @@ const LogsArea = glamorous.textarea({
   boxSizing: 'border-box',
   color: '#fff',
   flexGrow: 1,
+  fontFamily: 'Source Code Pro',
   fontSize: 13,
   margin: '0 auto',
   maxWidth: 600,
@@ -247,7 +248,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
   }
 
   // Create a  Kubeflow deployment.
-  private _createDeployment() {
+  private async _createDeployment() {
     for (const prop of ['project', 'zone', 'email', 'ipName', 'deploymentName', 'hostName']) {
       if (this.state[prop] === '') {
         this.setState({
@@ -263,7 +264,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
     kubeflow.name = this.state.deploymentName;
     kubeflow.properties.zone = this.state.zone;
 
-    // Load the bootstrapper config.
+    // Step 0: Load the bootstrapper config.
     const config: any = jsYaml.safeLoad(kubeflow.properties.bootstrapperConfig);
 
     if (config == null) {
@@ -297,6 +298,82 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
     const project = this.state.project;
     const deploymentName = this.state.deploymentName;
 
+    // Step 1: Enable required services
+    // Enabling takes some time, so we get the list of services that need
+    // enabling, make requests to enable them, then we repeat this in a loop
+    // until we have no more services left, or we try too many times.
+    this._appendLine(`Getting enabled services for project ${project}..`);
+
+    let servicesToEnable: string[] = [];
+    let enableAttempts = 0;
+    const retryTimeout = 3000;
+    do {
+      servicesToEnable = await this._getServicesToEnable(project)
+        .catch(e => {
+          this.setState({
+            error: 'Deployment Error',
+            errorMessage: 'Error trying to list enabled services: ' + e,
+          });
+          return [];
+        });
+
+      if (this.state.error) {
+        return;
+      }
+
+      if (servicesToEnable.length) {
+        if (enableAttempts) {
+          this._appendLine(`Retrying in ${retryTimeout / 1000} seconds`);
+          await wait(retryTimeout);
+        }
+
+        this._appendLine(
+          `Need to enable these services: ${servicesToEnable.join(', ')}..`);
+      }
+
+      for (const s of servicesToEnable) {
+        this._appendLine('Enabling ' + s);
+        await Gapi.servicemanagement.enable(project, s)
+          .catch(e => this.setState({
+            error: 'Deployment Error',
+            errorMessage: 'Error trying to enable this required service: ' + s + '.\n' + e,
+          }));
+      }
+
+      if (this.state.error) {
+        return;
+      }
+
+      enableAttempts++;
+    } while (servicesToEnable.length && enableAttempts < 5);
+
+    if (servicesToEnable.length && enableAttempts >= 5) {
+      this.setState({
+        error: 'Deployment Error',
+        errorMessage: 'Tried too many times to enable these services: ' +
+          servicesToEnable.join(', '),
+      });
+      return;
+    }
+
+    // Step 2: Set IAM Adming Policy
+    const projectNumber = await Gapi.cloudresourcemanager.getProjectNumber(project)
+      .catch(e => {
+        this.setState({
+          error: 'Deployment Error',
+          errorMessage: 'Error trying to get the project number: ' + e,
+        });
+        return undefined
+      });
+
+    if (this.state.error) {
+      return;
+    }
+
+    this._appendLine('Proceeding with project number: ' + projectNumber);
+
+    // Step 3: Create GCP Deployment
+
     const resource = {
       'name': deploymentName,
       'target': {
@@ -314,18 +391,40 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
 
     Gapi.deploymentmanager.insert(project, resource)
       .then(res => {
-        this._appendLine('Result of insert:\n' + JSON.stringify(res));
+        this._appendLine('Result of create deployment operation:\n' + JSON.stringify(res));
         this._monitorDeployment(project, deploymentName)
       })
       .catch(err => {
-        this._appendLine('Error doing insert:\n' + err);
+        this._appendLine('Error trying to create deployment:\n' + err);
         this.setState({
           error: 'Deployment Error',
           errorMessage: 'Error trying to create deployment: ' + err,
         });
       });
 
-  } // insertDeployment
+  }
+
+  /**
+   * Returns a list of services that are needed but not enabled for the given project.
+   */
+  private async _getServicesToEnable(project: string) {
+    const enabledServices = await Gapi.servicemanagement.list(project);
+
+    const servicesToEnable = new Set([
+      'deploymentmanager.googleapis.com',
+      'cloudresourcemanager.googleapis.com',
+      'endpoints.googleapis.com',
+      'iam.googleapis.com',
+    ]);
+
+    for (const k of Array.from(servicesToEnable.keys())) {
+      if (enabledServices!.services!.find(s => s.serviceName === k)) {
+        servicesToEnable.delete(k);
+      }
+    }
+
+    return Array.from(servicesToEnable);
+  }
 
   private _monitorDeployment(project: string, deploymentName: string) {
     const monitorInterval = setInterval(() => {

--- a/components/gcp-click-to-deploy/src/Gapi.ts
+++ b/components/gcp-click-to-deploy/src/Gapi.ts
@@ -1,5 +1,17 @@
 import { flattenDeploymentOperationError } from './Utils';
 
+interface ManagedService {
+  producerProjectId?: string;
+  serviceName?: string;
+}
+interface ListServicesResponse {
+  nextPageToken?: string;
+  services?: ManagedService[];
+}
+interface EnableServiceRequest {
+  consumerId?: string;
+}
+
 export default class Gapi {
 
   public static deploymentmanager = class {
@@ -30,6 +42,50 @@ export default class Gapi {
         gapi.client.load('deploymentmanager', 'v2', () => resolve()))
         .then(() => {
           this._deploymentManager = (gapi.client as any).deploymentmanager.deployments;
+        });
+    }
+
+  }
+
+  public static servicemanagement = class {
+
+    public static async list(project: string) {
+      await Gapi.load();
+      const consumerId = encodeURIComponent(`project:${project}`);
+      return gapi.client.request({
+        path: `https://content-servicemanagement.googleapis.com/v1/services?consumerId=${consumerId}`,
+      }).then(response => response.result as ListServicesResponse,
+        badResult => {
+          throw new Error('Errors listing services: ' + flattenDeploymentOperationError(badResult.result));
+        });
+    }
+
+    public static async enable(project: string, serviceName: string) {
+      await Gapi.load();
+      const consumerId = `project:${project}`;
+      return gapi.client.request({
+        body: {
+          consumerId
+        },
+        method: 'POST',
+        path: `https://content-servicemanagement.googleapis.com/v1/services/${serviceName}:enable`,
+      }).then(response => response.result as EnableServiceRequest,
+        badResult => {
+          throw new Error('Errors enabling service: ' + flattenDeploymentOperationError(badResult.result));
+        });
+    }
+
+  }
+
+  public static cloudresourcemanager = class {
+
+    public static async getProjectNumber(projectId: string) {
+      await Gapi.load();
+      return gapi.client.request({
+        path: `https://cloudresourcemanager.googleapis.com/v1/projects/${projectId}`
+      }).then(response => (response.result as any).projectNumber as number,
+        badResult => {
+          throw new Error('Errors enabling service: ' + flattenDeploymentOperationError(badResult.result));
         });
     }
 

--- a/components/gcp-click-to-deploy/src/Header.tsx
+++ b/components/gcp-click-to-deploy/src/Header.tsx
@@ -10,12 +10,11 @@ const styles = {
     fontWeight: 300,
   },
   google: {
-    fontWeight: 400,
+    fontWeight: 600,
     paddingRight: 5,
   },
   header: {
     color: '#fff',
-    fontFamily: '"open sans", Helvetica',
     fontSize: '1.3em',
     padding: 20,
   },

--- a/components/gcp-click-to-deploy/src/Utils.ts
+++ b/components/gcp-click-to-deploy/src/Utils.ts
@@ -1,10 +1,21 @@
-type Operation = gapi.client.deploymentmanager.Operation;
-
 export function log(...args: any[]) {
   // tslint:disable-next-line:no-console
   console.log(...args);
 }
 
-export function flattenDeploymentOperationError(operation: Operation) {
-  return operation.error!.errors!.map(e => e.message).join('\n');
+export function flattenDeploymentOperationError(operation: any) {
+  const error = operation.error!;
+  if (error.errors) {
+    return error.errors!.map((e: any) => e.message).join('\n');
+  } else if (error.message) {
+    return error.message;
+  } else {
+    return JSON.stringify(error);
+  }
+}
+
+export async function wait(timeoutMs: number) {
+  return new Promise(resolve => {
+    window.setTimeout(() => resolve(), timeoutMs);
+  });
 }


### PR DESCRIPTION
This PR uses the Service Management API to enable any required services that are disabled before proceeding with the deployment. It does this by listing services, and enabling the disabled ones in a loop until the listed services include all of the required ones.

Additionally, the PR also adds Google Sans font.

/assign @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1235)
<!-- Reviewable:end -->
