### PR TITLE
Add more tests to the subgraph we created to run the tests.

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,16 +1,7 @@
 # This file configures the workflows to trigger in our Prow jobs.
 # see kubeflow/testing/py/run_e2e_workflow.py
 workflows:
-  # Run tests on GKE
-  - app_dir: kubeflow/kubeflow/testing/workflows
-    component: workflows
-    name: kubeflow-e2e-gke
-    job_types:
-      - presubmit
-      - postsubmit
-    params:
-      platform: gke
-  # kfctl test
+  # kfctl test runs tests on gke.
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: kfctl_test
     name: kfctl
@@ -23,6 +14,19 @@ workflows:
       - testing/*
     params:
       platform: gke
+  # Run unittests
+  # TODO(jlewi): Need to add step to run go and python unittests
+  - app_dir: kubeflow/kubeflow/testing/workflows
+    component: unit_tests
+    name: unittests    
+  # TODO(jlewi): We should be running the minikube workflow
+  # on presubmit when the minikube E2E test itself changes
+  # so we verify the test is working before submitting
+  # changes to it. But right now we can't match a regex or
+  # glob.
+  # see: https://github.com/kubeflow/testing/issues/187
+  # see: https://github.com/kubeflow/kubeflow/issues/1350
+  #   
   # Run tests on minikube
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: workflows

--- a/testing/deploy_kubeflow.py
+++ b/testing/deploy_kubeflow.py
@@ -1,3 +1,8 @@
+"""Deploy Kubeflow and wait for it to be deployed.
+
+TODO(jlewi): This script is outdated. Its no longer used for GKE.
+It is still used by minikube. For minikube we should be using kfctl.sh
+"""
 import argparse
 import logging
 import os

--- a/testing/wait_for_deployment.py
+++ b/testing/wait_for_deployment.py
@@ -20,6 +20,11 @@ Right now, it only checks for the presence of tfjobs and pytorchjobs crd. More t
 
 python -m testing.wait_for_deployment --cluster=kubeflow-testing --project=kubeflow-ci --zone=us-east1-d --timeout=3
 
+
+TODO(jlewi): Waiting for the CRD's to be created probably isn't that useful.
+I think that will be nearly instantaneous. If we're going to wait for something
+it should probably be waiting for the controllers to actually be deployed.
+We can probably get rid of this and just use wait_for_kubeflow.py.
 """
 
 from __future__ import print_function
@@ -36,21 +41,6 @@ from kubeflow.testing import test_helper, util
 
 def parse_args():
   parser = argparse.ArgumentParser()
-  parser.add_argument(
-    "--cluster",
-    default="",
-    type=str,
-    help="Cluster Name")
-  parser.add_argument(
-    "--zone",
-    default="",
-    type=str,
-    help="Zone Name")
-  parser.add_argument(
-    "--project",
-    default="",
-    type=str,
-    help="Project ID")
   parser.add_argument(
     "--timeout",
     default=5,
@@ -74,7 +64,7 @@ def wait_for_resource(resource, end_time):
 def test_wait_for_deployment(test_case): # pylint: disable=redefined-outer-name
   args = parse_args()
   util.maybe_activate_service_account()
-  util.run(["gcloud",  "container", "clusters", "get-credentials", args.cluster, "--zone=" + args.zone,  "--project=" + args.project])
+  util.load_kube_config()
   end_time =  datetime.datetime.now() + datetime.timedelta(0, args.timeout*60)
   wait_for_resource("crd/tfjobs.kubeflow.org", end_time)
   wait_for_resource("crd/pytorchjobs.kubeflow.org", end_time)

--- a/testing/wait_for_kubeflow.py
+++ b/testing/wait_for_kubeflow.py
@@ -1,0 +1,47 @@
+"""Wait for Kubeflow to be deployed."""
+import argparse
+import logging
+
+from testing import deploy_utils
+from kubeflow.testing import test_helper
+from kubeflow.testing import util  # pylint: disable=no-name-in-module
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "--namespace", default=None, type=str, help=("The namespace to use."))
+
+  args, _ = parser.parse_known_args()
+  return args
+
+def deploy_kubeflow(_):
+  """Deploy Kubeflow."""
+  args = parse_args()
+  namespace = args.namespace
+  api_client = deploy_utils.create_k8s_client()
+
+  util.load_kube_config()
+  # Verify that the TfJob operator is actually deployed.
+  tf_job_deployment_name = "tf-job-operator-v1alpha2"
+  logging.info("Verifying TfJob controller started.")
+  util.wait_for_deployment(api_client, namespace, tf_job_deployment_name)
+
+  # Verify that JupyterHub is actually deployed.
+  jupyterhub_name = "tf-hub"
+  logging.info("Verifying TfHub started.")
+  util.wait_for_statefulset(api_client, namespace, jupyterhub_name)
+
+  # Verify that PyTorch Operator actually deployed
+  pytorch_operator_deployment_name = "pytorch-operator"
+  logging.info("Verifying PyTorchJob controller started.")
+  util.wait_for_deployment(api_client, namespace, pytorch_operator_deployment_name)
+
+def main():
+  test_case = test_helper.TestCase(
+    name='deploy_kubeflow', test_func=deploy_kubeflow)
+  test_suite = test_helper.init(
+    name='deploy_kubeflow', test_cases=[test_case])
+  test_suite.run()
+
+if __name__ == "__main__":
+  main()

--- a/testing/workflows/components/params.libsonnet
+++ b/testing/workflows/components/params.libsonnet
@@ -27,6 +27,13 @@
       name: "somefakename",
       namespace: "kubeflow-test-infra",
       prow_env: "",
+      deleteKubeflow: true,
+    },
+    unit_tests: {
+      bucket: "kubeflow-ci_temp",
+      name: "somefakename",
+      namespace: "kubeflow-test-infra",
+      prow_env: "",
     },
   },
 }

--- a/testing/workflows/components/unit_tests.jsonnet
+++ b/testing/workflows/components/unit_tests.jsonnet
@@ -1,4 +1,4 @@
-local params = std.extVar("__ksonnet/params").components.kfctl_test;
+local params = std.extVar("__ksonnet/params").components.unit_tests;
 
 local k = import "k.libsonnet";
 local util = import "workflows.libsonnet";
@@ -12,8 +12,6 @@ local name = params.name;
 local prowEnv = util.parseEnv(params.prow_env);
 local bucket = params.bucket;
 
-// The name for the workspace to run the steps in
-local stepsNamespace = "kubeflow";
 // mountPath is the directory where the volume to store the test data
 // should be mounted.
 local mountPath = "/mnt/" + "test-data-volume";
@@ -26,21 +24,6 @@ local artifactsDir = outputDir + "/artifacts";
 local srcRootDir = testDir + "/src";
 // The directory containing the kubeflow/kubeflow repo
 local srcDir = srcRootDir + "/kubeflow/kubeflow";
-
-local runPath = srcDir + "/testing/workflows/run.sh";
-local kfCtlPath = srcDir + "/scripts/kfctl.sh";
-
-local kubeConfig = testDir + "/kfctl_test/.kube/kubeconfig";
-
-// Name for the Kubeflow app.
-// This needs to be unique for each test run because it is
-// used to name GCP resources
-// We take the suffix of the name because it should provide some random salt.
-local appName = "kfctl-" + std.substr(name, std.length(name) - 4, 4);
-
-// Directory containing the app. This is the directory
-// we execute kfctl commands from
-local appDir = testDir + "/" + appName;
 
 local image = "gcr.io/kubeflow-ci/test-worker:latest";
 local testing_image = "gcr.io/kubeflow-ci/kubeflow-testing";
@@ -80,22 +63,6 @@ local buildTemplate(step_name, command, working_dir=null, env_vars=[], sidecars=
         name: "GOOGLE_APPLICATION_CREDENTIALS",
         value: "/secret/gcp-credentials/key.json",
       },
-      {
-        name: "GITHUB_TOKEN",
-        valueFrom: {
-          secretKeyRef: {
-            name: "github-token",
-            key: "github_token",
-          },
-        },
-      },
-      {
-        // We use a directory in our NFS share to store our kube config.
-        // This way we can configure it on a single step and reuse it on subsequent steps.
-        // The directory should be unique for each workflow so that multiple workflows don't collide.
-        name: "KUBECONFIG",
-        value: kubeConfig,
-      },
     ] + prowEnv + env_vars,
     volumeMounts: [
       {
@@ -115,12 +82,6 @@ local buildTemplate(step_name, command, working_dir=null, env_vars=[], sidecars=
   sidecars: sidecars,
 };  // buildTemplate
 
-local componentTests = util.kfTests {
-  name: "gke-tests",
-  platform: "gke",
-  testDir: testDir,
-  kubeConfig: kubeConfig,
-};
 
 // Create a list of dictionary.c
 // Each item is a dictionary describing one step in the graph.
@@ -133,7 +94,7 @@ local dagTemplates = [
                               value: "kubeflow/tf-operator@HEAD;kubeflow/testing@HEAD",
                             }]),
     dependencies: null,
-  },  // checkout
+  },
   {
     template: buildTemplate("create-pr-symlink", [
       "python",
@@ -146,117 +107,35 @@ local dagTemplates = [
     dependencies: ["checkout"],
   },  // create-pr-symlink
   {
-    template: buildTemplate(
-      "kfctl-init",
-      [
-        runPath,
-        kfCtlPath,
-        "init",
-        appName,
-        "--platform",
-        "gcp",
-        "--project",
-        project,
-      ],
-      working_dir=testDir,
-    ),
+    template: buildTemplate("jsonnet-test", [
+      "python",
+      "-m",
+      "testing.test_jsonnet",
+      "--artifacts_dir=" + artifactsDir,
+      "--test_files_dirs=" + srcDir + "/kubeflow",
+      "--jsonnet_path_dirs=" + srcDir,
+    ]),  // jsonnet-test
+
     dependencies: ["checkout"],
   },
   {
-    template: buildTemplate(
-      "kfctl-generate-gcp",
-      [
-        runPath,
-        kfCtlPath,
-        "generate",
-        "platform",
-      ],
-      working_dir=appDir
-    ),
-    dependencies: ["kfctl-init"],
-  },
-  {
-    template: buildTemplate(
-      "kfctl-apply-gcp",
-      [
-        runPath,
-        kfCtlPath,
-        "apply",
-        "platform",
-      ],
-      env_vars=[
-        {
-          name: "CLIENT_ID",
-          value: "dummy",
-        },
-        {
-          name: "CLIENT_SECRET",
-          value: "dummy",
-        },
-      ],
-      working_dir=appDir
-    ),
-    dependencies: ["kfctl-generate-gcp"],
-  },
-  // We can't generate the ksonnet app
-  // until we create the GKE cluster because we need
-  // a KubeConfig file
-  {
-    template: buildTemplate(
-      "kfctl-generate-k8s",
-      [
-        runPath,
-        kfCtlPath,
-        "generate",
-        "k8s",
-      ],
-      working_dir=appDir
-    ),
-    dependencies: ["kfctl-apply-gcp"],
-  },
-  {
-    template: buildTemplate(
-      "kfctl-apply-k8s",
-      [
-        runPath,
-        kfCtlPath,
-        "apply",
-        "k8s",
-      ],
-      working_dir=appDir
-    ),
-    dependencies: ["kfctl-generate-k8s"],
-  },
-  // Run the nested tests.
-  {
-    template: componentTests.argoDagTemplate,
-    dependencies: ["kfctl-apply-k8s"],
+    template: buildTemplate("test-jsonnet-formatting", [
+      "python",
+      "-m",
+      "kubeflow.testing.test_jsonnet_formatting",
+      "--project=" + project,
+      "--artifacts_dir=" + artifactsDir,
+      "--src_dir=" + srcDir,
+      "--exclude_dirs=" + srcDir + "/bootstrap/vendor/",
+    ]),  // test-jsonnet-formatting
+
+    dependencies: ["checkout"],
   },
 ];
 
 // Each item is a dictionary describing one step in the graph
 // to execute on exit
-local deleteKubeflow = util.toBool(params.deleteKubeflow);
-
-local deleteStep = if deleteKubeflow  then
-    [{
-      template: buildTemplate(
-        "kfctl-delete",
-        [
-          runPath,
-          kfCtlPath,
-          "delete",
-          "all",
-        ],
-        working_dir=appDir
-      ),
-      dependencies: null,
-    }]
-else [];
-
-local exitTemplates = 
-  deleteStep +
-  [  
+local exitTemplates = [
   {
     template: buildTemplate("copy-artifacts", [
       "python",
@@ -266,10 +145,7 @@ local exitTemplates =
       "copy_artifacts",
       "--bucket=" + bucket,
     ]),  // copy-artifacts,
-
-    dependencies: if deleteKubeflow then
-     ["kfctl-delete"]
-     else null,
+    dependencies: null,
   },
   {
     template:
@@ -319,7 +195,7 @@ local exitDag = {
 local stepTemplates = std.map(function(i) i.template
                               , dagTemplates) +
                       std.map(function(i) i.template
-                              , exitTemplates) + componentTests.argoTaskTemplates;
+                              , exitTemplates);
 
 
 // Add a task to a dag.

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -55,7 +55,6 @@
   // 1. In your Argo Dag add a step that uses template tests.name
   // 2. In your Argo Workflow add argoTemplates as templates.
   //
-  // TODO(jlewi): We need to add the remaining test steps in the e2e worfklow and then reuse kfTests in it.
   kfTests:: {
     // name and platform should be given unique values.
     name: "somename",
@@ -304,6 +303,13 @@
 
   parts(namespace, name):: {
     // Workflow to run the e2e test.
+    //
+    // TODO(jlewi): This needs to be refactored. Its only used for running the minikube
+    // tests. kfct_test.jsonnet is used for GKE and unit_tests is used for unittests.
+    // We should make the following changes.
+    //
+    // Create a new .jsonnet file for minikube and define the workflow there.
+    // Reuse kfTests above to add the actual tests to that file.
     e2e(prow_env, bucket, platform="minikube"):
       // The name for the workspace to run the steps in
       local stepsNamespace = "kubeflow";

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -16,6 +16,20 @@
       )
     else [],
 
+  // Convert non-boolean types like string,number to a boolean.
+  // This is primarily intended for dealing with parameters that should be booleans.
+  toBool:: function(x) {
+    result::
+      if std.type(x) == "boolean" then
+        x
+      else if std.type(x) == "string" then
+        $.upper(x) == "TRUE"
+      else if std.type(x) == "number" then
+        x != 0
+      else
+        false,
+  }.result,
+
   // kfTests defines an Argo DAG for running job tests to validate a Kubeflow deployment.
   //
   // The dag is intended to be reused as a sub workflow by other workflows.
@@ -175,6 +189,22 @@
     // argoTaskTemplates is constructing from tasks as well.
     tasks:: [
       {
+
+        // Wait for Kubeflow and run some basic tests such as checking
+        // that various components started.
+        template: tests.buildTemplate {
+          name: "wait-for-kubeflow",
+          command: [
+            "python",
+            "-m",
+            "testing.wait_for_kubeflow",
+            "--test_dir=" + tests.testDir,
+            "--namespace=" + tests.stepsNamespace,
+          ],
+        },  // wait-for-kubeflow
+        dependencies: null,
+      },  // wait-for-kubeflow
+      {
         local v1alpha2Suffix = "-v1a2",
         template: tests.buildTemplate {
           name: "tfjob-test",
@@ -192,8 +222,61 @@
             "--junit_path=" + tests.artifactsDir + "/junit_e2e-" + tests.platform + v1alpha2Suffix + ".xml",
           ],
         },  // run tests
-        dependencies: null,
-      },
+        dependencies: ["wait-for-kubeflow"],
+      },  // tf-job-test
+      {
+
+        template: tests.buildTemplate {
+          name: "test-argo-deploy",
+          command: [
+            "python",
+            "-m",
+            "testing.test_deploy",
+            "--project=kubeflow-ci",
+            "--github_token=$(GITHUB_TOKEN)",
+            "--namespace=" + tests.stepsNamespace,
+            "--test_dir=" + tests.testDir,
+            "--artifacts_dir=" + tests.artifactsDir,
+            "--deploy_name=test-argo-deploy",
+            "deploy_argo",
+          ],
+        },
+        dependencies: ["wait-for-kubeflow"],
+      },  // test-argo-deploy
+      {
+        template: tests.buildTemplate {
+          name: "pytorchjob-deploy",
+          command: [
+            "python",
+            "-m",
+            "testing.test_deploy",
+            "--project=kubeflow-ci",
+            "--github_token=$(GITHUB_TOKEN)",
+            "--namespace=" + tests.stepsNamespace,
+            "--test_dir=" + tests.testDir,
+            "--artifacts_dir=" + tests.artifactsDir,
+            "--deploy_name=pytorch-job",
+            "deploy_pytorchjob",
+            "--params=image=pytorch/pytorch:v0.2,num_workers=1",
+          ],
+        },
+        dependencies: ["wait-for-kubeflow"],
+      },  // pytorchjob - deploy,
+      {
+
+        template: tests.buildTemplate {
+          name: "tfjob-simple-prototype-test",
+          command: [
+            "python",
+            "-m",
+            "testing.tf_job_simple_test",
+            "--src_dir=" + tests.srcDir,
+            "--tf_job_version=v1alpha2",
+          ],
+        },
+
+        dependencies: ["wait-for-kubeflow"],
+      },  // tfjob-simple-prototype-test
     ],
 
     // An Argo template for the dag.
@@ -529,10 +612,6 @@
               "python",
               "-m",
               "testing.wait_for_deployment",
-              "--cluster=" + cluster,
-              "--project=" + project,
-              "--zone=" + zone,
-              "--timeout=5",
             ]),  // wait-for-kubeflow
             buildTemplate("test-jsonnet-formatting", [
               "python",

--- a/testing/workflows/environments/kubeflow-testing/params.libsonnet
+++ b/testing/workflows/environments/kubeflow-testing/params.libsonnet
@@ -1,21 +1,21 @@
-local params = import '../../components/params.libsonnet';
+local params = import "../../components/params.libsonnet";
 
 params {
   components+: {
     kfctl_Test+: {
-      namespace: 'kubeflow-test-infra',
-      name: 'jlewi-kfctl-test-1308-0539',
-      prow_env: 'JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0539,PULL_NUMBER=1308',
+      namespace: "kubeflow-test-infra",
+      name: "jlewi-kfctl-test-1308-0539",
+      prow_env: "JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0539,PULL_NUMBER=1308",
     },
     kfctl_test+: {
-      namespace: 'kubeflow-test-infra',
-      name: 'jlewi-kfctl-test-1342-0810-172406',
-      prow_env: 'JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0810-172406,PULL_NUMBER=1342',
+      namespace: "kubeflow-test-infra",
+      name: "jlewi-kfctl-test-1342-0810-172406",
+      prow_env: "JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0810-172406,PULL_NUMBER=1342",
     },
     unit_tests+: {
-      namespace: 'kubeflow-test-infra',
-      name: 'jlewi-unittests-1342-0809-235820',
-      prow_env: 'JOB_NAME=unittests,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0809-235820,PULL_NUMBER=1342',
+      namespace: "kubeflow-test-infra",
+      name: "jlewi-unittests-1342-0809-235820",
+      prow_env: "JOB_NAME=unittests,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0809-235820,PULL_NUMBER=1342",
     },
   },
 }

--- a/testing/workflows/environments/kubeflow-testing/params.libsonnet
+++ b/testing/workflows/environments/kubeflow-testing/params.libsonnet
@@ -1,16 +1,21 @@
-local params = import "../../components/params.libsonnet";
+local params = import '../../components/params.libsonnet';
 
 params {
   components+: {
     kfctl_Test+: {
-      namespace: "kubeflow-test-infra",
-      name: "jlewi-kfctl-test-1308-0539",
-      prow_env: "JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0539,PULL_NUMBER=1308",
+      namespace: 'kubeflow-test-infra',
+      name: 'jlewi-kfctl-test-1308-0539',
+      prow_env: 'JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0539,PULL_NUMBER=1308',
     },
     kfctl_test+: {
-      namespace: "kubeflow-test-infra",
-      name: "jlewi-kfctl-test-1308-0808-122152",
-      prow_env: "JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0808-122152,PULL_NUMBER=1308",
+      namespace: 'kubeflow-test-infra',
+      name: 'jlewi-kfctl-test-1342-0810-172406',
+      prow_env: 'JOB_NAME=kfctl-test,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0810-172406,PULL_NUMBER=1342',
+    },
+    unit_tests+: {
+      namespace: 'kubeflow-test-infra',
+      name: 'jlewi-unittests-1342-0809-235820',
+      prow_env: 'JOB_NAME=unittests,JOB_TYPE=presubmit,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0809-235820,PULL_NUMBER=1342',
     },
   },
 }


### PR DESCRIPTION
* Update wait_for_deployment.py to use KUBECONFIG so its not limited to GKE.

* I don't think we actually need wait_for_deployment; all it does is wait
  for the CRD to be created and that's not very useful. It would
  be better to wait for the actual controller deployments to start.

* Create a script wait_for_kubeflow based on deploy_kubeflow.py that
  waits for Kubeflow to be deployed and performs basic checks like
  ensuring everything started correctly.

* Fix a typo in wait_for_kubeflow
* Add steps to copy artifacts to prow bucket.
* Create a workflow for unittests."

* Don't run workflows.jsonnet on presubmit; we use kfctl_test now.

* Add an option to kfctl_test to not delete the cluster; useful
  for leaving it up to debug tests.

Related to: #1325 Make our E2E tests more reusable and composable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1342)
<!-- Reviewable:end -->
