### PR TITLE
TF serving template cleanup

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-gcp.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-gcp.jsonnet
@@ -13,6 +13,7 @@
 // @optionalParam defaultGpuImage string tensorflow/serving:1.10.0-gpu The default model server image (gpu)
 // @optionalParam httpProxyImage string gcr.io/kubeflow-images-public/tf-model-server-http-proxy:v20180723 Http proxy image
 // @optionalParam gcpCredentialSecretName string null If not empty, insert the secret credential
+// @optionalParam injectIstio string false Whether to inject istio sidecar; should be true or false.
 
 local k = import "k.libsonnet";
 local deployment = k.apps.v1beta1.deployment;

--- a/kubeflow/tf-serving/tf-serving-template.libsonnet
+++ b/kubeflow/tf-serving/tf-serving-template.libsonnet
@@ -33,22 +33,6 @@
               "---",
               "apiVersion: ambassador/v0",
               "kind:  Mapping",
-              "name: tfserving-mapping-" + name + "-get",
-              "prefix: /models/" + name + "/",
-              "rewrite: /",
-              "method: GET",
-              "service: " + name + "." + namespace + ":8000",
-              "---",
-              "apiVersion: ambassador/v0",
-              "kind:  Mapping",
-              "name: tfserving-mapping-" + name + "-post",
-              "prefix: /models/" + name + "/",
-              "rewrite: /model/" + name + ":predict",
-              "method: POST",
-              "service: " + name + "." + namespace + ":8000",
-              "---",
-              "apiVersion: ambassador/v0",
-              "kind:  Mapping",
               "name: tfserving-predict-mapping-" + name,
               "prefix: tfserving/models/" + name + "/",
               "rewrite: /v1/models/" + name + ":predict",
@@ -65,12 +49,7 @@
             targetPort: 9000,
           },
           {
-            name: "http-tf-serving-proxy",
-            port: 8000,
-            targetPort: 8000,
-          },
-          {
-            name: "tf-serving-builtin-http",
+            name: "http-tf-serving",
             port: 8500,
             targetPort: 8500,
           },
@@ -128,39 +107,6 @@
       },
     },  // modelServerContainer
 
-    local httpProxyContainer = {
-      name: name + "-http-proxy",
-      image: params.httpProxyImage,
-      imagePullPolicy: "IfNotPresent",
-      command: [
-        "python",
-        "/usr/src/app/server.py",
-        "--port=8000",
-        "--rpc_port=9000",
-        "--rpc_timeout=10.0",
-      ],
-      env: [],
-      ports: [
-        {
-          containerPort: 8000,
-        },
-      ],
-      resources: {
-        requests: {
-          memory: "500Mi",
-          cpu: "0.5",
-        },
-        limits: {
-          memory: "1Gi",
-          cpu: "1",
-        },
-      },
-      securityContext: {
-        runAsUser: 1000,
-        fsGroup: 1000,
-      },
-    },  // httpProxyContainer
-
     local tfDeployment = {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
@@ -170,6 +116,9 @@
         },
         name: name,
         namespace: namespace,
+        annotations: {
+          "sidecar.istio.io/inject": params.injectIstio,
+        }
       },
       spec: {
         template: {
@@ -181,9 +130,7 @@
           spec: {
             containers: [
               modelServerContainer,
-            ] + if util.toBool(params.deployHttpProxy) then [
-              httpProxyContainer,
-            ] else [],
+            ],
             volumes: [],
           },
         },

--- a/kubeflow/tf-serving/tf-serving-template.libsonnet
+++ b/kubeflow/tf-serving/tf-serving-template.libsonnet
@@ -118,7 +118,7 @@
         namespace: namespace,
         annotations: {
           "sidecar.istio.io/inject": params.injectIstio,
-        }
+        },
       },
       spec: {
         template: {

--- a/testing/test_tf_serving.py
+++ b/testing/test_tf_serving.py
@@ -108,7 +108,6 @@ def main():
     service_ip = service.spec.cluster_ip
     model_urls = [
       "http://" + service_ip + ":8500/v1/models/mnist:predict",  # tf serving's http server
-      "http://" + service_ip + ":8000/model/mnist:predict"  # http proxy
     ]
     for model_url in model_urls:
       logging.info("Try predicting with endpoint {}".format(model_url))


### PR DESCRIPTION
1. remove http proxy as we have http from TF serving. We should be able use istio for request logging [1], so http proxy is not needed anymore.
2. Add istio annotation. Will update documentation for this later (in website repo). Related: #1309 

[1]: https://istio.io/docs/tasks/telemetry/fluentd/#configure-istio

/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1714)
<!-- Reviewable:end -->
