### PR TITLE
Cleanup the OWNERs files.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,6 @@
 # list approvers for individual components (e.g. Seldon folks for Seldon component)
 approvers:
   - abhi-g
-  - gaocegege
   - jlewi
   - kunmingg
   - lluunn

--- a/OWNERS
+++ b/OWNERS
@@ -2,16 +2,10 @@
 # list approvers for individual components (e.g. Seldon folks for Seldon component)
 approvers:
   - abhi-g
-  - DjangoPeng
   - gaocegege
   - jlewi
   - kunmingg
   - lluunn
   - pdmack
   - richardsliu
-  - ScorpioCPH
-  - texasmichelle
-  - willb
 reviewers:
-  - richardsliu
-  - swiftdiaries

--- a/bootstrap/OWNERS
+++ b/bootstrap/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - kunmingg
+reviewers:

--- a/components/centraldashboard/OWNERS
+++ b/components/centraldashboard/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - swiftdiaries
+reviewers:

--- a/components/gcp-click-to-deploy/OWNERS
+++ b/components/gcp-click-to-deploy/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - kunmingg
+reviewers:

--- a/components/jupyterhub/OWNERS
+++ b/components/jupyterhub/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - pdmack
+reviewers:

--- a/components/k8s-model-server/OWNERS
+++ b/components/k8s-model-server/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - lluunn
+reviewers:

--- a/components/tensorflow-notebook-image/OWNERS
+++ b/components/tensorflow-notebook-image/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - pdmack
+reviewers:

--- a/kubeflow/OWNERS
+++ b/kubeflow/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - pdmack
+reviewers:

--- a/kubeflow/core/OWNERS
+++ b/kubeflow/core/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - gaocegege
+reviewers:


### PR DESCRIPTION
* Move some top level approvers into subdirectory OWNERs files that better
  match their areas of expertise
* Remove some reviewers that haven't been that active.
* This will make blunderbuss more efficient.
* Data can be seen here
https://devstats.kubeflow.org/d/46/user-reviews-repository-groups?orgId=1&var-period=d7&var-repo_name=All&var-repo=all&var-reviewers=ScorpioCPH&var-reviewers=willb

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1773)
<!-- Reviewable:end -->
