### PR TITLE
Fix groups for various resources

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -233,16 +233,24 @@
           ],
           resources: [
             "pods",
-            "deployments",
             "services",
-            "jobs",
           ],
           verbs: [
-            "get",
-            "watch",
-            "list",
-            "create",
-            "delete",
+            "*",
+          ],
+        },
+        {
+          apiGroups: [
+            "",
+            "apps",
+            "extensions",
+          ],
+          resources: [
+            "deployments",
+            "replicasets",
+          ],
+          verbs: [
+            "*",
           ],
         },
         {
@@ -251,6 +259,17 @@
           ],
           resources: [
             "*",
+          ],
+          verbs: [
+            "*",
+          ],
+        },
+        {
+          apiGroups: [
+            "batch",
+          ],
+          resources: [
+            "jobs",
           ],
           verbs: [
             "*",


### PR DESCRIPTION
Role groups for a few resources were not correct.

- `deployments` belongs to `apps` group (and also `extensions` for compatibility with older versions)
- `jobs` belongs to `batch` group
- Allow all resource verbs

/cc @ankushagarwal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1380)
<!-- Reviewable:end -->
