### PR TITLE
Remove unused Azure specific config

### DIFF
--- a/kubeflow/core/kubeform_spawner.py
+++ b/kubeflow/core/kubeform_spawner.py
@@ -228,24 +228,6 @@ if pvc_mount and pvc_mount != 'null':
         }
     )
 
-# ###################################################
-# ### Extra volumes for NVIDIA drivers (Azure)
-# ###################################################
-# # Temporary fix:
-# # AKS / acs-engine doesn't yet use device plugin so we have to mount the drivers to use GPU
-# # TODO(wbuchwalter): Remove once device plugin is merged
-if cloud == 'aks' or cloud == 'acsengine':
-    volumes.append({
-        'name': 'nvidia',
-        'hostPath': {
-            'path': '/usr/local/nvidia'
-        }
-    })
-    volume_mounts.append({
-        'name': 'nvidia',
-        'mountPath': '/usr/local/nvidia'
-    })
-
 c.KubeSpawner.volumes = volumes
 c.KubeSpawner.volume_mounts = volume_mounts
 # Set both service_account and singleuser_service_account because

--- a/kubeflow/core/tests/tf-job_test.jsonnet
+++ b/kubeflow/core/tests/tf-job_test.jsonnet
@@ -1,7 +1,6 @@
 local tfjob = import "../tf-job-operator.libsonnet";
 local params = {
   namespace:: "test-kf-001",
-  cloud:: "azure",
   tfJobImage:: "gcr.io/kubeflow-images-public/tf_operator:v20180226-403",
   tfDefaultImage:: "null",
 };
