### PR TITLE
Remove argo & katib from default minikube

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -230,9 +230,14 @@ ksApply () {
   ks apply default -c jupyterhub
   ks apply default -c centraldashboard
   ks apply default -c tf-job-operator
-  ks apply default -c argo
-  ks apply default -c katib
   ks apply default -c spartakus
+
+  # Reduce resource demands locally
+  if [ "${PLATFORM}" != "minikube" ]; then
+    ks apply default -c argo
+    ks apply default -c katib
+  fi
+
   popd
 
   set +x


### PR DESCRIPTION
Fixes #1837 

Deploy all other default components except argo & katib when platform is minikube.

Due to the large image sizes of default KF components, this makes it possible to deploy the platform to a minikube instance with 8GB RAM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1838)
<!-- Reviewable:end -->
