### PR TITLE
Redirect deployer webapp page to Kubeflow dashboard after its ready

### DIFF
--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -460,6 +460,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
   }
 
   private _monitorDeployment(project: string, deploymentName: string) {
+    const dashboardUri = 'https://' + this.state.deploymentName + '.endpoints.' + this.state.project + 'cloud.goog/';
     const monitorInterval = setInterval(() => {
       Gapi.deploymentmanager.get(this.state.project, deploymentName)
         .then(r => {
@@ -471,14 +472,26 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
             const readyTime = new Date();
             readyTime.setTime(readyTime.getTime() + (20 * 60 * 1000));
             this._appendLine('Deployment is done, your kubeflow app url should be ready within 20 minutes (by '
-              + readyTime.toLocaleTimeString() + '): https://'
-              + this.state.deploymentName + '.endpoints.' + this.state.project + '.cloud.goog');
+              + readyTime.toLocaleTimeString() + '): ' + dashboardUri);
             clearInterval(monitorInterval);
+            this._redirectToKFDashboard(dashboardUri);
           } else {
             this._appendLine(`Status of ${deploymentName}: ` + r.operation!.status!);
           }
         })
         .catch(err => this._appendLine('deployment failed with error:' + err));
+    }, 10000);
+  }
+
+  private _redirectToKFDashboard(dashboardUri: string) {
+    const monitorInterval = setInterval(() => {
+      var xmlHttp = new XMLHttpRequest();
+      xmlHttp.onreadystatechange = function() {
+        if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
+          window.location.href(dashboardUri);
+      }
+      xmlHttp.open("GET", theUrl, true); // true for asynchronous
+      xmlHttp.send(null);
     }, 10000);
   }
 

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -484,6 +484,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
   }
 
   private _redirectToKFDashboard(dashboardUri: string) {
+    // relying on JupyterHub logo image to be available when the site is ready.
     const imgUri = dashboardUri + 'hub/logo';
     const startTime = new Date().getTime() / 1000;
 		const img=document.createElement('img');

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -484,17 +484,25 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
   }
 
   private _redirectToKFDashboard(dashboardUri: string) {
-    const monitorInterval = setInterval(() => {
-      const xmlHttp = new XMLHttpRequest();
-      xmlHttp.onreadystatechange = () => {
-        if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
-          window.location.href = dashboardUri;
-          clearInterval(monitorInterval);
+    const imgUri = dashboardUri + 'hub/logo';
+    const startTime = new Date().getTime() / 1000;
+		const img=document.createElement('img');
+		img.src = imgUri + '?rand='+Math.random();
+    img.id = 'ready_test';
+		img.onload= () => {window.location.href = dashboardUri; };
+		img.onerror= () => {
+      const timeSince = (new Date().getTime() / 1000) - startTime;
+      if (timeSince > 1500) {
+        this._appendLine('Could not redirect to Kubeflow Dashboard at: ' + dashboardUri);
+      } else {
+        const ready_test = document.getElementById('ready_test') as HTMLImageElement;
+        if (ready_test != null) {
+          ready_test.src = imgUri + '?rand=' + Math.random();
         }
-      };
-      xmlHttp.open('GET', dashboardUri, true); // true for asynchronous
-      xmlHttp.send(null);
-    }, 10000);
+      }
+    };
+		img.style.display='none';
+		document.body.appendChild(img);
   }
 
   private _handleChange(event: Event) {

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -485,13 +485,19 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
 
   private _redirectToKFDashboard(dashboardUri: string) {
     // relying on JupyterHub logo image to be available when the site is ready.
+    // The dashboard URI is hosted at a domain different from the deployer
+    // app. Fetching a GET on the dashboard is blocked by the browser due
+    // to CORS. Therefore we use an img element as a hack which fetches
+    // an image served by the target site, the img load is a simple html
+    // request and not an AJAX request, thus bypassing the CORS in this
+    // case.
     const imgUri = dashboardUri + 'hub/logo';
     const startTime = new Date().getTime() / 1000;
-    const img=document.createElement('img');
-    img.src = imgUri + '?rand='+Math.random();
+    const img = document.createElement('img');
+    img.src = imgUri + '?rand=' + Math.random();
     img.id = 'ready_test';
-    img.onload= () => {window.location.href = dashboardUri; };
-    img.onerror= () => {
+    img.onload = () => { window.location.href = dashboardUri; };
+    img.onerror = () => {
       const timeSince = (new Date().getTime() / 1000) - startTime;
       if (timeSince > 1500) {
         this._appendLine('Could not redirect to Kubeflow Dashboard at: ' + dashboardUri);
@@ -502,7 +508,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
         }
       }
     };
-    img.style.display='none';
+    img.style.display = 'none';
     document.body.appendChild(img);
   }
 

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -504,8 +504,10 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
       } else {
         const ready_test = document.getElementById('ready_test') as HTMLImageElement;
         if (ready_test != null) {
-          ready_test.src = imgUri + '?rand=' + Math.random();
-          this._appendLine('Waiting for the IAP setup to get ready...');
+          setTimeout(() => {
+            ready_test.src = imgUri + '?rand=' + Math.random();
+            this._appendLine('Waiting for the IAP setup to get ready...');
+          }, 10000);
         }
       }
     };

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -487,11 +487,11 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
     // relying on JupyterHub logo image to be available when the site is ready.
     const imgUri = dashboardUri + 'hub/logo';
     const startTime = new Date().getTime() / 1000;
