### PR TITLE
Roll out model with istio

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-gcp.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-gcp.jsonnet
@@ -1,14 +1,14 @@
 // @apiVersion 0.1
-// @name io.ksonnet.pkg.tf-serving-gcp
+// @name io.ksonnet.pkg.tf-serving-deployment-gcp
 // @description TensorFlow serving
 // @shortDescription A TensorFlow serving deployment
 // @param name string Name to give to each of the components
 // @optionalParam namespace string kubeflow The namespace
-// @optionalParam serviceType string ClusterIP The k8s service type for tf serving.
 // @optionalParam numGpus string 0 Number of gpus to use
 // @optionalParam deployHttpProxy string false Whether to deploy http proxy
 // @optionalParam modelBasePath string gs://kubeflow-examples-data/mnist The model path
 // @optionalParam modelName string null The model name
+// @optionalParam versionName string v1 The version name
 // @optionalParam defaultCpuImage string tensorflow/serving:1.8.0 The default model server image (cpu)
 // @optionalParam defaultGpuImage string tensorflow/serving:1.10.0-gpu The default model server image (gpu)
 // @optionalParam httpProxyImage string gcr.io/kubeflow-images-public/tf-model-server-http-proxy:v20180723 Http proxy image
@@ -57,5 +57,4 @@ local tfDeployment = base.tfDeployment +
                      );
 util.list([
   tfDeployment,
-  base.tfService,
 ],)

--- a/kubeflow/tf-serving/prototypes/tf-serving-service.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-service.jsonnet
@@ -1,0 +1,19 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.tf-serving-service
+// @description TensorFlow serving
+// @shortDescription A TensorFlow serving model
+// @param name string Name to give to each of the components
+// @optionalParam namespace string kubeflow The namespace
+// @optionalParam serviceType string ClusterIP The k8s service type for tf serving.
+// @optionalParam modelName string null The model name
+// @optionalParam trafficRule string v1:100 The traffic rule, in the format of version:percentage,version:percentage,..
+
+local k = import "k.libsonnet";
+local util = import "kubeflow/tf-serving/util.libsonnet";
+local tfservingService = import "kubeflow/tf-serving/tf-serving-service-template.libsonnet";
+
+local base = tfservingService.new(env, params);
+util.list([
+  base.tfService,
+  base.virtualService,
+],)

--- a/kubeflow/tf-serving/tf-serving-service-template.libsonnet
+++ b/kubeflow/tf-serving/tf-serving-service-template.libsonnet
@@ -1,0 +1,99 @@
+{
+  local k = import "k.libsonnet",
+  local util = import "kubeflow/tf-serving/util.libsonnet",
+  new(_env, _params):: {
+    local params = _env + _params {
+      namespace: if std.objectHas(_params, "namespace") && _params.namespace != "null" then
+        _params.namespace else _env.namespace,
+    },
+    local namespace = params.namespace,
+    local name = params.name,
+    local modelName =
+      if params.modelName == "null" then
+        params.name
+      else
+        params.modelName,
+
+    local tfService = {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        labels: {
+          app: modelName,
+        },
+        name: name,
+        namespace: namespace,
+        annotations: {
+          "getambassador.io/config":
+            std.join("\n", [
+              "---",
+              "apiVersion: ambassador/v0",
+              "kind:  Mapping",
+              "name: tfserving-predict-mapping-" + modelName,
+              "prefix: /tfserving/models/" + modelName,
+              "rewrite: /v1/models/" + modelName + ":predict",
+              "method: POST",
+              "service: " + name + "." + namespace + ":8500",
+              "---",
+              "apiVersion: ambassador/v0",
+              "kind:  Mapping",
+              "name: tfserving-predict-mapping-" + modelName + "-get",
+              "prefix: /tfserving/models/" + modelName,
+              "rewrite: /v1/models/" + modelName,
+              "method: GET",
+              "service: " + name + "." + namespace + ":8500",
+            ]),
+        },  //annotations
+      },
+      spec: {
+        ports: [
+          {
+            name: "grpc-tf-serving",
+            port: 9000,
+            targetPort: 9000,
+          },
+          {
+            name: "http-tf-serving",
+            port: 8500,
+            targetPort: 8500,
+          },
+        ],
+        selector: {
+          app: modelName,
+        },
+        type: params.serviceType,
+      },
+    },  // tfService
+    tfService:: tfService,
+
+    local versionWeights = std.split(params.trafficRule, ","),
+    local virtualService = {
+      apiVersion: "networking.istio.io/v1alpha3",
+      kind: "VirtualService",
+      metadata: {
+        name: name,
+        namespace: namespace,
+      },
+      spec: {
+        hosts: [
+          name,
+        ],
+        http: [
+          {
+            route: [
+              {
+                destination: {
+                  host: name,
+                  subset: std.split(versionWeight, ":")[0],
+                },
+                weight: std.parseInt(std.split(versionWeight, ":")[1]),
+              },
+              for versionWeight in versionWeights
+            ],
+          }
+        ],
+      },
+    },
+    virtualService:: virtualService,
+  },  // new
+}


### PR DESCRIPTION
Separate the service part (model) and the deployment (version) of TF serving.

## To serve a model, we should deploy service + deployment as:
Service
```
ks generate tf-serving-service mnist-service
ks param set mnist-service modelName mnist
ks param set mnist-service trafficRule v1:100    // optional, it's the default value
```
Deployment
```
ks generate tf-serving-deployment-gcp mnist-v1
ks param set mnist-v1 modelName mnist
ks param set mnist-v1 versionName v1   // optional, it's the default value
ks param set mnist-v1  modelBasePath gs://kubeflow-examples-data/mnist
ks param set mnist-v1 gcpCredentialSecretName user-gcp-sa
ks param set mnist-v1 injectIstio true
```

## To rollout the version v2,
```
ks generate tf-serving-deployment-gcp mnist-v2
ks param set mnist-v2 modelName mnist
ks param set mnist-v2 versionName v2
ks param set mnist-v2  modelBasePath gs://kubeflow-examples-data/mnist
ks param set mnist-v2 gcpCredentialSecretName user-gcp-sa
ks param set mnist-v2 injectIstio true
// traffic split
ks param set mnist-service trafficRule v1:50,v2:50
```

/cc @jlewi 