### PR TITLE
HubSync v1.0

### DIFF
--- a/releasing/hubsync/.gitignore
+++ b/releasing/hubsync/.gitignore
@@ -1,0 +1,4 @@
+venv
+keys.yml
+cloudbuild.yml
+buildme.yml

--- a/releasing/hubsync/README.md
+++ b/releasing/hubsync/README.md
@@ -1,0 +1,14 @@
+# HubSync
+## Syncing GCR to DockerHub
+
+If you are using DockerHub, copy _keys.yaml.sample_ to _keys.yaml_ and add the DockerHub "username" and "password".
+
+In _hubsync.py_ you will want to change the __myRepo__ url to yours. If DockerHub, just your username with a "/" at the end. If GCR.io, then "gcr.io/<myrepo>/"
+
+Before executing, be sure to run this line to install Python modules (be sure to use a virtualenv).
+
+```
+pip install -r requirements.txt
+```
+
+This will install a few components such as pyyaml and jinja2.

--- a/releasing/hubsync/README.md
+++ b/releasing/hubsync/README.md
@@ -11,4 +11,4 @@ Before executing, be sure to run this line to install Python modules (be sure to
 pip install -r requirements.txt
 ```
 
-This will install a few components such as pyyaml and jinja2.
+This will install a few components such as pyyaml and jinja.

--- a/releasing/hubsync/hubsync.py
+++ b/releasing/hubsync/hubsync.py
@@ -1,0 +1,88 @@
+# Copyright 2015 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# [START app]
+
+
+import os
+import subprocess
+import logging
+import yaml
+import json
+import re
+import argparse
+
+#declaring some variables
+images = []
+timeout = '7200s'
+filename = 'cloudbuild.yaml'
+builder = 'gcr.io/cloud-builders/docker'
+kfRepo = 'gcr.io/kubeflow-images-public/'
+myRepo = 'gcr.io/<my_repo>'
+
+#Get Auth
+with open('keys.yaml', 'r') as keyfile:
+    kcfg = yaml.load(keyfile)
+
+login = kcfg['username']
+pswd= kcfg['password']
+
+#build a json file with all files.
+repos = subprocess.run(["gcloud","--project=kubeflow-images-public","container","images","list","--format=json"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+my_json = json.loads(repos.stdout.decode('utf8').strip().replace("'", '"'))
+for data in my_json:
+    for name, image in data.items():
+        #get Tags and Repos
+        raw_images = subprocess.run(["gcloud","container","images","list","--repository="+image+"","--format=json"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        imgData = raw_images.stdout.decode("utf-8")
+        if "[]" not in imgData:
+            imgJson = json.loads(raw_images.stdout.decode("utf-8").strip().replace("'", '"'))
+            for stuff in imgJson:
+                for a,b in stuff.items():
+                    images.append(b)
+            images.append(image)
+
+
+for item in images:
+    getTags = subprocess.run(["gcloud","--project=kubeflow-images-public","container","images","list-tags",item,"--format=json","--limit=1"], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    preTags = json.loads(getTags.stdout.decode('utf8').replace("'", '"'))
+    for datum in preTags:
+        t = datum['digest']
+        s = item[30:]
+        myTag = item+"@"+t
+        theyaml = {
+                'timeout': timeout,
+                'steps' : [
+                    {'name': builder, 'args':
+                        [ 'login', '-u',login,'-p',pswd],
+                    'timeout': timeout,
+                    },
+                    {'name': builder, 'args':
+                        [ 'pull', myTag ],
+                    'timeout': timeout,
+                    },
+                    {'name': builder, 'args':
+                        [ 'tag', myTag, myRepo+s ],
+                    'timeout': timeout,
+                    },
+                    {'name': builder, 'args':
+                        [ 'push', myRepo+s ],
+                    'timeout': timeout,
+                    },
+                ]
+            }
+        with open(filename, 'a') as outfile:
+            yaml.dump(theyaml, outfile, default_flow_style=False)
+
+        subprocess.run(["gcloud","builds","submit","--config",filename], stdout=subprocess.PIPE, stderr=subprocess.STDOUT)

--- a/releasing/hubsync/hubsync.py
+++ b/releasing/hubsync/hubsync.py
@@ -14,6 +14,7 @@
 
 # [START app]
 
+#import
 
 import os
 import subprocess

--- a/releasing/hubsync/hubsync.py
+++ b/releasing/hubsync/hubsync.py
@@ -14,7 +14,7 @@
 
 # [START app]
 
-#import
+#import modules
 
 import os
 import subprocess

--- a/releasing/hubsync/keys.yaml.sample
+++ b/releasing/hubsync/keys.yaml.sample
@@ -1,0 +1,2 @@
+username:
+password:

--- a/releasing/hubsync/requirements.txt
+++ b/releasing/hubsync/requirements.txt
@@ -1,0 +1,2 @@
+pyyaml
+jinja2


### PR DESCRIPTION
This will sync gcr to dockerhub per #1320 . It functions in this way

1) runs gcloud to pull down all image repos within gcr.io/kubeflow-images-public
2) runs a follow-up gcloud command to pull down image tags (latest)
3) Build cloudbuild.yaml file to authenticate with DockerHub, pull the image from gcr.io/kubeflow-images-public, tag the image, and push it to DockerHub

This is base code and is pre-coded largely just to pull from GCR to DockerHub. Users could modify the code in order to push to their own GCR or DockerHub. keys.yaml is the file where you store your credentials. 

I am hoping for a version 2.0 with a CLI. This would break it down into steps so that a user can build and sync what they want. However, for now, this will move all images from gcr.io/kubeflow-images-public to DockerHub

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1548)
<!-- Reviewable:end -->