-		const img=document.createElement('img');
-		img.src = imgUri + '?rand='+Math.random();
+    const img=document.createElement('img');
+    img.src = imgUri + '?rand='+Math.random();
     img.id = 'ready_test';
-		img.onload= () => {window.location.href = dashboardUri; };
-		img.onerror= () => {
+    img.onload= () => {window.location.href = dashboardUri; };
+    img.onerror= () => {
       const timeSince = (new Date().getTime() / 1000) - startTime;
       if (timeSince > 1500) {
         this._appendLine('Could not redirect to Kubeflow Dashboard at: ' + dashboardUri);
@@ -502,8 +502,8 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
         }
       }
     };
-		img.style.display='none';
-		document.body.appendChild(img);
+    img.style.display='none';
+    document.body.appendChild(img);
   }
 
   private _handleChange(event: Event) {

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -505,6 +505,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
         const ready_test = document.getElementById('ready_test') as HTMLImageElement;
         if (ready_test != null) {
           ready_test.src = imgUri + '?rand=' + Math.random();
+          this._appendLine('Waiting for the IAP setup to get ready...');
         }
       }
     };

--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -485,12 +485,14 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
 
   private _redirectToKFDashboard(dashboardUri: string) {
     const monitorInterval = setInterval(() => {
-      var xmlHttp = new XMLHttpRequest();
-      xmlHttp.onreadystatechange = function() {
-        if (xmlHttp.readyState == 4 && xmlHttp.status == 200)
-          window.location.href(dashboardUri);
-      }
-      xmlHttp.open("GET", theUrl, true); // true for asynchronous
+      const xmlHttp = new XMLHttpRequest();
+      xmlHttp.onreadystatechange = () => {
+        if (xmlHttp.readyState === 4 && xmlHttp.status === 200) {
+          window.location.href = dashboardUri;
+          clearInterval(monitorInterval);
+        }
+      };
+      xmlHttp.open('GET', dashboardUri, true); // true for asynchronous
       xmlHttp.send(null);
     }, 10000);
   }


### PR DESCRIPTION
fixes #1420 

Fetching a GET on the dashboard URI which belongs in a different domain from the deployer in general gets prevented by the browser due to CORS prevention. This fix gets around that issue by leveraging the fact that a static image fetch hosted at the other dashboard site would not be prevented by the browser. Once that image is able to load within the deployer, it can redirect the user to the dashboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1945)
<!-- Reviewable:end -->
