### PR TITLE
Remove K8s dashboard link from central UI

### DIFF
--- a/components/centraldashboard/frontend/layout/index.html
+++ b/components/centraldashboard/frontend/layout/index.html
@@ -26,7 +26,6 @@
         <a href="https://www.kubeflow.org/docs/about/kubeflow/" class="mdl-layout__tab mdl-color-text--white">Kubeflow docs</a>
         <a href="/hub/" class="mdl-layout__tab is-active mdl-color-text--white">JupyterHub</a>
         <a href="/tfjobs/ui/" class="mdl-layout__tab mdl-color-text--white">TFJob Dashboard</a>
-        <a href="/k8s/ui/" class="mdl-layout__tab mdl-color-text--white">k8s Dashboard</a>
         <a href="/" class="isDisabled mdl-layout__tab mdl-color-text--white">Katib Dashboard</a>
       </div>  
     </header>

--- a/kubeflow/core/ambassador.libsonnet
+++ b/kubeflow/core/ambassador.libsonnet
@@ -217,55 +217,6 @@
     },  // deploy
     ambassadorDeployment:: ambassadorDeployment,
 
-    // This service adds a rule to our reverse proxy for accessing the K8s dashboard.
-    local k8sDashboard = {
-      local isDashboardTls = if params.cloud == "acsengine" || params.cloud == "aks" then
-        "false"
-      else
-        "true",
-      // Due to https://github.com/ksonnet/ksonnet/issues/670, escaped characters in
-      // jsonnet files are not interpreted correctly by ksonnet, which causes runtime
-      // parsing failures. This is fixed in ksonnet 0.12.0, so we can merge this back
-      // to the jsonnet file when we take a dependency on ksonnet 0.12.0 or later.
-      local annotations = function(isDashboardTls) {
-        "getambassador.io/config":
-          std.join("\n", [
-            "---",
-            "apiVersion: ambassador/v0",
-            "kind:  Mapping",
-            "name: k8s-dashboard-ui-mapping",
-            "prefix: /k8s/ui/",
-            "rewrite: /",
-            "tls: " + isDashboardTls,
-            // We redirect to the K8s service created for the dashboard
-            // in namespace kube-system. We don't use the k8s-dashboard service
-            // because that isn't in the kube-system namespace and I don't think
-            // it can select pods in a different namespace.
-            "service: kubernetes-dashboard.kube-system",
-          ]),
-      },
-      apiVersion: "v1",
-      kind: "Service",
-      metadata: {
-        name: "k8s-dashboard",
-        namespace: params.namespace,
-        annotations: annotations(isDashboardTls),
-      },
-      spec: {
-        ports: [
-          {
-            port: 443,
-            targetPort: 8443,
-          },
-        ],
-        selector: {
-          "k8s-app": "kubernetes-dashboard",
-        },
-        type: "ClusterIP",
-      },
-    },  // k8sDashboard
-    k8sDashboard:: k8sDashboard,
-
     parts:: self,
     all:: [
       self.ambassadorService,
@@ -274,7 +225,6 @@
       self.ambassadorServiceAccount,
       self.ambassadorRoleBinding,
       self.ambassadorDeployment,
-      self.k8sDashboard,
     ],
 
     list(obj=self.all):: util.list(obj),


### PR DESCRIPTION
* The K8s dashboard is not always installed; so just adding a link
  to it leads to confusion because it may not actually be present.

* Furthermore, even when the dashboard is running there might not be
  a convenient way to authenticate to it short of having users generate
  and paste access tokens.

Fix #1699