### PR TITLE
remove prune from kubeflow core which delete required fields

### DIFF
--- a/kubeflow/core/cert-manager.libsonnet
+++ b/kubeflow/core/cert-manager.libsonnet
@@ -169,7 +169,8 @@
           privateKeySecretRef: {
             name: "letsencrypt-prod-secret",
           },
-          http01: "",
+          http01: {
+          },
         },
       },
     },

--- a/kubeflow/core/util.libsonnet
+++ b/kubeflow/core/util.libsonnet
@@ -44,5 +44,5 @@
   }.result,
 
   // Produce a list of manifests. obj must be an array
-  list(obj):: std.prune(k.core.v1.list.new(obj,),),
+  list(obj):: k.core.v1.list.new(obj,),
 }


### PR DESCRIPTION
std.prune will delete key with empty value, which could be dangerous as we have some required keys with empty value.

related: 
https://github.com/kubeflow/kubeflow/issues/1567
https://github.com/kubeflow/kubeflow/pull/1544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1580)
<!-- Reviewable:end -->
