### PR TITLE
Cherrypick #1650; automatically set master version to supported version.

### DIFF
--- a/scripts/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/scripts/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -29,6 +29,8 @@ resources:
   properties:
     # You need to use a zone with Haswell because that's what TFServing requires.
     zone: SET_THE_ZONE
+    # We need to set the initialCluserVersion to prevent auto upgrading
+    cluster-version: SET_CLUSTER_VERSION
     # Set this to v1beta1 to use beta features such as private clusters,
     gkeApiVersion: v1
     # An arbitrary string appending to name of nodepools

--- a/scripts/gke/deployment_manager_configs/cluster.jinja
+++ b/scripts/gke/deployment_manager_configs/cluster.jinja
@@ -22,10 +22,10 @@ limitations under the License.
    There is type corresponding to each API endpoint.
 #}
 
-{% set VM_OAUTH_SCOPES = ['https://www.googleapis.com/auth/logging.write', 
+{% set VM_OAUTH_SCOPES = ['https://www.googleapis.com/auth/logging.write',
                           'https://www.googleapis.com/auth/monitoring',
                           'https://www.googleapis.com/auth/devstorage.read_only'] %}
-                          
+
 {# Names for service accounts.
    -admin is to be used for admin tasks
    -user is to be used by users for actual jobs.
@@ -65,7 +65,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ CLUSTER_NAME }}
-      initialClusterVersion: 1.10.7-gke.2
+      initialClusterVersion: {{ properties['cluster-version'] }}
       # We need 1.10.2 to support Stackdrivier GKE.
       # loggingService: none
       # monitoringService: none

--- a/scripts/gke/util.sh
+++ b/scripts/gke/util.sh
@@ -59,6 +59,7 @@ generateDMConfigs() {
 
     # Set values in DM config file
     sed -i.bak "s/zone: SET_THE_ZONE/zone: ${ZONE}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+    sed -i.bak "s/cluster-version: SET_CLUSTER_VERSION/cluster-version: ${CLUSTER_VERSION}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
     sed -i.bak "s/users:/users: [\"${IAP_IAM_ENTRY}\"]/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
     sed -i.bak "s/ipName: kubeflow-ip/ipName: ${KUBEFLOW_IP_NAME}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
     rm "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}.bak"

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -15,6 +15,9 @@ WHAT=$2
 
 ENV_FILE="env.sh"
 
+SKIP_INIT_PROJECT=false
+MIN_CLUSTER_VERSION="1.10.7-gke.2"
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "${DIR}/util.sh"
 source "${DIR}/gke/util.sh"
@@ -90,6 +93,19 @@ createEnv() {
       fi
 
       echo PROJECT_NUMBER=${PROJECT_NUMBER} >> ${ENV_FILE}
+
+      # Settig cluster version, while ensuring we still stick with kubernetes 'v1.10.x'
+      CLUSTER_VERSION=$(\
+          gcloud --project=${PROJECT} container get-server-config --zone=${ZONE} | \
+          awk '/validNodeVersions/{f=0} f; /validMasterVersions/{f=1}' | \
+          awk '{print $2}' | \
+          grep '^1.10.[0-9]*[-d]gke.[0-9]*$' | \
+          head -1)
+      if [[ ${CLUSTER_VERSION} == "" ]]; then
+          echo "Setting cluster version to ${MIN_CLUSTER_VERSION}"
+          CLUSTER_VERSION=${MIN_CLUSTER_VERSION}
+      fi
+      echo CLUSTER_VERSION=${CLUSTER_VERSION} >> ${ENV_FILE}
       ;;
     *)
       echo KUBEFLOW_CLOUD=null >> ${ENV_FILE}


### PR DESCRIPTION
Update initial clsuter version in cluster.jinja based on what gcloud get-server-config returns (#1650)

* Update initial clsuter version in cluster.jinja based on what gcloud get-server-config returns

* Fix cluster-version string for cluster.jinja

* update the grep for more strict version checking and enhance the code style

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1654)
<!-- Reviewable:end -->
