### PR TITLE
Fix TFMA and TFDV in Jupyter Images

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -5,10 +5,12 @@ ARG BASE_IMAGE=ubuntu:latest
 
 FROM $BASE_IMAGE
 
-ARG INSTALL_TFMA=yes
 ARG TF_PACKAGE=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp36-cp36m-linux_x86_64.whl
 ARG TF_PACKAGE_PY_27=https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp27-none-linux_x86_64.whl
 ARG TF_SERVING_VERSION=0.0.0
+ARG TFMA_VERSION
+ARG TFDV_VERSION
+
 USER root
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -20,6 +22,14 @@ ENV HOME /home/$NB_USER
 # to minimize the amount of content in $HOME
 ENV CONDA_DIR=/opt/conda
 ENV PATH $CONDA_DIR/bin:$PATH
+
+# Export args as environment variables.
+# This is solely to make them available to install.sh
+ENV TF_PACKAGE $TF_PACKAGE
+ENV TF_PACKAGE_27 $TF_PACKAGE_PY_27
+ENV TF_SERVING_VERSION $TF_PACKAGE_PY_27
+ENV TFMA_VERSION $TFMA_VERSION
+ENV TFDV_VERSION $TFDV_VERSION
 
 # Use bash instead of sh
 SHELL ["/bin/bash", "-c"]
@@ -109,42 +119,9 @@ COPY --chown=jovyan:users requirements.txt /tmp
 
 # Install python2 and ipython2 kernel for jupyter notebook
 # Install tf packages which only support py2
-RUN conda create -n py2 python=2 && \
-    source activate py2 && \
-    pip install --upgrade pip && \
-    pip --no-cache-dir install \
-    ipykernel \
-    # Tensorflow
-    ${TF_PACKAGE_PY_27} \
-    # Tensorflow packages which only supports python 2
-    tensorflow-transform \
-    tensorflow-serving-api===${TF_SERVING_VERSION} \
-    # ipykernel for python 2 jupyter notebook kernel
-    && \
-    python -m ipykernel install && \
-    # tensorflow-model-analysis is only supported for TF 1.6 and above
-    if [[ $INSTALL_TFMA == "yes" ]]; then \
-      pip install --no-cache-dir tensorflow-model-analysis && \
-      pip install --no-cache-dir tensorflow-data-validation && \
-      # We use --system because if we don't the config is written to the home directory
-      # and the changes are lost when we mount a PV over them.
-      jupyter nbextension enable --py --system widgetsnbextension && \
-      jupyter nbextension install --py --system --symlink tensorflow_model_analysis && \
-      jupyter nbextension enable --py --system tensorflow_model_analysis ; \
-    fi \
-    && \
-    # Install jupyterlab-manager
-    conda install --quiet --yes \
-    # nodejs required for jupyterlab-manager
-    nodejs && \
-    jupyter labextension install @jupyter-widgets/jupyterlab-manager && \
-    # Install common packages from requirements.txt for both python2 and python3
-    pip --no-cache-dir install -r /tmp/requirements.txt && \
-    source activate py2 && \
-    pip --no-cache-dir install -r /tmp/requirements.txt && \
-    # Do chown in this layer for significant size savings
-    chown -R ${NB_USER}:users $HOME && \
-    chown -R ${NB_USER}:users $CONDA_DIR
+COPY --chown=jovyan:users install.sh /tmp/
+RUN chmod a+rx /tmp/install.sh && \
+    /tmp/install.sh
 
 # Add basic config
 COPY --chown=jovyan:users  jupyter_notebook_config.py /tmp

--- a/components/tensorflow-notebook-image/build_image.sh
+++ b/components/tensorflow-notebook-image/build_image.sh
@@ -3,7 +3,7 @@
 # A simple script to build the Docker images.
 # This is intended to be invoked as a step in Argo to build the docker image.
 #
-# build_image.sh ${DOCKERFILE} ${IMAGE} ${TAG} ${IS_LATEST} ${BASE_IMAGE} ${TF_PACKAGE}
+# build_image.sh ${DOCKERFILE} ${IMAGE} ${TAG} ${JSON_CONFIG_FILE}
 set -ex
 
 DOCKERFILE=$1
@@ -13,12 +13,29 @@ IMAGE=$2
 TAG=$3
 # Takes a value of true or false. Determines if we should tag the image
 # with the "latest" tag
