### PR TITLE
Add Jobs permission to jupyterhub-noteook role to  for common use cases

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -235,6 +235,7 @@
             "pods",
             "deployments",
             "services",
+            "jobs",
           ],
           verbs: [
             "get",


### PR DESCRIPTION
Deploying `Jobs` is a common use case and was missing earlier. This PR makes the tiny change.

/cc @ankushagarwal @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1374)
<!-- Reviewable:end -->
