### PR TITLE
Add logging statements to help figure out why test results aren't reported

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -271,6 +271,8 @@
             "testing.tf_job_simple_test",
             "--src_dir=" + tests.srcDir,
             "--tf_job_version=v1alpha2",
+            "--test_dir=" + tests.testDir,
+            "--artifacts_dir=" + tests.artifactsDir,
           ],
         },
 


### PR DESCRIPTION
Fix the E2E test for the TFJob simple prototype test.

* Fix #1426

There are two problems with the test

  1. Test isn't properly reporting results to gubernator; so test failures
     aren't being noticed.
  2. Test needs to be updated to work with v1alpha2.

* The TestSuite name needs to be set because this is used as the name
  of the junit XML file.

* simple-prototype-test should set test_dir and artifacts_dir.

* Fix the test; use tf_job_client to wait for the job to be in the Running
  condition. This should be more reliable than checking for actual pods.

* The test has probably been broken for a while but this went unnoticed
  because results weren't being properly surfaced in test grid because
  the XML file is improperly named. I suspect things broke as part of
  the switch to v1alpha2 which changed the names of the pods.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1427)
<!-- Reviewable:end -->
