### PR TITLE
create secrets in apply stage

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -288,12 +288,12 @@ if [ "${COMMAND}" == "apply" ]; then
   if [ "${WHAT}" == "platform" ] || [ "${WHAT}" == "all" ] ; then
   	if [ "${PLATFORM}" == "gcp" ]; then
     	updateDM
-    	createSecrets
     fi
   fi
 
   if [ "${WHAT}" == "k8s"  ] || [ "${WHAT}" == "all" ]; then
     createNamespace
+    createSecrets
     ksApply
 
     if [ "${PLATFORM}" == "gcp" ]; then


### PR DESCRIPTION
secrets are deleted in the `kfctl.sh delete k8s` phase as part of the
namespace, but not created in `kfctl.sh apply k8s`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1867)
<!-- Reviewable:end -->
