### PR TITLE
initial change - add pipeline entry to kubeflow registry

### DIFF
--- a/kubeflow/pipeline/all.libsonnet
+++ b/kubeflow/pipeline/all.libsonnet
@@ -18,9 +18,9 @@
     local uiImage = params.uiImage,
     local deploy_argo = params.deploy_argo,
     local reportUsage = params.reportUsage,
-    local usage_id = params.usage_id,
+    local usageId = params.usageId,
     reporting:: if (reportUsage == true) || (reportUsage == "true") then
-      spartakus.all(namespace, usage_id)
+      spartakus.all(namespace, usageId)
     else [],
     all:: minio.parts(namespace).all +
           mysql.parts(namespace).all +

--- a/kubeflow/pipeline/all.libsonnet
+++ b/kubeflow/pipeline/all.libsonnet
@@ -20,14 +20,14 @@
     local reportUsage = params.reportUsage,
     local usage_id = params.usage_id,
     reporting:: if (reportUsage == true) || (reportUsage == "true") then
-                  spartakus.all(namespace,usage_id)
-                else [],
+      spartakus.all(namespace, usage_id)
+    else [],
     all:: minio.parts(namespace).all +
           mysql.parts(namespace).all +
-          pipeline_apiserver.all(namespace,apiImage) +
-          pipeline_scheduledworkflow.all(namespace,scheduledWorkflowImage) +
-          pipeline_persistenceagent.all(namespace,persistenceAgentImage) +
-          pipeline_ui.all(namespace,uiImage) +
+          pipeline_apiserver.all(namespace, apiImage) +
+          pipeline_scheduledworkflow.all(namespace, scheduledWorkflowImage) +
+          pipeline_persistenceagent.all(namespace, persistenceAgentImage) +
+          pipeline_ui.all(namespace, uiImage) +
           $.parts(_env, _params).reporting,
   },
 }

--- a/kubeflow/pipeline/all.libsonnet
+++ b/kubeflow/pipeline/all.libsonnet
@@ -12,22 +12,22 @@
 
     local name = params.name,
     local namespace = params.namespace,
-    local api_image = params.api_image,
-    local scheduledworkflow_image = params.scheduledworkflow_image,
-    local persistenceagent_image = params.persistenceagent_image,
-    local ui_image = params.ui_image,
+    local apiImage = params.apiImage,
+    local scheduledWorkflowImage = params.scheduledWorkflowImage,
+    local persistenceAgentImage = params.persistenceAgentImage,
+    local uiImage = params.uiImage,
     local deploy_argo = params.deploy_argo,
-    local report_usage = params.report_usage,
+    local reportUsage = params.reportUsage,
     local usage_id = params.usage_id,
-    reporting:: if (report_usage == true) || (report_usage == "true") then
+    reporting:: if (reportUsage == true) || (reportUsage == "true") then
                   spartakus.all(namespace,usage_id)
                 else [],
     all:: minio.parts(namespace).all +
           mysql.parts(namespace).all +
-          pipeline_apiserver.all(namespace,api_image) +
-          pipeline_scheduledworkflow.all(namespace,scheduledworkflow_image) +
-          pipeline_persistenceagent.all(namespace,persistenceagent_image) +
-          pipeline_ui.all(namespace,ui_image) +
+          pipeline_apiserver.all(namespace,apiImage) +
+          pipeline_scheduledworkflow.all(namespace,scheduledWorkflowImage) +
+          pipeline_persistenceagent.all(namespace,persistenceAgentImage) +
+          pipeline_ui.all(namespace,uiImage) +
           $.parts(_env, _params).reporting,
   },
 }

--- a/kubeflow/pipeline/all.libsonnet
+++ b/kubeflow/pipeline/all.libsonnet
@@ -8,7 +8,6 @@
     local pipeline_scheduledworkflow = import "kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet",
     local pipeline_persistenceagent = import "kubeflow/pipeline/pipeline-persistenceagent.libsonnet",
     local pipeline_ui = import "kubeflow/pipeline/pipeline-ui.libsonnet",
-    local spartakus = import "kubeflow/pipeline/spartakus.libsonnet",
 
     local name = params.name,
     local namespace = params.namespace,
@@ -16,18 +15,11 @@
     local scheduledWorkflowImage = params.scheduledWorkflowImage,
     local persistenceAgentImage = params.persistenceAgentImage,
     local uiImage = params.uiImage,
-    local deploy_argo = params.deploy_argo,
-    local reportUsage = params.reportUsage,
-    local usageId = params.usageId,
-    reporting:: if (reportUsage == true) || (reportUsage == "true") then
-      spartakus.all(namespace, usageId)
-    else [],
     all:: minio.parts(namespace).all +
           mysql.parts(namespace).all +
           pipeline_apiserver.all(namespace, apiImage) +
           pipeline_scheduledworkflow.all(namespace, scheduledWorkflowImage) +
           pipeline_persistenceagent.all(namespace, persistenceAgentImage) +
-          pipeline_ui.all(namespace, uiImage) +
-          $.parts(_env, _params).reporting,
+          pipeline_ui.all(namespace, uiImage),
   },
 }

