### PR TITLE
Fix bug with updating an existing deployment.

### DIFF
--- a/scripts/gke/deploy.sh
+++ b/scripts/gke/deploy.sh
@@ -102,12 +102,13 @@ else
 fi
 
 if ${KUBEFLOW_DEPLOY}; then
-  # Check if it already exists
-  set +e
+  # Check if it already exists  
+  set +e    
   gcloud deployment-manager --project=${PROJECT} deployments describe ${DEPLOYMENT_NAME}
   exists=$?
   set -e
 
+  cd "${KUBEFLOW_DM_DIR}"
   if [ ${exists} -eq 0 ]; then
     echo ${DEPLOYMENT_NAME} exists
     gcloud deployment-manager --project=${PROJECT} deployments update ${DEPLOYMENT_NAME} --config=${CONFIG_FILE}


### PR DESCRIPTION
* We need to cd to the directory containing the deployment manager configs
  before issuing gcloud deployment-manager update

* It works when the deployment doesn't exist because in that case we execute
  a code block that cd's to the directory.

* Looks like previous fix #1243 never got cherrypicked onto 0.2 branch.

* Fix #1233

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1475)
<!-- Reviewable:end -->
