### PR TITLE
Restore missing tf-hub-lb service

### DIFF
--- a/kubeflow/core/jupyterhub.libsonnet
+++ b/kubeflow/core/jupyterhub.libsonnet
@@ -386,6 +386,7 @@
       self.hubStatefulSet,
       self.hubRole,
       self.notebookRole,
+      self.hubService,
       self.hubServiceAccount,
       self.notebookServiceAccount,
       self.hubRoleBinding,


### PR DESCRIPTION
/assign @kkasravi 

Kam, looks like the tf-hub-lb got left out in #1437 maybe.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1539)
<!-- Reviewable:end -->
