### PR TITLE
Bump GKE version because 1.10.7-gke.1 is no longer valid master version.

### DIFF
--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -65,7 +65,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ CLUSTER_NAME }}
-      initialClusterVersion: 1.10.7-gke.1
+      initialClusterVersion: 1.10.7-gke.2
       # We need 1.10.2 to support Stackdrivier GKE.
       # loggingService: none
       # monitoringService: none


### PR DESCRIPTION
* This should fix presubmits.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1571)
<!-- Reviewable:end -->
