### PR TITLE
make web app stateless & backend security update

### DIFF
--- a/bootstrap/cmd/bootstrap/app/saKey.go
+++ b/bootstrap/cmd/bootstrap/app/saKey.go
@@ -21,6 +21,17 @@ type InsertSaKeyRequest struct {
 	Zone string
 }
 
+func (s *ksServer) InsertSaKeys(ctx context.Context, req InsertSaKeyRequest) error {
+	err := s.InsertSaKey(ctx, req, "admin-gcp-sa.json", "admin-gcp-sa",
+		fmt.Sprintf("%v-admin@%v.iam.gserviceaccount.com", req.Cluster, req.Project))
+	if err != nil {
+		return err
+	}
+	err = s.InsertSaKey(ctx, req, "user-gcp-sa.json", "user-gcp-sa",
+		fmt.Sprintf("%v-user@%v.iam.gserviceaccount.com", req.Cluster, req.Project))
+	return err
+}
+
 func (s *ksServer) InsertSaKey(ctx context.Context, request InsertSaKeyRequest, secretKey string,
 	secretName string, serviceAccount string) error {
 	ts := oauth2.StaticTokenSource(&oauth2.Token{
@@ -41,8 +52,8 @@ func (s *ksServer) InsertSaKey(ctx context.Context, request InsertSaKeyRequest, 
 		Name: fmt.Sprintf("projects/%v/serviceAccounts/%v", request.Project, serviceAccount),
 	}
 
-	s.iamMux.Lock()
-	defer s.iamMux.Unlock()
+	s.serverMux.Lock()
+	defer s.serverMux.Unlock()
 
 	createdKey, err := c.CreateServiceAccountKey(ctx, &createServiceAccountKeyRequest)
 	if err != nil {

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -18,8 +18,6 @@ import { flattenDeploymentOperationError, log, wait } from './Utils';
 // So for security reasons it might be better to just bundle the configs.
 // When we build a docker image as part of our release process we can just
 // copy in the latest configs.
-import clusterSpecPath from './configs/cluster-kubeflow.yaml';
-import clusterJinjaPath from './configs/cluster.jinja';
 import appConfigPath from './user_config/app-config.yaml';
 
 // TODO(jlewi): For the FQDN we should have a drop down box to select custom
@@ -101,8 +99,6 @@ const YamlBtn = glamorous(Button)({
 
 export default class DeployForm extends React.Component<any, DeployFormState> {
 
-  private _clusterJinja = '';
-  private _clusterSpec: any;
   private _configSpec: any;
 
   constructor(props: any) {
@@ -125,36 +121,6 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
     // be able to click submit until the fetches have succeeded. How can we do
     // that?
 
-    this._appendLine('loadClusterJinjaPath');
-    // Load the jinja template into a string because 
-    // we will need it for the deployments insert request.
-    fetch(clusterJinjaPath, { mode: 'no-cors' })
-      .then((response) => {
-        log('Got response');
-        return response.text();
-      })
-      .then((text) => {
-        this._clusterJinja = text;
-        log('Loaded clusterJinja successfully');
-      })
-      .catch((error) => {
-        log('Request failed', error);
-      });
-
-    this._appendLine('loadClusterSpec');
-    // Load the YAML for the actual config and parse it.
-    fetch(clusterSpecPath, { mode: 'no-cors' })
-      .then((response) => {
-        log('Got response');
-        return response.text();
-      })
-      .then((text) => {
-        this._clusterSpec = jsYaml.safeLoad(text);
-        // log('Loaded clusterSpecPath successfully');
-      })
-      .catch((error) => {
-        log('Request failed', error);
-      });
     fetch(appConfigPath, { mode: 'no-cors' })
       .then((response) => {
         log('Got response');
@@ -263,20 +229,12 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
       return;
     }
 
-    const kubeflow = this._clusterSpec.resources[0];
-
-    kubeflow.name = this.state.deploymentName;
-    kubeflow.properties.zone = this.state.zone;
-    kubeflow.properties.clientId = btoa(this.state.clientId);
-    kubeflow.properties.clientSecret = btoa(this.state.clientSecret);
-    kubeflow.properties.ipName = this.state.deploymentName + '-ip';
-
     const state = this.state;
     const email = await Gapi.getSignedInEmail();
 
     this._configSpec.defaultApp.parameters.forEach((p: any) => {
       if (p.name === 'ipName') {
-        p.value = kubeflow.properties.ipName;
+        p.value = this.state.deploymentName + '-ip';
       }
 
       if (p.name === 'hostname') {
@@ -288,24 +246,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
       }
     });
 
-    this._clusterSpec.resources[0] = kubeflow;
-    const clusterSpec = jsYaml.dump(this._clusterSpec);
-
-    return {
-      'name': this.state.deploymentName,
-      'target': {
-        'config': {
-          'content': clusterSpec,
-        },
-        'imports': [
-          {
-            'content': this._clusterJinja,
-            'name': 'cluster.jinja',
-          }
-        ],
-      },
-    };
-
+    return this._configSpec;
   }
 
   // Create a  Kubeflow deployment.
@@ -397,7 +338,6 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
       return;
     }
 
-    // Step 2: Set IAM Admin Policy
     const projectNumber = await Gapi.cloudresourcemanager.getProjectNumber(project)
       .catch(e => {
         this.setState({
@@ -413,122 +353,13 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
 
     this._appendLine('Proceeding with project number: ' + projectNumber);
     const token = await Gapi.getToken();
-    let readiness = false;
-    request(
-      {
-        body: JSON.stringify(
-          {
-            Project: project,
-            ProjectNumber: projectNumber,
-            Token: token,
-          }
-        ),
-        headers: { 'content-type': 'application/json' },
-        method: 'PUT',
-        uri: this._configSpec.appAddress + '/kfctl/initProject',
-      },
-      (error, response, body) => {
-        if (!error) {
-          try {
-            const msg = JSON.parse(response.body).Reply;
-            this._appendLine('project init succeeded: ' + msg);
-            readiness = true;
-          }
-          catch (e) {
-            this._appendLine('Backend returned non-json response: ');
-          }
-        } else {
-          this._appendLine('Backend error: ' + error);
-          return;
-        }
-      }
-    );
 
-    let initAttempts = 0;
-    const initTimeout = 2000;
-    do {
-      initAttempts++;
-      await wait(initTimeout);
-    } while (!readiness && initAttempts < 10);
-
-    // Step 3: Create GCP Deployment
-
-    if (!readiness) {
-      return;
-    }
+    const deploymentName = this.state.deploymentName;
 
     const resource = await this._getYaml();
     if (!resource) {
       return;
     }
-
-    this._appendLine('Starting new deployment..');
-
-    const deploymentName = this.state.deploymentName;
-    await Gapi.deploymentmanager.insert(project, resource)
-      .then(res => {
-        this._appendLine('Result of create deployment operation:\n' + JSON.stringify(res));
-        this._monitorDeployment(project, deploymentName);
-      })
-      .catch(err => {
-        this._appendLine('Error trying to create deployment:\n' + err);
-        this.setState({
-          dialogBody: 'Error trying to create deployment: ' + err,
-          dialogTitle: 'Deployment Error',
-        });
-      });
-
-
-    // Step 4: In-cluster resources set up
-    let status = '';
-    let getAttempts = 0;
-    const getTimeout = 20000;
-    do {
-      getAttempts++;
-      await wait(getTimeout);
-      const curStatus = await Gapi.deploymentmanager.get(this.state.project, deploymentName)
-            .catch(err => {
-              this._appendLine('Deployment status not available yet.');
-            });
-      if (!curStatus) {
-        continue;
-      }
-      status = curStatus.operation!.status!;
-      this._appendLine(`Status of ${deploymentName}: ` + status);
-    } while (status !== 'DONE' && getAttempts < 30);
-
-    if (status !== 'DONE') {
-      const dmConsole = 'https://console.cloud.google.com/deployments';
-      this._appendLine(`Deployment ${deploymentName} didn't finish within 10 minutes, check ${dmConsole} for more info`);
-      return;
-    }
-
-    request(
-      {
-        body: JSON.stringify(
-          {
-            Cluster: deploymentName,
-            Namespace: 'kubeflow',
-            Project: project,
-            SecretKey: 'admin-gcp-sa.json',
-            SecretName: 'admin-gcp-sa',
-            ServiceAccount:  `${deploymentName}-admin@${project}.iam.gserviceaccount.com`,
-            Token: token,
-            Zone: this.state.zone,
-          }
-        ),
-        headers: { 'content-type': 'application/json' },
-        method: 'PUT',
-        uri: this._configSpec.appAddress + '/kfctl/iam/insertSaKey',
-      },
-      (error, response, body) => {
-        if (!error) {
-          this._appendLine('Service Account Key inserted.');
-        } else {
-          this._appendLine('error: ' + error);
-        }
-      }
-    );
 
     const email = await Gapi.getSignedInEmail();
     const createBody = JSON.stringify(
@@ -536,11 +367,15 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
         AppConfig: this._configSpec.defaultApp,
         Apply: true,
         AutoConfigure: true,
+        ClientId: btoa(this.state.clientId),
+        ClientSecret: btoa(this.state.clientSecret),
         Cluster: deploymentName,
         Email: email,
+        IpName: this.state.deploymentName + '-ip',
         Name: deploymentName,
         Namespace: 'kubeflow',
         Project: project,
+        ProjectNumber: projectNumber,
         Token: token,
         Zone: this.state.zone,
       }
@@ -550,13 +385,24 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
         body: createBody,
         headers: { 'content-type': 'application/json' },
         method: 'PUT',
-        uri: this._configSpec.appAddress + '/kfctl/apps/create',
+        uri: this._configSpec.appAddress + '/kfctl/e2eDeploy',
       },
       (error, response, body) => {
         if (!error) {
-          this._appendLine('ksonnet app created.');
+          try {
+            const err = JSON.parse(response.body).err;
+            if (err) {
+              this._appendLine('Deploy failed with backend error: ' + err);
+            } else {
+              this._appendLine('Deploy acknowledged by backend');
+              this._monitorDeployment(project, deploymentName);
+            }
+          }
+          catch (e) {
+            this._appendLine('Backend returned non-json response: ' + body);
+          }
         } else {
-          this._appendLine('error: ' + error);
+          this._appendLine('Error: ' + error);
         }
       }
     );


### PR DESCRIPTION
1. make web app stateless: frontend only did one RPC call to backend and then wait.
    refresh or close page during wait won't affect ongoing deployment anymore.
2. fix backend potential deployment name conflict:
  Basically in memory map ```apps``` migrate from ```name -> app``` to ```project + name -> apps``` 
  Now deployment name only need to be unique within each project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1458)
<!-- Reviewable:end -->
