### PR TITLE
Run minikube e2e test if core components change

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -49,7 +49,7 @@ workflows:
       - periodic
     params:
       platform: minikube
-    include_dirs:       
+    include_dirs:
       # Run on presubmit if any files used by minikube change
       - kubeflow/core/*
       - kubeflow/pytorch-job/*

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -49,8 +49,10 @@ workflows:
       - periodic
     params:
       platform: minikube
-    include_dirs:
+    include_dirs:       
       # Run on presubmit if any files used by minikube change
+      - kubeflow/core/*
+      - kubeflow/pytorch-job/*
       - testing/deploy_kubeflow.py
       - testing/workflows/components/workflows.jsonnet
       - testing/workflows/components/workflows.libsonnet


### PR DESCRIPTION
PR https://github.com/kubeflow/kubeflow/pull/1829 broke minikube e2e tests, but it got merged because the tests were not triggered. This PR adds scoping such that e2e minikube tests are run when core component files change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1864)
<!-- Reviewable:end -->