-IS_LATEST=$4
-BASE_IMAGE=${5:-"ubuntu:latest"}
-TF_PACKAGE=${6:-"tf-nightly"}
-TF_PACKAGE_PY_27=${7:-"tf-nightly"}
-INSTALL_TFMA=$8
-TF_SERVING_VERSION=$9
+#
+# TODO(jlewi): We should take in the json config file and then parse that.
+CONFIG_FILE=$4
+BASE_IMAGE=$(jq -r .BASE_IMAGE  ${CONFIG_FILE})
+TF_PACKAGE=$(jq -r .TF_PACKAGE  ${CONFIG_FILE})
+TF_PACKAGE_PY_27=$(jq -r .TF_PACKAGE_PY_27 ${CONFIG_FILE})
+TF_SERVING_VERSION=$(jq -r .TF_SERVING_VERSION ${CONFIG_FILE})
+TFMA_VERSION=$(jq -r .TFMA_VERSION ${CONFIG_FILE})
+TFDV_VERSION=$(jq -r .TFDV_VERSION ${CONFIG_FILE})
+
+
+# JQ returns null for non defined values.
+if [ ${BASE_IMAGE} == "null" ]; then
+   BASE_IMAGE=""
+fi
+
+if [ ${TFMA_VERSION} == "null" ]; then
+   TFMA_VERSION=""
+fi
+
+if [ ${TFDV_VERSION} == "null" ]; then
+   TFDV_VERSION=""
+fi
 
 # Wait for the Docker daemon to be available.
 until docker ps
@@ -29,8 +46,9 @@ docker build --pull \
         --build-arg "BASE_IMAGE=${BASE_IMAGE}" \
         --build-arg "TF_PACKAGE=${TF_PACKAGE}" \
         --build-arg "TF_PACKAGE_PY_27=${TF_PACKAGE_PY_27}" \
-        --build-arg "INSTALL_TFMA=${INSTALL_TFMA}" \
         --build-arg "TF_SERVING_VERSION=${TF_SERVING_VERSION}" \
+        --build-arg "TFMA_VERSION=${TFMA_VERSION}" \
+        --build-arg "TFDV_VERSION=${TFDV_VERSION}" \
         -t "${IMAGE}:${TAG}" \
 	-f ${DOCKERFILE} ${CONTEXT_DIR}
 

--- a/components/tensorflow-notebook-image/install.sh
+++ b/components/tensorflow-notebook-image/install.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# An install script to be called from the DOCKERFILE
+set -ex
+conda create -n py2 python=2
+
+source activate py2
+pip install --upgrade pip 
+
+# TFX packages only supports python 2 
+pip --no-cache-dir install \
+    ipykernel \
+    ${TF_PACKAGE_PY_27} \
+    tensorflow-transform \
+    tensorflow-serving-api===${TF_SERVING_VERSION}    
+
+python -m ipykernel install
+
+# TODO(jlewi): Does TFDV not have jupyter extensions?
+if [[ $TFDV_VERSION ]]; then
+    pip install --no-cache-dir tensorflow-data-validation==$TFDV_VERSION
+fi
+
+# tensorflow-model-analysis is only supported for TF 1.6 and above
+# TODO temporarily remove tensorflow-model-analysis because of gpu problem 
+# https://github.com/kubeflow/kubeflow/pull/1759
+if [[ $TFMA_VERSION ]]; then
+  # if you find any dependency problems in the future
+  # please visit https://github.com/tensorflow/model-analysis#compatible-versions
+  # and fix the TFA_VERSION with compatible version number in the config json
+  pip install --no-cache-dir tensorflow-model-analysis==$TFMA_VERSION
+  # We use --system because if we don't the config is written to the home directory
+  # and the changes are lost when we mount a PV over them.
+  jupyter nbextension enable --py --system widgetsnbextension  
+fi
+
+# TODO a quick fix for tensorflow_serving_api when install gpu
+# https://github.com/tensorflow/serving/issues/1142
+# now the dep in tensorflow can meet the require of tensorflow-serving-api but not ensure future
+pip install --no-cache-dir --no-deps tensorflow-serving-api
+
+# Install jupyterlab-manager
+# nodejs required for jupyterlab-manager
+conda install --quiet --yes nodejs
+jupyter labextension install @jupyter-widgets/jupyterlab-manager
+
+# Install common packages from requirements.txt for both python2 and python
+pip --no-cache-dir install -r /tmp/requirements.txt
+source activate py2 
+pip --no-cache-dir install -r /tmp/requirements.txt 
+    
+# Do chown in this layer for significant size savings
+chown -R ${NB_USER}:users $HOME 
+chown -R ${NB_USER}:users $CONDA_DIR

