### PR TITLE
Create a simple flask server to redirect http to https

### DIFF
--- a/components/https-redirect/Dockerfile
+++ b/components/https-redirect/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:2.7-slim
+
+ADD . /app
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT ["gunicorn", "-b", ":8080", "main:app"]

--- a/components/https-redirect/Makefile
+++ b/components/https-redirect/Makefile
@@ -1,0 +1,50 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+GCLOUD_PROJECT ?= kubeflow-images-public
+IMG = gcr.io/$(GCLOUD_PROJECT)/https-redirect
+
+# List any changed  files. We only include files in the notebooks directory.
+# because that is the code in the docker image.
+# In particular we exclude changes to the ksonnet configs.
+CHANGED_FILES := $(shell git diff-files --relative=components/https-redirect)
+
+ifeq ($(strip $(CHANGED_FILES)),)
+# Changed files is empty; not dirty
+# Don't include --dirty because it could be dirty if files outside the ones we care
+# about changed.
+GIT_VERSION := $(shell git describe --always)
+else
+GIT_VERSION := $(shell git describe --always)-dirty-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
+TAG := $(shell date +v%Y%m%d)-$(GIT_VERSION)
+all: build
+
+# To build without the cache set the environment variable
+# export DOCKER_BUILD_OPTS=--no-cache
+build:
+	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) . \
+					--label=git-verions=$(GIT_VERSION)
+	docker tag $(IMG):$(TAG) $(IMG):latest
+	@echo Built $(IMG):latest
+	@echo Built $(IMG):$(TAG)
+
+# Build but don't attach the latest tag. This allows manual testing/inspection of the image
+# first.
+push: build
+	gcloud docker -- push $(IMG):$(TAG)
+
+push-latest: push
+	gcloud docker -- push $(IMG):$(TAG)

--- a/components/https-redirect/main.py
+++ b/components/https-redirect/main.py
@@ -1,0 +1,41 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A simple flask app to redirect all requests to https.
+"""
+
+import logging
+
+from flask import Flask, redirect, request
+
+app = Flask(__name__)
+
+@app.route('/')
+@app.route('/<path:path>')
+def all_handler(path=None):
+  new_url = request.url
+  if request.scheme == "http":
+    prefix = "http"
+    new_url = "https" + new_url[len(prefix):]
+  logging.info("Redirecting to: %s", new_url)
+  return redirect(new_url)
+
+if __name__ == '__main__':
+  logging.basicConfig(
+      level=logging.INFO,
+      format=('%(levelname)s|%(asctime)s'
+              '|%(pathname)s|%(lineno)d| %(message)s'),
+      datefmt='%Y-%m-%dT%H:%M:%S',)
+  logging.getLogger().setLevel(logging.INFO)
+  app.run(host='127.0.0.1', port=8080, debug=False)

--- a/components/https-redirect/main.py
+++ b/components/https-redirect/main.py
@@ -33,7 +33,17 @@ def all_handler(path=None):
     prefix = "http"
     new_url = "https" + new_url[len(prefix):]
   logging.info("Redirecting to: %s", new_url)
-  return redirect(new_url)
+
+  response = redirect(new_url)
+
+  # For "/" we return a 200 (ok) and not a 302 (redirect) because on GKE
+  # we want to be able to use this to redirect http://mydomain.com/ to
+  # https://mydomain.com/. However, the Ingress sets up the GCP loadbalancer
+  # health check requires that a 200 be served on "/". So if we return a 302
+  # the backend will be considered unhealthy.
+  if not path:
+    response.status_code = 200
+  return response
 
 if __name__ == '__main__':
   logging.basicConfig(

--- a/components/https-redirect/main.py
+++ b/components/https-redirect/main.py
@@ -17,9 +17,13 @@
 
 import logging
 
-from flask import Flask, redirect, request
+from flask import Flask, jsonify, redirect, request
 
 app = Flask(__name__)
+
+@app.route('/healthz')
+def health_check():
+  return jsonify({'isHealthy': True})
 
 @app.route('/')
 @app.route('/<path:path>')

--- a/components/https-redirect/main_test.py
+++ b/components/https-redirect/main_test.py
@@ -1,0 +1,35 @@
+# Copyright 2016 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+import main
+
+class TestRedirect(unittest.TestCase):
+  def test_auth_info(self):
+    main.app.testing = True
+    client = main.app.test_client()
+
+    endpoint = '/hello/world'
+    r = client.get(
+          endpoint,
+            headers={
+              'Content-Type': 'application/json'
+            })
+
+    self.assertEqual(302, r.status_code)
+    self.assertEqual(r.data,
+                     '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<title>Redirecting...</title>\n<h1>Redirecting...</h1>\n<p>You should be redirected automatically to target URL: <a href="https://localhost/hello/world">https://localhost/hello/world</a>.  If not click the link.')
+
+if __name__ == "__main__":
+  unittest.main()

--- a/components/https-redirect/main_test.py
+++ b/components/https-redirect/main_test.py
@@ -31,5 +31,18 @@ class TestRedirect(unittest.TestCase):
     self.assertEqual(r.data,
                      '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<title>Redirecting...</title>\n<h1>Redirecting...</h1>\n<p>You should be redirected automatically to target URL: <a href="https://localhost/hello/world">https://localhost/hello/world</a>.  If not click the link.')
 
+  def test_health_check(self):
+    main.app.testing = True
+    client = main.app.test_client()
+
+    endpoint = '/healthz'
+    r = client.get(
+          endpoint,
+            headers={
+              'Content-Type': 'application/json'
+            })
+
+    self.assertEqual(200, r.status_code)
+
 if __name__ == "__main__":
   unittest.main()

--- a/components/https-redirect/main_test.py
+++ b/components/https-redirect/main_test.py
@@ -16,7 +16,7 @@ import unittest
 import main
 
 class TestRedirect(unittest.TestCase):
-  def test_auth_info(self):
+  def test_non_empty_path(self):
     main.app.testing = True
     client = main.app.test_client()
 
@@ -30,6 +30,21 @@ class TestRedirect(unittest.TestCase):
     self.assertEqual(302, r.status_code)
     self.assertEqual(r.data,
                      '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<title>Redirecting...</title>\n<h1>Redirecting...</h1>\n<p>You should be redirected automatically to target URL: <a href="https://localhost/hello/world">https://localhost/hello/world</a>.  If not click the link.')
+
+  def test_empty_path(self):
+    main.app.testing = True
+    client = main.app.test_client()
+
+    endpoint = '/'
+    r = client.get(
+          endpoint,
+            headers={
+              'Content-Type': 'application/json'
+            })
+
+    self.assertEqual(200, r.status_code)
+    self.assertEqual(r.data,
+                     '<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">\n<title>Redirecting...</title>\n<h1>Redirecting...</h1>\n<p>You should be redirected automatically to target URL: <a href="https://localhost/">https://localhost/</a>.  If not click the link.')
 
   def test_health_check(self):
     main.app.testing = True

--- a/components/https-redirect/requirements.txt
+++ b/components/https-redirect/requirements.txt
@@ -1,0 +1,3 @@
+Flask==0.12.2
+gunicorn==19.7.1
+requests==2.18.4


### PR DESCRIPTION
* We can use this with Envoy/Ambassador to redirect HTTP to HTTPs
* Example would be redirecting devstats.kubeflow.org to HTTPS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1832)
<!-- Reviewable:end -->
