### PR TITLE
Allow folks to have the kubeflow github repo over https + improve error message

### DIFF
--- a/scripts/autoformat_jsonnet.sh
+++ b/scripts/autoformat_jsonnet.sh
@@ -35,6 +35,7 @@ raw=`git remote`
 readarray -t remotes <<< "$raw"
 
 repo_name=''
+non_matching=''
 for r in "${remotes[@]}"
 do
    url=`git remote get-url ${r}`
@@ -42,13 +43,13 @@ do
    if [[ ${url} =~ (git@github[.]com:kubeflow/.*|https://github[.]com/kubeflow/.*) ]]; then
        repo_name=${r}
    else
-       echo "${r} at ${url} did not match"
+       non_matching="${non_matching}${r} at ${url} did not match"
    fi
 done
 
 echo using ${repo_name}
 if [ -z "$repo_name" ]; then
-    echo "Could not find remote repository pointing at git@github.com:kubeflow/.*.git"
+    echo "Could not find remote repository pointing at git@github.com:kubeflow/.*.git in ${non_matching}"
     exit 1
 fi
 

--- a/scripts/autoformat_jsonnet.sh
+++ b/scripts/autoformat_jsonnet.sh
@@ -39,14 +39,16 @@ for r in "${remotes[@]}"
 do
    url=`git remote get-url ${r}`
    # Period is in brackets because its a special character.
-   if [[ ${url} =~ git@github[.]com:kubeflow/.* ]]; then
-      repo_name=${r}
+   if [[ ${url} =~ (git@github[.]com:kubeflow/.*|https://github[.]com/kubeflow/.*) ]]; then
+       repo_name=${r}
+   else
+       echo "${r} at ${url} did not match"
    fi
 done
 
 echo using ${repo_name}
 if [ -z "$repo_name" ]; then
-    echo "Could not find remote repository pointing at git@github.com:kubeflow/testing.git"
+    echo "Could not find remote repository pointing at git@github.com:kubeflow/.*.git"
     exit 1
 fi
 


### PR DESCRIPTION
Allow folks to have the kubeflow github repo over https + improve error message -- we don't actually need testing.git for the remote

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1626)
<!-- Reviewable:end -->