--- a/kubeflow/pipeline/all.libsonnet
+++ b/kubeflow/pipeline/all.libsonnet
@@ -1,0 +1,33 @@
+{
+  parts(_env, _params):: {
+    local params = _env + _params,
+
+    local minio = import "kubeflow/pipeline/minio.libsonnet",
+    local mysql = import "kubeflow/pipeline/mysql.libsonnet",
+    local pipeline_apiserver = import "kubeflow/pipeline/pipeline-apiserver.libsonnet",
+    local pipeline_scheduledworkflow = import "kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet",
+    local pipeline_persistenceagent = import "kubeflow/pipeline/pipeline-persistenceagent.libsonnet",
+    local pipeline_ui = import "kubeflow/pipeline/pipeline-ui.libsonnet",
+    local spartakus = import "kubeflow/pipeline/spartakus.libsonnet",
+
+    local name = params.name,
+    local namespace = params.namespace,
+    local api_image = params.api_image,
+    local scheduledworkflow_image = params.scheduledworkflow_image,
+    local persistenceagent_image = params.persistenceagent_image,
+    local ui_image = params.ui_image,
+    local deploy_argo = params.deploy_argo,
+    local report_usage = params.report_usage,
+    local usage_id = params.usage_id,
+    reporting:: if (report_usage == true) || (report_usage == "true") then
+                  spartakus.all(namespace,usage_id)
+                else [],
+    all:: minio.parts(namespace).all +
+          mysql.parts(namespace).all +
+          pipeline_apiserver.all(namespace,api_image) +
+          pipeline_scheduledworkflow.all(namespace,scheduledworkflow_image) +
+          pipeline_persistenceagent.all(namespace,persistenceagent_image) +
+          pipeline_ui.all(namespace,ui_image) +
+          $.parts(_env, _params).reporting,
+  },
+}

--- a/kubeflow/pipeline/minio.libsonnet
+++ b/kubeflow/pipeline/minio.libsonnet
@@ -1,0 +1,131 @@
+{
+  parts(namespace):: {
+    all:: [
+      $.parts(namespace).pvc,
+      $.parts(namespace).service,
+      $.parts(namespace).deploy,
+      $.parts(namespace).secret,
+    ],
+
+    pvc: {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: "minio-pv-claim",
+        namespace: namespace,
+      },
+      spec: {
+        accessModes: [
+          "ReadWriteOnce",
+        ],
+        resources: {
+          requests: {
+            storage: "10Gi",
+          },
+        },
+      },
+    }, //pvc
+
+    service: {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "minio-service",
+        namespace: namespace,
+      },
+      spec: {
+        ports: [
+          {
+            port: 9000,
+            targetPort: 9000,
+            protocol: "TCP",
+          },
+        ],
+        selector: {
+          app: "minio",
+        },
+      },
+      status: {
+        loadBalancer: {}
+      },
+    }, //service
+
+    deploy: {
+      apiVersion: "apps/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: "minio",
+        namespace: namespace,
+      },
+      spec: {
+        strategy: {
+          type: "Recreate"
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "minio",
+            },
+          },
+          spec: {
+            volumes: [
+              {
+                name: "data",
+                persistentVolumeClaim: {
+                  claimName: "minio-pv-claim",
+                },
+              },
+            ],
+            containers: [
+              {
+                name: "minio",
+                volumeMounts: [
+                  {
+                    name: "data",
+                    mountPath: "/data"
+                  },
+                ],
+                image: "minio/minio:RELEASE.2018-02-09T22-40-05Z",
+                args: [
+                  "server",
+                  "/data",
+                ],
+                env: [
+                  {
+                    name: "MINIO_ACCESS_KEY",
+                    value: "minio",
+                  },
+                  {
+                    name: "MINIO_SECRET_KEY",
+                    value: "minio123",
+                  },
+                ],
+                ports: [
+                  {
+                    containerPort: 9000,
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    }, // deploy
+
+    // The motivation behind the minio secret creation is that argo workflows depend on this secret to
+    // store the artifact in minio.
+    secret: {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name: "mlpipeline-minio-artifact",
+        namespace: namespace,
+      },
+      type: "Opaque",
+      data: {
+        "accesskey": std.base64("minio"),
+        "secretkey": std.base64("minio123"),
+      },
+    }, // secret
+  },  // parts
+}

--- a/kubeflow/pipeline/minio.libsonnet
+++ b/kubeflow/pipeline/minio.libsonnet
@@ -24,7 +24,7 @@
           },
         },
       },
-    }, //pvc
+    },  //pvc
 
     service: {
       apiVersion: "v1",
@@ -46,9 +46,9 @@
         },
       },
       status: {
-        loadBalancer: {}
+        loadBalancer: {},
       },
-    }, //service
+    },  //service
 
     deploy: {
       apiVersion: "apps/v1beta1",
@@ -59,7 +59,7 @@
       },
       spec: {
         strategy: {
-          type: "Recreate"
+          type: "Recreate",
         },
         template: {
           metadata: {
@@ -82,7 +82,7 @@
                 volumeMounts: [
                   {
                     name: "data",
-                    mountPath: "/data"
+                    mountPath: "/data",
                   },
                 ],
                 image: "minio/minio:RELEASE.2018-02-09T22-40-05Z",
@@ -110,7 +110,7 @@
           },
         },
       },
-    }, // deploy
+    },  // deploy
 
     // The motivation behind the minio secret creation is that argo workflows depend on this secret to
     // store the artifact in minio.
@@ -123,9 +123,9 @@
       },
       type: "Opaque",
       data: {
-        "accesskey": std.base64("minio"),
-        "secretkey": std.base64("minio123"),
+        accesskey: std.base64("minio"),
+        secretkey: std.base64("minio123"),
       },
-    }, // secret
+    },  // secret
   },  // parts
 }

--- a/kubeflow/pipeline/mysql.libsonnet
+++ b/kubeflow/pipeline/mysql.libsonnet
@@ -23,7 +23,7 @@
           },
         },
       },
-    }, //pvc
+    },  //pvc
 
     service: {
       apiVersion: "v1",
@@ -43,9 +43,9 @@
         },
       },
       status: {
-        loadBalancer: {}
+        loadBalancer: {},
       },
-    }, //service
+    },  //service
 
     deploy: {
       apiVersion: "apps/v1beta2",
@@ -105,6 +105,6 @@
           },
         },
       },
-    }, //deploy
-  }, //parts
+    },  //deploy
+  },  //parts
 }

