### PR TITLE
Add namespaces to the tf-job-dashboard role

### DIFF
--- a/kubeflow/core/tf-job-operator.libsonnet
+++ b/kubeflow/core/tf-job-operator.libsonnet
@@ -569,6 +569,7 @@
             "endpoints",
             "persistentvolumeclaims",
             "events",
+            "namespaces",
           ],
           verbs: [
             "*",


### PR DESCRIPTION
This fixes the 500 errors in tf-job-dashboard

Related to kubeflow/tf-operator#754

/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1397)
<!-- Reviewable:end -->
