### PR TITLE
Fix iap-ingress certificate creation and use BackendConfig for IAP

### DIFF
--- a/kubeflow/core/configure_envoy_for_iap.sh
+++ b/kubeflow/core/configure_envoy_for_iap.sh
@@ -4,8 +4,6 @@
 # given the information for the service.
 # Script executed by the iap container to configure IAP. When finished, the envoy config is created with the JWT audience.
 
-[ -z ${CLIENT_ID} ] && echo Error CLIENT_ID must be set && exit 1
-[ -z ${CLIENT_SECRET} ] && echo Error CLIENT_SECRET must be set && exit 1
 [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
 [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
 

--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -288,7 +288,7 @@
                 name: "iap",
                 image: "google/cloud-sdk:alpine",
                 command: [
-                  "sh",
+                  "bash",
                   "/var/envoy-config/setup_backend.sh",
                 ],
                 env: [

--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -20,7 +20,10 @@
 
     ingressParts(secretName, ipName, hostname, issuer, envoyImage, disableJwt, oauthSecretName):: std.prune(k.core.v1.list.new([
       $.parts(namespace).service,
-      $.parts(namespace).ingress(secretName, ipName, hostname),
+      $.parts(namespace).backendConfig(oauthSecretName),
+      $.parts(namespace).ingressBootstrapConfigMap,
+      $.parts(namespace).ingressBootstrapJob(secretName),
+      $.parts(namespace).ingress(ipName, hostname),
       $.parts(namespace).certificate(secretName, hostname, issuer),
       $.parts(namespace).initServiceAccount,
       $.parts(namespace).initClusterRoleBinding,
@@ -42,6 +45,9 @@
         },
         name: "envoy",
         namespace: namespace,
+        annotations: {
+          "beta.cloud.google.com/backend-config": '{"ports": {"envoy":"envoy-iap"}}',
+        },
       },
       spec: {
         ports: [
@@ -98,8 +104,13 @@
       rules: [
         {
           apiGroups: [""],
-          resources: ["services", "configmaps"],
+          resources: ["services", "configmaps", "secrets"],
           verbs: ["get", "list", "patch", "update"],
+        },
+        {
+          apiGroups: ["extensions"],
+          resources: ["ingresses"],
+          verbs: ["get", "list", "update", "patch"],
         },
       ],
     },  // initClusterRoleBinding
@@ -199,24 +210,6 @@
                     value: namespace,
                   },
                   {
-                    name: "CLIENT_ID",
-                    valueFrom: {
-                      secretKeyRef: {
-                        name: oauthSecretName,
-                        key: "CLIENT_ID",
-                      },
-                    },
-                  },
-                  {
-                    name: "CLIENT_SECRET",
-                    valueFrom: {
-                      secretKeyRef: {
-                        name: oauthSecretName,
-                        key: "CLIENT_SECRET",
-                      },
-                    },
-                  },
-                  {
                     name: "SERVICE",
                     value: "envoy",
                   },
@@ -296,30 +289,12 @@
                 image: "google/cloud-sdk:alpine",
                 command: [
                   "sh",
-                  "/var/envoy-config/setup_iap.sh",
+                  "/var/envoy-config/setup_backend.sh",
                 ],
                 env: [
                   {
                     name: "NAMESPACE",
                     value: namespace,
-                  },
-                  {
-                    name: "CLIENT_ID",
-                    valueFrom: {
-                      secretKeyRef: {
-                        name: oauthSecretName,
-                        key: "CLIENT_ID",
-                      },
-                    },
-                  },
-                  {
-                    name: "CLIENT_SECRET",
-                    valueFrom: {
-                      secretKeyRef: {
-                        name: oauthSecretName,
-                        key: "CLIENT_SECRET",
-                      },
-                    },
                   },
                   {
                     name: "SERVICE",
@@ -376,7 +351,7 @@
       },
       data: {
         "envoy-config.json": std.manifestJson($.parts(namespace).envoyConfig(disableJwt)),
-        "setup_iap.sh": importstr "setup_iap.sh",
+        "setup_backend.sh": importstr "setup_backend.sh",
         "configure_envoy_for_iap.sh": importstr "configure_envoy_for_iap.sh",
       },
     },
@@ -725,7 +700,91 @@
       },
     },
 
-    ingress(secretName, ipName, hostname):: {
+    backendConfig(oauthSecretName):: {
+      apiVersion: "cloud.google.com/v1beta1",
+      kind: "BackendConfig",
+      metadata: {
+        name: "envoy-iap",
+        namespace: namespace,
+      },
+      spec: {
+        iap: {
+          enabled: true,
+          oauthclientCredentials: {
+            secretName: oauthSecretName,
+          },
+        },
+      },
+    },  // backendConfig
+
+    // TODO(danisla): Remove afer https://github.com/kubernetes/ingress-gce/pull/388 is resolved per #1327.
+    ingressBootstrapConfigMap:: {
+      apiVersion: "v1",
+      kind: "ConfigMap",
+      metadata: {
+        name: "ingress-bootstrap-config",
+        namespace: namespace,
+      },
+      data: {
+        "ingress_bootstrap.sh": importstr "ingress_bootstrap.sh",
+      },
+    },
+
+    ingressBootstrapJob(secretName):: {
+      apiVersion: "batch/v1",
+      kind: "Job",
+      metadata: {
+        name: "ingress-bootstrap",
+        namespace: namespace,
+      },
+      spec: {
+        template: {
+          spec: {
+            restartPolicy: "OnFailure",
+            serviceAccountName: "envoy",
+            containers: [
+              {
+                name: "bootstrap",
+                image: "google/cloud-sdk:alpine",
+                command: ["/var/ingress-config/ingress_bootstrap.sh"],
+                env: [
+                  {
+                    name: "NAMESPACE",
+                    value: namespace,
+                  },
+                  {
+                    name: "TLS_SECRET_NAME",
+                    value: secretName,
+                  },
+                  {
+                    name: "INGRESS_NAME",
+                    value: "envoy-ingress",
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    mountPath: "/var/ingress-config/",
+                    name: "ingress-config",
+                  },
+                ],
+              },
+            ],
+            volumes: [
+              {
+                configMap: {
+                  name: "ingress-bootstrap-config",
+                  // TODO(danisla): replace with std.parseOctal("0755") after upgrading to ksonnet 0.12
+                  defaultMode: 493,
+                },
+                name: "ingress-config",
+              },
+            ],
+          },
+        },
+      },
+    },  // ingressBootstrapJob
+
+    ingress(ipName, hostname):: {
       apiVersion: "extensions/v1beta1",
       kind: "Ingress",
       metadata: {
@@ -757,11 +816,6 @@
             },
           },
         ],
-        tls: [
-          {
-            secretName: secretName,
-          },
-        ],
       },
     },  // iapIngress
 
