### PR TITLE
WIP: Add prometheus exporter for tf serving

### DIFF
--- a/components/k8s-model-server/http-proxy/requirements/production.txt
+++ b/components/k8s-model-server/http-proxy/requirements/production.txt
@@ -1,4 +1,6 @@
 grpcio==1.10.1
 tornado==4.5.2
 tensorflow==1.6.0
-tensorflow-serving-api==1.6.0
+tensorflow-serving-api==1.9.0
+protobuf==3.6.0
+prometheus_client==0.3.0

--- a/components/k8s-model-server/http-proxy/requirements/production.txt
+++ b/components/k8s-model-server/http-proxy/requirements/production.txt
@@ -1,6 +1,6 @@
 grpcio==1.10.1
 tornado==4.5.2
 tensorflow==1.6.0
-tensorflow-serving-api==1.9.0
+tensorflow-serving-api==1.10.0-rc1
 protobuf==3.6.0
 prometheus_client==0.3.0


### PR DESCRIPTION
TF Serving exporter from #1160, for more details: #1036, [tf_serving.md](https://github.com/kubeflow/kubeflow/blob/master/docs_dev/tf_serving.md). First, It could export model status via `get_model_status` on tensorflow-serving-api.

### Figure for example:
<img width="1241" alt="prometheus" src="https://user-images.githubusercontent.com/6745370/43030081-55cc509a-8cc7-11e8-8e55-de04ce0d3316.png">


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1253)
<!-- Reviewable:end -->
