### PR TITLE
Use upper method from std library on v0.3 branch

### DIFF
--- a/kubeflow/core/tests/util_test.jsonnet
+++ b/kubeflow/core/tests/util_test.jsonnet
@@ -20,8 +20,6 @@ std.assertEqual(std.length(util.toArray("a,b,c,d")), 4) &&
 std.assertEqual(std.length(util.toArray(2)), 0) &&
 std.assertEqual(std.length(util.toArray("hello world")), 1) &&
 std.assertEqual(std.length(util.toArray([1, 2, 3, 4])), 0) &&
-std.assertEqual(util.isUpper(std.substr("Hi", 0, 1)), true) &&
-std.assertEqual(util.isUpper(std.substr("lo", 0, 1)), false) &&
 std.assertEqual(
   {
     new():: self + {

--- a/kubeflow/core/tests/util_test.jsonnet
+++ b/kubeflow/core/tests/util_test.jsonnet
@@ -1,9 +1,5 @@
 local util = import "../util.libsonnet";
 
-std.assertEqual(util.upper("True"), "TRUE") &&
-std.assertEqual(util.upper("TrUe"), "TRUE") &&
-std.assertEqual(util.upper("true"), "TRUE") &&
-std.assertEqual(util.upper("TRUE"), "TRUE") &&
 std.assertEqual(util.toBool(false), false) &&
 std.assertEqual(util.toBool(true), true) &&
 std.assertEqual(util.toBool("true"), true) &&

--- a/kubeflow/core/util.libsonnet
+++ b/kubeflow/core/util.libsonnet
@@ -2,25 +2,6 @@
 {
   local k = import "k.libsonnet",
 
-  // Is the character upper case?
-  isUpper:: function(c) {
-    local cp = std.codepoint,
-    local value = if cp(c) >= 65 && cp(c) < 91 then
-      true
-    else
-      false,
-    result:: value,
-  }.result,
-
-  // Convert a string to upper case.
-  upper:: function(x) {
-    local cp(c) = std.codepoint(c),
-    local upLetter(c) = if cp(c) >= 97 && cp(c) < 123 then
-      std.char(cp(c) - 32)
-    else c,
-    result:: std.join("", std.map(upLetter, std.stringChars(x))),
-  }.result,
-
   // Convert non-boolean types like string,number to a boolean.
   // This is primarily intended for dealing with parameters that should be booleans.
   toBool:: function(x) {
@@ -28,7 +9,7 @@
       if std.type(x) == "boolean" then
         x
       else if std.type(x) == "string" then
-        $.upper(x) == "TRUE"
+        std.asciiUpper(x) == "TRUE"
       else if std.type(x) == "number" then
         x != 0
       else

--- a/kubeflow/tf-serving/util.libsonnet
+++ b/kubeflow/tf-serving/util.libsonnet
@@ -9,7 +9,7 @@
       if std.type(x) == "boolean" then
         x
       else if std.type(x) == "string" then
-        $.upper(x) == "TRUE"
+        std.asciiUpper(x) == "TRUE"
       else if std.type(x) == "number" then
         x != 0
       else

--- a/kubeflow/weaveflux/util.libsonnet
+++ b/kubeflow/weaveflux/util.libsonnet
@@ -1,14 +1,5 @@
 // Some useful routines.
 {
-  // Convert a string to upper case.
-  upper:: function(x) {
-    local cp(c) = std.codepoint(c),
-    local upLetter(c) = if cp(c) >= 97 && cp(c) < 123 then
-      std.char(cp(c) - 32)
-    else c,
-    result:: std.join("", std.map(upLetter, std.stringChars(x))),
-  }.result,
-
   // Convert non-boolean types like string,number to a boolean.
   // This is primarily intended for dealing with parameters that should be booleans.
   toBool:: function(x) {
@@ -16,7 +7,7 @@
       if std.type(x) == "boolean" then
         x
       else if std.type(x) == "string" then
-        $.upper(x) == "TRUE"
+        std.asciiUpper(x) == "TRUE"
       else if std.type(x) == "number" then
         x != 0
       else

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -23,7 +23,7 @@
       if std.type(x) == "boolean" then
         x
       else if std.type(x) == "string" then
-        $.upper(x) == "TRUE"
+        std.asciiUpper(x) == "TRUE"
       else if std.type(x) == "number" then
         x != 0
       else


### PR DESCRIPTION
Can not generate resource file due to this issue. Use Upper function from std instead. it's already patched on master branch. I do think a lot of people still use 0.3 branch so let's fix it.

```
$  ks_app ks show default -c inception
ERROR find objects: RUNTIME ERROR: Field does not exist: upper
	vendor/kubeflow/tf-serving/util.libsonnet:12:9-16	object <anonymous>
	vendor/kubeflow/tf-serving/util.libsonnet:(7:24)-(17:11)	function <anonymous>
	vendor/kubeflow/tf-serving/tf-serving-template.libsonnet:184:20-55	object <anonymous>
	lib/ksonnet-lib/v1.10.11/k.libsonnet:4:27-62	object <anonymous>
	lib/ksonnet-lib/v1.10.11/k.libsonnet:8:34-47	thunk from <object <anonymous>>
	<std>:232:22-25	thunk from <function <anonymous>>
	<std>:232:13-26	function <anonymous>

	lib/ksonnet-lib/v1.10.11/k.libsonnet:8:23-48	object <anonymous>
	During manifestation

```


ksonnet version: 0.13.0
jsonnet version: v0.11.2
client-go version: kubernetes-1.10.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2073)
<!-- Reviewable:end -->