--- a/kubeflow/pipeline/mysql.libsonnet
+++ b/kubeflow/pipeline/mysql.libsonnet
@@ -1,0 +1,110 @@
+{
+  parts(namespace):: {
+    all:: [
+      $.parts(namespace).pvc,
+      $.parts(namespace).service,
+      $.parts(namespace).deploy,
+    ],
+
+    pvc: {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: "mysql-pv-claim",
+        namespace: namespace,
+      },
+      spec: {
+        accessModes: [
+          "ReadWriteOnce",
+        ],
+        resources: {
+          requests: {
+            storage: "10Gi",
+          },
+        },
+      },
+    }, //pvc
+
+    service: {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "mysql",
+        namespace: namespace,
+      },
+      spec: {
+        ports: [
+          {
+            port: 3306,
+          },
+        ],
+        selector: {
+          app: "mysql",
+        },
+      },
+      status: {
+        loadBalancer: {}
+      },
+    }, //service
+
+    deploy: {
+      apiVersion: "apps/v1beta2",
+      kind: "Deployment",
+      metadata: {
+        name: "mysql",
+        namespace: namespace,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: "mysql",
+          },
+        },
+        strategy: {
+          type: "Recreate",
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "mysql",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                image: "mysql:5.6",
+                name: "mysql",
+                env: [
+                  {
+                    name: "MYSQL_ALLOW_EMPTY_PASSWORD",
+                    value: "true",
+                  },
+                ],
+                ports: [
+                  {
+                    containerPort: 3306,
+                    name: "mysql",
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "mysql-persistent-storage",
+                    mountPath: "/var/lib/mysql",
+                  },
+                ],
+              },
+            ],
+            volumes: [
+              {
+                name: "mysql-persistent-storage",
+                persistentVolumeClaim: {
+                  claimName: "mysql-pv-claim",
+                },
+              },
+            ],
+          },
+        },
+      },
+    }, //deploy
+  }, //parts
+}

--- a/kubeflow/pipeline/parts.yaml
+++ b/kubeflow/pipeline/parts.yaml
@@ -1,0 +1,47 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{
+   "name": "pipeline",
+   "apiVersion": "0.0.1",
+   "kind": "ksonnet.io/parts",
+   "description": "Prototypes for running Kubeflow pipeline.\n",
+   "author": "kubeflow-team <kubeflow-discuss@googlegroups.com>",
+   "contributors": [
+      {
+         "name": "Yang Pan",
+         "email": "yangpa@google.com"
+      }
+   ],
+   "repository": {
+      "type": "git",
+      "url": "https://github.com/kubeflow/pipelines"
+   },
+   "bugs": {
+      "url": "https://github.com/kubeflow/pipelines/issues"
+   },
+   "keywords": [
+      "pipeline"
+   ],
+   "quickStart": {
+      "prototype": "io.ksonnet.pkg.pipeline",
+      "componentName": "pipeline",
+      "flags": {
+         "name": "pipeline",
+         "namespace": "default"
+      },
+      "comment": "Deploy Kubeflow pipeline"
+   },
+   "license": "Apache 2.0"
+}

--- a/kubeflow/pipeline/parts.yaml
+++ b/kubeflow/pipeline/parts.yaml
@@ -1,47 +1,47 @@
-# Copyright 2018 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 {
-   "name": "pipeline",
-   "apiVersion": "0.0.1",
-   "kind": "ksonnet.io/parts",
-   "description": "Prototypes for running Kubeflow pipeline.\n",
-   "author": "kubeflow-team <kubeflow-discuss@googlegroups.com>",
-   "contributors": [
-      {
-         "name": "Yang Pan",
-         "email": "yangpa@google.com"
-      }
-   ],
-   "repository": {
-      "type": "git",
-      "url": "https://github.com/kubeflow/pipelines"
-   },
-   "bugs": {
-      "url": "https://github.com/kubeflow/pipelines/issues"
-   },
-   "keywords": [
-      "pipeline"
-   ],
-   "quickStart": {
-      "prototype": "io.ksonnet.pkg.pipeline",
-      "componentName": "pipeline",
-      "flags": {
-         "name": "pipeline",
-         "namespace": "default"
-      },
-      "comment": "Deploy Kubeflow pipeline"
-   },
-   "license": "Apache 2.0"
+  name: "pipeline",
+  apiVersion: "0.0.1",
+  kind: "ksonnet.io/parts",
+  description: "Prototypes for running Kubeflow pipeline.\n",
+  author: "kubeflow-team <kubeflow-discuss@googlegroups.com>",
+  contributors: [
+    {
+      name: "Yang Pan",
+      email: "yangpa@google.com",
+    },
+  ],
+  repository: {
+    type: "git",
+    url: "https://github.com/kubeflow/pipelines",
+  },
+  bugs: {
+    url: "https://github.com/kubeflow/pipelines/issues",
+  },
+  keywords: [
+    "pipeline",
+  ],
+  quickStart: {
+    prototype: "io.ksonnet.pkg.pipeline",
+    componentName: "pipeline",
+    flags: {
+      name: "pipeline",
+      namespace: "default",
+    },
+    comment: "Deploy Kubeflow pipeline",
+  },
+  license: "Apache 2.0",
 }

--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -121,16 +121,16 @@
         },
       },
       status: {
-        loadBalancer: {}
+        loadBalancer: {},
       },
