### PR TITLE
Make it easier to debug jsonnet tests

### DIFF
--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -224,4 +224,4 @@ local testSuite = suiteResult {
   testCases: testCasesWithResults,
 };
 
-testSuite.pass
+testSuite

--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -224,6 +224,4 @@ local testSuite = suiteResult {
   testCases: testCasesWithResults,
 };
 
-// TODO(https://github.com/kubeflow/kubeflow/issues/1988): Output testSuite
-// rather than std.assertEqual
-std.assertEqual(testSuite.pass, true)
+testSuite.pass

--- a/testing/test_jsonnet.py
+++ b/testing/test_jsonnet.py
@@ -61,7 +61,13 @@ def run(test_files_dirs, jsonnet_path_args, test_case):
             output = util.run(
               ['jsonnet', 'eval', full_path] + jsonnet_path_args,
               cwd=os.path.dirname(full_path))
-            parsed = json.loads(output)
+            try:
+              parsed = json.loads(output)
+            except AttributeError:
+              logging.error(
+                "Output of jsonnet eval could not be parsed as json; "
+                "output: %s", output)
+              parsed = {}
 
             test_passed = parsed.get("pass", false)
 


### PR DESCRIPTION
* jsonnet tests should be able to output a json object containing a field
  "pass"

* The python test wrapper can then check this value to see if the test passed.

* This allows the object to output information about expected and actual
  values which make it easier to debug.

Fix #1988

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/1989)
<!-- Reviewable:end -->
