### PR TITLE
add chainer-job package to registry.yaml

### DIFF
--- a/kubeflow/registry.yaml
+++ b/kubeflow/registry.yaml
@@ -40,3 +40,6 @@ libraries:
   nvidia-inference-server:
     version: master
     path: nvidia-inference-server
+  chainer-job:
+    version: master
+    path: chainer-job


### PR DESCRIPTION
I found `chainer-job` package is missing in `registry.yaml`.  So, `ks pkg list` doesn't show `chainer-job` package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1529)
<!-- Reviewable:end -->
