### PR TITLE
Add Rest API Port to TF Serving

### DIFF
--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -118,9 +118,7 @@
       args: [
         "/usr/bin/tensorflow_model_server",
         "--port=9000",
-      ] +
-      if $.params.exposeRestApi then ["--rest_api_port=8000"] else []
-      + [
+        if $.params.exposeRestApi then "--rest_api_port=8000",
         "--model_name=" + $.params.modelName,
         "--model_base_path=" + $.params.modelPath,
       ],
@@ -129,8 +127,8 @@
           containerPort: 9000,
         },
         {
-          containerPort: 8000,
-        },
+          [if $.params.exposeRestApi then "containerPort"]: 8000
+        }
       ],
       // TODO(jlewi): We should add readiness and liveness probes. I think the blocker is that
       // model-server doesn't have something we can use out of the box.
@@ -365,7 +363,7 @@
           spec+: {
             containers: [
               $.gcpParts.tfServingContainer,
-              if $.util.toBool($.params.deployHttpProxy) then
+              if $.util.toBool($.params.deployHttpProxy) && !$.params.exposeRestApi then
                 $.parts.httpProxyContainer,
             ],
             volumes: [

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -117,12 +117,16 @@
       args: [
         "/usr/bin/tensorflow_model_server",
         "--port=9000",
+        "--rest_api_port=8000",
         "--model_name=" + $.params.modelName,
         "--model_base_path=" + $.params.modelPath,
       ],
       ports: [
         {
           containerPort: 9000,
+        },
+        {
+          containerPort: 8000,
         },
       ],
       // TODO(jlewi): We should add readiness and liveness probes. I think the blocker is that

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -17,7 +17,7 @@
 
     deployIstio: false,
 
-    exposeRestApi:: false,
+    exposeRestApi:: true,
     deployHttpProxy: false,
     httpProxyImage: "gcr.io/kubeflow-images-public/tf-model-server-http-proxy:v20180606-9dfda4f2",
 
@@ -27,8 +27,8 @@
     // in which case the image used will still depend on whether GPUs are used or not.
     // Users can also override modelServerImage in which case the user supplied value will always be used
     // regardless of numGpus.
-    defaultCpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.7:v20180604-0da89b8a",
-    defaultGpuImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.6gpu:v20180604-0da89b8a",
+    defaultCpuImage: "tensorflow/serving:1.9.0",
+    defaultGpuImage: "tensorflow/serving:1.9.0-devel-gpu",
     modelServerImage: if $.params.numGpus == 0 then
       $.params.defaultCpuImage
     else

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -363,7 +363,8 @@
           spec+: {
             containers: [
               $.gcpParts.tfServingContainer,
-              if $.util.toBool($.params.deployHttpProxy) && !$.params.exposeRestApi then
+              if $.util.toBool($.params.deployHttpProxy) &&
+                 $.util.toBool($.params.exposeRestApi) == false then
                 $.parts.httpProxyContainer,
             ],
             volumes: [

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -17,6 +17,7 @@
 
     deployIstio: false,
 
+    exposeRestApi:: false,
     deployHttpProxy: false,
     httpProxyImage: "gcr.io/kubeflow-images-public/tf-model-server-http-proxy:v20180606-9dfda4f2",
 
@@ -117,7 +118,9 @@
       args: [
         "/usr/bin/tensorflow_model_server",
         "--port=9000",
-        "--rest_api_port=8000",
+      ] +
+      if $.params.exposeRestApi then ["--rest_api_port=8000"] else []
+      + [
         "--model_name=" + $.params.modelName,
         "--model_base_path=" + $.params.modelPath,
       ],

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -115,7 +115,7 @@
       image: $.params.modelServerImage,
       imagePullPolicy: "IfNotPresent",
       args: [
-        "/usr/bin/tensorflow_model_server",
+        "tensorflow_model_server",
         "--port=9000",
         "--rest_api_port=9001",
         "--model_name=" + $.params.modelName,

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -26,8 +26,8 @@
     // in which case the image used will still depend on whether GPUs are used or not.
     // Users can also override modelServerImage in which case the user supplied value will always be used
     // regardless of numGpus.
-    defaultCpuImage: "tensorflow/serving:1.9.0",
-    defaultGpuImage: "tensorflow/serving:1.9.0-devel-gpu",
+    defaultCpuImage: "tensorflow/serving:1.10.0",
+    defaultGpuImage: "tensorflow/serving:1.10.0-gpu",
     modelServerImage: if $.params.numGpus == 0 then
       $.params.defaultCpuImage
     else


### PR DESCRIPTION
This adds the ability to expose the Rest API port directly from Tensorflow Model Server instead of adding a sidecar proxy container. See [Tensorflow docs](https://www.tensorflow.org/serving/api_rest).

We also move away from custom TF Serving images and move to official ones. (Fixes #1299)

/cc @lluunn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1321)
<!-- Reviewable:end -->
