### PR TITLE
components: tf-notebook-image: pin to base image

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-ARG BASE_IMAGE=ubuntu:latest
+ARG BASE_IMAGE=ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378
 
 FROM $BASE_IMAGE
 

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-ARG BASE_IMAGE=ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378
+ARG BASE_IMAGE=ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378
 
 FROM $BASE_IMAGE
 

--- a/components/tensorflow-notebook-image/versions/1.10.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.10.1/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
+  "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.10.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.10.1-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.9.2",

--- a/components/tensorflow-notebook-image/versions/1.10.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.10.1/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:latest",
+  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.10.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.10.1-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.9.2",

--- a/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
+  "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp27-none-linux_x86_64.whl",
   "TF_SERVING_VERSION": "1.4.0"

--- a/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:latest",
+  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp27-none-linux_x86_64.whl",
   "TF_SERVING_VERSION": "1.4.0"

--- a/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:latest",
+  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp27-none-linux_x86_64.whl",
   "TF_SERVING_VERSION": "1.5.0"

--- a/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
+  "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp27-none-linux_x86_64.whl",
   "TF_SERVING_VERSION": "1.5.0"

--- a/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:latest",
+  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
+  "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:latest",
+  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp27-none-linux_x86_64.whl",  
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
+  "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp27-none-linux_x86_64.whl",  
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.8.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.8.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
+  "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.8.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.8.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:latest",
+  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.9.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.9.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
+  "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.9.2",

--- a/components/tensorflow-notebook-image/versions/1.9.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.9.0/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "ubuntu:latest",
+  "BASE_IMAGE": "ubuntu:18:04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.9.2",


### PR DESCRIPTION
You can reference images by digest in the FROM or `docker pull` commands.

https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier

The tag is ignored, but you can keep it there to give more context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1784)
<!-- Reviewable:end -->
