### PR TITLE
Enable TPU in GKE (#1766)

### DIFF
--- a/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -48,6 +48,8 @@ resources:
     gpu-pool-enable-autoscaling: true
     gpu-pool-min-nodes: 0
     gpu-pool-max-nodes: 10
+    # Whether to enable TPUs
+    enable_tpu: false
     # Whether to deploy the new Stackdriver Kubernetes agents
     stackdriver-kubernetes: false
     securityConfig:

--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -74,15 +74,14 @@ resources:
       name: {{ CLUSTER_NAME }}
       initialClusterVersion: {{ properties['cluster-version'] }}
       {% if properties['gkeApiVersion'] == 'v1beta1' %}
-      # We need 1.10.2 to support Stackdrivier GKE.
+      # We need 1.10.2 to support Stackdriver GKE.
       loggingService: logging.googleapis.com/kubernetes
       monitoringService: monitoring.googleapis.com/kubernetes
-      {% if properties['gkeApiVersion'] == 'v1beta1' %}
-        {% if properties['enable_tpu'] %}
-          enable_tpu: {{ properties['enable_tpu'] }}
-          ipAllocationPolicy:
-            useIpAliases: {{ properties['enable_tpu'] }}
-        {% endif %}
+      {% if properties['enable_tpu'] %}
+        enable_tpu: {{ properties['enable_tpu'] }}
+        ipAllocationPolicy:
+          useIpAliases: {{ properties['enable_tpu'] }}
+      {% endif %}
       podSecurityPolicyConfig:
         enabled: {{ properties['securityConfig']['podSecurityPolicy'] }}
       {% endif %}

--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -78,9 +78,9 @@ resources:
       loggingService: logging.googleapis.com/kubernetes
       monitoringService: monitoring.googleapis.com/kubernetes
       {% if properties['enable_tpu'] %}
-        enable_tpu: {{ properties['enable_tpu'] }}
-        ipAllocationPolicy:
-          useIpAliases: {{ properties['enable_tpu'] }}
+      enable_tpu: {{ properties['enable_tpu'] }}
+      ipAllocationPolicy:
+        useIpAliases: {{ properties['enable_tpu'] }}
       {% endif %}
       podSecurityPolicyConfig:
         enabled: {{ properties['securityConfig']['podSecurityPolicy'] }}

--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -77,6 +77,12 @@ resources:
       # We need 1.10.2 to support Stackdrivier GKE.
       loggingService: logging.googleapis.com/kubernetes
       monitoringService: monitoring.googleapis.com/kubernetes
+      {% if properties['gkeApiVersion'] == 'v1beta1' %}
+        {% if properties['enable_tpu'] %}
+          enable_tpu: {{ properties['enable_tpu'] }}
+          ipAllocationPolicy:
+            useIpAliases: {{ properties['enable_tpu'] }}
+        {% endif %}
       podSecurityPolicyConfig:
         enabled: {{ properties['securityConfig']['podSecurityPolicy'] }}
       {% endif %}


### PR DESCRIPTION
Modify the below two files within deployment_manager_configs to enable TPU if using API v1beta1:
cluster-kubeflow.yaml -> Add boolean option "tpu: false"
cluster.jinja -> Add settings to enable TPU and IP Aliases if tpu: true and API v1beta1