### PR TITLE
Separate logic for setup_backend.sh

### DIFF
--- a/kubeflow/core/iap.libsonnet
+++ b/kubeflow/core/iap.libsonnet
@@ -251,6 +251,87 @@
     },  // deploy
     deploy:: deploy,
 
+    // Run the process to update the backend service
+    local backendUpdater = {
+      apiVersion: "apps/v1",
+      kind: "StatefulSet",
+      metadata: {
+        name: "backend-updater",
+        namespace: params.namespace,
+        labels: {
+          service: "backend-updater",
+        },
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            service: "backend-updater",
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              service: "backend-updater",
+            },
+          },
+          spec: {
+            serviceAccountName: "envoy",
+            containers: [
+              {
+                name: "backend-updater",
+                image: params.ingressSetupImage,
+                command: [
+                  "bash",
+                  "/var/envoy-config/update_backend.sh",
+                ],
+                env: [
+                  {
+                    name: "NAMESPACE",
+                    value: params.namespace,
+                  },
+                  {
+                    name: "SERVICE",
+                    value: "envoy",
+                  },
+                  {
+                    name: "GOOGLE_APPLICATION_CREDENTIALS",
+                    value: "/var/run/secrets/sa/admin-gcp-sa.json",
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    mountPath: "/var/envoy-config/",
+                    name: "config-volume",
+                  },
+                  {
+                    name: "sa-key",
+                    readOnly: true,
+                    mountPath: "/var/run/secrets/sa",
+                  },
+                ],
+              },
+            ],
+            volumes: [
+              {
+                configMap: {
+                  name: "envoy-config",
+                },
+                name: "config-volume",
+              },
+              {
+                name: "sa-key",
+                secret: {
+                  secretName: "admin-gcp-sa",
+                },
+              },
+            ],
+          },
+        },
+      },
+
+    },  // backendUpdater
+    backendUpdater:: backendUpdater,
+
     // Run the process to enable iap
     local iapEnabler = {
       apiVersion: "extensions/v1beta1",
@@ -631,6 +712,7 @@
       data: {
         "envoy-config.json": std.manifestJson(envoyConfig(params)),
         "setup_backend.sh": importstr "setup_backend.sh",
+        "update_backend.sh": importstr "update_backend.sh",
         "configure_envoy_for_iap.sh": importstr "configure_envoy_for_iap.sh",
       },
     },
@@ -910,6 +992,7 @@
       self.initClusterRole,
       self.deploy,
       self.iapEnabler,
+      self.backendUpdater,
       self.configMap,
       self.whoamiService,
       self.whoamiApp,

