### PR TITLE
Scope postsubmit jobs by modified directories

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -78,6 +78,9 @@ workflows:
       - postsubmit
     params:
       registry: "gcr.io/kubeflow-images-public"
+    include_dirs:
+      - components/centraldashboard/*
+      - releasing/releaser/components/centraldashboard.jsonnet
   - app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
     component: workflows
     name: tf-notebook-release
@@ -95,3 +98,5 @@ workflows:
       - postsubmit
     params:
       registry: "gcr.io/kubeflow-images-public"
+    include_dirs:
+      - components/tensorflow-notebook-image/*


### PR DESCRIPTION
Only run the image release postsubmit jobs if relevant directories are modified. 

Requires https://github.com/kubeflow/testing/pull/223 to work properly.