### PR TITLE
Fix bad merge conflict on v0.3-branch

### DIFF
--- a/components/gcp-click-to-deploy/manifest/kf_app.yaml
+++ b/components/gcp-click-to-deploy/manifest/kf_app.yaml
@@ -11,6 +11,8 @@ data:
     appAddress: https://deploy.kubeflow.dev
     defaultApp:
       components:
+      - name: jupyterhub
+        prototype: jupyterhub
       - name: pipeline
         prototype: pipeline
       - name: argo


### PR DESCRIPTION
The jupyterhub component was erroneously deleted from the gcp-click-to-deploy kf_app in #1998  (although I'm not sure if this is even used, since click-to-deploy maintains its own separate component yaml)

https://github.com/kubeflow/kubeflow/pull/1998/files#diff-cd856e8ab03263ee7dca07ad17f6405aL14

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2003)
<!-- Reviewable:end -->
