### PR TITLE
add permission to get pod's log

### DIFF
--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -255,6 +255,7 @@
           resources: [
             "pods",
             "pods/exec",
+            "pods/log",
             "services",
           ],
           verbs: [


### PR DESCRIPTION
Pipeline component needs the permission to  get tf serving pod log
https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/deployer/src/deploy.sh#L202