### PR TITLE
Enable new beta Stackdriver Kubernetes Monitoring feature if using v1beta1 (#1768)

### DIFF
--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -73,10 +73,10 @@ resources:
     cluster:
       name: {{ CLUSTER_NAME }}
       initialClusterVersion: {{ properties['cluster-version'] }}
+      {% if properties['gkeApiVersion'] == 'v1beta1' %}
       # We need 1.10.2 to support Stackdrivier GKE.
       loggingService: logging.googleapis.com/kubernetes
       monitoringService: monitoring.googleapis.com/kubernetes
-      {% if properties['gkeApiVersion'] == 'v1beta1' %}
       podSecurityPolicyConfig:
         enabled: {{ properties['securityConfig']['podSecurityPolicy'] }}
       {% endif %}


### PR DESCRIPTION
Added condition to enable this beta feature if using API version v1beta1.
Information about the feature can be found [here](https://cloud.google.com/monitoring/kubernetes-engine/installing).
Fixes #1768

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1772)
<!-- Reviewable:end -->
