### PR TITLE
add chainer-operator to kfctl.sh (just generating ks component)

### DIFF
--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -54,11 +54,14 @@ function createKsApp() {
   ks pkg install kubeflow/katib
   ks pkg install kubeflow/mpi-job
   ks pkg install kubeflow/pytorch-job
+  ks pkg install kubeflow/chainer-job
   ks pkg install kubeflow/seldon
   ks pkg install kubeflow/tf-serving
 
   # Generate all required components
   ks generate pytorch-operator pytorch-operator
+  ks generate chainer-operator chainer-operator
+  
   # TODO(jlewi): Why are we overloading the ambassador images here?
   ks generate ambassador ambassador
   ks generate jupyterhub jupyterhub


### PR DESCRIPTION
currently `kfctl.sh` doesn't generate chainer-operator in `ks_app` dir.  I added chainer-operator component in `ks_app` dir.  It just creat component (doesn't deploy actually). 

I opened another issue in website repo (kubeflow/website#237) to add chainer-operator installation guide.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1642)
<!-- Reviewable:end -->
