### PR TITLE
Fix routing problem of jupyterhub service

### DIFF
--- a/kubeflow/core/kubeform_spawner.py
+++ b/kubeflow/core/kubeform_spawner.py
@@ -145,6 +145,18 @@ class KubeFormSpawner(KubeSpawner):
             )[:63]
         return rname
 
+    def _build_common_labels(self, extra_labels):
+        # By default, KubeSpawner will assign the 'app: jupyterhub' label to
+        # newly created Jupyter notebooks. This poses a problem for Kubeflow,
+        # which uses the 'app: jupyterhub' label to identify the JupyterHub
+        # server e.g., it sets 'app: jupyterhub' as a selector for jupyterhub-0
+        # and jupyterhub-lb services. Override the _build_common_labels()
+        # KubeSpawner method and remove the 'app: jupyterhub' label.
+        labels = {'app': 'jupyter-notebook',
+                  'heritage': 'jupyterhub'}
+        labels.update(extra_labels)
+        return labels
+
 
 ###################################################
 # JupyterHub Options


### PR DESCRIPTION
By default, KubeSpawner will assign the 'app: jupyterhub' label to newly
created Jupyter notebooks. Since PR #1410 was merged, kubeflow also uses
the same label for the JupyterHub server (it previously was tf-hub).

This causes routing problems for the jupyterhub-0 and jupyterhub-lb
services, since both use the 'app: jupyterhub' label as a selector and
will route the traffic to the spawned notebooks instead of the
JupyterHub server.

Fix the above error by modifying KubeSpawner and changing
the 'app:jupyterhub' label for newly spawned notebooks to
'app: jupyter-notebook'.

This PR should fix #1710.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1900)
<!-- Reviewable:end -->
