### PR TITLE
Change the default branch in download.sh to v0.3-branch as opposed to master

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -10,7 +10,7 @@ if [ ! -z "${KUBEFLOW_VERSION}" ]; then
 	KUBEFLOW_TAG=v${KUBEFLOW_VERSION}
 fi
 
-KUBEFLOW_TAG=${KUBEFLOW_TAG:-master}
+KUBEFLOW_TAG=${KUBEFLOW_TAG:-v0.3-branch}
 
 if [ -d "${KUBEFLOW_REPO}" ]; then
   echo Directory ${KUBEFLOW_REPO} already exists


### PR DESCRIPTION

* This should prevent people from running the v0.3 version of download.sh
  and then downloading the code on master.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1734)
<!-- Reviewable:end -->
