### PR TITLE
Fix cert-manager

### DIFF
--- a/kubeflow/core/cert-manager.libsonnet
+++ b/kubeflow/core/cert-manager.libsonnet
@@ -169,8 +169,7 @@
           privateKeySecretRef: {
             name: "letsencrypt-prod-secret",
           },
-          http01: {
-          },
+          http01: "",
         },
       },
     },


### PR DESCRIPTION
The value of http01 is not important. The point is it can't be trimmed by ks.
https://github.com/jetstack/cert-manager/blob/release-0.5/pkg/apis/certmanager/v1alpha1/types_issuer.go#L137

fix #1567 

/cc @kunmingg 
cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1568)
<!-- Reviewable:end -->