--- a/components/tensorflow-notebook-image/releaser/components/params.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/params.libsonnet
@@ -13,7 +13,7 @@
       namespace: "kubeflow-releasing",
       prow_env: "JOB_NAME=notebook-release,JOB_TYPE=presubmit,PULL_NUMBER=317,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=0892",
       registry: "gcr.io/kubeflow-images-public",
-      versionTag: "v20180301-pr317",
+      versionTag: "",
     },
   },
 }

--- a/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/components/workflows.libsonnet
@@ -22,6 +22,26 @@
       )
     else [],
 
+  // Function turn comma separated list of prow environment variables into a dictionary.
+
+  listToDict:: function(v)
+    {
+      [v[0]]: v[1],
+    },
+
+  parseEnvToDict: function(v)
+    local pieces = std.split(v, ",");
+    if v != "" && std.length(pieces) > 0 then
+      std.foldl(
+        function(a, b) a + b,
+        std.map(
+          function(i) $.listToDict(std.split(i, "=")),
+          std.split(v, ",")
+        ),
+        {}
+      )
+    else {},
+
   // Default parameters.
   // The defaults are suitable based on suitable values for our test cluster.
   defaultParams:: {
@@ -53,6 +73,7 @@
       local name = params.name;
 
       local prow_env = $.parseEnv(params.prow_env);
+      local prowDict = $.parseEnvToDict(params.prow_env);
       local bucket = params.bucket;
 
       local stepsNamespace = name;
@@ -79,14 +100,22 @@
       // Location where Dockerfiles and other sources are found.
       local notebookDir = srcRootDir + "/kubeflow/kubeflow/components/tensorflow-notebook-image/";
 
+      // Subdirectory containing the version config.
       local supportedVersions = [
-        "1.4.1",
-        "1.5.1",
-        "1.6.0",
-        "1.7.0",
-        "1.8.0",
-        "1.9.0",
-        "1.10.1",
+        ["1.4.1", "cpu"],
+        ["1.4.1gpu", "gpu"],
+        ["1.5.1", "cpu"],
+        ["1.5.1gpu", "gpu"],
+        ["1.6.0", "cpu"],
+        ["1.6.0gpu", "gpu"],
+        ["1.7.0", "cpu"],
+        ["1.7.0gpu", "gpu"],
+        ["1.8.0", "cpu"],
+        ["1.8.0gpu", "gpu"],
+        ["1.9.0", "cpu"],
+        ["1.9.0gpu", "gpu"],
+        ["1.10.1", "cpu"],
+        ["1.10.1gpu", "gpu"],
       ];
 
       // Build an Argo template to execute a particular command.
@@ -141,46 +170,46 @@
         },
         sidecars: sidecars,
       };  // buildTemplate
