### PR TITLE
remove statsd from ambassador deployment

### DIFF
--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -33,37 +33,6 @@
     },  // service
     ambassadorService:: ambassadorService,
 
-    local metricsService = {
-      apiVersion: "v1",
-      kind: "Service",
-      metadata: {
-        labels: {
-          service: "ambassador",
-        },
-        name: "statsd-sink",
-        namespace: params.namespace,
-        annotations: {
-          "prometheus.io/scrape": "true",
-          "prometheus.io/port": "9102",
-        },
-      },
-      spec: {
-        ports: [
-          {
-            name: "statsd-sink",
-            port: 9102,
-            targetPort: 9102,
-            protocol: "TCP",
-          },
-        ],
-        selector: {
-          service: "ambassador",
-        },
-        type: "ClusterIP",
-      },
-    },  // metricsService
-    metricsService:: metricsService,
-
     local adminService = {
       apiVersion: "v1",
       kind: "Service",
@@ -239,14 +208,6 @@
                   },
                 },
               },
-              {
-                image: params.statsdImage,
-                name: "statsd",
-              },
-              {
-                image: params.statsdSinkImage,
-                name: "statsd-sink",
-              },
             ],
             restartPolicy: "Always",
             serviceAccountName: "ambassador",
@@ -307,7 +268,6 @@
 
     all:: [
       self.ambassadorService,
-      self.metricsService,
       self.adminService,
       self.ambassadorRole,
       self.ambassadorServiceAccount,

--- a/kubeflow/core/prototypes/ambassador.jsonnet
+++ b/kubeflow/core/prototypes/ambassador.jsonnet
@@ -6,8 +6,6 @@
 // @optionalParam cloud string null Cloud
 // @optionalParam ambassadorServiceType string ClusterIP The service type for the API Gateway.
 // @optionalParam ambassadorImage string quay.io/datawire/ambassador:0.37.0 The image for the API Gateway.
-// @optionalParam statsdImage string quay.io/datawire/statsd:0.37.0 The image for the Stats and Monitoring.
-// @optionalParam statsdSinkImage string prom/statsd-exporter:v0.6.0 The image for the Statsd exporter.
 
 local ambassador = import "kubeflow/core/ambassador.libsonnet";
 local instance = ambassador.new(env, params);

--- a/scripts/gke/use_gcr_for_all_images.sh
+++ b/scripts/gke/use_gcr_for_all_images.sh
@@ -31,8 +31,6 @@ fi
 
 if ks component list | awk '{print $1}' | grep -q "^ambassador$" ; then
   ks param set ambassador ambassadorImage gcr.io/kubeflow-images-public/quay.io/datawire/ambassador:0.37.0
-  ks param set ambassador statsdImage gcr.io/kubeflow-images-public/quay.io/datawire/statsd:0.37.0
-  ks param set ambassador statsdSinkImage gcr.io/kubeflow-images-public/prom/statsd-exporter:v0.6.0
 fi
 
 if ks component list | awk '{print $1}' | grep -q "^katib$" ; then


### PR DESCRIPTION
Fixes https://github.com/kubeflow/kubeflow/issues/1651

The next step should be upgrading the ambasssador deployment to 0.40.0, where statsd is disabled by default.

I'm not sure if theres a set of e2e tests I should be running to verify behavior, but I went through and ran the kfctl.sh deploy scripts manually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1760)
<!-- Reviewable:end -->
