### PR TITLE
Add postsubmits to push centralui and Jupyter notebook images to kubeflow-images-public

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -63,9 +63,6 @@ workflows:
     job_types:
       # TODO(jlewi): Reenable on presubmit once its passing.
       #- presubmit
-      # TODO(jlewi): We should probably create a separate postsubmit job that pushes
-      # to kubeflow-images-public.
-      - postsubmit
     params:
       cluster: "kubeflow-testing"
       gcpCredentialsSecretName: "gcp-credentials"
@@ -77,14 +74,25 @@ workflows:
     include_dirs:
       - components/centraldashboard/*
       - releasing/releaser/components/centraldashboard.jsonnet
+  # The postsubmit run publishes the docker images to gcr.io/kubeflow-images-public
+  - app_dir: kubeflow/kubeflow/releasing/releaser
+    component: centraldashboard
+    name: dashboard-release
+    job_types:
+      - postsubmit
+    params:
+      cluster: "kubeflow-testing"
+      gcpCredentialsSecretName: "gcp-credentials"
+      namespace: "kubeflow-test-infra"
+      nfsVolumeClaim: "nfs-external"
+      project: "kubeflow-releasing"
+      registry: "gcr.io/kubeflow-images-public"
+      testing_image: "gcr.io/kubeflow-ci/test-worker:latest"
   - app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
     component: workflows
     name: tf-notebook-release
     job_types:
       - presubmit
-      # TODO(jlewi): We should probably create a separate postsubmit job that pushes
-      # to kubeflow-images-public.
-      - postsubmit
     params:
       cluster: "kubeflow-testing"
       gcpCredentialsSecretName: "gcp-credentials"
@@ -95,3 +103,17 @@ workflows:
       testing_image: "gcr.io/kubeflow-ci/test-worker:latest"
     include_dirs:
       - components/tensorflow-notebook-image/*
+  # The postsubmit run publishes the docker images to gcr.io/kubeflow-images-public
+  - app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
+    component: workflows
+    name: tf-notebook-release
+    job_types:
+      - postsubmit
+    params:
+      cluster: "kubeflow-testing"
+      gcpCredentialsSecretName: "gcp-credentials"
+      namespace: "kubeflow-test-infra"
+      nfsVolumeClaim: "nfs-external"
+      project: "kubeflow-releasing"
+      registry: "gcr.io/kubeflow-images-public"
+      testing_image: "gcr.io/kubeflow-ci/test-worker:latest"

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -64,13 +64,7 @@ workflows:
       # TODO(jlewi): Reenable on presubmit once its passing.
       #- presubmit
     params:
-      cluster: "kubeflow-testing"
-      gcpCredentialsSecretName: "gcp-credentials"
-      namespace: "kubeflow-test-infra"
-      nfsVolumeClaim: "nfs-external"
-      project: "kubeflow-releasing"
       registry: "gcr.io/kubeflow-ci"
-      testing_image: "gcr.io/kubeflow-ci/test-worker:latest"
     include_dirs:
       - components/centraldashboard/*
       - releasing/releaser/components/centraldashboard.jsonnet
@@ -81,26 +75,14 @@ workflows:
     job_types:
       - postsubmit
     params:
-      cluster: "kubeflow-testing"
-      gcpCredentialsSecretName: "gcp-credentials"
-      namespace: "kubeflow-test-infra"
-      nfsVolumeClaim: "nfs-external"
-      project: "kubeflow-releasing"
       registry: "gcr.io/kubeflow-images-public"
-      testing_image: "gcr.io/kubeflow-ci/test-worker:latest"
   - app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
     component: workflows
     name: tf-notebook-release
     job_types:
       - presubmit
     params:
-      cluster: "kubeflow-testing"
-      gcpCredentialsSecretName: "gcp-credentials"
-      namespace: "kubeflow-test-infra"
-      nfsVolumeClaim: "nfs-external"
-      project: "kubeflow-releasing"
       registry: "gcr.io/kubeflow-ci"
-      testing_image: "gcr.io/kubeflow-ci/test-worker:latest"
     include_dirs:
       - components/tensorflow-notebook-image/*
   # The postsubmit run publishes the docker images to gcr.io/kubeflow-images-public
@@ -110,10 +92,4 @@ workflows:
     job_types:
       - postsubmit
     params:
-      cluster: "kubeflow-testing"
-      gcpCredentialsSecretName: "gcp-credentials"
-      namespace: "kubeflow-test-infra"
-      nfsVolumeClaim: "nfs-external"
-      project: "kubeflow-releasing"
       registry: "gcr.io/kubeflow-images-public"
-      testing_image: "gcr.io/kubeflow-ci/test-worker:latest"


### PR DESCRIPTION
This change adds post-submit jobs that push CentralDashboard and Jupyter notebook images to gcr.io/kubeflow-images-public.

Related to #1601 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1624)
<!-- Reviewable:end -->