@@ -777,6 +831,7 @@
         secretName: secretName,
         issuerRef: {
           name: issuer,
+          kind: "Issuer",
         },
         commonName: hostname,
         dnsNames: [

--- a/kubeflow/core/ingress_bootstrap.sh
+++ b/kubeflow/core/ingress_bootstrap.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -x
+set -e
+
+apk add --update openssl
+
+# This is a workaround until this is resolved: https://github.com/kubernetes/ingress-gce/pull/388
+# The long-term solution is to use a managed SSL certificate on GKE once the feature is GA.
+
+# Install kubectl
+K8S_VERSION=v1.11.0
+curl -sfSL https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
+chmod +x /usr/local/bin/kubectl
+
+# The ingress is initially created without a tls spec.
+# Wait until cert-manager generates the certificate using the http-01 challenge on the GCLB ingress.
+# After the certificate is obtained, patch the ingress with the tls spec to enable SSL on the GCLB.
+
+# Wait for certificate.
+(until kubectl -n ${NAMESPACE} get secret ${TLS_SECRET_NAME} 2>/dev/null; do echo "Waiting for certificate..." ; sleep 2; done)
+
+kubectl -n ${NAMESPACE} patch ingress ${INGRESS_NAME} --type='json' -p '[{"op": "add", "path": "/spec/tls", "value": [{"secretName": "'${TLS_SECRET_NAME}'"}]}]'
+
+echo "Done"

--- a/kubeflow/core/metric-collector.libsonnet
+++ b/kubeflow/core/metric-collector.libsonnet
@@ -131,7 +131,7 @@
                     valueFrom: {
                       secretKeyRef: {
                         name: oauthSecretName,
-                        key: "CLIENT_ID",
+                        key: "client_id",
                       },
                     },
                   },

--- a/kubeflow/core/prototypes/cert-manager.jsonnet
+++ b/kubeflow/core/prototypes/cert-manager.jsonnet
@@ -5,9 +5,8 @@
 // @param name string Name for the component
 // @optionalParam namespace string null Namespace to use for the components. It is automatically inherited from the environment if not set.
 // @param acmeEmail string The Lets Encrypt account email address
