### PR TITLE
Fix the TFJobs Dashboard UI

### DIFF
--- a/kubeflow/core/tests/tf-job_test.jsonnet
+++ b/kubeflow/core/tests/tf-job_test.jsonnet
@@ -520,4 +520,32 @@ std.assertEqual(
       },
     ],
   }
-)
+) 
+
+&&
+
+std.assertEqual(
+  tfjobv1alpha1.tfUiRoleBinding,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRoleBinding",
+    metadata: {
+      labels: {
+        app: "tf-job-dasbhoard",
+      },
+      name: "tf-job-dashboard",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "tf-job-dashboard",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: "tf-job-dashboard",
+        namespace: "test-kf-001",
+      },
+    ],
+  }
+) 

--- a/kubeflow/core/tf-job-operator.libsonnet
+++ b/kubeflow/core/tf-job-operator.libsonnet
@@ -486,9 +486,9 @@
       },
       subjects: [
         {
-          kind: tfServiceAccount.kind,
-          name: tfServiceAccount.metadata.name,
-          namespace: tfServiceAccount.metadata.namespace,
+          kind: tfUiServiceAccount.kind,
+          name: tfUiServiceAccount.metadata.name,
+          namespace: tfUiServiceAccount.metadata.namespace,
         },
       ],
     },


### PR DESCRIPTION
* The UI isn't able to list jobs in all namespaces because the
  cluster role binding isn't using the correct role

Related to kubeflow/tf-operator#836