### PR TITLE
pin to minor GKE version in dm config

### DIFF
--- a/bootstrap/cmd/bootstrap/app/gcpUtils.go
+++ b/bootstrap/cmd/bootstrap/app/gcpUtils.go
@@ -4,15 +4,16 @@ import (
 	"fmt"
 	"time"
 
+	"io/ioutil"
+	"path"
+	"strings"
+
 	"github.com/ghodss/yaml"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/deploymentmanager/v2"
-	"io/ioutil"
-	"path"
-	"strings"
 )
 
 type Resource struct {
@@ -56,8 +57,9 @@ func (s *ksServer) InsertDeployment(ctx context.Context, req CreateRequest) erro
 		dmconf.Resources[0].Properties["clientSecret"] = req.ClientSecret
 		dmconf.Resources[0].Properties["ipName"] = req.IpName
 		dmconf.Resources[0].Properties["isWebapp"] = true
-		// TODO: use get-server-config
-		dmconf.Resources[0].Properties["cluster-version"] = "1.10.6-gke.2"
+		// "1.X": picks the highest valid patch+gke.N patch in the 1.X version
+		// https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
+		dmconf.Resources[0].Properties["cluster-version"] = "1.10"
 	}
 	confByte, err := yaml.Marshal(dmconf)
 	if err != nil {

--- a/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -30,7 +30,7 @@ resources:
     # You need to use a zone with Haswell because that's what TFServing requires.
     zone: SET_THE_ZONE
     # We need to set the initialCluserVersion to prevent auto upgrading
-    cluster-version: "SET_CLUSTER_VERSION"
+    cluster-version: SET_CLUSTER_VERSION
     # Set this to v1beta1 to use beta features such as private clusters,
     gkeApiVersion: v1
     # An arbitrary string appending to name of nodepools

--- a/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -30,7 +30,7 @@ resources:
     # You need to use a zone with Haswell because that's what TFServing requires.
     zone: SET_THE_ZONE
     # We need to set the initialCluserVersion to prevent auto upgrading
-    cluster-version: SET_CLUSTER_VERSION
+    cluster-version: "SET_CLUSTER_VERSION"
     # Set this to v1beta1 to use beta features such as private clusters,
     gkeApiVersion: v1
     # An arbitrary string appending to name of nodepools

--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -72,7 +72,7 @@ resources:
     zone: {{ properties['zone'] }}
     cluster:
       name: {{ CLUSTER_NAME }}
-      initialClusterVersion: {{ properties['cluster-version'] }}
+      initialClusterVersion: "{{ properties['cluster-version'] }}"
       {% if properties['gkeApiVersion'] == 'v1beta1' %}
       # We need 1.10.2 to support Stackdrivier GKE.
       loggingService: logging.googleapis.com/kubernetes

--- a/scripts/gke/util.sh
+++ b/scripts/gke/util.sh
@@ -59,7 +59,7 @@ generateDMConfigs() {
 
     # Set values in DM config file
     sed -i.bak "s/zone: SET_THE_ZONE/zone: ${ZONE}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
-    sed -i.bak "s/cluster-version: SET_CLUSTER_VERSION/cluster-version: ${CLUSTER_VERSION}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
+    sed -i.bak "s/cluster-version: SET_CLUSTER_VERSION/cluster-version: \"${CLUSTER_VERSION}\"/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
     sed -i.bak "s/users:/users: [\"${IAP_IAM_ENTRY}\"]/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
     sed -i.bak "s/ipName: kubeflow-ip/ipName: ${KUBEFLOW_IP_NAME}/" "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}"
     rm "${KUBEFLOW_DM_DIR}/${CONFIG_FILE}.bak"

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -15,7 +15,7 @@ WHAT=$2
 
 ENV_FILE="env.sh"
 SKIP_INIT_PROJECT=false
-MIN_CLUSTER_VERSION="1.10"
+CLUSTER_VERSION="1.10"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "${DIR}/util.sh"
@@ -98,8 +98,7 @@ createEnv() {
 
       # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
       # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
-      echo "Setting cluster version to ${MIN_CLUSTER_VERSION}"
-      CLUSTER_VERSION=${MIN_CLUSTER_VERSION}
+      echo "Setting cluster version to ${CLUSTER_VERSION}"
       echo CLUSTER_VERSION=${CLUSTER_VERSION} >> ${ENV_FILE}
       ;;
     *)

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -15,7 +15,7 @@ WHAT=$2
 
 ENV_FILE="env.sh"
 SKIP_INIT_PROJECT=false
-MIN_CLUSTER_VERSION="1.10.6-gke.2"
+MIN_CLUSTER_VERSION="1.10"
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 source "${DIR}/util.sh"
@@ -96,18 +96,10 @@ createEnv() {
 
       echo PROJECT_NUMBER=${PROJECT_NUMBER} >> ${ENV_FILE}
 
-      # Settig cluster version, while ensuring we still stick with kubernetes 'v1.10.x'
-      SERVER_CONFIG=$(gcloud --project=${PROJECT} container get-server-config --zone=${ZONE})
-      CLUSTER_VERSION=$(\
-          echo "${SERVER_CONFIG}" | \
-          awk '/validNodeVersions/{f=0} f; /validMasterVersions/{f=1}' | \
-          awk '{print $2}' | \
-          grep '^1.10.[0-9]*[-d]gke.[0-9]*$' | \
-          head -1)
-      if [[ ${CLUSTER_VERSION} == "" ]]; then
-          echo "Setting cluster version to ${MIN_CLUSTER_VERSION}"
-          CLUSTER_VERSION=${MIN_CLUSTER_VERSION}
-      fi
+      # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
+      # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
+      echo "Setting cluster version to ${MIN_CLUSTER_VERSION}"
+      CLUSTER_VERSION=${MIN_CLUSTER_VERSION}
       echo CLUSTER_VERSION=${CLUSTER_VERSION} >> ${ENV_FILE}
       ;;
     *)


### PR DESCRIPTION
This pins the bootstrapper to use the highest patch and build version of a minor release of Kubernetes.

From the deployment manager config:
```
"latest": picks the highest valid Kubernetes version
"1.X": picks the highest valid patch+gke.N patch in the 1.X version
"1.X.Y": picks the highest valid gke.N patch in the 1.X.Y version
"1.X.Y-gke.N": picks an explicit Kubernetes version
"","-": picks the default Kubernetes version
```

https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters


Lets merge https://github.com/kubeflow/kubeflow/pull/1762 first, so this change will be much smaller.

Related to #1653 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1763)
<!-- Reviewable:end -->
