### PR TITLE
Check for python module pyyaml when using kfctl.sh on platform GCP.

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -286,7 +286,9 @@ main() {
   check_install ks
   check_install kubectl
 
-  source "${ENV_FILE}"
+  if [ "${PLATFORM}" == "gcp" ]; then
+    checkInstallPy pyyaml yaml
+  fi
 
   if [ "${COMMAND}" == "generate" ]; then
     if [ "${WHAT}" == "platform" ] || [ "${WHAT}" == "all" ]; then

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -22,6 +22,16 @@ check_install() {
   fi
 }
 
+checkInstallPy() {
+  local PYPI=$1
+  local MOD=$2
+  if python -c "import pkgutil; exit(pkgutil.find_loader('${MOD}'))" &>/dev/null; then
+    echo "Failed to import python module ${MOD}."
+    echo "You don't have ${PYPI} installed. Please install ${PYPI}."
+    exit 1
+  fi
+}
+
 check_variable() {
   if [[ -z "${1}" ]]; then
     echo "'${2}' environment variable is not set. Please set it using export ${2}=value."


### PR DESCRIPTION
Fixes #1739.
Stems from discussion in #1898.

Add check to `kfctl.sh` for platform GCP to ensure python module `pyyaml` is present before function `updateDM` calls `iam_patch.py` and imports `yaml`.

Script ends `exit 1` if module not present.

Also removed a duplicate `source ${ENV_FILE}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1975)
<!-- Reviewable:end -->
