### PR TITLE
[openmpi] support `volumes` and `volumeMounts`

### DIFF
--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -28,6 +28,8 @@
 // @optionalParam runAsUser string null uid of the first process of containers in master/worker pods. If not set, this will be default value of your cluster configuration.
 // @optionalParam runAsGroup string null Primary gid of the first process of containers in master/worker pods. If not set, this will be default value of your cluster configuration.
 // @optionalParam supplementalGroups string null Comma-delimited list of supplemental group ids to put the user of the first process of containers in master/worker pods.
+// @optionalParam volumes array [] 'volumes' to put master/workers pods.
+// @optionalParam volumeMounts array [] 'volumes' to put job containers in master/workers pods.
 
 local k = import "k.libsonnet";
 local openmpi = import "kubeflow/openmpi/all.libsonnet";

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -94,7 +94,7 @@ local ROLE_WORKER = "worker";
         defaultMode: 420,  // 0644
       },
     },
-  ],
+  ] + params.volumes,
 
   containers(params, role, podName):: {
     local job = {
@@ -132,7 +132,7 @@ local ROLE_WORKER = "worker";
           name: "openmpi-secrets",
           mountPath: "/kubeflow/openmpi/secrets",
         },
-      ],
+      ] + params.volumeMounts,
     },
     local controller = {
       name: "openmpi-controller",
@@ -148,7 +148,7 @@ local ROLE_WORKER = "worker";
           name: "openmpi-data",
           mountPath: "/kubeflow/openmpi/data",
         },
-      ],
+      ] + params.volumeMounts,
     },
 
     result:: if role == ROLE_MASTER then [job] else [job, controller],


### PR DESCRIPTION
fixes #838 

now kubeflow support ks `0.11.0`, so no blocking issues to merge this feature.

This supports `volume` and `volumeMounts` parameter on `openmpi` package.

This enables users to mount arbitrary volumes to master and worker pods like below:

```shell
ks param set ${COMPONENT} volumes '[{ "name": "vol", "hostPath": { "path": "/mnt/vol" }}]'
ks param set ${COMPONENT} volumeMounts '[{ "name": "vol", "mountPath": "/mnt/vol"}]'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1750)
<!-- Reviewable:end -->
