### PR TITLE
Update deploy.sh

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -9,6 +9,7 @@ KUBEFLOW_REPO=${KUBEFLOW_REPO:-"`pwd`/kubeflow_repo"}
 KUBEFLOW_VERSION=${KUBEFLOW_VERSION:-"master"}
 KUBEFLOW_DEPLOY=${KUBEFLOW_DEPLOY:-true}
 K8S_NAMESPACE=${K8S_NAMESPACE:-"kubeflow"}
+K8S_VERSION=${K8S_VERSION:-"1.8.0"}
 KUBEFLOW_CLOUD=${KUBEFLOW_CLOUD:-"minikube"}
 
 if [[ ! -d "${KUBEFLOW_REPO}" ]]; then
@@ -43,7 +44,7 @@ set +e
 kubectl create ns ${K8S_NAMESPACE}
 set -e
 
-ks init $(basename "${KUBEFLOW_KS_DIR}")
+ks init --api-spec=version:v{K8S_VERSION} $(basename "${KUBEFLOW_KS_DIR}")
 cd "${KUBEFLOW_KS_DIR}"
 
 ks env set default --namespace "${K8S_NAMESPACE}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -44,7 +44,7 @@ set +e
 kubectl create ns ${K8S_NAMESPACE}
 set -e
 
-ks init --api-spec=version:v{K8S_VERSION} $(basename "${KUBEFLOW_KS_DIR}")
+ks init --api-spec=version:v${K8S_VERSION} $(basename "${KUBEFLOW_KS_DIR}")
 cd "${KUBEFLOW_KS_DIR}"
 
 ks env set default --namespace "${K8S_NAMESPACE}"


### PR DESCRIPTION
kubeflow requires that k8s version should be >= 1.8. Now kubernetes has 1.11 released.  Now user can specify k8s version to `ks init`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1311)
<!-- Reviewable:end -->
