### PR TITLE
gke/deploy.sh: test uuidgen exists before using it

### DIFF
--- a/scripts/gke/deploy.sh
+++ b/scripts/gke/deploy.sh
@@ -167,7 +167,7 @@ ks generate iap-ingress iap-ingress --ipName=${KUBEFLOW_IP_NAME} --hostname=${KU
 # Enable collection of anonymous usage metrics
 # Skip this step if you don't want to enable collection.
 ks param set kubeflow-core reportUsage true
-ks param set kubeflow-core usageId $(uuidgen)
+[ $(which uuidgen) ] && ks param set kubeflow-core usageId $(uuidgen)
 
 # Apply the components generated
 if ${KUBEFLOW_DEPLOY}; then


### PR DESCRIPTION
line 170: uuidgen is used for generating a unique identifyer for optional usage metrics collection.
But uuidgen isn't available in Cloud Shell, and deploy.sh exists with an error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1674)
<!-- Reviewable:end -->
