### PR TITLE
add kubeflow sync/load persistent resource feature

### DIFF
--- a/bootstrap/cmd/bootstrap/app/gcpUtils.go
+++ b/bootstrap/cmd/bootstrap/app/gcpUtils.go
@@ -293,7 +293,7 @@ func (s *ksServer) SyncPersistentResource(ctx context.Context, req SyncResourceR
 	if err == nil {
 		os.RemoveAll(secretDir)
 	}
-	if err = os.Mkdir(secretDir, os.ModePerm); err != nil {
+	if err = os.MkdirAll(secretDir, os.ModePerm); err != nil {
 		return err
 	}
 	k8sClientset, err := getK8sClientSet(ctx, req.Token, req.Project, req.Zone, req.Cluster)
@@ -305,7 +305,7 @@ func (s *ksServer) SyncPersistentResource(ctx context.Context, req SyncResourceR
 		if err != nil {
 			return err
 		}
-		DumpConfig(path.Join(secretDir, sec), secret)
+		DumpConfig(path.Join(secretDir, sec + ".yaml"), secret)
 	}
 	if err = os.Chdir(secretDir); err != nil {
 		return err

--- a/bootstrap/cmd/bootstrap/app/k8sAuth.go
+++ b/bootstrap/cmd/bootstrap/app/k8sAuth.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 	containerpb "google.golang.org/genproto/googleapis/container/v1"
+	"k8s.io/api/rbac/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	log "github.com/sirupsen/logrus"

--- a/bootstrap/cmd/bootstrap/app/k8sAuth.go
+++ b/bootstrap/cmd/bootstrap/app/k8sAuth.go
@@ -8,9 +8,9 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 	containerpb "google.golang.org/genproto/googleapis/container/v1"
-	"k8s.io/api/rbac/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	log "github.com/sirupsen/logrus"
 )
 
 func buildClusterConfig(ctx context.Context, token string, project string, zone string,
@@ -39,6 +39,20 @@ func buildClusterConfig(ctx context.Context, token string, project string, zone 
 			CAData: []byte(string(caDec)),
 		},
 	}, nil
+}
+
+func getK8sClientSet(ctx context.Context, token string, project string, zone string,
+	cluster string) (*clientset.Clientset, error) {
+	k8sConfig, err := buildClusterConfig(ctx, token, project, zone, cluster)
+	if err != nil {
+		log.Errorf("Failed getting GKE cluster config: %v", err)
+		return nil, err
+	}
+	k8sClientset, err := clientset.NewForConfig(k8sConfig)
+	if err != nil {
+		return nil, err
+	}
+	return k8sClientset, nil
 }
 
 func createK8sRoleBing(config *rest.Config, roleBinding *v1.ClusterRoleBinding) error {

--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -718,7 +718,10 @@ func (s *ksServer) LoadPersistentResource(ctx context.Context, req ApplyRequest)
 	if err != nil {
 		return err
 	}
-	files, _ := ioutil.ReadDir(secretDir)
+	files, err := ioutil.ReadDir(secretDir)
+	if err != nil {
+		return err
+	}
 	for _, file := range files {
 		var sec core_v1.Secret
 		LoadConfig(path.Join(secretDir, file.Name()), &sec)

--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -725,6 +725,7 @@ func (s *ksServer) LoadPersistentResource(ctx context.Context, req ApplyRequest)
 	for _, file := range files {
 		var sec core_v1.Secret
 		LoadConfig(path.Join(secretDir, file.Name()), &sec)
+		sec.ResourceVersion = ""
 		_, err = k8sClientset.CoreV1().Secrets(sec.Namespace).Create(&sec)
 		if err != nil {
 			log.Errorf("Failed creating persistent secret in GKE cluster: %v", err)

--- a/bootstrap/cmd/bootstrap/app/saKey.go
+++ b/bootstrap/cmd/bootstrap/app/saKey.go
@@ -10,8 +10,7 @@ import (
 	"google.golang.org/genproto/googleapis/iam/admin/v1"
 	"k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	clientset "k8s.io/client-go/kubernetes"
-)
+	)
 
 type InsertSaKeyRequest struct {
 	Cluster   string
@@ -37,9 +36,8 @@ func (s *ksServer) InsertSaKey(ctx context.Context, request InsertSaKeyRequest, 
 	ts := oauth2.StaticTokenSource(&oauth2.Token{
 		AccessToken: request.Token,
 	})
-	k8sConfig, err := buildClusterConfig(ctx, request.Token, request.Project, request.Zone, request.Cluster)
+	k8sClientset, err := getK8sClientSet(ctx, request.Token, request.Project, request.Zone, request.Cluster)
 	if err != nil {
-		log.Errorf("Failed getting GKE cluster config: %v", err)
 		return err
 	}
 
@@ -60,7 +58,6 @@ func (s *ksServer) InsertSaKey(ctx context.Context, request InsertSaKeyRequest, 
 		log.Errorf("Failed creating sa key: %v", err)
 		return err
 	}
-	k8sClientset, err := clientset.NewForConfig(k8sConfig)
 	secretData := make(map[string][]byte)
 	secretData[secretKey] = createdKey.PrivateKeyData
 	_, err = k8sClientset.CoreV1().Secrets(request.Namespace).Create(

--- a/bootstrap/cmd/bootstrap/app/server.go
+++ b/bootstrap/cmd/bootstrap/app/server.go
@@ -130,6 +130,21 @@ func LoadConfig(path string, o interface{}) error {
 	return nil
 }
 
+// Dump object to yaml file
+func DumpConfig(path string, o interface{}) error {
+	if path == "" {
+		return errors.New("empty path")
+	}
+	data, err := yaml.Marshal(o)
+	if err != nil {
+		return err
+	}
+	if err = ioutil.WriteFile(path, data, os.ModePerm); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ModifyGcloudCommand modifies the cmd-path in the kubeconfig file.
 //
 // We do this because we want to be able to mount the kubeconfig file into the container.

--- a/kubeflow/core/configure_envoy_for_iap.sh
+++ b/kubeflow/core/configure_envoy_for_iap.sh
@@ -20,7 +20,10 @@ exit 1
 fi
 
 # Activate the service account
-gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+for i in 1 2 3
+do gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} && break || sleep 10
+done
+
 # Print out the config for debugging
 gcloud config list
 


### PR DESCRIPTION
Enable persistent resource backup/recovery for kubeflow cluster (now only in yaml format):
* backup: provide api on go backend which will backup persistent resources to cloud source repo
* recovery: when a new deployment happens, server will check cloud source repo and recovery any existing ones.

A direct use case is to reuse https cert on redeploy as lets-encrypt has rate limit of 5 per domain name per week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1801)
<!-- Reviewable:end -->
