### PR TITLE
Add user service account developer access to k8s cluster

### DIFF
--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -228,6 +228,10 @@ resources:
           members:
             - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
 
+        - role: roles/container.developer
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
         - role: roles/logging.logWriter
           members:
             {# VM service account is used to write logs. #}
@@ -309,6 +313,10 @@ resources:
             - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
 
         - role: roles/dataflow.admin
+          members:
+            - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
+
+        - role: roles/container.developer
           members:
             - {{ 'serviceAccount:' + KF_USER_NAME + '@' + env['project'] + '.iam.gserviceaccount.com' }}
 


### PR DESCRIPTION
This PR updates the base GKE deployment.

The User Service Account provided with the cluster deployment may need access to deploy resources on to GKE. The addition of this role allows that. This role is most restrictive possible.

Since, we aim to allow users to interact with the cluster from Jupyter notebooks, this change has implications on general usage and not a particular use case.

/cc @jlewi @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1371)
<!-- Reviewable:end -->
