### PR TITLE
Fix tfjob test; the simple tfjob test prototype was renamed.

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -417,7 +417,7 @@
               "--component=simple_tfjob_v1alpha2",
               // Name is used for the test case name so it should be unique across
               // all E2E tests.
-              "--params=name=simple-tfjob-" + platform + ",namespace=" + stepsNamespace + ",
+              "--params=name=simple-tfjob-" + platform + ",namespace=" + stepsNamespace,
               "--junit_path=" + artifactsDir + "/junit_e2e-" + platform + v1alpha2Suffix + ".xml",
             ]),  // run tests
             buildTemplate("pytorchjob-deploy", [

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -233,11 +233,7 @@
                     {},
                   {
                     name: "tfjob-test",
-                    template:
-                      if platform == "minikube" then
-                        "tfjob-test"
-                      else
-                        "tfjob-test" + v1alpha2Suffix
+                    template: "tfjob-test" + v1alpha2Suffix
                     ,
                     dependencies: [
                       if platform == "minikube" then
@@ -408,22 +404,6 @@
               "testing.tf_job_simple_test",
               "--src_dir=" + srcDir,
             ]),  // tfjob-simple-prototype-test
-            buildTemplate("tfjob-test", [
-              "python",
-              "-m",
-              "py.test_runner",
-              "test",
-              "--cluster=" + cluster,
-              "--zone=" + zone,
-              "--project=" + project,
-              "--app_dir=" + tfOperatorRoot + "/test/workflows",
-              "--tfjob_version=v1alpha1",
-              "--component=simple_tfjob",
-              // Name is used for the test case name so it should be unique across
-              // all E2E tests.
-              "--params=name=simple-tfjob-" + platform + ",namespace=" + stepsNamespace + ",apiVersion=kubeflow.org/" + "v1alpha1" + ",image=" + "gcr.io/tf-on-k8s-dogfood/tf_sample:dc944ff",
-              "--junit_path=" + artifactsDir + "/junit_e2e-" + platform + ".xml",
-            ]),  // run tests
             buildTemplate("tfjob-test" + v1alpha2Suffix, [
               "python",
               "-m",
@@ -434,10 +414,10 @@
               "--project=" + project,
               "--app_dir=" + tfOperatorRoot + "/test/workflows",
               "--tfjob_version=v1alpha2",
-              "--component=simple_tfjob",
+              "--component=simple_tfjob_v1alpha2",
               // Name is used for the test case name so it should be unique across
               // all E2E tests.
-              "--params=name=simple-tfjob-" + platform + ",namespace=" + stepsNamespace + ",apiVersion=kubeflow.org/" + "v1alpha2" + ",image=" + "gcr.io/kubeflow-ci/tf-dist-mnist-test:1.0",
+              "--params=name=simple-tfjob-" + platform + ",namespace=" + stepsNamespace + ",
               "--junit_path=" + artifactsDir + "/junit_e2e-" + platform + v1alpha2Suffix + ".xml",
             ]),  // run tests
             buildTemplate("pytorchjob-deploy", [


### PR DESCRIPTION
* kubeflow/tf-operator#749 renamed the prototype
* ksonnet just fails silently if the component doesn't exist so the test just ends up failing with 404 trying to wait for the job.
* Fix 1266

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1267)
<!-- Reviewable:end -->
