### PR TITLE
Add support for using host network for OpenMPI worker pods

### DIFF
--- a/kubeflow/core/util.libsonnet
+++ b/kubeflow/core/util.libsonnet
@@ -12,6 +12,7 @@
     result:: value,
   }.result,
 
+  // TODO(https://github.com/kubeflow/kubeflow/issues/1826): Replace with std.asciiUpper once supported by required version of jsonnet
   // Convert a string to upper case.
   upper:: function(x) {
     local cp(c) = std.codepoint(c),

--- a/kubeflow/openmpi/prototypes/openmpi.jsonnet
+++ b/kubeflow/openmpi/prototypes/openmpi.jsonnet
@@ -30,6 +30,7 @@
 // @optionalParam supplementalGroups string null Comma-delimited list of supplemental group ids to put the user of the first process of containers in master/worker pods.
 // @optionalParam volumes array [] 'volumes' to put master/workers pods.
 // @optionalParam volumeMounts array [] 'volumes' to put job containers in master/workers pods.
+// @optionalParam useHostNetwork string false Use host network for worker pods.
 
 local k = import "k.libsonnet";
 local openmpi = import "kubeflow/openmpi/all.libsonnet";

--- a/kubeflow/openmpi/util.libsonnet
+++ b/kubeflow/openmpi/util.libsonnet
@@ -14,4 +14,27 @@
       [std.splitLimit(keyValue, "=", 1)[0]]: std.splitLimit(keyValue, "=", 1)[1]
       for keyValue in $.toArray(str)
     } else {},
+
+  // Convert a string to upper case.
+  upper:: function(x) {
+    local cp(c) = std.codepoint(c),
+    local upLetter(c) = if cp(c) >= 97 && cp(c) < 123 then
+      std.char(cp(c) - 32)
+    else c,
+    result:: std.join("", std.map(upLetter, std.stringChars(x))),
+  }.result,
+
+  // Convert non-boolean types like string,number to a boolean.
+  // This is primarily intended for dealing with parameters that should be booleans.
+  toBool:: function(x) {
+    result::
+      if std.type(x) == "boolean" then
+        x
+      else if std.type(x) == "string" then
+        $.upper(x) == "TRUE"
+      else if std.type(x) == "number" then
+        x != 0
+      else
+        false,
+  }.result,
 }

--- a/kubeflow/openmpi/util.libsonnet
+++ b/kubeflow/openmpi/util.libsonnet
@@ -15,6 +15,7 @@
       for keyValue in $.toArray(str)
     } else {},
 
+  // TODO(https://github.com/kubeflow/kubeflow/issues/1826): Replace with std.asciiUpper once supported by required version of jsonnet
   // Convert a string to upper case.
   upper:: function(x) {
     local cp(c) = std.codepoint(c),

--- a/kubeflow/openmpi/workloads.libsonnet
+++ b/kubeflow/openmpi/workloads.libsonnet
@@ -41,7 +41,7 @@ local ROLE_WORKER = "worker";
       subdomain: service.name(params),
       restartPolicy: "Never",
       terminationGracePeriodSeconds: 30,
-      dnsPolicy: "ClusterFirst",
+      dnsPolicy: "ClusterFirstWithHostNet",
       schedulerName: params.schedulerName,
       volumes: $.volumes(params),
       containers: $.containers(params, role, podName),
@@ -49,6 +49,7 @@ local ROLE_WORKER = "worker";
       serviceAccountName: serviceaccount.name(params),
       nodeSelector: $.nodeSelector(params, role),
       securityContext: $.securityContext(params),
+      hostNetwork: role == ROLE_WORKER && util.toBool(params.useHostNetwork),
     },
   },
 

--- a/kubeflow/weaveflux/util.libsonnet
+++ b/kubeflow/weaveflux/util.libsonnet
@@ -1,5 +1,6 @@
 // Some useful routines.
 {
+  // TODO(https://github.com/kubeflow/kubeflow/issues/1826): Replace with std.asciiUpper once supported by required version of jsonnet
   // Convert a string to upper case.
   upper:: function(x) {
     local cp(c) = std.codepoint(c),


### PR DESCRIPTION
Some workloads are impacted by overhead of overlay network and I believe can benefit from running on the host network.
Allows passing in `useHostNetwork true` to configure worker pods to run on the host network.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1805)
<!-- Reviewable:end -->