-// @optionalParam acmeUrl string https://acme-v01.api.letsencrypt.org/directory The ACME server URL, set to https://acme-staging.api.letsencrypt.org/directory for staging API.
-// @optionalParam certManagerImage string quay.io/jetstack/cert-manager-controller:v0.2.4 certManagerImage
-// @optionalParam certManagerIngressShimImage string quay.io/jetstack/cert-manager-ingress-shim:v0.2.4 certManagerIngressShimImage
+// @optionalParam acmeUrl string https://acme-v02.api.letsencrypt.org/directory The ACME server URL, set to https://acme-staging-v02.api.letsencrypt.org/directory for staging API.
+// @optionalParam certManagerImage string quay.io/jetstack/cert-manager-controller:v0.4.0 certManagerImage
 
 local k = import "k.libsonnet";
 local certManager = import "kubeflow/core/cert-manager.libsonnet";

--- a/kubeflow/core/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/core/prototypes/iap-ingress.jsonnet
@@ -10,7 +10,7 @@
 // @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.
 // @optionalParam envoyImage string gcr.io/kubeflow-images-public/envoy:v20180309-0fb4886b463698702b6a08955045731903a18738 The image for envoy.
 // @optionalParam disableJwtChecking string false Disable JWT checking.
-// @optionalParam oauthSecretName string kubeflow-oauth The name of the secret containing the OAuth CLIENT_ID and CLIENT_SECRET.
+// @optionalParam oauthSecretName string kubeflow-oauth The name of the secret containing the OAuth client_id and client_secret.
 
 local k = import "k.libsonnet";
 local iap = import "kubeflow/core/iap.libsonnet";

--- a/kubeflow/core/setup_backend.sh
+++ b/kubeflow/core/setup_backend.sh
@@ -105,8 +105,10 @@ function checkBackend() {
 
 # If node port or backend id change, so does the JWT audience.
 CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
-CURR_BACKEND_ID=$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${CURR_NODE_PORT}- --format='value(id)')
-[ "$BACKEND_ID" == "$CURR_BACKEND_ID" ]
+read -ra toks <<< "$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${CURR_NODE_PORT}- --format='value(id,timeoutSec)')"
+CURR_BACKEND_ID="${toks[0]}"
+CURR_BACKEND_TIMEOUT="${toks[1]}"
+[[ "$BACKEND_ID" == "$CURR_BACKEND_ID" && "${CURR_BACKEND_TIMEOUT}" -eq 3600 ]]
 }
 
 # Verify configuration every 10 seconds.