-    }, //service
+    },  //service
 
     deploy(image): {
       apiVersion: "apps/v1beta2",
       kind: "Deployment",
       metadata: {
-        "labels": {
-          "app": "ml-pipeline",
+        labels: {
+          app: "ml-pipeline",
         },
         name: "ml-pipeline",
         namespace: namespace,
@@ -152,14 +152,14 @@
               {
                 name: "ml-pipeline-api-server",
                 image: image,
-                imagePullPolicy: 'Always',
+                imagePullPolicy: "Always",
                 ports: [
-                    {
-                      containerPort: 8888,
-                    },
-                    {
-                      containerPort: 8887,
-                    },
+                  {
+                    containerPort: 8888,
+                  },
+                  {
+                    containerPort: 8887,
+                  },
                 ],
                 env: [
                   {
@@ -177,7 +177,7 @@
           },
         },
       },
-    }, // deploy
+    },  // deploy
 
     pipelineRunnerServiceAccount: {
       apiVersion: "v1",

--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -1,10 +1,10 @@
 {
-  all(namespace, api_image):: [
+  all(namespace, apiImage):: [
     $.parts(namespace).serviceAccount,
     $.parts(namespace).roleBinding,
     $.parts(namespace).role,
     $.parts(namespace).service,
-    $.parts(namespace).deploy(api_image),
+    $.parts(namespace).deploy(apiImage),
     $.parts(namespace).pipelineRunnerServiceAccount,
     $.parts(namespace).pipelineRunnerRole,
     $.parts(namespace).pipelineRunnerRoleBinding,

--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -1,0 +1,327 @@
+{
+  all(namespace, api_image):: [
+    $.parts(namespace).serviceAccount,
+    $.parts(namespace).roleBinding,
+    $.parts(namespace).role,
+    $.parts(namespace).service,
+    $.parts(namespace).deploy(api_image),
+    $.parts(namespace).pipelineRunnerServiceAccount,
+    $.parts(namespace).pipelineRunnerRole,
+    $.parts(namespace).pipelineRunnerRoleBinding,
+  ],
+
+  parts(namespace):: {
+    serviceAccount: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "ml-pipeline",
+        namespace: namespace,
+      },
+    },  // service account
+
+    roleBinding:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "RoleBinding",
+      metadata: {
+        labels: {
+          app: "ml-pipeline",
+        },
+        name: "ml-pipeline",
+        namespace: namespace,
+      },
+      roleRef: {
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "Role",
+        name: "ml-pipeline",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "ml-pipeline",
+          namespace: namespace,
+        },
+      ],
+    },  // role binding
+
+    role: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "Role",
+      metadata: {
+        labels: {
+          app: "ml-pipeline",
+        },
+        name: "ml-pipeline",
+        namespace: namespace,
+      },
+      rules: [
+        {
+          apiGroups: [
+            "argoproj.io",
+          ],
+          resources: [
+            "workflows",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+            "delete",
+          ],
+        },
+        {
+          apiGroups: [
+            "kubeflow.org",
+          ],
+          resources: [
+            "scheduledworkflows",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "update",
+            "patch",
+            "delete",
+          ],
+        },
+      ],
+    },  // role
+
+    service: {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        labels: {
+          app: "ml-pipeline",
+        },
+        name: "ml-pipeline",
+        namespace: namespace,
+      },
+      spec: {
+        ports: [
+          {
+            port: 8888,
+            targetPort: 8888,
+            protocol: "TCP",
+            name: "http",
+          },
+          {
+            port: 8887,
+            targetPort: 8887,
+            protocol: "TCP",
+            name: "grpc",
+          },
+        ],
+        selector: {
+          app: "ml-pipeline",
+        },
+      },
+      status: {
+        loadBalancer: {}
+      },
+    }, //service
+
+    deploy(image): {
+      apiVersion: "apps/v1beta2",
+      kind: "Deployment",
+      metadata: {
+        "labels": {
+          "app": "ml-pipeline",
+        },
+        name: "ml-pipeline",
+        namespace: namespace,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: "ml-pipeline",
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "ml-pipeline",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: "ml-pipeline-api-server",
+                image: image,
+                imagePullPolicy: 'Always',
+                ports: [
+                    {
+                      containerPort: 8888,
+                    },
+                    {
+                      containerPort: 8887,
+                    },
+                ],
+                env: [
+                  {
+                    name: "POD_NAMESPACE",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.namespace",
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            serviceAccountName: "ml-pipeline",
+          },
+        },
+      },
+    }, // deploy
+
+    pipelineRunnerServiceAccount: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "pipeline-runner",
+        namespace: namespace,
+      },
+    },  // service account
+
+
+    // Grant admin permission so the pipeline can launch any resource in the cluster.
+    pipelineRunnerRole: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRole",
+      metadata: {
+        labels: {
+          app: "pipeline-runner",
+        },
+        name: "pipeline-runner",
+        namespace: namespace,
+      },
+      rules: [
+        {
+          apiGroups: [""],
+          resources: [
+            "secrets",
+          ],
+          verbs: [
+            "get",
+          ],
+        },
+        {
+          apiGroups: [""],
+          resources: [
+            "configmaps",
+          ],
+          verbs: [
+            "get",
+            "watch",
+            "list",
+          ],
+        },
+        {
+          apiGroups: [
+            "",
+          ],
+          resources: [
+            "persistentvolumeclaims",
+          ],
+          verbs: [
+            "create",
+            "delete",
+          ],
+        },
+        {
+          apiGroups: [
+            "argoproj.io",
+          ],
+          resources: [
+            "workflows",
+          ],
+          verbs: [
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+          ],
+        },
+        {
+          apiGroups: [
+            "",
+          ],
+          resources: [
+            "pods",
+            "pods/exec",
+            "services",
+          ],
+          verbs: [
+            "*",
+          ],
+        },
+        {
+          apiGroups: [
+            "",
+            "apps",
+            "extensions",
+          ],
+          resources: [
+            "deployments",
+            "replicasets",
+          ],
+          verbs: [
+            "*",
+          ],
+        },
+        {
+          apiGroups: [
+            "kubeflow.org",
+          ],
+          resources: [
+            "*",
+          ],
+          verbs: [
+            "*",
+          ],
+        },
+        {
+          apiGroups: [
+            "batch",
+          ],
+          resources: [
+            "jobs",
+          ],
+          verbs: [
+            "*",
+          ],
+        },
+      ],
+    },  // operator-role
+
+    pipelineRunnerRoleBinding:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRoleBinding",
+      metadata: {
+        labels: {
+          app: "pipeline-runner",
+        },
+        name: "pipeline-runner",
+        namespace: namespace,
+      },
+      roleRef: {
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "ClusterRole",
+        name: "pipeline-runner",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "pipeline-runner",
+          namespace: namespace,
+        },
+      ],
+    },  // role binding
+  },  // parts
+}

