### PR TITLE
Updates to iap component to support private clusters

### DIFF
--- a/components/ingress-setup-image/Dockerfile
+++ b/components/ingress-setup-image/Dockerfile
@@ -1,0 +1,5 @@
+FROM google/cloud-sdk:alpine
+
+RUN apk add --update jq openssl
+
+RUN curl https://storage.googleapis.com/kubernetes-release/release/v1.11.0/bin/linux/amd64/kubectl > /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl

--- a/components/ingress-setup-image/README.md
+++ b/components/ingress-setup-image/README.md
@@ -1,0 +1,10 @@
+# Ingress Setup
+
+Ingress Setup is a docker image which is used to run scripts for setting up ingress. We build this and push it to gcr so that it can be used in private GKE clusters
+
+To build and push this, run
+
+```
+docker build . -t gcr.io/kubeflow-images-public/ingress-setup:latest
+docker push gcr.io/kubeflow-images-public/ingress-setup:latest
+```

--- a/kubeflow/core/configure_envoy_for_iap.sh
+++ b/kubeflow/core/configure_envoy_for_iap.sh
@@ -7,10 +7,6 @@
 [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
 [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
 
-apk add --update jq
-curl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl > /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
-
-
 PROJECT=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
 if [ -z ${PROJECT} ]; then
 echo Error unable to fetch PROJECT from compute metadata
@@ -54,7 +50,7 @@ curl -s ${ENVOY_ADMIN}/quitquitquit
 
 function checkIAP() {
 # created by init container.
-. /var/shared/healthz.env 
+. /var/shared/healthz.env
 
 # If node port or backend id change, so does the JWT audience.
 CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')

--- a/kubeflow/core/ingress_bootstrap.sh
+++ b/kubeflow/core/ingress_bootstrap.sh
@@ -3,15 +3,8 @@
 set -x
 set -e
 
-apk add --update openssl
-
 # This is a workaround until this is resolved: https://github.com/kubernetes/ingress-gce/pull/388
 # The long-term solution is to use a managed SSL certificate on GKE once the feature is GA.
-
-# Install kubectl
-K8S_VERSION=v1.11.0
-curl -sfSL https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/kubectl > /usr/local/bin/kubectl
-chmod +x /usr/local/bin/kubectl
 
 # The ingress is initially created without a tls spec.
 # Wait until cert-manager generates the certificate using the http-01 challenge on the GCLB ingress.

--- a/kubeflow/core/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/core/prototypes/iap-ingress.jsonnet
@@ -9,8 +9,10 @@
 // @optionalParam hostname string null The hostname associated with this ingress. Eg: mykubeflow.example.com
 // @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.
 // @optionalParam envoyImage string gcr.io/kubeflow-images-public/envoy:v20180309-0fb4886b463698702b6a08955045731903a18738 The image for envoy.
+// @optionalParam ingressSetupImage string gcr.io/kubeflow-images-public/ingress-setup:latest The image for setting up ingress.
 // @optionalParam disableJwtChecking string false Disable JWT checking.
 // @optionalParam oauthSecretName string kubeflow-oauth The name of the secret containing the OAuth client_id and client_secret.
+// @optionalParam privateGKECluster string false Is the k8s cluster a private GKE cluster
 
 local k = import "k.libsonnet";
 local iap = import "kubeflow/core/iap.libsonnet";
@@ -25,4 +27,4 @@ local updatedParams = params {
 local namespace = updatedParams.namespace;
 local disableJwtChecking = util.toBool(params.disableJwtChecking);
 
-iap.parts(namespace).ingressParts(params.secretName, params.ipName, params.hostname, params.issuer, params.envoyImage, disableJwtChecking, params.oauthSecretName)
+iap.parts(namespace).ingressParts(params.secretName, params.ipName, params.hostname, params.issuer, params.envoyImage, params.ingressSetupImage, disableJwtChecking, params.oauthSecretName, params.privateGKECluster)

--- a/kubeflow/core/setup_backend.sh
+++ b/kubeflow/core/setup_backend.sh
@@ -4,9 +4,6 @@
 [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
 [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
 
-apk add --update jq
-curl https://storage.googleapis.com/kubernetes-release/release/v1.9.4/bin/linux/amd64/kubectl > /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
-
 # Stagger init of replicas when acquiring lock
 sleep $(( $RANDOM % 5 + 1 ))
 
@@ -91,7 +88,7 @@ echo "JWT_AUDIENCE=${JWT_AUDIENCE}" > /var/shared/healthz.env
 echo "NODE_PORT=${NODE_PORT}" >> /var/shared/healthz.env
 echo "BACKEND_ID=${BACKEND_ID}" >> /var/shared/healthz.env
 
-# TODO(https://github.com/kubeflow/kubeflow/issues/942): We should publish the modified envoy 
+# TODO(https://github.com/kubeflow/kubeflow/issues/942): We should publish the modified envoy
 # config as a config map and use that in the envoy sidecars.
 kubectl get configmap -n ${NAMESPACE} envoy-config -o jsonpath='{.data.envoy-config\.json}' | \
 sed -e "s|{{JWT_AUDIENCE}}|${JWT_AUDIENCE}|g" > /var/shared/envoy-config.json
@@ -101,7 +98,7 @@ kubectl patch svc "${SERVICE}" -p "{\"metadata\": { \"annotations\": {\"backendl
 
 function checkBackend() {
 # created by init container.
-. /var/shared/healthz.env 
+. /var/shared/healthz.env
 
 # If node port or backend id change, so does the JWT audience.
 CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')


### PR DESCRIPTION
Docs changes are here : https://github.com/kubeflow/website/pull/173

* Creates a new component: Ingress Setup
* Updates all various ingress related bash scripts to use Ingress Setup docker image
* Don't create certificate CRD when using private cluster
* Add `privateGKECluster` and `ingressSetupImage` flags to iap prototype

/cc @jlewi @danisla

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1396)
<!-- Reviewable:end -->
