### PR TITLE
Prevent ambassador getaddrinfo error logs

### DIFF
--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -40,7 +40,7 @@
         labels: {
           service: "ambassador",
         },
-        name: "ambassador-exporter",
+        name: "statsd-sink",
         namespace: params.namespace,
         annotations: {
           "prometheus.io/scrape": "true",
@@ -50,7 +50,7 @@
       spec: {
         ports: [
           {
-            name: "ambassador-exporter",
+            name: "statsd-sink",
             port: 9102,
             targetPort: 9102,
             protocol: "TCP",
@@ -244,8 +244,8 @@
                 name: "statsd",
               },
               {
-                image: params.statsdExporterImage,
-                name: "statsd-exporter",
+                image: params.statsdSinkImage,
+                name: "statsd-sink",
               },
             ],
             restartPolicy: "Always",

--- a/kubeflow/core/prototypes/ambassador.jsonnet
+++ b/kubeflow/core/prototypes/ambassador.jsonnet
@@ -7,7 +7,7 @@
 // @optionalParam ambassadorServiceType string ClusterIP The service type for the API Gateway.
 // @optionalParam ambassadorImage string quay.io/datawire/ambassador:0.37.0 The image for the API Gateway.
 // @optionalParam statsdImage string quay.io/datawire/statsd:0.37.0 The image for the Stats and Monitoring.
-// @optionalParam statsdExporterImage string prom/statsd-exporter:v0.6.0 The image for the Statsd exporter.
+// @optionalParam statsdSinkImage string prom/statsd-exporter:v0.6.0 The image for the Statsd exporter.
 
 local ambassador = import "kubeflow/core/ambassador.libsonnet";
 local instance = ambassador.new(env, params);

--- a/scripts/gke/use_gcr_for_all_images.sh
+++ b/scripts/gke/use_gcr_for_all_images.sh
@@ -32,7 +32,7 @@ fi
 if ks component list | awk '{print $1}' | grep -q "^ambassador$" ; then
   ks param set ambassador ambassadorImage gcr.io/kubeflow-images-public/quay.io/datawire/ambassador:0.37.0
   ks param set ambassador statsdImage gcr.io/kubeflow-images-public/quay.io/datawire/statsd:0.37.0
-  ks param set ambassador statsdExporterImage gcr.io/kubeflow-images-public/prom/statsd-exporter:v0.6.0
+  ks param set ambassador statsdSinkImage gcr.io/kubeflow-images-public/prom/statsd-exporter:v0.6.0
 fi
 
 if ks component list | awk '{print $1}' | grep -q "^katib$" ; then


### PR DESCRIPTION
This prevents that appear the following error logs in large quantities
```
socat[1581671] E getaddrinfo("statsd-sink", "NULL", {1,0,2,17}, {}): Name does not resolve
```

This error always occurs.
It is hardcoded [here](https://github.com/datawire/ambassador/blob/0.37.0/statsd/Dockerfile#L5) in ambassador and it is mismatched so it seems to fail to resolve name.

It may resolve #945 (or it maybe already resolved)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1537)
<!-- Reviewable:end -->