--- a/kubeflow/pipeline/pipeline-persistenceagent.libsonnet
+++ b/kubeflow/pipeline/pipeline-persistenceagent.libsonnet
@@ -84,8 +84,8 @@
       apiVersion: "apps/v1beta2",
       kind: "Deployment",
       metadata: {
-        "labels": {
-          "app": "ml-pipeline-persistenceagent",
+        labels: {
+          app: "ml-pipeline-persistenceagent",
         },
         name: "ml-pipeline-persistenceagent",
         namespace: namespace,
@@ -107,7 +107,7 @@
               {
                 name: "ml-pipeline-persistenceagent",
                 image: image,
-                imagePullPolicy: 'Always',
+                imagePullPolicy: "Always",
                 env: [
                   {
                     name: "POD_NAMESPACE",
@@ -124,6 +124,6 @@
           },
         },
       },
-    }, // deploy
+    },  // deploy
   },  // parts
 }

--- a/kubeflow/pipeline/pipeline-persistenceagent.libsonnet
+++ b/kubeflow/pipeline/pipeline-persistenceagent.libsonnet
@@ -1,9 +1,9 @@
 {
-  all(namespace, persistenceagent_image):: [
+  all(namespace, persistenceAgentImage):: [
     $.parts(namespace).serviceAccount,
     $.parts(namespace).roleBinding,
     $.parts(namespace).role,
-    $.parts(namespace).deploy(persistenceagent_image),
+    $.parts(namespace).deploy(persistenceAgentImage),
   ],
 
   parts(namespace):: {

--- a/kubeflow/pipeline/pipeline-persistenceagent.libsonnet
+++ b/kubeflow/pipeline/pipeline-persistenceagent.libsonnet
@@ -1,0 +1,129 @@
+{
+  all(namespace, persistenceagent_image):: [
+    $.parts(namespace).serviceAccount,
+    $.parts(namespace).roleBinding,
+    $.parts(namespace).role,
+    $.parts(namespace).deploy(persistenceagent_image),
+  ],
+
+  parts(namespace):: {
+    serviceAccount: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "ml-pipeline-persistenceagent",
+        namespace: namespace,
+      },
+    },  // service account
+
+    roleBinding:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRoleBinding",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-persistenceagent",
+        },
+        name: "ml-pipeline-persistenceagent",
+      },
+      roleRef: {
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "ClusterRole",
+        // TODO: These permissions are too broad. This must be fixed.
+        name: "cluster-admin",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "ml-pipeline-persistenceagent",
+          namespace: namespace,
+        },
+      ],
+    },  // role binding
+
+    role: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRole",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-persistenceagent",
+        },
+        name: "ml-pipeline-persistenceagent",
+        namespace: namespace,
+      },
+      rules: [
+        {
+          apiGroups: [
+            "argoproj.io",
+          ],
+          resources: [
+            "workflows",
+          ],
+          verbs: [
+            "get",
+            "list",
+            "watch",
+          ],
+        },
+        {
+          apiGroups: [
+            "kubeflow.org",
+          ],
+          resources: [
+            "scheduledworkflows",
+          ],
+          verbs: [
+            "get",
+            "list",
+            "watch",
+          ],
+        },
+      ],
+    },  // role
+
+    deploy(image): {
+      apiVersion: "apps/v1beta2",
+      kind: "Deployment",
+      metadata: {
+        "labels": {
+          "app": "ml-pipeline-persistenceagent",
+        },
+        name: "ml-pipeline-persistenceagent",
+        namespace: namespace,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: "ml-pipeline-persistenceagent",
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "ml-pipeline-persistenceagent",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: "ml-pipeline-persistenceagent",
+                image: image,
+                imagePullPolicy: 'Always',
+                env: [
+                  {
+                    name: "POD_NAMESPACE",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.namespace",
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            serviceAccountName: "ml-pipeline-persistenceagent",
+          },
+        },
+      },
+    }, // deploy
+  },  // parts
+}

