### PR TITLE
The minikube test should not be running the jsonnet unittests.

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -483,11 +483,6 @@
                     dependencies: ["checkout"],
                   },
                   {
-                    name: "test-jsonnet-formatting",
-                    template: "test-jsonnet-formatting",
-                    dependencies: ["checkout"],
-                  },
-                  {
                     name: "deploy-kubeflow",
                     template: "deploy-kubeflow",
                     dependencies: ["setup-minikube"],
@@ -529,11 +524,6 @@
                     dependencies: [
                       "deploy-kubeflow",
                     ],
-                  },
-                  {
-                    name: "jsonnet-test",
-                    template: "jsonnet-test",
-                    dependencies: ["checkout"],
                   },
                 ]),  // tasks
               },  // dag
@@ -592,15 +582,6 @@
               "-m",
               "testing.wait_for_deployment",
             ]),  // wait-for-kubeflow
-            buildTemplate("test-jsonnet-formatting", [
-              "python",
-              "-m",
-              "kubeflow.testing.test_jsonnet_formatting",
-              "--project=" + project,
-              "--artifacts_dir=" + artifactsDir,
-              "--src_dir=" + srcDir,
-              "--exclude_dirs=" + srcDir + "/bootstrap/vendor/",
-            ]),  // test-jsonnet-formatting
             // Setup and teardown using minikube
             buildTemplate("setup-minikube", [
               "python",
@@ -652,14 +633,6 @@
               "copy_artifacts",
               "--bucket=" + bucket,
             ]),  // copy-artifacts
-            buildTemplate("jsonnet-test", [
-              "python",
-              "-m",
-              "testing.test_jsonnet",
-              "--artifacts_dir=" + artifactsDir,
-              "--test_files_dirs=" + srcDir + "/kubeflow",
-              "--jsonnet_path_dirs=" + srcDir,
-            ]),  // jsonnet-test
             buildTemplate("tfjob-simple-prototype-test", [
               "python",
               "-m",


### PR DESCRIPTION
* jsonnet unittests are now run by a separate E2E workflow.
* The jsonnet tests when run as part of minikube were failing because they
  were not updated as part of #1437

* Fix #1543 failing postsubmits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1545)
<!-- Reviewable:end -->
