### PR TITLE
Enforce use string type param for S3_USE_HTTPS and S3_VERIFY_SSL

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-aws.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-aws.jsonnet
@@ -47,8 +47,8 @@ local tfDeployment = base.tfDeployment +
                                    valueFrom: { secretKeyRef: { name: params.s3SecretName, key: params.s3SecretSecretaccesskeyKeyName } },
                                  },
                                  { name: "AWS_REGION", value: params.s3AwsRegion },
-                                 { name: "S3_USE_HTTPS", value: params.s3UseHttps },
-                                 { name: "S3_VERIFY_SSL", value: params.s3VerifySsl },
+                                 { name: "S3_USE_HTTPS", value: std.toString(params.s3UseHttps) },
+                                 { name: "S3_VERIFY_SSL", value: std.toString(params.s3VerifySsl) },
                                  { name: "S3_ENDPOINT", value: params.s3Endpoint },
                                ]
                              ) else [],


### PR DESCRIPTION
By default, if we just enable s3 for model storage, we get string type from default template. 

```
ks param set ${MODEL_COMPONENT} s3Enable True

ks show default -c mnist-v3

...
        - name: S3_REGION
          value: us-west-1
        - name: S3_USE_HTTPS
          value: "true"
        - name: S3_VERIFY_SSL
          value: "true"
...

```

If we set true/false or 1/0 to these two parameters,  it will become boolean in libsonnet and kubernetes resource file. 

```
ks param set ${MODEL_COMPONENT} s3UseHttps true
ks param set ${MODEL_COMPONENT} s3VerifySsl true

# I tried using "true" and still got same result.

...
        - name: S3_REGION
          value: us-west-1
        - name: S3_USE_HTTPS
          value: true
        - name: S3_VERIFY_SSL
          value: true
...

```

In that case, since kubernetes environment require `String` value. deployment creation will fail as following log shows. 

I think if we enforce use string type in `tf-serving-aws.jsonnet` and we can get rid of this problem and make code more robust. User doesn't have to debug these kind of issues. 

```

➜  ks_app ks apply default -c mnist-v3
INFO Applying services kubeflow.mnist-v3
INFO Creating non-existent services kubeflow.mnist-v3
INFO Applying deployments kubeflow.mnist-v3
INFO Creating non-existent deployments kubeflow.mnist-v3
ERROR handle object: creating object: creating object: Deployment in version "v1beta1" cannot be handled as a Deployment: v1beta1.Deployment.Spec: v1beta1.DeploymentSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.Containers: []v1.Container: v1.Container.Env: []v1.EnvVar: v1.EnvVar.Value: ReadString: expects " or n, but found t, error found in #10 byte of ...|,"value":true},{"nam|..., bigger context ...|lue":"us-west-1"},{"name":"S3_USE_HTTPS","value":true},{"name":"S3_VERIFY_SSL","value":true},{"name"|...

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2067)
<!-- Reviewable:end -->
