### PR TITLE
Don't add a GPU pool by default

### DIFF
--- a/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -46,9 +46,12 @@ resources:
     cpu-pool-enable-autoscaling: true
     cpu-pool-min-nodes: 0
     cpu-pool-max-nodes: 10
+    # GPUs are not enabled by default. To add GPUs
+    # set gpu-pool-max-nodes to a none-zero value.
     gpu-pool-enable-autoscaling: true
     gpu-pool-min-nodes: 0
-    gpu-pool-max-nodes: 10
+    gpu-pool-max-nodes: 0
+    gpu-type: nvidia-tesla-k80
     # Whether to enable TPUs
     enable_tpu: false
     securityConfig:

--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -125,6 +125,7 @@ resources:
 # We do this so that if we want to make changes we can delete the existing resource and then recreate it.
 # Updating doesn't work so well because we are limited in what changes GKE's update method supports.
 
+{% if properties['gpu-pool-max-nodes'] > 0 %}
 - name: {{ GPU_POOL }}
   {% if properties['gkeApiVersion'] == 'v1beta1' %}
   type: gcp-types/container-v1beta1:projects.locations.clusters.nodePools
@@ -157,12 +158,13 @@ resources:
         minCpuPlatform: 'Intel Broadwell'
         accelerators:
           - acceleratorCount: 1
-            acceleratorType: nvidia-tesla-k80
+            acceleratorType: {{ properties['gpu-type'] }}
 
   metadata:
     dependsOn:
     # We can only create 1 node pool at a time.
     - {{ CLUSTER_NAME }}
+{% endif %}
 
 {# Project defaults to the project of the deployment. #}
 - name: {{ properties['ipName']  }}


### PR DESCRIPTION
* Cluster deployment will fail in regions with no GPUs.
* GPUs are expensive and not included in default GCP quota.
* To support deploying in regions with no GPUs we don't create a GPU
  node pool by setting max GPU nodes to 0.

* Also expose a jinja parameter to set the GPU type.

Fix #1767 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1810)
<!-- Reviewable:end -->
