### PR TITLE
fix iap script

### DIFF
--- a/kubeflow/core/configure_envoy_for_iap.sh
+++ b/kubeflow/core/configure_envoy_for_iap.sh
@@ -20,7 +20,7 @@ exit 1
 fi
 
 # Activate the service account
-for i in {1..10}
+for i in $(seq 1 10)
 do gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS} && break || sleep 10
 done
 


### PR DESCRIPTION
format ```{1..10}``` doesn't work inside iap image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1874)
<!-- Reviewable:end -->
