### PR TITLE
Scope kubeflow prow jobs by job type and modified dirs

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -5,14 +5,24 @@ workflows:
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: workflows
     name: kubeflow-e2e-gke
+    job_types:
+      - presubmit
+      - postsubmit
     params:
       platform: gke
   # Run tests on minikube
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: workflows
     name: kubeflow-e2e-minikube
+    job_types:
+      - postsubmit
     params:
       platform: minikube
   - app_dir: kubeflow/kubeflow/components/k8s-model-server/images/releaser
     component: workflows
     name: tf-serving-image
+    job_types:
+      - presubmit
+      - postsubmit
+    include_dirs:
+      - kubeflow/tf-serving/*


### PR DESCRIPTION
Scoping the kubeflow workflows such that:
- GKE is run on pre and postsubmit jobs
- Minikube is only run on postsubmit jobs
- TF-serving-image is only run when tf-serving directory is modified

Fix kubeflow/testing#150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1244)
<!-- Reviewable:end -->
