### PR TITLE
Changes to incorporate multi-stage docker builds for centraldashboard

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10 AS builder
+FROM golang:1.10 as builder
 
 # Download and install the latest release of dep
 ADD https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 /usr/bin/dep
@@ -10,6 +10,14 @@ COPY Gopkg.toml Gopkg.lock ./
 RUN dep ensure --vendor-only
 COPY . ./
 ENV PORT_1=8082
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o app .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o centraldashboard .
+RUN pwd && ls
+
+FROM alpine
+RUN apk --no-cache add ca-certificates
+WORKDIR /app
+RUN pwd && ls
+COPY --from=builder /go/src/github.com/kubeflow/kubeflow/components/centraldashboard/centraldashboard /app
+COPY --from=builder /go/src/github.com/kubeflow/kubeflow/components/centraldashboard/frontend /app
 EXPOSE 8082
-ENTRYPOINT ["./app"]
+CMD [ "/app/centraldashboard" ]

--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -9,15 +9,12 @@ WORKDIR $GOPATH/src/github.com/kubeflow/kubeflow/components/centraldashboard
 COPY Gopkg.toml Gopkg.lock ./
 RUN dep ensure --vendor-only
 COPY . ./
-ENV PORT_1=8082
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix nocgo -o centraldashboard .
-RUN pwd && ls
 
 FROM alpine
 RUN apk --no-cache add ca-certificates
 WORKDIR /app
-RUN pwd && ls
-COPY --from=builder /go/src/github.com/kubeflow/kubeflow/components/centraldashboard/centraldashboard /app
-COPY --from=builder /go/src/github.com/kubeflow/kubeflow/components/centraldashboard/frontend /app
+COPY --from=builder /go/src/github.com/kubeflow/kubeflow/components/centraldashboard/ /app
+ENV PORT_1=8082
 EXPOSE 8082
 CMD [ "/app/centraldashboard" ]


### PR DESCRIPTION
Reduces size of centraldashboard image from ~1.2GB to ~60MB.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1339)
<!-- Reviewable:end -->
