### PR TITLE
Fixing the conflict with the getting started guide

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -12,11 +12,6 @@ fi
 
 KUBEFLOW_TAG=${KUBEFLOW_TAG:-master}
 
-if [ -d "${KUBEFLOW_REPO}" ]; then
-  echo Directory ${KUBEFLOW_REPO} already exists
-  exit 1
-fi
-
 # Create a local copy of the Kubeflow source repo
 TMPDIR=$(mktemp -d /tmp/tmp.kubeflow-repo-XXXX)
 curl -L -o ${TMPDIR}/kubeflow.tar.gz https://github.com/kubeflow/kubeflow/archive/${KUBEFLOW_TAG}.tar.gz


### PR DESCRIPTION
According to the getting started guide, the KUBEFLOW_REPO is already made before running this script.

* The script no longer uses the env ${KUBEFLOW_REPO} so there's no reason to check whether
   that directory exists.

* The script now downloads the source to the current directory.

* The check if directory ${KUBEFLOW_REPO} exists is a legacy of a previous version of the script

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1873)
<!-- Reviewable:end -->
