### PR TITLE
fixes issue #1344

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -60,6 +60,7 @@
               "rewrite: /hub/",
               "timeout_ms: 300000",
               "service: tf-hub-lb." + params.namespace,
+              "use_websocket: true",
               "---",
               "apiVersion: ambassador/v0",
               "kind:  Mapping",
@@ -68,6 +69,7 @@
               "rewrite: /user/",
               "timeout_ms: 300000",
               "service: tf-hub-lb." + params.namespace,
+              "use_websocket: true",
             ]),
         },  //annotations
       },


### PR DESCRIPTION
Jupyter connections are failing because Ambassador rules don't not enable websockets.

Fix #1344
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1345)
<!-- Reviewable:end -->