--- a/kubeflow/core/setup_backend.sh
+++ b/kubeflow/core/setup_backend.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 #
-# A simple shell script to enable IAP and configure timeouts by using gcloud.
-[ -z ${CLIENT_ID} ] && echo Error CLIENT_ID must be set && exit 1
-[ -z ${CLIENT_SECRET} ] && echo Error CLIENT_SECRET must be set && exit 1
+# A simple shell script to configure the backend timeouts and health checks by using gcloud.
 [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
 [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
 
@@ -15,7 +13,7 @@ sleep $(( $RANDOM % 5 + 1 ))
 # We acquire a lock because we want to ensure  there is a single process
 # trying to modify the backend at a time.
 kubectl get svc ${SERVICE} -o json > service.json
-LOCK=$(jq -r ".metadata.annotations.iaplock" service.json)
+LOCK=$(jq -r ".metadata.annotations.backendlock" service.json)
 
 NOW=$(date -u +'%s')
 if [[ -z "${LOCK}" || "${LOCK}" == "null" ]]; then
@@ -26,10 +24,10 @@ fi
 LOCK_AGE=$(( $NOW - $LOCK_T ))
 LOCK_TTL=120
 if [[ -z "${LOCK}" || "${LOCK}" == "null" || "${LOCK_AGE}" -gt "${LOCK_TTL}" ]]; then
-jq -r ".metadata.annotations.iaplock=\"$(hostname -s) ${NOW}\"" service.json > service_lock.json
+jq -r ".metadata.annotations.backendlock=\"$(hostname -s) ${NOW}\"" service.json > service_lock.json
 kubectl apply -f service_lock.json 2>/dev/null
 if [[ $? -eq 0 ]]; then
-  echo "Acquired lock on service annotation to update IAP."
+  echo "Acquired lock on service annotation to configure backend."
 else
   echo "WARN: Failed to acquire lock on service annotation."
   exit 1
@@ -67,10 +65,6 @@ echo BACKEND_ID=${BACKEND_ID}
 
 NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
 BACKEND_SERVICE=$(gcloud --project=${PROJECT} compute backend-services list --filter=name~k8s-be-${NODE_PORT}- --uri)
-# Enable IAP on the backend service:
-gcloud --project=${PROJECT} compute backend-services update ${BACKEND_SERVICE} \
-    --global \
-    --iap=enabled,oauth2-client-id=${CLIENT_ID},oauth2-client-secret=${CLIENT_SECRET}
 
 while [[ -z ${HEALTH_CHECK_URI} ]];
 do HEALTH_CHECK_URI=$(gcloud compute --project=${PROJECT} health-checks list --filter=name~k8s-be-${NODE_PORT}- --uri);
@@ -103,9 +97,9 @@ kubectl get configmap -n ${NAMESPACE} envoy-config -o jsonpath='{.data.envoy-con
 sed -e "s|{{JWT_AUDIENCE}}|${JWT_AUDIENCE}|g" > /var/shared/envoy-config.json
 
 echo "Clearing lock on service annotation"
-kubectl patch svc "${SERVICE}" -p "{\"metadata\": { \"annotations\": {\"iaplock\": \"\" }}}"
+kubectl patch svc "${SERVICE}" -p "{\"metadata\": { \"annotations\": {\"backendlock\": \"\" }}}"
 
-function checkIAP() {
+function checkBackend() {
 # created by init container.
 . /var/shared/healthz.env 
 
@@ -115,10 +109,10 @@ CURR_BACKEND_ID=$(gcloud compute --project=${PROJECT} backend-services list --fi
 [ "$BACKEND_ID" == "$CURR_BACKEND_ID" ]
 }
 
-# Verify IAP every 10 seconds.
+# Verify configuration every 10 seconds.
 while true; do
-if ! checkIAP; then
-  echo "$(date) WARN: IAP check failed, restarting container."
+if ! checkBackend; then
+  echo "$(date) WARN: Backend check failed, restarting container."
   exit 1
 fi
 sleep 10

--- a/kubeflow/core/tests/iap_test.jsonnet
+++ b/kubeflow/core/tests/iap_test.jsonnet
@@ -7,6 +7,9 @@ std.assertEqual(iap.parts("namespace").service, {
     labels: {
       service: "envoy",
     },
+    annotations: {
+      "beta.cloud.google.com/backend-config": '{"ports": {"envoy":"envoy-iap"}}',
+    },
     name: "envoy",
     namespace: "namespace",
   },
@@ -25,7 +28,7 @@ std.assertEqual(iap.parts("namespace").service, {
   },
 }) &&
 
-std.assertEqual(iap.parts("namespace").ingress("secretName", "ipName", "hostname"), {
+std.assertEqual(iap.parts("namespace").ingress("ipName", "hostname"), {
   apiVersion: "extensions/v1beta1",
   kind: "Ingress",
   metadata: {
@@ -54,15 +57,10 @@ std.assertEqual(iap.parts("namespace").ingress("secretName", "ipName", "hostname
         },
       },
     ],
-    tls: [
-      {
-        secretName: "secretName",
-      },
-    ],
   },
 }) &&
 
-std.assertEqual(iap.parts("namespace").ingress("secretName", "ipName", "null"), {
+std.assertEqual(iap.parts("namespace").ingress("ipName", "null"), {
   apiVersion: "extensions/v1beta1",
   kind: "Ingress",
   metadata: {
@@ -90,11 +88,6 @@ std.assertEqual(iap.parts("namespace").ingress("secretName", "ipName", "null"), 
         },
       },
     ],
-    tls: [
-      {
-        secretName: "secretName",
-      },
-    ],
   },
 }) &&
 
@@ -109,6 +102,7 @@ std.assertEqual(iap.parts("namespace").certificate("secretName", "hostname", "is
     secretName: "secretName",
     issuerRef: {
       name: "issuer",
+      kind: "Issuer",
     },
     commonName: "hostname",
     dnsNames: [

--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -63,7 +63,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ CLUSTER_NAME }}
-      initialClusterVersion: 1.9.7-gke.5
+      initialClusterVersion: 1.10.6-gke.1
       # We need 1.10.2 to support Stackdrivier GKE.
       # loggingService: none
       # monitoringService: none


### PR DESCRIPTION
- Added k8s job for patching ingress with the TLS spec after the certificate is acquired.
- Refactored IAP enabler to use BackendConfig to enable IAP. Script still has to set timeout and health check. BackendConfig is only available on GKE __1.10.5__.
- Updated cert-manager to v0.4.0 which no longer depends on container for ingress-shim. 

Fix #1146 Use BackendConfig to enable IAP
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1327)
<!-- Reviewable:end -->
