### PR TITLE
Enable tf serving prometheus metrics

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-gcp.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-gcp.jsonnet
@@ -13,6 +13,7 @@
 // @optionalParam httpProxyImage string gcr.io/kubeflow-images-public/tf-model-server-http-proxy:v20180723 Http proxy image
 // @optionalParam gcpCredentialSecretName string null If not empty, insert the secret credential
 // @optionalParam injectIstio string false Whether to inject istio sidecar; should be true or false.
+// @optionalParam enablePrometheus string true Whether to enable prometheus endpoint (requires TF 1.11)
 
 local k = import "k.libsonnet";
 local deployment = k.apps.v1beta1.deployment;
@@ -56,4 +57,5 @@ local tfDeployment = base.tfDeployment +
                      );
 util.list([
   tfDeployment,
+  base.tfservingConfig,
 ],)

--- a/kubeflow/tf-serving/tf-serving-template.libsonnet
+++ b/kubeflow/tf-serving/tf-serving-template.libsonnet
@@ -29,7 +29,9 @@
         "--rest_api_port=8500",
         "--model_name=" + modelName,
         "--model_base_path=" + params.modelBasePath,
-      ],
+      ] + if util.toBool(params.enablePrometheus) then [
+        "--monitoring_config_file=/var/config/monitoring_config.txt",
+      ] else [],
       image: modelServerImage,
       imagePullPolicy: "IfNotPresent",
       name: modelName,
@@ -54,7 +56,12 @@
           memory: "1Gi",
         },
       },
-      volumeMounts: [],
+      volumeMounts: [
+        {
+          mountPath: "/var/config/",
+          name: "config-volume",
+        },
+      ],
       // TCP liveness probe on gRPC port
       livenessProbe: {
         tcpSocket: {
@@ -90,11 +97,36 @@
             containers: [
               modelServerContainer,
             ],
-            volumes: [],
+            volumes: [
+              {
+                configMap: {
+                  name: name + "-config",
+                },
+                name: "config-volume",
+              },
+            ],
           },
         },
       },
     },  // tfDeployment
     tfDeployment:: tfDeployment,
+
+    local tfservingConfig = {
+      apiVersion: "v1",
+      kind: "ConfigMap",
+      metadata: {
+        name: name + "-config",
+        namespace: params.namespace,
+      },
+      data: {
+        "monitoring_config.txt": std.join("\n", [
+          "prometheus_config: {",
+          "  enable: true,",
+          "  path: \"/monitoring/prometheus/metrics\"",
+          "}"
+        ]),
+      },
+    },  // tfservingConfig
+    tfservingConfig:: tfservingConfig,
   },  // new
 }


### PR DESCRIPTION
For #1036 

Verify can get data from XXX:8500/monitoring/prometheus/metrics

```
# TYPE :tensorflow:cc:saved_model:load_attempt_count counter
:tensorflow:cc:saved_model:load_attempt_count{model_path="gs://kubeflow-examples-data/mnist/1",status="success"} 1
# TYPE :tensorflow:cc:saved_model:load_latency counter
:tensorflow:cc:saved_model:load_latency{model_path="gs://kubeflow-examples-data/mnist/1"} 620873
# TYPE :tensorflow:contrib:session_bundle:load_attempt_count counter
# TYPE :tensorflow:contrib:session_bundle:load_latency counter
# TYPE :tensorflow:core:direct_session_runs counter
:tensorflow:core:direct_session_runs{} 1
# TYPE :tensorflow:serving:request_example_count_total counter
# TYPE :tensorflow:serving:request_example_counts histogram
# TYPE :tensorflow:serving:request_log_count counter
```

So the current available metrics are
```
:tensorflow:cc:saved_model:load_attempt_count
:tensorflow:cc:saved_model:load_latency
:tensorflow:core:direct_session_runs
```

/cc @jlewi 