### PR TITLE
Use JupyterLab as default instead of Jupyter Tree interface

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -158,6 +158,10 @@
                   value: $.params.jupyterHubAuthenticator,
                 },
                 {
+                  name: "DEFAULT_JUPYTERLAB",
+                  value: $.params.useJupyterLabAsDefault,
+                },
+                {
                   name: "KF_PVC_LIST",
                   value: $.params.disks,
                 },

--- a/kubeflow/core/kubeform_spawner.py
+++ b/kubeflow/core/kubeform_spawner.py
@@ -114,7 +114,7 @@ class KubeFormSpawner(KubeSpawner):
         return env
 
     # TODO(kkasravi): add unit test
-    def _parse_user_name(self, username): 
+    def _parse_user_name(self, username):
         safe_chars = set(string.ascii_lowercase + string.digits)
         name = username.split(':')[-1]
         legacy = ''.join([s if s in safe_chars else '-' for s in name.lower()])
@@ -123,7 +123,7 @@ class KubeFormSpawner(KubeSpawner):
 
     def _expand_user_properties(self, template):
         # override KubeSpawner method to remove prefix accounts.google: for iap
-        # and truncate to 63 characters 
+        # and truncate to 63 characters
 
         # Set servername based on whether named-server initialised
         if self.name:
@@ -236,6 +236,9 @@ if os.environ.get('KF_AUTHENTICATOR') == 'iap':
     c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'
 else:
     c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
+
+if os.environ.get('DEFAULT_JUPYTERLAB') == 'true':
+    c.KubeSpawner.default_url = '/lab'
 
 # PVCs
 pvcs = os.environ.get('KF_PVC_LIST')

--- a/kubeflow/core/kubeform_spawner.py
+++ b/kubeflow/core/kubeform_spawner.py
@@ -237,7 +237,7 @@ if os.environ.get('KF_AUTHENTICATOR') == 'iap':
 else:
     c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
 
-if os.environ.get('DEFAULT_JUPYTERLAB') == 'true':
+if os.environ.get('DEFAULT_JUPYTERLAB').lower() == 'true':
     c.KubeSpawner.default_url = '/lab'
 
 # PVCs

--- a/kubeflow/core/prototypes/jupyterhub.jsonnet
+++ b/kubeflow/core/prototypes/jupyterhub.jsonnet
@@ -8,6 +8,7 @@
 // @optionalParam serviceType string ClusterIP The service type for Jupyterhub.
 // @optionalParam image string gcr.io/kubeflow/jupyterhub-k8s:v20180531-3bb991b1 The image to use for JupyterHub.
 // @optionalParam jupyterHubAuthenticator string null The authenticator to use
+// @optionalParam useJupyterLabAsDefault string true Set JupterLab interface as the default
 // @optionalParam notebookPVCMount string /home/jovyan Mount path for PVC. Set empty to disable PVC
 // @optionalParam registry string gcr.io The docker image registry for JupyterNotebook.
 // @optionalParam repoName string kubeflow-images-public The repository name for JupyterNotebook.


### PR DESCRIPTION
This is configurable via the ksonnet parameter - useJupyterLabAsDefault

/assign @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1423)
<!-- Reviewable:end -->