+
       local buildImageTemplate(tf_version, device, is_latest=true) = {
         local workflow_name = $.workflowName(tf_version, device),
-        local image = params.registry + "/tensorflow-" + tf_version + "-notebook-" + device,
-        local tag = params.versionTag,
-        local base_image =
-          if device == "cpu" then
-            "ubuntu:latest"
-          // device = gpu
-          else if std.startsWith(tf_version, "1.4.") then
-            "nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04"
-          else
-            "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
-        local tf_serving_version =
-          if tf_version == "1.4.1" then
-            "1.4.0"
-          else if tf_version == "1.5.1" then
-            "1.5.0"
-          else
-            tf_version,
-        local installTfma =
-          if tf_version < "1.9" then
-            "no"
-          else
-            "yes",
-        local tf_package =
-          "https://storage.googleapis.com/tensorflow/linux/" +
-          device +
-          "/tensorflow" +
-          (if device == "gpu" then "_gpu" else "") +
-          "-" +
-          tf_version +
-          "-cp36-cp36m-linux_x86_64.whl",
-        local tf_package_py_27 =
-          "https://storage.googleapis.com/tensorflow/linux/" +
-          device +
-          "/tensorflow" +
-          (if device == "gpu" then "_gpu" else "") +
-          "-" +
-          tf_version +
-          "-cp27-none-linux_x86_64.whl",
+
+        local version_label = if std.endsWith(tf_version, "gpu") then
+          std.substr(tf_version, 0, std.length(tf_version) - 3)
+        else
+          tf_version,
+
+        local image = params.registry + "/tensorflow-" + version_label + "-notebook-" + device,
+
+        local jobType = if std.objectHas(prowDict, "JOB_TYPE") then
+          prowDict.JOB_TYPE
+        else "",
+
+        local tagElements = [
+          "v",
+          if std.length(params.versionTag) > 0 then
+            params.versiontag
+          else null,
+          if std.objectHas(prowDict, "PULL_BASE_SHA") then
+            "base-" + std.substr(prowDict.PULL_BASE_SHA, 0, 7)
+          else null,
+          if std.objectHas(prowDict, "PULL_PULL_SHA") then
+            "pull-" + std.substr(prowDict.PULL_PULL_SHA, 0, 7)
+          else null,
+
+          if std.objectHas(prowDict, "PULL_NUMBER") then
+            "pr-" + prowDict.PULL_NUMBER
+          else null,
+          if std.objectHas(prowDict, "BUILD_NUMBER") then
+            prowDict.BUILD_NUMBER
+          else null,
+        ],
+
+        local tag = std.join(
+          "-",
+          std.prune(tagElements)
+        ),
+
         result:: buildTemplate(
           workflow_name,
           [
@@ -192,12 +221,7 @@
             + notebookDir + "Dockerfile" + " "
             + image + " "
             + tag + " "
-            + std.toString(is_latest) + " "
-            + base_image + " "
-            + tf_package + " "
-            + tf_package_py_27 + " "
-            + installTfma + " "
-            + tf_serving_version,
+            + notebookDir + "versions/" + tf_version + "/version-config.json" + " ",
           ],
           [
             {
@@ -288,16 +312,8 @@
                                   ] +
                                   [
                                     {
-                                      name: $.workflowName(version, "cpu"),
-                                      template: $.workflowName(version, "cpu"),
-                                      dependencies: ["checkout"],
-                                    }
-                                    for version in supportedVersions
-                                  ] +
-                                  [
-                                    {
-                                      name: $.workflowName(version, "gpu"),
-                                      template: $.workflowName(version, "gpu"),
+                                      name: $.workflowName(version[0], version[1]),
+                                      template: $.workflowName(version[0], version[1]),
                                       dependencies: ["checkout"],
                                     }
                                     for version in supportedVersions
@@ -356,11 +372,7 @@
                        ),  // copy-artifacts
                      ] +
                      [
-                       buildImageTemplate(version, "cpu")
-                       for version in supportedVersions
-                     ] +
-                     [
-                       buildImageTemplate(version, "gpu")
+                       buildImageTemplate(version[0], version[1])
                        for version in supportedVersions
                      ],  // templates
         },

--- a/components/tensorflow-notebook-image/releaser/environments/kubeflow-ci/params.libsonnet
+++ b/components/tensorflow-notebook-image/releaser/environments/kubeflow-ci/params.libsonnet
@@ -9,8 +9,8 @@ params {
     workflows+: {
       name: "jlewi-notebook-release-317-c33e",
       namespace: "kubeflow-test-infra",
-      prow_env: "JOB_NAME=notebook-release,JOB_TYPE=presubmit,PULL_NUMBER=317,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=c33e",
-      versionTag: "v20180301-pr317",
+      prow_env: "JOB_NAME=notebook-release,JOB_TYPE=presubmit,PULL_BASE_SHA=123456789,PULL_PULL_SHA=678abcdefg,PULL_NUMBER=317,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=c33e",
+      versionTag: "",
     },
   },
 }

--- a/components/tensorflow-notebook-image/start-singleuser.sh
+++ b/components/tensorflow-notebook-image/start-singleuser.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
+set -ex
 
 # set default ip to 0.0.0.0
 if [[ "$NOTEBOOK_ARGS $@" != *"--ip="* ]]; then
@@ -48,5 +48,23 @@ fi
 
 # check to see if a PV has been mounted 
 . /usr/local/bin/pvc-check.sh
+
+# We delay enabling the Jupyter extension until runtime because
+# enabling it tries to import tensorflow and on GPUs that requires
+# the CUDA libraries.
+# We do this after the PVC check because we will be instlaling it into the
+# home directory. We can't install into the system directory
+# because we run as Jovyan and don't have permission
+if [ -z "$DISABLE_TFMA_EXTENSION" ]; then
+  # Ignore errors because we don't want to prevent notebook startup.
+  # The commands will fail on older images which don't have TFMA in them.
+  # We also get errors when rerunning install if its already been installed.
+  set +e
+  # Need to activate the py2 environment to install TFMA
+  source activate py2
+  jupyter nbextension install --py --user --symlink tensorflow_model_analysis
+  jupyter nbextension enable --py --user tensorflow_model_analysis
+  set -e
+fi
 
 . /usr/local/bin/start.sh jupyterhub-singleuser $NOTEBOOK_ARGS $@

--- a/components/tensorflow-notebook-image/versions/1.10.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.10.1/version-config.json
@@ -2,5 +2,7 @@
   "BASE_IMAGE": "ubuntu:latest",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.10.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.10.1-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "0.9.2",
