### PR TITLE
Add roles/dataproc.editor for kubeflow user account

### DIFF
--- a/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
+++ b/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
@@ -27,6 +27,7 @@ bindings:
   - roles/bigquery.admin
   - roles/dataflow.admin
   - roles/ml.admin
+  - roles/dataproc.editor
 - members:
   - set-kubeflow-vm-service-account
   roles:


### PR DESCRIPTION
Pipeline needs the dataproc editor permission to run the xgboost dataproc samples
For details, see
https://github.com/kubeflow/pipelines/tree/master/components/dataproc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2035)
<!-- Reviewable:end -->
