### PR TITLE
Build TF notebook images for TF 1.9.0 and 1.10.1

### DIFF
--- a/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
@@ -309,6 +309,26 @@
                     dependencies: ["checkout"],
                   },
                   {
+                    name: "build-1-9-0-gpu",
+                    template: "build-1-9-0-gpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "build-1-9-0-cpu",
+                    template: "build-1-9-0-cpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "build-1-10-1-gpu",
+                    template: "build-1-10-1-gpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
+                    name: "build-1-10-1-cpu",
+                    template: "build-1-10-1-cpu",
+                    dependencies: ["checkout"],
+                  },
+                  {
                     name: "create-pr-symlink",
                     template: "create-pr-symlink",
                     dependencies: ["checkout"],
@@ -326,6 +346,10 @@
             buildImageTemplate("1.7.0", "1-7-0", "gpu"),
             buildImageTemplate("1.8.0", "1-8-0", "cpu"),
             buildImageTemplate("1.8.0", "1-8-0", "gpu"),
+            buildImageTemplate("1.9.0", "1-9-0", "cpu"),
+            buildImageTemplate("1.9.0", "1-9-0", "gpu"),
+            buildImageTemplate("1.10.1", "1-10-1", "cpu"),
+            buildImageTemplate("1.10.1", "1-10-1", "gpu"),
             {
               name: "exit-handler",
               steps: [

--- a/kubeflow/core/kubeform_spawner.py
+++ b/kubeflow/core/kubeform_spawner.py
@@ -18,7 +18,7 @@ class KubeFormSpawner(KubeSpawner):
     <table style="width: 100%;">
     <tr>
         <td style="width: 30%;"><label for='image'>Image</label></td>
-        <td style="width: 70%;"><input value="{0}/{1}/tensorflow-1.8.0-notebook-cpu:v0.3.0" list="image" name="image" placeholder='repo/image:tag' style="width: 100%;">
+        <td style="width: 70%;"><input value="" list="image" name="image" placeholder='repo/image:tag' style="width: 100%;">
         <datalist id="image">
           <option value="{0}/{1}/tensorflow-1.4.1-notebook-cpu:v0.3.0">
           <option value="{0}/{1}/tensorflow-1.4.1-notebook-gpu:v0.3.0">
@@ -30,6 +30,10 @@ class KubeFormSpawner(KubeSpawner):
           <option value="{0}/{1}/tensorflow-1.7.0-notebook-gpu:v0.3.0">
           <option value="{0}/{1}/tensorflow-1.8.0-notebook-cpu:v0.3.0">
           <option value="{0}/{1}/tensorflow-1.8.0-notebook-gpu:v0.3.0">
+          <option value="{0}/{1}/tensorflow-1.9.0-notebook-cpu:v0.3.0">
+          <option value="{0}/{1}/tensorflow-1.9.0-notebook-gpu:v0.3.0">
+          <option value="{0}/{1}/tensorflow-1.10.1-notebook-cpu:v0.3.0">
+          <option value="{0}/{1}/tensorflow-1.10.1-notebook-gpu:v0.3.0">
         </datalist>
         </td>
     </tr>


### PR DESCRIPTION
- Build TF 1.9.0 and 1.10.1 notebook images on postsubmit
- Adds those images to kubeform spawner
- Fixes the HTML error where only default image is displayed in the dropdown

Fixes #1671 #1672

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1686)
<!-- Reviewable:end -->
