### PR TITLE
make builder image version consistent with glide.lock hash

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -4,6 +4,11 @@ ARG GOLANG_VERSION=1.10.3
 ARG BUILDER_IMG=gcr.io/kubeflow-images-public/bootstrapper-builder
 ARG BUILDER_IMG_VERSION=latest
 FROM ${BUILDER_IMG}:${BUILDER_IMG_VERSION} AS build_base_remote
+# Copy the src
+COPY ./ $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/
+
+RUN go build ${GOLANG_GCFLAGS} -i -o /opt/kubeflow/bootstrapper \
+    ${GOPATH}/src/github.com/kubeflow/kubeflow/bootstrap/cmd/bootstrap/main.go
 
 FROM golang:${GOLANG_VERSION} AS build
 

--- a/bootstrap/Dockerfile.Builder
+++ b/bootstrap/Dockerfile.Builder
@@ -18,10 +18,3 @@ RUN mkdir -p $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap
 COPY ./glide* $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/
 RUN cd $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/ && \
     glide install -v
-
-# Copy the src
-COPY ./ $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/
-
-RUN go build ${GOLANG_GCFLAGS} -i -o /opt/kubeflow/bootstrapper \
-    ${GOPATH}/src/github.com/kubeflow/kubeflow/bootstrap/cmd/bootstrap/main.go
-

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -19,7 +19,7 @@ GOLANG_GCFLAGS ?= ""
 IMG ?= gcr.io/$(GCLOUD_PROJECT)/bootstrapper
 
 BUILDER_IMG ?= gcr.io/$(GCLOUD_PROJECT)/bootstrapper-builder
-BUILDER_IMG_VERSION ?= latest
+BUILDER_IMG_VERSION ?= $(shell head -1 glide.lock | cut -d ' ' -f 2)
 
 TAG ?= $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
 PORT ?= 2345
@@ -51,16 +51,16 @@ build:
 
 build-builder:
 	docker build ${DOCKER_BUILD_OPTS} --build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-           --build-arg GOLANG_GCFLAGS="$(GOLANG_GCFLAGS)" -t $(BUILDER_IMG):$(TAG) \
+           --build-arg GOLANG_GCFLAGS="$(GOLANG_GCFLAGS)" -t $(BUILDER_IMG):$(BUILDER_IMG_VERSION) \
            --label=git-verions=$(GIT_VERSION) -f Dockerfile.Builder .
-	@echo Built $(BUILDER_IMG):$(TAG)
+	@echo Built $(BUILDER_IMG):$(BUILDER_IMG_VERSION)
 
 push-builder: build-builder
-	gcloud docker -- push $(BUILDER_IMG):$(TAG)
-	@echo Pushed $(BUILDER_IMG):$(TAG)
+	gcloud docker -- push $(BUILDER_IMG):$(BUILDER_IMG_VERSION)
+	@echo Pushed $(BUILDER_IMG):$(BUILDER_IMG_VERSION)
 
 push-builder-latest: push-builder
-	gcloud container images add-tag --quiet $(BUILDER_IMG):$(TAG) $(BUILDER_IMG):latest --verbosity=info
+	gcloud container images add-tag --quiet $(BUILDER_IMG):$(BUILDER_IMG_VERSION) $(BUILDER_IMG):latest --verbosity=info
 	@echo created $(BUILDER_IMG):latest
 
 # Build but don't attach the latest tag. This allows manual testing/inspection of the image


### PR DESCRIPTION
To simplify test and local dev.

Old method:
go pkg was compiled in builder image:
1. every line of change requires build two images: builder and final image. 
2. resulting in need of edit builder image version in Makefile every time before run ```make build``` 
3. resulting in frequent version change of builder image.

New method:
builder image is cache of glide & vendor dir, ```glide.lock``` file 100% determines the content of builder image. So use hash code of ```glide.lock``` as builder image version. And resolve 1,2,3 of old method

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1621)
<!-- Reviewable:end -->
