### PR TITLE
Fix minikube test and trigger on presubmit when modified.

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -32,9 +32,16 @@ workflows:
     component: workflows
     name: kubeflow-e2e-minikube
     job_types:
+      - presubmit
       - postsubmit
     params:
       platform: minikube
+    include_dirs:
+      # Run on presubmit if any files used by minikube change
+      - testing/deploy_kubeflow.py
+      - testing/workflows/components/workflows.jsonnet
+      - testing/workflows/components/workflows.libsonnet
+      - testing/install_minikube.sh
   - app_dir: kubeflow/kubeflow/components/k8s-model-server/images/releaser
     component: workflows
     name: tf-serving-image

--- a/testing/deploy_kubeflow.py
+++ b/testing/deploy_kubeflow.py
@@ -60,8 +60,6 @@ def deploy_kubeflow(test_case):
     [
       "ks", "generate", "tf-job-operator", "tf-job-operator",
       "--namespace=" + namespace,
-      "--tfJobImage=gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf",
-      "--tfJobVersion=v1alpha1"
     ],
     cwd=app_dir)
 

--- a/testing/deploy_kubeflow.py
+++ b/testing/deploy_kubeflow.py
@@ -1,0 +1,129 @@
+"""Deploy Kubeflow and wait for it to be deployed.
+
+TODO(jlewi): This script is outdated. Its no longer used for GKE.
+It is still used by minikube. For minikube we should be using kfctl.sh
+"""
+import argparse
+import logging
+import os
+
+import yaml
+from kubernetes.config import kube_config
+# TODO(jlewi): We should be using absolute imports always.
+# So it should be from testing import deploy_utils because testing
+# is the top level python package.
+from . import deploy_utils
+from kubeflow.testing import test_helper
+from kubeflow.testing import util  # pylint: disable=no-name-in-module
+
+def parse_args():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "--namespace", default=None, type=str, help=("The namespace to use."))
+  parser.add_argument(
+    "--as_gcloud_user",
+    dest="as_gcloud_user",
+    action="store_true",
+    help=("Impersonate the user corresponding to the gcloud "
+          "command with kubectl and ks."))
+  parser.add_argument(
+    "--no-as_gcloud_user", dest="as_gcloud_user", action="store_false")
+  parser.set_defaults(as_gcloud_user=False)
+  parser.add_argument(
+    "--github_token",
+    default=None,
+    type=str,
+    help=("The GitHub API token to use. This is needed since ksonnet uses the "
+          "GitHub API and without it we get rate limited. For more info see: "
+          "https://github.com/ksonnet/ksonnet/blob/master/docs"
+          "/troubleshooting.md. Can also be set using environment variable "
+          "GITHUB_TOKEN."))
+  parser.set_defaults(as_gcloud_user=False)
+
+  args, _ = parser.parse_known_args()
+  return args
+
+def deploy_kubeflow(test_case):
+  """Deploy Kubeflow."""
+  args = parse_args()
+  test_dir = test_case.test_suite.test_dir
+  namespace = args.namespace
+  api_client = deploy_utils.create_k8s_client()
+  app_dir = deploy_utils.setup_kubeflow_ks_app(test_dir, namespace, args.github_token, api_client)
+
+
+  # ks generate tf-job-operator tf-job-operator
+  # TODO(jlewi): We don't need to generate a core component if we are
+  # just deploying TFServing. Might be better to refactor this code.
+  # Deploy Kubeflow
+  util.run(
+    [
+      "ks", "generate", "tf-job-operator", "tf-job-operator",
+      "--namespace=" + namespace,
+      "--tfJobImage=gcr.io/kubeflow-images-public/tf_operator:v20180522-77375baf",
+      "--tfJobVersion=v1alpha1"
+    ],
+    cwd=app_dir)
+
+  util.run(
+    [
+      "ks", "generate", "pytorch-operator", "pytorch-operator",
+      "--namespace=" + namespace
+    ],
+    cwd=app_dir)
+
+  util.run(
+    [
+      "ks", "generate", "jupyterhub", "jupyterhub",
+      "--namespace=" + namespace
+    ],
+    cwd=app_dir)
+
+  apply_command = [
+    "ks",
+    "apply",
+    "default",
+    "-c",
+    "tf-job-operator",
+    "-c",
+    "pytorch-operator",
+    "-c",
+    "jupyterhub",
+  ]
+
+  if args.as_gcloud_user:
+    account = deploy_utils.get_gcp_identity()
+    logging.info("Impersonate %s", account)
+
+    # If we don't use --as to impersonate the service account then we
+    # observe RBAC errors when doing certain operations. The problem appears
+    # to be that we end up using the in cluster config (e.g. pod service account)
+    # and not the GCP service account which has more privileges.
+    apply_command.append("--as=" + account)
+  util.run(apply_command, cwd=app_dir)
+
+  # Verify that the TfJob operator is actually deployed.
+  tf_job_deployment_name = "tf-job-operator"
+  logging.info("Verifying TfJob controller started.")
+  util.wait_for_deployment(api_client, namespace, tf_job_deployment_name)
+
+  # Verify that JupyterHub is actually deployed.
+  jupyterhub_name = "tf-hub"
+  logging.info("Verifying TfHub started.")
+  util.wait_for_statefulset(api_client, namespace, jupyterhub_name)
+
+  # Verify that PyTorch Operator actually deployed
+  pytorch_operator_deployment_name = "pytorch-operator"
+  logging.info("Verifying PyTorchJob controller started.")
+  util.wait_for_deployment(api_client, namespace, pytorch_operator_deployment_name)
+
+
+def main():
+  test_case = test_helper.TestCase(
+    name='deploy_kubeflow', test_func=deploy_kubeflow)
+  test_suite = test_helper.init(
+    name='deploy_kubeflow', test_cases=[test_case])
+  test_suite.run()
+
+if __name__ == "__main__":
+  main()

--- a/testing/deploy_kubeflow.py
+++ b/testing/deploy_kubeflow.py
@@ -101,7 +101,7 @@ def deploy_kubeflow(test_case):
   util.run(apply_command, cwd=app_dir)
 
   # Verify that the TfJob operator is actually deployed.
-  tf_job_deployment_name = "tf-job-operator"
+  tf_job_deployment_name = "tf-job-operator-v1alpha2"
   logging.info("Verifying TfJob controller started.")
   util.wait_for_deployment(api_client, namespace, tf_job_deployment_name)
 

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -663,6 +663,7 @@
               "-m",
               "testing.tf_job_simple_test",
               "--src_dir=" + srcDir,
+              "--tf_job_version=v1alpha2",
             ]),  // tfjob-simple-prototype-test
             buildTemplate("tfjob-test" + v1alpha2Suffix, [
               "python",


### PR DESCRIPTION
* In #1406 we deleted deploy_kubeflow.py but this file is still used
  by the minikube test.

* Partially reverts commit a4e4a8e9caf7bfa40958d9b8c9094fd7f9c7534e.

* Related to #1331

* Trigger minikube on presubmits if files used by minikube E2E test are changed.
  run_e2e_workflow.py uses fnmatch so we can specify individual files
  or other expressions

* Fix #1350 trigger minikube test on presubmit when test modified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1411)
<!-- Reviewable:end -->
