### PR TITLE
Add job to load pipeline samples

### DIFF
--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -180,7 +180,7 @@
       },
     },  // deploy
 
-	  loadSampleJob(image): {
+    loadSampleJob(image): {
       apiVersion: "batch/v1",
       kind: "Job",
       metadata: {
@@ -199,7 +199,7 @@
                 command: ["apiserver"],
                 args: [
                   "--config=/config",
-                  "--sampleconfig=/config/sample_config.json"
+                  "--sampleconfig=/config/sample_config.json",
                 ],
                 env: [
                   {
@@ -216,9 +216,9 @@
             serviceAccountName: "ml-pipeline",
           },
         },
-        backoffLimit: 0
+        backoffLimit: 0,
       },
-    }, // loadSampleJob
+    },  // loadSampleJob
 
     pipelineRunnerServiceAccount: {
       apiVersion: "v1",

--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -5,6 +5,7 @@
     $.parts(namespace).role,
     $.parts(namespace).service,
     $.parts(namespace).deploy(apiImage),
+    $.parts(namespace).loadSampleJob(apiImage),
     $.parts(namespace).pipelineRunnerServiceAccount,
     $.parts(namespace).pipelineRunnerRole,
     $.parts(namespace).pipelineRunnerRoleBinding,
@@ -178,6 +179,46 @@
         },
       },
     },  // deploy
+
+	  loadSampleJob(image): {
+      apiVersion: "batch/v1",
+      kind: "Job",
+      metadata: {
+        name: "ml-pipelines-load-samples",
+        namespace: namespace,
+      },
+      spec: {
+        template: {
+          spec: {
+            restartPolicy: "Never",
+            containers: [
+              {
+                name: "ml-pipelines-load-samples",
+                image: image,
+                imagePullPolicy: "Always",
+                command: ["apiserver"],
+                args: [
+                  "--config=/config",
+                  "--sampleconfig=/config/sample_config.json"
+                ],
+                env: [
+                  {
+                    name: "POD_NAMESPACE",
+                    valueFrom: {
+                      fieldRef: {
+                        fieldPath: "metadata.namespace",
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+            serviceAccountName: "ml-pipeline",
+          },
+        },
+        backoffLimit: 0
+      },
+    }, // loadSampleJob
 
     pipelineRunnerServiceAccount: {
       apiVersion: "v1",


### PR DESCRIPTION
Adding a job meets the requirement of 
- Load samples once when pipeline is deployed
- Not run job again during kf upgrade
- If loading samples failed, not blocking api server from start

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2071)
<!-- Reviewable:end -->
