### PR TITLE
cherrypick - Remove trailing slash from KUBEFLOW_REPO (#1664)

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -30,6 +30,8 @@ createEnv() {
   # a file for consistency across runs.
   echo PLATFORM=${PLATFORM} >> ${ENV_FILE}
   DEFAULT_KUBEFLOW_REPO="$( cd "${DIR}/.." >/dev/null && pwd )"
+  # Remove trailing slash from the repo.
+  KUBEFLOW_REPO=${KUBEFLOW_REPO%/}
   echo KUBEFLOW_REPO=${KUBEFLOW_REPO:-"${DEFAULT_KUBEFLOW_REPO}"} >> ${ENV_FILE}
   echo KUBEFLOW_VERSION=${KUBEFLOW_VERSION:-"master"} >> ${ENV_FILE}
   echo KUBEFLOW_KS_DIR=${KUBEFLOW_KS_DIR:-"$(pwd)/ks_app"} >> ${ENV_FILE}


### PR DESCRIPTION
* Remove trailing slash from KUBEFLOW_REPO

* Parts of the script assume there is no trailing slash. So if we don't
  normalize things we have problems.

Related to #1663

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1677)
<!-- Reviewable:end -->