--- a/kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet
+++ b/kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet
@@ -1,9 +1,9 @@
 {
-  all(namespace, scheduledworkflow_image):: [
+  all(namespace, scheduledWorkflowImage):: [
     $.parts(namespace).serviceAccount,
     $.parts(namespace).roleBinding,
     $.parts(namespace).role,
-    $.parts(namespace).deploy(scheduledworkflow_image),
+    $.parts(namespace).deploy(scheduledWorkflowImage),
     $.parts(namespace).crd,
   ],
 

--- a/kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet
+++ b/kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet
@@ -93,8 +93,8 @@
       apiVersion: "apps/v1beta2",
       kind: "Deployment",
       metadata: {
-        "labels": {
-          "app": "ml-pipeline-scheduledworkflow",
+        labels: {
+          app: "ml-pipeline-scheduledworkflow",
         },
         name: "ml-pipeline-scheduledworkflow",
         namespace: namespace,
@@ -116,7 +116,7 @@
               {
                 name: "ml-pipeline-scheduledworkflow",
                 image: image,
-                imagePullPolicy: 'Always',
+                imagePullPolicy: "Always",
                 env: [
                   {
                     name: "POD_NAMESPACE",
@@ -133,7 +133,7 @@
           },
         },
       },
-    }, // deploy
+    },  // deploy
     crd: {
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",

--- a/kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet
+++ b/kubeflow/pipeline/pipeline-scheduledworkflow.libsonnet
@@ -1,0 +1,159 @@
+{
+  all(namespace, scheduledworkflow_image):: [
+    $.parts(namespace).serviceAccount,
+    $.parts(namespace).roleBinding,
+    $.parts(namespace).role,
+    $.parts(namespace).deploy(scheduledworkflow_image),
+    $.parts(namespace).crd,
+  ],
+
+  parts(namespace):: {
+    serviceAccount: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "ml-pipeline-scheduledworkflow",
+        namespace: namespace,
+      },
+    },  // service account
+
+    roleBinding:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRoleBinding",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-scheduledworkflow",
+        },
+        name: "ml-pipeline-scheduledworkflow",
+      },
+      roleRef: {
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "ClusterRole",
+        // TODO: These permissions are too broad. This must be fixed.
+        name: "cluster-admin",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "ml-pipeline-scheduledworkflow",
+          namespace: namespace,
+        },
+      ],
+    },  // role binding
+
+    role: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "Role",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-scheduledworkflow",
+        },
+        name: "ml-pipeline-scheduledworkflow",
+        namespace: namespace,
+      },
+      rules: [
+        {
+          apiGroups: [
+            "argoproj.io",
+          ],
+          resources: [
+            "workflows",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+            "delete",
+          ],
+        },
+        {
+          apiGroups: [
+            "kubeflow.org",
+          ],
+          resources: [
+            "scheduledworkflows",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+            "delete",
+          ],
+        },
+      ],
+    },  // role
+
+    deploy(image): {
+      apiVersion: "apps/v1beta2",
+      kind: "Deployment",
+      metadata: {
+        "labels": {
+          "app": "ml-pipeline-scheduledworkflow",
+        },
+        name: "ml-pipeline-scheduledworkflow",
+        namespace: namespace,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: "ml-pipeline-scheduledworkflow",
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "ml-pipeline-scheduledworkflow",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: "ml-pipeline-scheduledworkflow",
+                image: image,
+                imagePullPolicy: 'Always',
+                env: [
+                  {
+                    name: "POD_NAMESPACE",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.namespace",
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            serviceAccountName: "ml-pipeline-scheduledworkflow",
+          },
+        },
+      },
+    }, // deploy
+    crd: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "scheduledworkflows.kubeflow.org",
+      },
+      spec: {
+        group: "kubeflow.org",
+        names: {
+          kind: "ScheduledWorkflow",
+          listKind: "ScheduledWorkflowList",
+          plural: "scheduledworkflows",
+          shortNames: [
+            "swf",
+          ],
+          singular: "scheduledworkflow",
+        },
+        scope: "Namespaced",
+        version: "v1alpha1",
+      },
+    },  // crd
+  },  // parts
+}

--- a/kubeflow/pipeline/pipeline-ui.libsonnet
+++ b/kubeflow/pipeline/pipeline-ui.libsonnet
@@ -1,11 +1,11 @@
 {
-  all(namespace, ui_image):: [
+  all(namespace, uiImage):: [
     $.parts(namespace).serviceAccount,
     $.parts(namespace).serviceUi,
     $.parts(namespace).tensorboardData,
     $.parts(namespace).roleBinding,
     $.parts(namespace).role,
-    $.parts(namespace).deployUi(ui_image),
+    $.parts(namespace).deployUi(uiImage),
   ],
   parts(namespace):: {
     serviceAccount: {

--- a/kubeflow/pipeline/pipeline-ui.libsonnet
+++ b/kubeflow/pipeline/pipeline-ui.libsonnet
@@ -53,9 +53,9 @@
         },
       },
       status: {
-        loadBalancer: {}
+        loadBalancer: {},
       },
-    }, //serviceUi
+    },  //serviceUi
 
     tensorboardData: {
       apiVersion: "v1",
@@ -93,9 +93,9 @@
         },
       },
       status: {
-        loadBalancer: {}
+        loadBalancer: {},
       },
-    }, //tensorboardData
+    },  //tensorboardData
 
     roleBinding:: {
       apiVersion: "rbac.authorization.k8s.io/v1beta1",
@@ -151,8 +151,8 @@
       apiVersion: "apps/v1beta2",
       kind: "Deployment",
       metadata: {
-        "labels": {
-          "app": "ml-pipeline-ui",
+        labels: {
+          app: "ml-pipeline-ui",
         },
         name: "ml-pipeline-ui",
         namespace: namespace,
@@ -184,6 +184,6 @@
           },
         },
       },
-    }, // deployUi
+    },  // deployUi
   },  // parts
 }

