### PR TITLE
Support specifying registy version in create request

### DIFF
--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -81,18 +81,6 @@ type RegistryConfig struct {
 	RegUri  string
 }
 
-// KsAppRegistry specifies a registry to add to an app.
-// RegistryConfig on the other hand describe a bunch of registries
-// that are baked into the docker image. These registries can then
-// be added to the app using file:// as the URI.
-// KsAppRegistry can use any URI that ksonnet understands.
-// Additionally if the RegUri is blank we will try to map it to one of
-// the registries baked into the Docker image using the name.
-//type KsAppRegistry struct {
-//	Name   string
-//	RegUri string
-//}
-
 type AppConfig struct {
 	Registries []RegistryConfig
 	Packages   []KsPackage

--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -66,15 +66,19 @@ type KsParameter struct {
 	Value     string
 }
 
-// RegistryConfig is used to configure registries that should
-// be baked into the bootstrapper docker image.
-// See: https://github.com/kubeflow/kubeflow/blob/master/bootstrap/image_registries.yaml
+// RegistryConfig is used for two purposes:
+// 1. used during image build, to configure registries that should be baked into the bootstrapper docker image.
+//  (See: https://github.com/kubeflow/kubeflow/blob/master/bootstrap/image_registries.yaml)
+// 2. used during app create rpc call, specifies a registry to be added to an app.
+//	required info for registry: Name, Repo, Version, Path
+//  Additionally if any of required fields is blank we will try to map with one of
+//  the registries baked into the Docker image using the name.
 type RegistryConfig struct {
-	Name   string
-	Repo   string
-	Branch string
-	Path   string
-	RegUri string
+	Name    string
+	Repo    string
+	Version string
+	Path    string
+	RegUri  string
 }
 
 // KsAppRegistry specifies a registry to add to an app.
@@ -84,13 +88,13 @@ type RegistryConfig struct {
 // KsAppRegistry can use any URI that ksonnet understands.
 // Additionally if the RegUri is blank we will try to map it to one of
 // the registries baked into the Docker image using the name.
-type KsAppRegistry struct {
-	Name   string
-	RegUri string
-}
+//type KsAppRegistry struct {
+//	Name   string
+//	RegUri string
+//}
 
 type AppConfig struct {
-	Registries []KsAppRegistry
+	Registries []RegistryConfig
 	Packages   []KsPackage
 	Components []KsComponent
 	Parameters []KsParameter

--- a/components/gcp-click-to-deploy/manifest/kf_app.yaml
+++ b/components/gcp-click-to-deploy/manifest/kf_app.yaml
@@ -52,6 +52,10 @@ data:
         value: gke
       registries:
       - name: kubeflow
+        repo: https://github.com/kubeflow/kubeflow
+        # default leave empty
+        version:
+        path: kubeflow
 kind: ConfigMap
 metadata:
   name: kubeflow-controller

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -32,6 +32,7 @@ interface DeployFormState {
   project: string;
   showLogs: boolean;
   zone: string;
+  kfverison: string;
   clientId: string;
   clientSecret: string;
 }
@@ -109,6 +110,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
       deploymentName: 'kubeflow',
       dialogBody: '',
       dialogTitle: '',
+      kfverison: 'default',
       project: '',
       showLogs: false,
       zone: 'us-east1-d',
@@ -154,6 +156,9 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
         </Row>
         <Row>
           <Input name="zone" label="Zone" spellCheck={false} value={this.state.zone} onChange={this._handleChange.bind(this)} />
+        </Row>
+        <Row>
+          <Input name="kfverison" label="Kubeflow Version" spellCheck={false} value={this.state.kfverison} onChange={this._handleChange.bind(this)} />
         </Row>
         <Row>
           <Input name="clientId" label="Web App Client Id" spellCheck={false} value={this.state.clientId} onChange={this._handleChange.bind(this)} />
@@ -245,6 +250,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
         p.value = email;
       }
     });
+    this._configSpec.defaultApp.registries[0].version = this.state.kfverison;
 
     return this._configSpec;
   }


### PR DESCRIPTION
1. Support specifying registy version in create request;
2. Provide field for kubeflow version on UI.

So now we don't rely on bake-in repos any more.
User can choose to deploy with any kubeflow commit they want.

fix https://github.com/kubeflow/kubeflow/issues/1417

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1528)
<!-- Reviewable:end -->