--- a/kubeflow/core/setup_backend.sh
+++ b/kubeflow/core/setup_backend.sh
@@ -4,39 +4,6 @@
 [ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
 [ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
 
-# Stagger init of replicas when acquiring lock
-sleep $(($RANDOM % 5 + 1))
-
-# We acquire a lock because we want to ensure  there is a single process
-# trying to modify the backend at a time.
-kubectl get svc ${SERVICE} -o json > service.json
-LOCK=$(jq -r ".metadata.annotations.backendlock" service.json)
-
-NOW=$(date -u +'%s')
-if [[ -z "${LOCK}" || "${LOCK}" == "null" ]]; then
-  LOCK_T=$NOW
-else
-  LOCK_T=$(echo "${LOCK}" | cut -d' ' -f2)
-fi
-
-LOCK_AGE=$(($NOW - $LOCK_T))
-LOCK_TTL=120
-
-if [[ -z "${LOCK}" || "${LOCK}" == "null" || "${LOCK_AGE}" -gt "${LOCK_TTL}" ]]; then
-  jq -r ".metadata.annotations.backendlock=\"$(hostname -s) ${NOW}\"" service.json > service_lock.json
-  kubectl apply -f service_lock.json 2>/dev/null
-  if [[ $? -eq 0 ]]; then
-    echo "Acquired lock on service annotation to configure backend."
-  else
-    echo "WARN: Failed to acquire lock on service annotation."
-    exit 1
-  fi
-else
-  echo "WARN: Lock on service annotation already acquired by: $LOCK, age: $LOCK_AGE, TTL: $LOCK_TTL"
-  sleep 20
-  exit 1
-fi
-
 PROJECT=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
 if [ -z ${PROJECT} ]; then
   echo Error unable to fetch PROJECT from compute metadata
@@ -61,26 +28,6 @@ while [[ -z ${BACKEND_ID} ]]; do
   sleep 2
 done
 echo BACKEND_ID=${BACKEND_ID}
-
-NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
-BACKEND_SERVICE=$(gcloud --project=${PROJECT} compute backend-services list --filter=name~k8s-be-${NODE_PORT}- --uri)
-
-while [[ -z ${HEALTH_CHECK_URI} ]]; do
-  HEALTH_CHECK_URI=$(gcloud compute --project=${PROJECT} health-checks list --filter=name~k8s-be-${NODE_PORT}- --uri)
-  echo "Waiting for the healthcheck resource PROJECT=${PROJECT} NODEPORT=${NODE_PORT} SERVICE=${SERVICE}..."
-  sleep 2
-done
-
-# Since we create the envoy-ingress ingress object before creating the envoy
-# deployment object, healthcheck will not be configured correctly in the GCP
-# load balancer. It will default the healthcheck request path to a value of
-# / instead of the intended /healthz.
-# Manually update the healthcheck request path to /healthz
-gcloud --project=${PROJECT} compute health-checks update http ${HEALTH_CHECK_URI} --request-path=/healthz
-
-# Since Jupyter uses websockets we want to increase the backend timeout
-echo Increasing backend timeout for Jupyter
-gcloud --project=${PROJECT} compute backend-services update --global ${BACKEND_SERVICE} --timeout=3600
 
 JWT_AUDIENCE="/projects/${PROJECT_NUM}/global/backendServices/${BACKEND_ID}"
 

--- a/kubeflow/core/update_backend.sh
+++ b/kubeflow/core/update_backend.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# A simple shell script to configure the backend timeouts and health checks by using gcloud.
+
+[ -z ${NAMESPACE} ] && echo Error NAMESPACE must be set && exit 1
+[ -z ${SERVICE} ] && echo Error SERVICE must be set && exit 1
+
+PROJECT=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id)
+if [ -z ${PROJECT} ]; then
+  echo Error unable to fetch PROJECT from compute metadata
+  exit 1
+fi
+
+# Activate the service account, allow 5 retries
+for i in {1..5}; do gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} && break || sleep 10; done
+
+NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
+while [[ -z ${BACKEND_SERVICE} ]];
+do BACKEND_SERVICE=$(gcloud --project=${PROJECT} compute backend-services list --filter=name~k8s-be-${NODE_PORT}- --uri);
+echo "Waiting for the backend-services resource PROJECT=${PROJECT} NODEPORT=${NODE_PORT} SERVICE=${SERVICE}...";
+sleep 2;
+done
+
+while [[ -z ${HEALTH_CHECK_URI} ]];
+do HEALTH_CHECK_URI=$(gcloud compute --project=${PROJECT} health-checks list --filter=name~k8s-be-${NODE_PORT}- --uri);
+echo "Waiting for the healthcheck resource PROJECT=${PROJECT} NODEPORT=${NODE_PORT} SERVICE=${SERVICE}...";
+sleep 2;
+done
+
+# Since we create the envoy-ingress ingress object before creating the envoy
+# deployment object, healthcheck will not be configured correctly in the GCP
+# load balancer. It will default the healthcheck request path to a value of
+# / instead of the intended /healthz.
+# Manually update the healthcheck request path to /healthz
+gcloud --project=${PROJECT} compute health-checks update http ${HEALTH_CHECK_URI} --request-path=/healthz
+
+# Since JupyterHub uses websockets we want to increase the backend timeout
+echo Increasing backend timeout for JupyterHub
+gcloud --project=${PROJECT} compute backend-services update --global ${BACKEND_SERVICE} --timeout=3600
+
+echo "Backend updated successfully. Waiting 1 hour before updating again."
+sleep 3600


### PR DESCRIPTION
"setup_backend.sh is doing two things

1. updating the backend service
2. updating the envoy config in each instance with the info needed for
JWT validation
"
This PR separates those two concerns into two separate scripts.

Fixes #1145

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1841)
<!-- Reviewable:end -->