--- a/kubeflow/pipeline/pipeline-ui.libsonnet
+++ b/kubeflow/pipeline/pipeline-ui.libsonnet
@@ -1,0 +1,189 @@
+{
+  all(namespace, ui_image):: [
+    $.parts(namespace).serviceAccount,
+    $.parts(namespace).serviceUi,
+    $.parts(namespace).tensorboardData,
+    $.parts(namespace).roleBinding,
+    $.parts(namespace).role,
+    $.parts(namespace).deployUi(ui_image),
+  ],
+  parts(namespace):: {
+    serviceAccount: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "ml-pipeline-ui",
+        namespace: namespace,
+      },
+    },  // service account
+
+    serviceUi: {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-ui",
+        },
+        name: "ml-pipeline-ui",
+        namespace: namespace,
+        annotations: {
+          "getambassador.io/config":
+            std.join("\n", [
+              "---",
+              "apiVersion: ambassador/v0",
+              "kind:  Mapping",
+              "name: pipelineui-mapping",
+              "prefix: /pipeline",
+              "rewrite: /pipeline",
+              "timeout_ms: 300000",
+              "service: ml-pipeline-ui." + namespace,
+              "use_websocket: true",
+            ]),
+        },  //annotations
+      },
+      spec: {
+        ports: [
+          {
+            port: 80,
+            targetPort: 3000,
+          },
+        ],
+        selector: {
+          app: "ml-pipeline-ui",
+        },
+      },
+      status: {
+        loadBalancer: {}
+      },
+    }, //serviceUi
+
+    tensorboardData: {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-tensorboard-ui",
+        },
+        name: "ml-pipeline-tensorboard-ui",
+        namespace: namespace,
+        annotations: {
+          "getambassador.io/config":
+            std.join("\n", [
+              "---",
+              "apiVersion: ambassador/v0",
+              "kind:  Mapping",
+              "name: pipeline-tensorboard-ui-mapping",
+              "prefix: /data",
+              "rewrite: /data",
+              "timeout_ms: 300000",
+              "service: ml-pipeline-ui." + namespace,
+              "use_websocket: true",
+            ]),
+        },  //annotations
+      },
+      spec: {
+        ports: [
+          {
+            port: 80,
+            targetPort: 3000,
+          },
+        ],
+        selector: {
+          app: "ml-pipeline-tensorboard-ui",
+        },
+      },
+      status: {
+        loadBalancer: {}
+      },
+    }, //tensorboardData
+
+    roleBinding:: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "RoleBinding",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-ui",
+        },
+        name: "ml-pipeline-ui",
+        namespace: namespace,
+      },
+      roleRef: {
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "Role",
+        name: "ml-pipeline-ui",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "ml-pipeline-ui",
+          namespace: namespace,
+        },
+      ],
+    },  // role binding
+
+    role: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "Role",
+      metadata: {
+        labels: {
+          app: "ml-pipeline-ui",
+        },
+        name: "ml-pipeline-ui",
+        namespace: namespace,
+      },
+      rules: [
+        {
+          apiGroups: [""],
+          resources: [
+            "pods",
+            "pods/log",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+          ],
+        },
+      ],
+    },  // role
+
+    deployUi(image): {
+      apiVersion: "apps/v1beta2",
+      kind: "Deployment",
+      metadata: {
+        "labels": {
+          "app": "ml-pipeline-ui",
+        },
+        name: "ml-pipeline-ui",
+        namespace: namespace,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: "ml-pipeline-ui",
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "ml-pipeline-ui",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: "ml-pipeline-ui",
+                image: image,
+                imagePullPolicy: "Always",
+                ports: [{
+                  containerPort: 3000,
+                }],
+              },
+            ],
+            serviceAccountName: "ml-pipeline-ui",
+          },
+        },
+      },
+    }, // deployUi
+  },  // parts
+}

--- a/kubeflow/pipeline/prototypes/pipeline.jsonnet
+++ b/kubeflow/pipeline/prototypes/pipeline.jsonnet
@@ -7,7 +7,6 @@
 // @optionalParam scheduledWorkflowImage string gcr.io/ml-pipeline/scheduledworkflow:0.1.2 schedule workflow docker image
 // @optionalParam persistenceAgentImage string gcr.io/ml-pipeline/persistenceagent:0.1.2 persistence agent docker image
 // @optionalParam uiImage string gcr.io/ml-pipeline/frontend:0.1.2 UI docker image
-// @optionalParam reportUsage string false flag to report usage
 
 local k = import "k.libsonnet";
 local all = import "kubeflow/pipeline/all.libsonnet";

--- a/kubeflow/pipeline/prototypes/pipeline.jsonnet
+++ b/kubeflow/pipeline/prototypes/pipeline.jsonnet
@@ -3,11 +3,11 @@
 // @description a Kubeflow pipeline deployment. 
 // @shortDescription Kubeflow pipeline
 // @param name string Name to give to each of the components
-// @optionalParam api_image string gcr.io/ml-pipeline/api-server:0.1.2 API docker image
-// @optionalParam scheduledworkflow_image string gcr.io/ml-pipeline/scheduledworkflow:0.1.2 schedule workflow docker image
-// @optionalParam persistenceagent_image string gcr.io/ml-pipeline/persistenceagent:0.1.2 persistence agent docker image
-// @optionalParam ui_image string gcr.io/ml-pipeline/frontend:0.1.2 UI docker image
-// @optionalParam report_usage string false flag to report usage
+// @optionalParam apiImage string gcr.io/ml-pipeline/api-server:0.1.2 API docker image
+// @optionalParam scheduledWorkflowImage string gcr.io/ml-pipeline/scheduledworkflow:0.1.2 schedule workflow docker image
+// @optionalParam persistenceAgentImage string gcr.io/ml-pipeline/persistenceagent:0.1.2 persistence agent docker image
+// @optionalParam uiImage string gcr.io/ml-pipeline/frontend:0.1.2 UI docker image
+// @optionalParam reportUsage string false flag to report usage
 
 local k = import "k.libsonnet";
 local all = import "kubeflow/pipeline/all.libsonnet";

--- a/kubeflow/pipeline/prototypes/pipeline.jsonnet
+++ b/kubeflow/pipeline/prototypes/pipeline.jsonnet
@@ -1,6 +1,6 @@
 // @apiVersion 0.1
 // @name io.ksonnet.pkg.pipeline
-// @description a Kubeflow pipeline deployment. 
+// @description a Kubeflow pipeline deployment.
 // @shortDescription Kubeflow pipeline
 // @param name string Name to give to each of the components
 // @optionalParam apiImage string gcr.io/ml-pipeline/api-server:0.1.2 API docker image

