### PR TITLE
Enable node autoprovisioning in v1beta1 clusters

### DIFF
--- a/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -31,7 +31,7 @@ resources:
     zone: SET_THE_ZONE
     # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
     # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
-    cluster-version: "1.10"
+    cluster-version: "1.11"
     # Set this to v1beta1 to use beta features such as private clusterss
     # and the Kubernetes stackdriver agents.
     gkeApiVersion: v1
@@ -53,6 +53,12 @@ resources:
     gpu-pool-min-nodes: 0
     gpu-pool-max-nodes: 0
     gpu-type: nvidia-tesla-k80
+    # Autoprovisioning parameters (only supported in gkeApiVersion v1beta1)
+    autoprovisioning-config:
+      enabled: true
+      max-cpu: 20
+      max-memory: 200
+      max-nvidia-tesla-k80: 8
     # Whether to enable TPUs
     enable_tpu: false
     securityConfig:

--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -85,6 +85,18 @@ resources:
           {{ properties['securityConfig']['masterAuthorizedNetworksConfigCidr'] }}
         {% endif %}
       {% endif %}
+      # Autoprovisioning is only supported in v1beta1.
+      {% if properties['gkeApiVersion'] == 'v1beta1' and properties['autoprovisioning-config']['enabled'] %}
+      autoscaling:
+        enableNodeAutoprovisioning: true
+        resourceLimits:
+        - resourceType: 'cpu'
+          maximum: {{ properties['autoprovisioning-config']['max-cpu'] }}
+        - resourceType: 'memory'
+          maximum: {{ properties['autoprovisioning-config']['max-memory'] }}
+        - resourceType: 'nvidia-tesla-k80'
+          maximum: {{ properties['autoprovisioning-config']['max-nvidia-tesla-k80'] }}
+      {% endif %}
       nodePools:
       - name: default-pool
         initialNodeCount: {{ properties['cpu-pool-initialNodeCount'] }}


### PR DESCRIPTION
This enables the [node auto-provisioning](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-provisioning) feature in Kubeflow clusters. Parameters are configured in the cluster-kubeflow.yaml file.

Note that GKE v1beta1 API is required because the feature is still in Beta. GA is expected early 2019.

Also bumps the cluster version to 1.11.