### PR TITLE
Fix CRD scopes.

### DIFF
--- a/kubeflow/katib/studyjobcontroller.libsonnet
+++ b/kubeflow/katib/studyjobcontroller.libsonnet
@@ -16,6 +16,7 @@
       },
       spec: {
         group: "kubeflow.org",
+        scope: "Namespaced",
         version: "v1alpha1",
         names: {
           kind: "StudyJob",

--- a/kubeflow/pytorch-job/pytorch-operator.libsonnet
+++ b/kubeflow/pytorch-job/pytorch-operator.libsonnet
@@ -28,6 +28,7 @@
       },
       spec: {
         group: "kubeflow.org",
+        scope: "Namespaced",
         version: "v1alpha2",
         names: {
           kind: "PyTorchJob",
@@ -77,6 +78,7 @@
       spec: {
         group: "kubeflow.org",
         version: "v1beta1",
+        scope: "Namespaced",
         names: {
           kind: "PyTorchJob",
           singular: "pytorchjob",

--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -1,0 +1,229 @@
+// jsonnet tests for the manifests.
+// You can run the test as follows
+// jsonnet eval ./kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet --jpath ./kubeflow --jpath ./testing/workflows/lib/v1.7.0/
+
+local pyjob = import "../pytorch-operator.libsonnet";
+local paramsv1alpha2 = {
+  image: "pyControllerImage",
+  deploymentScope:: "cluster",
+  deploymentNamespace:: "null",
+  pyjobVersion: "v1alpha2",
+};
+local paramsv1beta1 = {
+  image: "pyControllerImage",
+  deploymentScope:: "cluster",
+  deploymentNamespace:: "null",
+  pyjobVersion: "v1beta1",
+};
+
+local env = {
+  namespace:: "test-kf-001",
+};
+
+local pyjobCrdV1alpha2 = pyjob.parts(paramsv1alpha2, env).crdV1alpha2;
+local pyjobCrdV1beta = pyjob.parts(paramsv1beta1, env).crdV1beta1;
+
+local pytorchJobDeployV1alpha1 = pyjob.parts(paramsv1alpha2, env).pytorchJobDeployV1alpha1;
+local pytorchJobDeployV1beta1 = pyjob.parts(paramsv1beta1, env).pytorchJobDeployV1beta1;
+
+local expectedCrdV1alpha2 = {
+  apiVersion: "apiextensions.k8s.io/v1beta1",
+  kind: "CustomResourceDefinition",
+  metadata: {
+    name: "pytorchjobs.kubeflow.org",
+  },
+  spec: {
+    group: "kubeflow.org",
+    scope: "Namespaced",
+    names: {
+      kind: "PyTorchJob",
+      plural: "pytorchjobs",
+      singular: "pytorchjob",
+    },
+    validation: {
+      openAPIV3Schema: {
+        properties: {
+          spec: {
+            properties: {
+              pytorchReplicaSpecs: {
+                properties: {
+                  Master: {
+                    properties: {
+                      replicas: {
+                        minimum: 1,
+                        maximum: 1,
+                        type: "integer",
+                      },
+                    },
+                  },
+                  Worker: {
+                    properties: {
+                      replicas: {
+                        minimum: 1,
+                        type: "integer",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    version: "v1alpha2",
+  },
+};
+
+local expectedCrdV1beta1 = {
+  apiVersion: "apiextensions.k8s.io/v1beta1",
+  kind: "CustomResourceDefinition",
+  metadata: {
+    name: "pytorchjobs.kubeflow.org",
+  },
+  spec: {
+    group: "kubeflow.org",
+    scope: "Namespaced",
+    names: {
+      kind: "PyTorchJob",
+      plural: "pytorchjobs",
+      singular: "pytorchjob",
+    },
+    validation: {
+      openAPIV3Schema: {
+        properties: {
+          spec: {
+            properties: {
+              pytorchReplicaSpecs: {
+                properties: {
+                  Master: {
+                    properties: {
+                      replicas: {
+                        minimum: 1,
+                        maximum: 1,
+                        type: "integer",
+                      },
+                    },
+                  },
+                  Worker: {
+                    properties: {
+                      replicas: {
+                        minimum: 1,
+                        type: "integer",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    version: "v1beta1",
+  },
+};
+
+local testCases = [
+  {
+    actual: pyjob.parts(paramsv1alpha2, env).crdV1alpha2,
+    expected: expectedCrdV1alpha2,
+  },
+  {
+    actual: pyjob.parts(paramsv1alpha2, env).crdV1beta1,
+    expected: expectedCrdV1beta1,
+  },
+  {
+    actual: pyjob.parts(paramsv1alpha2, env).pytorchJobDeployV1beta1(paramsv1beta1.image, paramsv1beta1.deploymentScope, paramsv1beta1.deploymentNamespace),
+    expected: {
+      apiVersion: "extensions/v1beta1",
+      kind: "Deployment",
+      metadata: {
+        name: "pytorch-operator",
+        namespace: "test-kf-001",
+      },
+      spec: {
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              name: "pytorch-operator",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                command: [
+                  "/pytorch-operator.v1beta1",
+                  "--alsologtostderr",
+                  "-v=1",
+                ],
+                env: [
+                  {
+                    name: "MY_POD_NAMESPACE",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.namespace",
+                      },
+                    },
+                  },
+                  {
+                    name: "MY_POD_NAME",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.name",
+                      },
+                    },
+                  },
+                ],
+                image: "pyControllerImage",
+                name: "pytorch-operator",
+                volumeMounts: [
+                  {
+                    mountPath: "/etc/config",
+                    name: "config-volume",
+                  },
+                ],
+              },
+            ],
+            serviceAccountName: "pytorch-operator",
+            volumes: [
+              {
+                configMap: {
+                  name: "pytorch-operator-config",
+                },
+                name: "config-volume",
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+];
+
+local testEqual(x) = x {
+  pass: x.actual == x.expected,
+};
+
+// For each test case determine whether expected matches equals
+local testCasesWithResults = std.map(
+  testEqual,
+  testCases,
+);
+
+// Compute test suite.
+local foldResults(left, right) = {
+  pass: left.pass && right.pass,
+};
+
+local initResult = { pass: true };
+local suiteResult = std.foldl(foldResults, testCasesWithResults, initResult);
+
+local testSuite = suiteResult {
+  testCases: testCasesWithResults,
+};
+
+// TODO(https://github.com/kubeflow/kubeflow/issues/1988): Output testSuite
+// rather than std.assertEqual
+std.assertEqual(testSuite.pass, true)

--- a/kubeflow/tf-training/tests/tf-job_test.jsonnet
+++ b/kubeflow/tf-training/tests/tf-job_test.jsonnet
@@ -32,6 +32,7 @@ std.assertEqual(
     },
     spec: {
       group: "kubeflow.org",
+      scope: "Namespaced",
       names: {
         kind: "TFJob",
         plural: "tfjobs",
@@ -300,6 +301,7 @@ std.assertEqual(
     },
     spec: {
       group: "kubeflow.org",
+      scope: "Namespaced",
       names: {
         kind: "TFJob",
         plural: "tfjobs",

--- a/kubeflow/tf-training/tf-job-operator.libsonnet
+++ b/kubeflow/tf-training/tf-job-operator.libsonnet
@@ -49,13 +49,8 @@
       },
     },
     local crd(inst) = {
-      local scope =
-        inst + if params.deploymentScope == "namespace" && params.deploymentNamespace != null then
-          { spec+: { scope: "Namespaced" } }
-        else
-          {},
       local version =
-        scope + if params.tfJobVersion == "v1alpha2" then
+        inst + if params.tfJobVersion == "v1alpha2" then
           { spec+: { version: "v1alpha2" } }
         else
           {},
@@ -70,6 +65,7 @@
       },
       spec: {
         group: "kubeflow.org",
+        scope: "Namespaced",
         version: "v1beta1",
         names: {
           kind: "TFJob",


### PR DESCRIPTION
* PyTorch, TFJob, StudyJob CRD's should have scope namespace because the
  resources always belong to a namespace.

* For TFJob the deploymentScope parameter doesn't affect the CRD definition
  it only affects the controller itself and determines whether the controller
  monitors a particular namespace or all namespaces.

* Add a unittest for the PyTorch CRD and Deployment ksonnet specs.

Fix #1985, #1524

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1987)
<!-- Reviewable:end -->
