### PR TITLE
fix tensorflow-notebook's prompt_toolkit bug (#1721)

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -97,7 +97,6 @@ RUN pip install --upgrade pip && \
     # Tensorflow
     ${TF_PACKAGE} \
     # Jupyter Stuff
-    jupyter \
     jupyterhub \
     jupyterlab \
     # Cleanup


### PR DESCRIPTION
Since the `jupyter` package is quite out-of-date. It will install `prompt-toolkit-1.5.x` for some reason(the python3). The python2 will also use `prompt-toolkit-1.5.x`, which is works well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1726)
<!-- Reviewable:end -->
