### PR TITLE
Fixes the install_minikube.sh script for non-Ubuntu OSes

### DIFF
--- a/testing/install_minikube.sh
+++ b/testing/install_minikube.sh
@@ -12,10 +12,10 @@ sudo apt-get install -y \
     curl \
     software-properties-common
     
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+curl -fsSL https://download.docker.com/linux/$(. /etc/os-release; echo "$ID")/gpg | sudo apt-key add -
  
 sudo add-apt-repository \
-   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   "deb [arch=amd64] https://download.docker.com/linux/$(. /etc/os-release; echo "$ID") \
    $(lsb_release -cs) \
    stable"
    


### PR DESCRIPTION
Fixes https://github.com/kubeflow/kubeflow/issues/1383

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1384)
<!-- Reviewable:end -->
