### PR TITLE
Enabled minkube install use ks 0.13.1

### DIFF
--- a/scripts/setup-minikube.sh
+++ b/scripts/setup-minikube.sh
@@ -40,17 +40,18 @@ main() {
 install_ks_kubectl_minikube() {
   # Installing ksonnet if needed
   KS_VERSION=$(ks version | grep 'ksonnet version' | awk '{print $3}')
-  if [[ $KS_VERSION != "0.11.0" ]]; then
+  EXPECTED_KS_VERSION=0.13.1
+  if [[ $KS_VERSION != $EXPECTED_KS_VERSION ]]; then
     echo -e "${YELLOW}Installing ksonnet...${NC}"
     if [[ ${HOST_PLATFORM} == $OSX ]]; then
-      curl -OL https://github.com/ksonnet/ksonnet/releases/download/v0.11.0/ks_0.11.0_darwin_amd64.tar.gz
-      tar zxf ks_0.11.0_darwin_amd64.tar.gz
-      export PATH=$PATH:$(pwd)/ks_0.11.0_darwin_amd64
+      curl -OL https://github.com/ksonnet/ksonnet/releases/download/v${EXPECTED_KS_VERSION}/ks_${EXPECTED_KS_VERSION}_darwin_amd64.tar.gz
+      tar zxf ks_${EXPECTED_KS_VERSION}_darwin_amd64.tar.gz
+      export PATH=$PATH:$(pwd)/ks_${EXPECTED_KS_VERSION}_darwin_amd64
 
     elif [[ ${HOST_PLATFORM} == $LINUX ]]; then
-      curl -OL https://github.com/ksonnet/ksonnet/releases/download/v0.11.0/ks_0.11.0_linux_amd64.tar.gz
-      tar zxf ks_0.11.0_linux_amd64.tar.gz
-      export PATH=$PATH:$(pwd)/ks_0.11.0_linux_amd64
+      curl -OL https://github.com/ksonnet/ksonnet/releases/download/v${EXPECTED_KS_VERSION}/ks_${EXPECTED_KS_VERSION}_linux_amd64.tar.gz
+      tar zxf ks_${EXPECTED_KS_VERSION}_linux_amd64.tar.gz
+      export PATH=$PATH:$(pwd)/ks_${EXPECTED_KS_VERSION}_linux_amd64
     fi
     echo -e "${GREEN}[OK]${NC}"
   fi


### PR DESCRIPTION
Fixed https://github.com/kubeflow/kubeflow/issues/2031

```release-note
Upgrade ks to 0.13.1 for minikube installation.
```