### PR TITLE
[cuda] use runtime image instead of development image

### DIFF
--- a/components/k8s-model-server/images/versions/1.7gpu/version-config.json
+++ b/components/k8s-model-server/images/versions/1.7gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "base_image": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "base_image": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "tf_version": "1.7.0",
   "cuda_version": "9.0",
   "cudnn_version": "7",

--- a/components/tensorflow-notebook-image/versions/1.10.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.10.1gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.10.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.10.1-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.9.2",

--- a/components/tensorflow-notebook-image/versions/1.5.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.5.1gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.1-cp27-none-linux_x86_64.whl",
   "TF_SERVING_VERSION": "1.5.0"

--- a/components/tensorflow-notebook-image/versions/1.6.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.6.0gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.6.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.6.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.7.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.7.0gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.7.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.7.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.8.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.8.0gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.8.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.8.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.6.0",

--- a/components/tensorflow-notebook-image/versions/1.9.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.9.0gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.9.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.9.0-cp27-none-linux_x86_64.whl",
   "TFMA_VERSION": "0.9.2",


### PR DESCRIPTION
Fixes #1783

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1785)
<!-- Reviewable:end -->
