### PR TITLE
Use iam-policy value for EMAIL if case-sensitive.

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -101,6 +101,14 @@ createEnv() {
           echo "or by setting a default account in gcloud config"
           exit 1
         fi
+        # Use iam-policy value for EMAIL if case-sensitive
+        EM_LIST="$(gcloud projects get-iam-policy $PROJECT | grep -io $EMAIL)"
+        for em in $EM_LIST; do
+          if [ "$em" != "$EMAIL" ]; then
+            EMAIL=$em
+            break
+          fi
+        done
       fi
       echo EMAIL=${EMAIL} >> ${ENV_FILE}
 


### PR DESCRIPTION
Fixes #1936  

Modify `kfctl.createEnv` to check for a case-mismatch between the `EMAIL` value provided by `$(gcloud config get-value account)` and the value in the iam-policy, and to use the iam-policy value in the case of a mismatch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1937)
<!-- Reviewable:end -->
