### PR TITLE
remove cluster version from DM config, use GKE default one 

### DIFF
--- a/components/gcp-click-to-deploy/src/configs/cluster.jinja
+++ b/components/gcp-click-to-deploy/src/configs/cluster.jinja
@@ -84,14 +84,12 @@ resources:
       # https://github.com/kubeflow/kubeflow/issues/821
       enableKubernetesAlpha: true
       # We need 1.10.2 to support Stackdrivier GKE.
-      initialClusterVersion: 1.10.2-gke.0
+      initialClusterVersion: 1.10.2-gke.4
       # Logging and monitoring have default value [logging/monitoring].googleapis.com
       # if not set. We are using the new Stackdricer Kubernetes agents here.
       # See cloud.google.com/monitoring/kubernetes-engine/.
       loggingService: logging.googleapis.com/kubernetes
       monitoringService: monitoring.googleapis.com/kubernetes
-      {% else %}
-      initialClusterVersion: 1.9.6-gke.1
       {% endif %}
       {% if properties['gkeApiVersion'] == 'v1beta1' %}
       podSecurityPolicyConfig:

--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -63,7 +63,6 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ CLUSTER_NAME }}
-      initialClusterVersion: 1.9.7-gke.5
       # We need 1.10.2 to support Stackdrivier GKE.
       # loggingService: none
       # monitoringService: none


### PR DESCRIPTION
To avoid GKE version deprecation errors happening again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1349)
<!-- Reviewable:end -->