@@ -76,7 +75,7 @@ std.assertEqual(
 ) &&
 
 std.assertEqual(
-  tfjob.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
+  tfjob.parts(params.namespace).configMap(params.tfDefaultImage),
   {
     apiVersion: "v1",
     data: {

--- a/kubeflow/core/tf-job-operator.libsonnet
+++ b/kubeflow/core/tf-job-operator.libsonnet
@@ -1,7 +1,7 @@
 {
   all(params):: [
 
-                  $.parts(params.namespace).configMap(params.cloud, params.tfDefaultImage),
+                  $.parts(params.namespace).configMap(params.tfDefaultImage),
                   $.parts(params.namespace).serviceAccount,
                   $.parts(params.namespace).operatorRole(params.deploymentScope, params.deploymentNamespace),
                   $.parts(params.namespace).operatorRoleBinding(params.deploymentScope, params.deploymentNamespace),
@@ -252,46 +252,10 @@
                                               else
                                                 {},
 
-    aksAccelerators:: {
-      accelerators: {
-        "alpha.kubernetes.io/nvidia-gpu": {
-          volumes: [
-            {
-              name: "nvidia",
-              mountPath: "/usr/local/nvidia",
-              hostPath: "/usr/local/nvidia",
-            },
-          ],
-        },
-      },
-    },
-
-    acsEngineAccelerators:: {
-      accelerators: {
-        "alpha.kubernetes.io/nvidia-gpu": {
-          volumes: [
-            {
-              name: "nvidia",
-              mountPath: "/usr/local/nvidia",
-              hostPath: "/usr/local/nvidia",
-            },
-          ],
-        },
-      },
-    },
-
-    configData(cloud, tfDefaultImage):: self.defaultControllerConfig(tfDefaultImage) +
-                                        if cloud == "aks" then
-                                          self.aksAccelerators
-                                        else if cloud == "acsengine" then
-                                          self.acsEngineAccelerators
-                                        else
-                                          {},
-
-    configMap(cloud, tfDefaultImage): {
+    configMap(tfDefaultImage): {
       apiVersion: "v1",
       data: {
-        "controller_config_file.yaml": std.manifestJson($.parts(namespace).configData(cloud, tfDefaultImage)),
+        "controller_config_file.yaml": std.manifestJson($.parts(namespace).defaultControllerConfig(tfDefaultImage)),
       },
       kind: "ConfigMap",
       metadata: {

--- a/kubeflow/mxnet-job/mxnet-operator.libsonnet
+++ b/kubeflow/mxnet-job/mxnet-operator.libsonnet
@@ -1,7 +1,7 @@
 {
   all(params, env):: [
     $.parts(params, env).mxnetJobDeploy(params.mxnetJobImage),
-    $.parts(params, env).configMap(params.cloud, params.mxnetDefaultImage),
+    $.parts(params, env).configMap(params.mxnetDefaultImage),
     $.parts(params, env).serviceAccount,
     $.parts(params, env).operatorRole,
     $.parts(params, env).operatorRoleBinding,
@@ -101,56 +101,10 @@
     else
       {},
 
-    aksAccelerators:: {
-      accelerators: {
-        "alpha.kubernetes.io/nvidia-gpu": {
-          volumes: [
-            {
-              name: "lib",
-              mountPath: "/usr/local/nvidia/lib64",
-              hostPath: "/usr/lib/nvidia-384",
-            },
-            {
-              name: "bin",
-              mountPath: "/usr/local/nvidia/bin",
-              hostPath: "/usr/lib/nvidia-384/bin",
-            },
-            {
-              name: "libcuda",
-              mountPath: "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
-              hostPath: "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
-            },
-          ],
-        },
-      },
-    },
-
-    acsEngineAccelerators:: {
-      accelerators: {
-        "alpha.kubernetes.io/nvidia-gpu": {
-          volumes: [
-            {
-              name: "nvidia",
-              mountPath: "/usr/local/nvidia",
-              hostPath: "/usr/local/nvidia",
-            },
-          ],
-        },
-      },
-    },
-
-    configData(cloud, mxnetDefaultImage):: self.defaultControllerConfig(mxnetDefaultImage) +
-                                           if cloud == "aks" then
-                                             self.aksAccelerators
-                                           else if cloud == "acsengine" then
-                                             self.acsEngineAccelerators
-                                           else
-                                             {},
-
-    configMap(cloud, mxnetDefaultImage): {
+    configMap(mxnetDefaultImage): {
       apiVersion: "v1",
       data: {
-        "controller_config_file.yaml": std.manifestJson($.parts(params, env).configData(cloud, mxnetDefaultImage)),
+        "controller_config_file.yaml": std.manifestJson($.parts(params, env).defaultControllerConfig(mxnetDefaultImage)),
       },
       kind: "ConfigMap",
       metadata: {

--- a/kubeflow/pytorch-job/pytorch-operator.libsonnet
+++ b/kubeflow/pytorch-job/pytorch-operator.libsonnet
@@ -1,6 +1,6 @@
 {
   all(params, env):: [
-                       $.parts(params, env).configMap(params.cloud, params.pytorchDefaultImage),
+                       $.parts(params, env).configMap(params.pytorchDefaultImage),
                        $.parts(params, env).serviceAccount,
                        $.parts(params, env).operatorRole(params.deploymentScope, params.deploymentNamespace),
                        $.parts(params, env).operatorRoleBinding(params.deploymentScope, params.deploymentNamespace),
@@ -233,56 +233,10 @@
     else
       {},
 
-    aksAccelerators:: {
-      accelerators: {
-        "alpha.kubernetes.io/nvidia-gpu": {
-          volumes: [
-            {
-              name: "lib",
-              mountPath: "/usr/local/nvidia/lib64",
-              hostPath: "/usr/lib/nvidia-384",
-            },
-            {
-              name: "bin",
-              mountPath: "/usr/local/nvidia/bin",
-              hostPath: "/usr/lib/nvidia-384/bin",
-            },
-            {
-              name: "libcuda",
-              mountPath: "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
-              hostPath: "/usr/lib/x86_64-linux-gnu/libcuda.so.1",
-            },
-          ],
-        },
-      },
-    },
-
-    acsEngineAccelerators:: {
-      accelerators: {
-        "alpha.kubernetes.io/nvidia-gpu": {
-          volumes: [
-            {
-              name: "nvidia",
-              mountPath: "/usr/local/nvidia",
-              hostPath: "/usr/local/nvidia",
-            },
-          ],
-        },
-      },
-    },
-
-    configData(cloud, pytorchDefaultImage):: self.defaultControllerConfig(pytorchDefaultImage) +
-                                             if cloud == "aks" then
-                                               self.aksAccelerators
-                                             else if cloud == "acsengine" then
-                                               self.acsEngineAccelerators
-                                             else
-                                               {},
-
-    configMap(cloud, pytorchDefaultImage): {
+    configMap(pytorchDefaultImage): {
       apiVersion: "v1",
       data: {
-        "controller_config_file.yaml": std.manifestJson($.parts(params, env).configData(cloud, pytorchDefaultImage)),
+        "controller_config_file.yaml": std.manifestJson($.parts(params, env).defaultControllerConfig(pytorchDefaultImage)),
       },
       kind: "ConfigMap",
       metadata: {


### PR DESCRIPTION
Azure supports device plugin in both AKS/acs-engine so we don't need the custom logic to use `alpha.kubernetes.io/nvidia-gpu` anymore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1512)
<!-- Reviewable:end -->
