### PR TITLE
allow IAP setup using VM service account when no service account was set

### DIFF
--- a/components/gcp-click-to-deploy/src/configs/cluster-kubeflow.yaml
+++ b/components/gcp-click-to-deploy/src/configs/cluster-kubeflow.yaml
@@ -95,9 +95,6 @@ resources:
           - name: iap-ingress
             prototype: iap-ingress
         parameters:
-          - component: cloud-endpoints
-            name: secretName
-            value: cloudep-sa
           - component: cert-manager
             name: acmeEmail
             # TODO: use your email for ssl cert

--- a/kubeflow/core/cloud-endpoints.libsonnet
+++ b/kubeflow/core/cloud-endpoints.libsonnet
@@ -290,13 +290,13 @@
                 name: "cloud-endpoints-controller",
                 image: cloudEndpointsImage,
                 imagePullPolicy: "Always",
-                env: [
+                [if secretName != "null" then 'env']: [
                   {
                     name: "GOOGLE_APPLICATION_CREDENTIALS",
                     value: "/var/run/secrets/sa/" + secretKey,
                   },
                 ],
-                volumeMounts: [
+                [if secretName != "null" then 'volumeMounts']: [
                   {
                     name: "sa-key",
                     readOnly: true,
@@ -316,7 +316,7 @@
                 },
               },
             ],
-            volumes: [
+            [if secretName != "null" then 'volumes']: [
               {
                 name: "sa-key",
                 secret: {

--- a/kubeflow/core/configure_envoy_for_iap.sh
+++ b/kubeflow/core/configure_envoy_for_iap.sh
@@ -25,8 +25,13 @@ echo Error unable to fetch PROJECT_NUM from compute metadata
 exit 1
 fi
 
-# Activate the service account
-gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+  echo Using VM Service Account
+else
+  # Activate the service account
+  gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+fi
+
 # Print out the config for debugging
 gcloud config list
 

--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -224,7 +224,7 @@
                     name: "ENVOY_ADMIN",
                     value: "http://localhost:" + envoyAdminPort,
                   },
-                  {
+                  if saSecretName != "null" then {
                     name: "GOOGLE_APPLICATION_CREDENTIALS",
                     value: "/var/run/secrets/sa/admin-gcp-sa.json",
                   },
@@ -238,7 +238,7 @@
                     mountPath: "/var/shared/",
                     name: "shared",
                   },
-                  {
+                  if saSecretName != "null" then {
                     name: "sa-key",
                     readOnly: true,
                     mountPath: "/var/run/secrets/sa",
@@ -260,10 +260,10 @@
                 },
                 name: "shared",
               },
-              {
+              if saSecretName != "null" then {
                 name: "sa-key",
                 secret: {
-                  secretName: "admin-gcp-sa",
+                  secretName: secretName,
                 },
               },
             ],
@@ -329,7 +329,7 @@
                     name: "ENVOY_ADMIN",
                     value: "http://localhost:" + envoyAdminPort,
                   },
-                  {
+                  if saSecretName != "null" then {
                     name: "GOOGLE_APPLICATION_CREDENTIALS",
                     value: "/var/run/secrets/sa/admin-gcp-sa.json",
                   },
@@ -339,7 +339,7 @@
                     mountPath: "/var/envoy-config/",
                     name: "config-volume",
                   },
-                  {
+                  if saSecretName != "null" then {
                     name: "sa-key",
                     readOnly: true,
                     mountPath: "/var/run/secrets/sa",
@@ -355,10 +355,10 @@
                 },
                 name: "config-volume",
               },
-              {
+              if saSecretName != "null" then {
                 name: "sa-key",
                 secret: {
-                  secretName: "admin-gcp-sa",
+                  secretName: secretName,
                 },
               },
             ],

--- a/kubeflow/core/prototypes/cloud-endpoints.jsonnet
+++ b/kubeflow/core/prototypes/cloud-endpoints.jsonnet
@@ -3,7 +3,7 @@
 // @description Provides cloud-endpoints prototypes for creating Cloud Endpoints services and DNS records.
 // @shortDescription Cloud Endpoint domain creation.
 // @param name string Name for the component
-// @optionalParam secretName string admin-gcp-sa Name of secret containing the json service account key.
+// @optionalParam secretName string null Name of secret containing the json service account key.
 // @optionalParam secretKey string admin-gcp-sa.json Name of the key in the secret containing the JSON service account key.
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 

--- a/kubeflow/core/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/core/prototypes/iap-ingress.jsonnet
@@ -5,6 +5,7 @@
 // @param name string Name for the component
 // @param ipName string The name of the global ip address to use.
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
+// @optionalParam saSecretName string null Name of secret containing the json service account key.
 // @optionalParam secretName string envoy-ingress-tls The name of the secret containing the SSL certificates.
 // @optionalParam hostname string null The hostname associated with this ingress. Eg: mykubeflow.example.com
 // @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.

--- a/kubeflow/core/setup_iap.sh
+++ b/kubeflow/core/setup_iap.sh
@@ -52,8 +52,13 @@ echo Error unable to fetch PROJECT_NUM from compute metadata
 exit 1
 fi
 
-# Activate the service account
-gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS}" ]]; then
+  echo Using VM Service Account
+else
+  # Activate the service account
+  gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+fi
+
 # Print out the config for debugging
 gcloud config list
 

--- a/scripts/gke/deploy.sh
+++ b/scripts/gke/deploy.sh
@@ -290,9 +290,9 @@ if ! ${PRIVATE_CLUSTER}; then
   # Enable collection of anonymous usage metrics
   # Skip this step if you don't want to enable collection.
   ks generate spartakus spartakus --usageId=$(uuidgen) --reportUsage=${COLLECT_METRICS}
-  ks generate cloud-endpoints cloud-endpoints
+  ks generate cloud-endpoints cloud-endpoints --secretName=admin-gcp-sa
   ks generate cert-manager cert-manager --acmeEmail=${EMAIL}
-  ks generate iap-ingress iap-ingress --ipName=${KUBEFLOW_IP_NAME} --hostname=${KUBEFLOW_HOSTNAME}
+  ks generate iap-ingress iap-ingress --ipName=${KUBEFLOW_IP_NAME} --hostname=${KUBEFLOW_HOSTNAME} --saSecretName=admin-gcp-sa
   ks param set jupyterhub jupyterHubAuthenticator iap
 fi
 


### PR DESCRIPTION
So we can setup IAP without inserting service account key into cluster.
 
Related: discussion in https://github.com/kubeflow/kubeflow/pull/1255