--- a/kubeflow/pipeline/prototypes/pipeline.jsonnet
+++ b/kubeflow/pipeline/prototypes/pipeline.jsonnet
@@ -1,0 +1,15 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.pipeline
+// @description a Kubeflow pipeline deployment. 
+// @shortDescription Kubeflow pipeline
+// @param name string Name to give to each of the components
+// @optionalParam api_image string gcr.io/ml-pipeline/api-server:0.1.2 API docker image
+// @optionalParam scheduledworkflow_image string gcr.io/ml-pipeline/scheduledworkflow:0.1.2 schedule workflow docker image
+// @optionalParam persistenceagent_image string gcr.io/ml-pipeline/persistenceagent:0.1.2 persistence agent docker image
+// @optionalParam ui_image string gcr.io/ml-pipeline/frontend:0.1.2 UI docker image
+// @optionalParam report_usage string false flag to report usage
+
+local k = import "k.libsonnet";
+local all = import "kubeflow/pipeline/all.libsonnet";
+
+std.prune(k.core.v1.list.new(all.parts(env, params).all))

--- a/kubeflow/pipeline/spartakus.libsonnet
+++ b/kubeflow/pipeline/spartakus.libsonnet
@@ -1,0 +1,99 @@
+{
+  all(namespace, usage_id):: [
+    $.parts(namespace).serviceAccount,
+    $.parts(namespace).clusterRole,
+    $.parts(namespace).clusterRoleBinding,
+    $.parts(namespace).deployVolunteer(usage_id),
+  ],
+
+  parts(namespace):: {
+    serviceAccount: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "spartakus",
+        namespace: namespace,
+      },
+    },  // service account
+    clusterRole: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRole",
+      metadata: {
+        name: "spartakus",
+      },
+      rules: [
+        {
+          apiGroups: [
+            "",
+          ],
+          resources: [
+            "nodes",
+          ],
+          verbs: [
+            "get",
+            "list",
+          ],
+        },
+      ],
+    },  // clusterRole
+    clusterRoleBinding: {
+      apiVersion: "rbac.authorization.k8s.io/v1beta1",
+      kind: "ClusterRoleBinding",
+      metadata: {
+        name: "spartakus",
+      },
+      roleRef: {
+        kind: "ClusterRole",
+        name: "spartakus",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "spartakus",
+          namespace: namespace,
+        },
+      ],
+    },  // clusterRoleBinding
+    deployVolunteer(usage_id): {
+      apiVersion: "apps/v1beta2",
+      kind: "Deployment",
+      metadata: {
+        "labels": {
+          "app": "pipeline-spartakus-volunteer",
+        },
+        name: "pipeline-spartakus-volunteer",
+        namespace: namespace,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            app: "pipeline-spartakus-volunteer",
+          },
+        },
+        replicas: 1,
+        template: {
+          metadata: {
+            "labels": {
+              "app": "pipeline-spartakus-volunteer",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: "pipeline-spartakus-volunteer",
+                image: "gcr.io/google_containers/spartakus-amd64:v1.0.0",
+                imagePullPolicy: "IfNotPresent",
+                args: [
+                  "volunteer",
+                  "--cluster-id=" + usage_id,
+                  "--database=https://ml-pipeline-reporting.appspot.com/",
+                ],
+              },
+            ],
+            serviceAccountName: "spartakus",
+          },
+        },
+      },
+    }, // deployVolunteer
+  },  // parts
+}

--- a/kubeflow/pipeline/spartakus.libsonnet
+++ b/kubeflow/pipeline/spartakus.libsonnet
@@ -58,8 +58,8 @@
       apiVersion: "apps/v1beta2",
       kind: "Deployment",
       metadata: {
-        "labels": {
-          "app": "pipeline-spartakus-volunteer",
+        labels: {
+          app: "pipeline-spartakus-volunteer",
         },
         name: "pipeline-spartakus-volunteer",
         namespace: namespace,
@@ -73,8 +73,8 @@
         replicas: 1,
         template: {
           metadata: {
-            "labels": {
-              "app": "pipeline-spartakus-volunteer",
+            labels: {
+              app: "pipeline-spartakus-volunteer",
             },
           },
           spec: {
@@ -94,6 +94,6 @@
           },
         },
       },
-    }, // deployVolunteer
+    },  // deployVolunteer
   },  // parts
 }

--- a/kubeflow/pipeline/spartakus.libsonnet
+++ b/kubeflow/pipeline/spartakus.libsonnet
@@ -1,9 +1,9 @@
 {
-  all(namespace, usage_id):: [
+  all(namespace, usageId):: [
     $.parts(namespace).serviceAccount,
     $.parts(namespace).clusterRole,
     $.parts(namespace).clusterRoleBinding,
-    $.parts(namespace).deployVolunteer(usage_id),
+    $.parts(namespace).deployVolunteer(usageId),
   ],
 
   parts(namespace):: {
@@ -54,7 +54,7 @@
         },
       ],
     },  // clusterRoleBinding
-    deployVolunteer(usage_id): {
+    deployVolunteer(usageId): {
       apiVersion: "apps/v1beta2",
       kind: "Deployment",
       metadata: {
@@ -85,7 +85,7 @@
                 imagePullPolicy: "IfNotPresent",
                 args: [
                   "volunteer",
-                  "--cluster-id=" + usage_id,
+                  "--cluster-id=" + usageId,
                   "--database=https://ml-pipeline-reporting.appspot.com/",
                 ],
               },

--- a/kubeflow/registry.yaml
+++ b/kubeflow/registry.yaml
@@ -28,6 +28,9 @@ libraries:
   pachyderm:
     version: master
     path: pachyderm
+  pipeline:
+    version: master
+    path: pipeline
   pytorch-job:
     version: master
     path: pytorch-job


### PR DESCRIPTION
Mostly copied from existing registry
https://github.com/kubeflow/pipelines/tree/master/ml-pipeline/ml-pipeline

- Removed argo from the pipeline package. Rely on kubeflow argo instead
- Keep Spartakus entry for tracking pipeline specific usage

I'll have a separate PR to integrate the one-click and kfctl deployment

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1973)
<!-- Reviewable:end -->