+  "TFDV_VERSION": "0.9.0",
+  "TF_SERVING_VERSION": "1.10.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.10.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.10.1gpu/version-config.json
@@ -2,5 +2,7 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.10.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.10.1-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "0.9.2",
+  "TFDV_VERSION": "0.9.0",
+  "TF_SERVING_VERSION": "1.10.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.4.1/version-config.json
@@ -2,5 +2,5 @@
   "BASE_IMAGE": "ubuntu:latest",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.4.1-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TF_SERVING_VERSION": "1.4.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.4.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.4.1gpu/version-config.json
@@ -2,5 +2,5 @@
   "BASE_IMAGE": "nvidia/cuda:8.0-cudnn6-devel-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.4.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.4.1-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TF_SERVING_VERSION": "1.4.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.5.1/version-config.json
@@ -2,5 +2,5 @@
   "BASE_IMAGE": "ubuntu:latest",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.5.1-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TF_SERVING_VERSION": "1.5.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.5.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.5.1gpu/version-config.json
@@ -2,5 +2,5 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.1-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.5.1-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TF_SERVING_VERSION": "1.5.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.6.0/version-config.json
@@ -2,5 +2,6 @@
   "BASE_IMAGE": "ubuntu:latest",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.6.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TFMA_VERSION": "0.6.0",
+  "TF_SERVING_VERSION": "1.6.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.6.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.6.0gpu/version-config.json
@@ -2,5 +2,6 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.6.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.6.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TFMA_VERSION": "0.6.0",
+  "TF_SERVING_VERSION": "1.6.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.7.0/version-config.json
@@ -1,6 +1,7 @@
 {
   "BASE_IMAGE": "ubuntu:latest",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp36-cp36m-linux_x86_64.whl",
-  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.7.0-cp27-none-linux_x86_64.whl",  
+  "TFMA_VERSION": "0.6.0",
+  "TF_SERVING_VERSION": "1.7.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.7.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.7.0gpu/version-config.json
@@ -2,5 +2,6 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.7.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.7.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TFMA_VERSION": "0.6.0",
+  "TF_SERVING_VERSION": "1.7.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.8.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.8.0/version-config.json
@@ -2,5 +2,6 @@
   "BASE_IMAGE": "ubuntu:latest",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.8.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TFMA_VERSION": "0.6.0",
+  "TF_SERVING_VERSION": "1.8.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.8.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.8.0gpu/version-config.json
@@ -2,5 +2,6 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.8.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.8.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "no"
+  "TFMA_VERSION": "0.6.0",
+  "TF_SERVING_VERSION": "1.8.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.9.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.9.0/version-config.json
@@ -2,5 +2,7 @@
   "BASE_IMAGE": "ubuntu:latest",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.9.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "0.9.2",
+  "TFDV_VERSION": "0.9.0",
+  "TF_SERVING_VERSION": "1.9.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.9.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.9.0gpu/version-config.json
@@ -2,5 +2,7 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-devel-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.9.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.9.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "0.9.2",
+  "TFDV_VERSION": "0.9.0",
+  "TF_SERVING_VERSION": "1.9.0"
 }

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -99,6 +99,7 @@ workflows:
       - presubmit
     params:
       registry: "gcr.io/kubeflow-ci"
+      step_image: "gcr.io/kubeflow-ci/test-worker:v20181017-bfeaaf5-dirty-4adcd0"
     include_dirs:
       - components/tensorflow-notebook-image/*
   # The postsubmit run publishes the docker images to gcr.io/kubeflow-images-public
@@ -109,5 +110,6 @@ workflows:
       - postsubmit
     params:
       registry: "gcr.io/kubeflow-images-public"
+      step_image: "gcr.io/kubeflow-ci/test-worker:v20181017-bfeaaf5-dirty-4adcd0"
     include_dirs:
       - components/tensorflow-notebook-image/*


### PR DESCRIPTION
Fix the build of the Jupyter images with TFMA and TFDV in the GPU Jupyter images.

* Looks like activating the widgets requires the GPU libraries because we end up importing tensorflow which fails without the GPU libraries.

* Modify the build of the jupyter images so the config (e.g. package versions) is loaded from the .json file rather than being specified in the Argo workflow file.

* Move a really long Dockerfile command into its own shell script (install.sh) to make it more readable.

* Related to #1818 installing and enabling the TFMA Jupyter extension at build time won't work because we end up trying to import TensorFlow which fails because the GPU cuda libraries are missing

* Related to #1718 TFMA and TFDV not properly installed in the appropriate versions of TF notebook images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1815)
<!-- Reviewable:end -->
