### PR TITLE
Allow CloudShell origin pattern in Jupyter config

### DIFF
--- a/components/tensorflow-notebook-image/jupyter_notebook_config.py
+++ b/components/tensorflow-notebook-image/jupyter_notebook_config.py
@@ -24,6 +24,7 @@ c = get_config()
 c.NotebookApp.ip = '*'
 c.NotebookApp.port = 8888
 c.NotebookApp.open_browser = False
+c.NotebookApp.allow_origin_pat = ".*-dot-devshell.appspot.com$"
 
 # Generate a self-signed certificate
 if 'GEN_CERT' in os.environ:


### PR DESCRIPTION
Little add-on to the jupyter notebook configuration, so that Jupyter Notebook deployed on GKE can be acessed via Cloud Shell (Avoid "Blocking Cross Origin API request" error) -  kubeflow/pipelines#179

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1956)
<!-- Reviewable:end -->
