### PR TITLE
Add GCS read only scope to GKE VM scopes

### DIFF
--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -21,9 +21,11 @@ limitations under the License.
    that will be created to represent Kubernetes objects.
    There is type corresponding to each API endpoint.
 #}
-{% set VM_OAUTH_SCOPES = ['https://www.googleapis.com/auth/logging.write', 'https://www.googleapis.com/auth/monitoring'] %}
 
-
+{% set VM_OAUTH_SCOPES = ['https://www.googleapis.com/auth/logging.write', 
+                          'https://www.googleapis.com/auth/monitoring',
+                          'https://www.googleapis.com/auth/devstorage.read_only'] %}
+                          
 {# Names for service accounts.
    -admin is to be used for admin tasks
    -user is to be used by users for actual jobs.


### PR DESCRIPTION
Regarding #1432 I've added the read only scope to the Google deployment manager templates (cluster.jinja). 

This will allow the GKE to pull private images from gcr.io/<project>.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1466)
<!-- Reviewable:end -->
