### PR TITLE
JH Spawner Enhancements - Fixes #2060

### DIFF
--- a/kubeflow/jupyter/jupyter_config.py
+++ b/kubeflow/jupyter/jupyter_config.py
@@ -85,6 +85,20 @@ c.KubeSpawner.user_storage_pvc_ensure = False
 
 volumes = []
 volume_mounts = []
+
+gcp_secret_name = os.environ.get('GCP_SECRET_NAME')
+if gcp_secret_name:
+    volumes.append({
+      'name': gcp_secret_name,
+      'secret': {
+        'secretName': gcp_secret_name,
+      }
+    })
+    volume_mounts.append({
+        'name': gcp_secret_name,
+        'mountPath': SERVICE_ACCOUNT_SECRET_MOUNT
+    })
+
 c.KubeSpawner.volumes = volumes
 c.KubeSpawner.volume_mounts = volume_mounts
 
@@ -109,19 +123,6 @@ else:
 
 if os.environ.get('DEFAULT_JUPYTERLAB').lower() == 'true':
     c.KubeSpawner.default_url = '/lab'
-
-gcp_secret_name = os.environ.get('GCP_SECRET_NAME')
-if gcp_secret_name:
-    volumes.append({
-      'name': gcp_secret_name,
-      'secret': {
-        'secretName': gcp_secret_name,
-      }
-    })
-    volume_mounts.append({
-        'name': gcp_secret_name,
-        'mountPath': SERVICE_ACCOUNT_SECRET_MOUNT
-    })
 
 # Set extra spawner configuration variables
 c.KubeSpawner.extra_spawner_config = {

--- a/kubeflow/jupyter/ui/default/config.yaml
+++ b/kubeflow/jupyter/ui/default/config.yaml
@@ -10,19 +10,19 @@
 # will be disabled for users and only set by the admin
 # If the 'readOnly' key is missing (defaults to 'false'), the respective option
 # will be available for users
-
-# Also note that some values (e.g. {servername}, {username}) may be templated
+#
+# Please note that some values (e.g. {servername}, {username}) may be templated
 # and expanded according to KubeSpawner's rules
-
+#
 # For more information regarding JupyterHub KubeSpawner and its configuration:
 # https://jupyterhub-kubespawner.readthedocs.io/en/latest/spawner.html
 
 spawnerFormDefaults:
   image:
-    # The container Image for user's Notebook
-    # Note that this value needs to be present in the options list below
+    # The container Image for the user's Jupyter Notebook
+    # If readonly, this value must be a member of the list below
     value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
-    # The list of available container Images
+    # The list of available standard container Images
     options:
       - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v0.4.0
       - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu:v0.4.0
@@ -38,6 +38,9 @@ spawnerFormDefaults:
       - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.4.0
       - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
       - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.4.0
+    # By default, custom container Images are allowed
+    # Uncomment the following line to only enable standard container Images
+    #readOnly: true
   cpu:
     # CPU for user's Notebook
     value: '1.0'
@@ -66,7 +69,7 @@ spawnerFormDefaults:
         value: /home/jovyan
       accessModes:
         # The Access Mode of the Workspace Volume
-        # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany
+        # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
         value: ReadWriteOnce
   dataVolumes:
     # List of additional Data Volumes to be attached to the user's Notebook
@@ -75,31 +78,32 @@ spawnerFormDefaults:
     # Type, Name, Size, MountPath and Access Mode
     #
     # For example, a list with 2 Data Volumes:
-    # value:
-    #   - value:
-    #       type:
-    #         value: New
-    #       name:
-    #         value: {username}{servername}-vol-1
-    #       size:
-    #         value: '10'
-    #       mountPath:
-    #         readOnly: true
-    #         value: /home/jovyan/{username}{servername}-vol-1
-    #       accessModes:
-    #         value: ReadWriteOnce
-    #   - value:
-    #       type:
-    #         value: New
-    #       name:
-    #         value: {username}{servername}-vol-2
-    #       size:
-    #         value: '5'
-    #       mountPath:
-    #         readOnly: true
-    #         value: /home/jovyan/{username}{servername}-vol-2
-    #       accessModes:
-    #         value: ReadWriteOnce
+    #value:
+    #  - value:
+    #      type:
+    #        value: New
+    #      name:
+    #        value: {username}{servername}-vol-1
+    #      size:
+    #        value: '10'
+    #      mountPath:
+    #        value: /home/jovyan/{username}{servername}-vol-1
+    #      accessModes:
+    #        value: ReadWriteOnce
+    #  - value:
+    #      type:
+    #        value: New
+    #      name:
+    #        value: {username}{servername}-vol-2
+    #      size:
+    #        value: '5'
+    #      mountPath:
+    #        value: /home/jovyan/{username}{servername}-vol-2
+    #      accessModes:
+    #        value: ReadWriteOnce
+    #
+    # Uncomment the following line to make the Data Volumes list readonly
+    #readOnly: true
   extraResources:
     # Extra Resource Limits for user's Notebook
     # Note that braces are escaped

--- a/kubeflow/jupyter/ui/default/script.js
+++ b/kubeflow/jupyter/ui/default/script.js
@@ -137,7 +137,7 @@ function setDefaultFormValues() {
             $('#ws_type').val(defaultWorkspace.type.value);
           }
           // Make the Workspace Volume Type readonly, if specified
-          if ('readOnly' in defaultWorkspace.type) {
+          if ('readOnly' in defaultWorkspace.type || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_type').attr({
               'readonly': defaultWorkspace.type.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.type.readOnly || defaultWorkspaceReadOnly
@@ -158,7 +158,7 @@ function setDefaultFormValues() {
             $('#ws_name').val(defaultWorkspace.name.value).trigger('focusout');
           }
           // Make the Workspace Volume Name readonly, if specified
-          if ('readOnly' in defaultWorkspace.name) {
+          if ('readOnly' in defaultWorkspace.name || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_name').attr({
               'readonly': defaultWorkspace.name.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.name.readOnly || defaultWorkspaceReadOnly
@@ -173,7 +173,7 @@ function setDefaultFormValues() {
             $('#ws_size').val(defaultWorkspace.size.value);
           }
           // Make the Workspace Volume Size readonly, if specified
-          if ('readOnly' in defaultWorkspace.size) {
+          if ('readOnly' in defaultWorkspace.size || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_size').attr({
               'readonly': defaultWorkspace.size.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.size.readOnly || defaultWorkspaceReadOnly
@@ -188,7 +188,7 @@ function setDefaultFormValues() {
             $('#ws_mount_path').val(defaultWorkspace.mountPath.value);
           }
           // Make the Workspace Volume MountPath readonly, if specified
-          if ('readOnly' in defaultWorkspace.mountPath) {
+          if ('readOnly' in defaultWorkspace.mountPath || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_mount_path').attr({
               'readonly': defaultWorkspace.mountPath.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.mountPath.readOnly || defaultWorkspaceReadOnly
@@ -203,7 +203,7 @@ function setDefaultFormValues() {
             $('#ws_access_modes').val(defaultWorkspace.accessModes.value);
           }
           // Make the Workspace Volume Access Modes readonly, if specified
-          if ('readOnly' in defaultWorkspace.accessModes) {
+          if ('readOnly' in defaultWorkspace.accessModes || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_access_modes').attr({
               'readonly': defaultWorkspace.accessModes.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.accessModes.readOnly || defaultWorkspaceReadOnly
@@ -220,9 +220,13 @@ function setDefaultFormValues() {
   }
 
   if ('dataVolumes' in formDefaults) {
+      var dataVolumesReadOnly = formDefaults.dataVolumes.readOnly
       // Disable Add Volume button, if specified
       if ('readOnly' in formDefaults.dataVolumes) {
-        $('#add_volume').attr('readonly', formDefaults.dataVolumes.readOnly);
+        $('#add_volume').attr({
+          'disabled': dataVolumesReadOnly,
+          'immutable': dataVolumesReadOnly
+        });
       }
 
       // Set default Data Volumes - Disable if specified
@@ -243,13 +247,13 @@ function setDefaultFormValues() {
           if ('value' in vol.type) {
             $('#vol_type' + counter).val(vol.type.value).trigger('change');
           }
-          if ('readOnly' in vol.type) {
+          if ('readOnly' in vol.type || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_type' + counter).attr({
-              'readonly': vol.type.readOnly,
-              'immutable': vol.type.readOnly
+              'readonly': vol.type.readOnly || dataVolumesReadOnly,
+              'immutable': vol.type.readOnly || dataVolumesReadOnly
             });
-            if ($('#vol_type').attr('readonly')) {
-              $('#vol_type').on('mousedown', function(e) {
+            if ($('#vol_type' + counter).attr('readonly')) {
+              $('#vol_type' + counter).on('mousedown', function(e) {
                 e.preventDefault(); this.blur(); window.focus();
               });
             }
@@ -261,10 +265,10 @@ function setDefaultFormValues() {
           if ('value' in vol.name) {
             $('#vol_name' + counter).val(vol.name.value).trigger('focusout');
           }
-          if ('readOnly' in vol.name) {
+          if ('readOnly' in vol.name || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_name' + counter).attr({
-              'readonly': vol.name.readOnly,
-              'immutable': vol.name.readOnly
+              'readonly': vol.name.readOnly || dataVolumesReadOnly,
+              'immutable': vol.name.readOnly || dataVolumesReadOnly
             });
           }
         }
@@ -274,10 +278,10 @@ function setDefaultFormValues() {
           if ('value' in vol.size) {
             $('#vol_size' + counter).val(vol.size.value);
           }
-          if ('readOnly' in vol.size) {
+          if ('readOnly' in vol.size || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_size' + counter).attr({
-              'readonly': vol.size.readOnly,
-              'immutable': vol.size.readOnly
+              'readonly': vol.size.readOnly || dataVolumesReadOnly,
+              'immutable': vol.size.readOnly || dataVolumesReadOnly
             });
           }
         }
@@ -287,10 +291,10 @@ function setDefaultFormValues() {
           if ('value' in vol.mountPath) {
             $('#vol_mount_path' + counter).val(vol.mountPath.value);
           }
-          if ('readOnly' in vol.mountPath) {
+          if ('readOnly' in vol.mountPath || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_mount_path' + counter).attr({
-              'readonly': vol.mountPath.readOnly,
-              'immutable': vol.mountPath.readOnly
+              'readonly': vol.mountPath.readOnly || dataVolumesReadOnly,
+              'immutable': vol.mountPath.readOnly || dataVolumesReadOnly
             });
           }
         }
@@ -300,13 +304,13 @@ function setDefaultFormValues() {
           if ('value' in vol.accessModes) {
             $('#vol_access_modes' + counter).val(vol.accessModes.value);
           }
-          if ('readOnly' in vol.accessModes) {
+          if ('readOnly' in vol.accessModes || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_access_modes' + counter).attr({
-              'readonly': vol.accessModes.readOnly,
-              'immutable': vol.accessModes.readOnly
+              'readonly': vol.accessModes.readOnly || dataVolumesReadOnly,
+              'immutable': vol.accessModes.readOnly || dataVolumesReadOnly
             });
-            if ($('#vol_access_modes').attr('readonly')) {
-              $('#vol_access_modes').on('mousedown', function(e) {
+            if ($('#vol_access_modes' + counter).attr('readonly')) {
+              $('#vol_access_modes' + counter).on('mousedown', function(e) {
                 e.preventDefault(); this.blur(); window.focus();
               });
             }
@@ -314,10 +318,10 @@ function setDefaultFormValues() {
         }
 
         // Disable Delete button, if specified
-        if ('readOnly' in defaultDataVolumes[i]) {
+        if ('readOnly' in formDefaults.dataVolumes) {
           $('#vol_delete_button' + counter).attr({
-            'readonly': defaultDataVolumes[i].readOnly,
-            'immutable': defaultDataVolumes[i].readOnly
+            'disabled': formDefaults.dataVolumes.readOnly,
+            'immutable': formDefaults.dataVolumes.readOnly
           });
         }
       }

--- a/kubeflow/jupyter/ui/default/script.js
+++ b/kubeflow/jupyter/ui/default/script.js
@@ -27,6 +27,9 @@ $(function() {
     $('#spawn_form').find('input[type="submit"]').remove();
   }
 
+  // Configure Image input elements
+  setImageType();
+
   // Dynamically change Workspace form fields behavior
   setWorkspaceEventListeners();
 
@@ -36,6 +39,22 @@ $(function() {
   // Set tooltip to readOnly form fields
   setTooltipsOnImmutable();
 });
+
+// Dynamically update Image input field, based on radio button selection
+function setImageType() {
+  imageType = $('#imageType').find('input:checked').val();
+  if (imageType == 'standard') {
+    $('select[for=standardImages]')
+      .attr({'id': 'image', 'name': 'image'}).css({'display': ''});
+    $('input[for=customImage]')
+      .attr({'id': '', 'name': ''}).removeAttr('required').css({'display': 'none'});
+  } else {
+    $('input[for=customImage]')
+      .attr({'id': 'image', 'name': 'image'}).css({'display': ''});
+    $('select[for=standardImages]')
+      .attr({'id': '', 'name': ''}).removeAttr('required').css({'display': 'none'});
+  }
+}
 
 // Set default values to form fields
 function setDefaultFormValues() {
@@ -60,15 +79,14 @@ function setDefaultFormValues() {
 
     // Make Container Image field readonly, if specified
     if ('readOnly' in formDefaults.image) {
-      $('#image').attr({
-        'readonly': formDefaults.image.readOnly,
-        'immutable': formDefaults.image.readOnly
+      $('#option_standard').prop({
+          'disabled': formDefaults.image.readOnly,
+          'immutable': formDefaults.image.readOnly
       });
-      if ($('#image').attr('readonly')) {
-        $('#image').on('mousedown', function(e) {
-          e.preventDefault(); this.blur(); window.focus();
-        });
-      }
+      $('#option_custom').prop({
+          'disabled': formDefaults.image.readOnly,
+          'immutable': formDefaults.image.readOnly
+      });
     }
   }
 

--- a/kubeflow/jupyter/ui/default/spawner.py
+++ b/kubeflow/jupyter/ui/default/spawner.py
@@ -15,7 +15,9 @@ SERVICE_ACCOUNT_SECRET_MOUNT = '/var/run/secrets/sa'
 
 class KubeFormSpawner(KubeSpawner):
     """Implement a custom Spawner to spawn pods in a Kubernetes Cluster."""
+
     def __init__(self, *args, **kwargs):
+        """Call init() of parent class and initialize volume lists."""
         super(KubeFormSpawner, self).__init__(*args, **kwargs)
         self.initial_volumes = list(self.volumes)
         self.initial_volume_mounts = list(self.volume_mounts)
@@ -82,115 +84,176 @@ class KubeFormSpawner(KubeSpawner):
             form_defaults = self.spawner_ui_config['spawnerFormDefaults']
 
         # Manage Image
+        image_readonly = False
         if self._default_config_contains('image'):
             options['image'] = form_defaults['image']['value']
-        if 'image' in formdata and formdata['image'][0]:
-            options['image'] = formdata['image'][0].strip()
+            image_readonly = form_defaults['image'].get('readOnly', False)
+        if ('image' in formdata and formdata['image'][0]):
+            image_from_form = formdata['image'][0].strip()
+            if image_readonly:
+                # Provided image must be standard
+                if image_from_form in form_defaults['image']['options']:
+                    options['image'] = image_from_form
+            else:
+                # Provided image can be standard or custom
+                options['image'] = image_from_form
 
         # Manage CPU
+        cpu_readonly = False
         if self._default_config_contains('cpu'):
             options['cpu'] = form_defaults['cpu']['value']
-        if 'cpu' in formdata and formdata['cpu'][0]:
+            cpu_readonly = form_defaults['cpu'].get('readOnly', False)
+        if (not cpu_readonly and 'cpu' in formdata and formdata['cpu'][0]):
             options['cpu'] = formdata['cpu'][0].strip()
 
         # Manage Memory
+        memory_readonly = False
         if self._default_config_contains('memory'):
             options['memory'] = form_defaults['memory']['value']
-        if 'memory' in formdata and formdata['memory'][0]:
-            options['memory'] = formdata['memory'][0].strip()
+            memory_readonly = form_defaults['memory'].get('readOnly', False)
+        if (not memory_readonly and 'memory' in formdata and
+           formdata['memory'][0]):
+                options['memory'] = formdata['memory'][0].strip()
 
         # Manage Workspace Volume
         options['workspaceVolume'] = {}
         ws_volume = {}
 
+        ws_volume_readonly = False
         if self._default_config_contains('workspaceVolume'):
+            ws_volume_readonly = \
+                form_defaults['workspaceVolume'].get('readOnly', False)
+
             # The Workspace Volume is specified in `config.yaml`
-            if 'value' in form_defaults['workspaceVolume']:
-                default_ws_volume = form_defaults['workspaceVolume']['value']
+            default_ws_volume = form_defaults['workspaceVolume']['value']
 
-                # Get the default values from the YAML configuration files
-                if ('type' in default_ws_volume and
-                   'value' in default_ws_volume['type']):
-                        ws_volume['type'] = default_ws_volume['type']['value']
+            # Get and set the default values from the YAML configuration file,
+            # if present and not marked as readonly
+            ws_type_readonly = False
+            if ('type' in default_ws_volume and
+               'value' in default_ws_volume['type']):
+                    ws_volume['type'] = default_ws_volume['type']['value']
+                    ws_type_readonly = \
+                        default_ws_volume['type'].get('readOnly', False)
 
-                if ('name' in default_ws_volume and
-                   'value' in default_ws_volume['name']):
-                        ws_volume['name'] = default_ws_volume['name']['value']
+            ws_name_readonly = False
+            if ('name' in default_ws_volume and
+               'value' in default_ws_volume['name']):
+                    ws_volume['name'] = default_ws_volume['name']['value']
+                    ws_name_readonly = \
+                        default_ws_volume['name'].get('readOnly', False)
 
-                if ('size' in default_ws_volume and
-                   'value' in default_ws_volume['size']):
-                        ws_volume['size'] = (
-                            '%sGi' % default_ws_volume['size']['value'])
+            ws_size_readonly = False
+            if ('size' in default_ws_volume and
+               'value' in default_ws_volume['size']):
+                    ws_volume['size'] = \
+                        '%sGi' % default_ws_volume['size']['value']
+                    ws_size_readonly = \
+                        default_ws_volume['size'].get('readOnly', False)
 
-                if ('mountPath' in default_ws_volume and
-                   'value' in default_ws_volume['mountPath']):
-                        ws_volume['mountPath'] = (
-                            default_ws_volume['mountPath']['value'])
+            ws_mount_path_readonly = False
+            if ('mountPath' in default_ws_volume and
+               'value' in default_ws_volume['mountPath']):
+                    ws_volume['mountPath'] = \
+                        default_ws_volume['mountPath']['value']
+                    ws_mount_path_readonly = \
+                        default_ws_volume['mountPath'].get('readOnly', False)
 
-                if ('accessModes' in default_ws_volume and
-                   'value' in default_ws_volume['accessModes']):
-                        ws_volume['accessModes'] = (
-                            default_ws_volume['accessModes']['value'])
+            ws_access_modes_readonly = False
+            if ('accessModes' in default_ws_volume and
+               'value' in default_ws_volume['accessModes']):
+                    ws_volume['accessModes'] = \
+                        default_ws_volume['accessModes']['value']
+                    ws_access_modes_readonly = \
+                        default_ws_volume['accessModes'].get('readOnly', False)
 
-        # Get the Workspace Volume values from the form, if user specified them
-        if 'ws_type' in formdata and formdata['ws_type'][0]:
-            ws_volume['type'] = formdata['ws_type'][0].strip()
+        # Get and set the Workspace Volume values from the form, if present
+        # and not marked as readonly
+        if not ws_volume_readonly:
+            if (not ws_type_readonly and 'ws_type' in formdata and
+               formdata['ws_type'][0]):
+                    ws_volume['type'] = formdata['ws_type'][0].strip()
 
-        if 'ws_name' in formdata and formdata['ws_name'][0]:
-            ws_volume['name'] = formdata['ws_name'][0].strip()
+            if (not ws_name_readonly and 'ws_name' in formdata and
+               formdata['ws_name'][0]):
+                    ws_volume['name'] = formdata['ws_name'][0].strip()
 
-        if 'ws_size' in formdata and formdata['ws_size'][0]:
-            ws_volume['size'] = '%sGi' % formdata['ws_size'][0].strip()
+            if (not ws_size_readonly and 'ws_size' in formdata and
+               formdata['ws_size'][0]):
+                    ws_volume['size'] = '%sGi' % formdata['ws_size'][0].strip()
 
-        if 'ws_mount_path' in formdata and formdata['ws_mount_path'][0]:
-            ws_volume['mountPath'] = formdata['ws_mount_path'][0].strip()
+            if (not ws_mount_path_readonly and 'ws_mount_path' in formdata and
+               formdata['ws_mount_path'][0]):
+                    ws_volume['mountPath'] = \
+                        formdata['ws_mount_path'][0].strip()
 
-        if 'ws_access_modes' in formdata and formdata['ws_access_modes'][0]:
-            ws_volume['accessModes'] = formdata['ws_access_modes'][0].strip()
+            if (not ws_access_modes_readonly and 'ws_access_modes' in formdata
+               and formdata['ws_access_modes'][0]):
+                    ws_volume['accessModes'] = \
+                        formdata['ws_access_modes'][0].strip()
 
         options['workspaceVolume'] = ws_volume
 
         # Manage Data Volumes
         options['dataVolumes'] = []
+        data_volumes_readonly = False
+        if self._default_config_contains('dataVolumes'):
+            data_volumes_readonly = \
+                form_defaults['dataVolumes'].get('readOnly', False)
 
-        data_volumes_cnt = 0
-        # Deduce the total number of Data Volumes
-        for k, v in formdata.items():
-            if k.startswith('vol_type'):
-                data_volumes_cnt += 1
+        if data_volumes_readonly:
+            # Set Data Volumes as specified in the Spawner configuration file
+            for volume in form_defaults['dataVolumes']['value']:
+                data_volume = {}
+                for f in ['type', 'name', 'size', 'mountPath', 'accessModes']:
+                    data_volume[f] = volume['value'][f]['value']
+                data_volume['size'] += 'Gi'
+                options['dataVolumes'].append(data_volume)
+        else:
+            # Deduce the total number of Data Volumes
+            data_volumes_cnt = 0
+            for k, v in formdata.items():
+                if k.startswith('vol_type'):
+                    data_volumes_cnt += 1
 
-        for i in range(1, data_volumes_cnt + 1):
-            data_volume = {}
+            # Set Data Volumes as specified in the Spawner form
+            for i in range(1, data_volumes_cnt + 1):
+                data_volume = {}
 
-            # Get all Data Volume fields from the form
-            id = 'vol_type' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['type'] = formdata[id][0].strip()
+                # Get all Data Volume fields from the form
+                id = 'vol_type' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['type'] = formdata[id][0].strip()
 
-            id = 'vol_name' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['name'] = formdata[id][0].strip()
+                id = 'vol_name' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['name'] = formdata[id][0].strip()
 
-            id = 'vol_size' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['size'] = '%sGi' % formdata[id][0].strip()
+                id = 'vol_size' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['size'] = '%sGi' % formdata[id][0].strip()
 
-            id = 'vol_mount_path' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['mountPath'] = formdata[id][0].strip()
+                id = 'vol_mount_path' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['mountPath'] = formdata[id][0].strip()
 
-            id = 'vol_access_modes' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['accessModes'] = formdata[id][0].strip()
+                id = 'vol_access_modes' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['accessModes'] = formdata[id][0].strip()
 
-            options['dataVolumes'].append(data_volume)
+                options['dataVolumes'].append(data_volume)
 
         # Manage Extra Resources
+        extra_resources_readonly = False
         if self._default_config_contains('extraResources'):
             options['extraResources'] = (
                 form_defaults['extraResources']['value'])
-        if 'extraResources' in formdata and formdata['extraResources'][0]:
-            options['extraResources'] = formdata['extraResources'][0].strip()
+            extra_resources_readonly = \
+                form_defaults['extraResources'].get('readOnly', False)
+        if (not extra_resources_readonly and 'extraResources' in formdata and
+           formdata['extraResources'][0]):
+                options['extraResources'] = \
+                    formdata['extraResources'][0].strip()
 
         return options
 
@@ -265,10 +328,10 @@ class KubeFormSpawner(KubeSpawner):
             form_defaults = None
             if 'spawnerFormDefaults' in self.spawner_ui_config:
                 form_defaults = self.spawner_ui_config['spawnerFormDefaults']
-            if form_defaults is not None:
-                if option in form_defaults:
-                    if 'value' in form_defaults[option]:
-                        return True
+
+            if form_defaults is not None and option in form_defaults:
+                if 'value' in form_defaults[option]:
+                    return True
         return False
 
     def _get_pvc_manifest(self, name, storage_class, access_modes,
@@ -401,4 +464,5 @@ class KubeFormSpawner(KubeSpawner):
     def start(self):
         """Override KubeSpawner class start method."""
         yield self._prepare_volumes()
-        return (yield super(KubeFormSpawner, self).start())
+        _start = yield super(KubeFormSpawner, self).start()
+        return _start

--- a/kubeflow/jupyter/ui/default/spawner.py
+++ b/kubeflow/jupyter/ui/default/spawner.py
@@ -15,6 +15,10 @@ SERVICE_ACCOUNT_SECRET_MOUNT = '/var/run/secrets/sa'
 
 class KubeFormSpawner(KubeSpawner):
     """Implement a custom Spawner to spawn pods in a Kubernetes Cluster."""
+    def __init__(self, *args, **kwargs):
+        super(KubeFormSpawner, self).__init__(*args, **kwargs)
+        self.initial_volumes = list(self.volumes)
+        self.initial_volume_mounts = list(self.volume_mounts)
 
     @property
     def spawner_ui_config(self):
@@ -314,6 +318,10 @@ class KubeFormSpawner(KubeSpawner):
     @gen.coroutine
     def _prepare_volumes(self):
         """Create PVC manifests and attach as volumes to the Notebook."""
+        # Reset Volumes and VolumeMounts to initial KubeSpawner values
+        self.volumes = list(self.initial_volumes)
+        self.volume_mounts = list(self.initial_volume_mounts)
+
         # Workspace and Data Volumes are managed as PVCs
         persistent_volumes = [self.workspace_volume] + self.data_volumes
 

--- a/kubeflow/jupyter/ui/default/template.html
+++ b/kubeflow/jupyter/ui/default/template.html
@@ -55,7 +55,18 @@
         <label>Image</label>
       </div>
       <div class="panel-body" style="padding: 10px;">
-        <select id="image" class="form-control" name="image" placeholder='repo/image:tag'/ required></select>
+        <div id='imageType' style="padding-bottom: 5px;">
+          <label class="radio-inline">
+            <input id="option_standard" type="radio" name="imageType" onclick="setImageType()"
+                   value="standard" checked>Standard
+          </label>
+          <label class="radio-inline">
+            <input id="option_custom" type="radio" name="imageType" onclick="setImageType()"
+                   value="custom">Custom
+          </label>
+        </div>
+        <select class="form-control" for="standardImages" required></select>
+        <input class="form-control" for="customImage" placeholder="repo/image:tag" required>
       </div>
       <p class="text-muted" style="padding: 10px;">
         A starter Docker image for JupyterHub with a baseline deployment and typical ML packages.

--- a/kubeflow/jupyter/ui/rok/config.yaml
+++ b/kubeflow/jupyter/ui/rok/config.yaml
@@ -27,11 +27,16 @@ spawnerFormDefaults:
       - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.3.1
       - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.3.1
       - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.3.1
+    # By default, custom container Images are allowed
+    # Uncomment the following line to only enable standard container Images
+    #readOnly: true
   cpu:
     value: '1.0'
   memory:
     value: 1.0Gi
   workspaceVolume:
+    # Each Workspace Volume is declared with the following attributes:
+    # Type, RokURL, Name, Size and MountPath
     value:
       type:
         value: New
@@ -46,5 +51,24 @@ spawnerFormDefaults:
         value: /home/jovyan
   dataVolumes:
     value: []
+    # Each Data Volume is declared with the following attributes:
+    # Type, RokURL, Name, Size and MountPath
+    #
+    # For example, a list with a single Data Volume
+    #value:
+    #  - value:
+    #      type:
+    #        value: New
+    #      rokURL:
+    #        value: ''
+    #      name:
+    #        value: {username}{servername}-vol-1
+    #      size:
+    #        value: '10'
+    #      mountPath:
+    #        value: /home/jovyan/{username}{servername}-vol-1
+    #
+    # Uncomment the following line to make the Data Volumes list readonly
+    #readOnly: true
   extraResources:
     value: "{{}}"

--- a/kubeflow/jupyter/ui/rok/script.js
+++ b/kubeflow/jupyter/ui/rok/script.js
@@ -706,7 +706,7 @@ function autofillWorkspaceVolume(rok_member_url) {
     },
     success: function(data, textStatus, request) {
       setValue($('#ws_name'), getHeader(request, 'X-Object-Meta-workspace'));
-      setValue($('#ws_size'), Math.round(getHeader(request, 'Content-Length')/Math.pow(1024, 3)));
+      setValue($('#ws_size'), getHeader(request, 'Content-Length')/Math.pow(1024, 3));
       setValue($('#ws_mount_path'), getHeader(request, 'X-Object-Meta-mountpoint'));
     },
     error: function(XMLHttpRequest, e) {
@@ -725,7 +725,7 @@ function autofillDataVolume(rok_member_url, data_volume_id) {
     },
     success: function(data, textStatus, request) {
       setValue($('#vol_name' + data_volume_id), getHeader(request, 'X-Object-Meta-dataset'));
-      setValue($('#vol_size' + data_volume_id), Math.round(getHeader(request, 'Content-Length')/Math.pow(1024, 3)));
+      setValue($('#vol_size' + data_volume_id), getHeader(request, 'Content-Length')/Math.pow(1024, 3));
       setValue($('#vol_mount_path' + data_volume_id), getHeader(request, 'X-Object-Meta-mountpoint'));
     },
     error: function(XMLHttpRequest, e) {

--- a/kubeflow/jupyter/ui/rok/script.js
+++ b/kubeflow/jupyter/ui/rok/script.js
@@ -72,6 +72,9 @@ $(function() {
     $('#spawn_form').find('input[type="submit"]').remove();
   }
 
+  // Configure Image input elements
+  setImageType();
+
   // Dynamically change Workspace form fields behavior
   setWorkspaceEventListeners();
 
@@ -81,6 +84,22 @@ $(function() {
   // Set tooltip to admin-disabled form fields
   setTooltipsOnImmutable();
 });
+
+// Dynamically update Image input field, based on radio button selection
+function setImageType() {
+  imageType = $('#imageType').find('input:checked').val();
+  if (imageType == 'standard') {
+    $('select[for=standardImages]')
+      .attr({'id': 'image', 'name': 'image'}).css({'display': ''});
+    $('input[for=customImage]')
+      .attr({'id': '', 'name': ''}).removeAttr('required').css({'display': 'none'});
+  } else {
+    $('input[for=customImage]')
+      .attr({'id': 'image', 'name': 'image'}).css({'display': ''});
+    $('select[for=standardImages]')
+      .attr({'id': '', 'name': ''}).removeAttr('required').css({'display': 'none'});
+  }
+}
 
 // Set default values to form fields
 function setDefaultFormValues() {
@@ -119,15 +138,14 @@ function setDefaultFormValues() {
 
     // Make Container Image field readonly, if specified
     if ('readOnly' in formDefaults.image) {
-      $('#image').attr({
-        'readonly': formDefaults.image.readOnly,
-        'immutable': formDefaults.image.readOnly
+      $('#option_standard').prop({
+          'disabled': formDefaults.image.readOnly,
+          'immutable': formDefaults.image.readOnly
       });
-      if ($('#image').attr('readonly')) {
-        $('#image').on('mousedown', function(e) {
-          e.preventDefault(); this.blur(); window.focus();
-        });
-      }
+      $('#option_custom').prop({
+          'disabled': formDefaults.image.readOnly,
+          'immutable': formDefaults.image.readOnly
+      });
     }
   }
 

--- a/kubeflow/jupyter/ui/rok/script.js
+++ b/kubeflow/jupyter/ui/rok/script.js
@@ -202,7 +202,7 @@ function setDefaultFormValues() {
             $('#ws_type').val(defaultWorkspace.type.value);
           }
           // Make the Workspace Volume Type readonly, if specified
-          if ('readOnly' in defaultWorkspace.type) {
+          if ('readOnly' in defaultWorkspace.type || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_type').attr({
               'readonly': defaultWorkspace.type.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.type.readOnly || defaultWorkspaceReadOnly
@@ -223,7 +223,7 @@ function setDefaultFormValues() {
             $('#ws_rok_url').val(defaultWorkspace.rokURL.value).trigger('change');
           }
           // Make the Workspace Rok URL readonly, if specified
-          if ('readOnly' in defaultWorkspace.rokURL) {
+          if ('readOnly' in defaultWorkspace.rokURL || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_rok_url').attr('readonly', defaultWorkspace.rokURL.readOnly || defaultWorkspaceReadOnly);
           }
         }
@@ -235,7 +235,7 @@ function setDefaultFormValues() {
             $('#ws_name').val(defaultWorkspace.name.value).trigger('focusout');
           }
           // Make the Workspace Volume Name readonly, if specified
-          if ('readOnly' in defaultWorkspace.name) {
+          if ('readOnly' in defaultWorkspace.name || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_name').attr({
               'readonly': defaultWorkspace.name.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.name.readOnly || defaultWorkspaceReadOnly
@@ -250,7 +250,7 @@ function setDefaultFormValues() {
             $('#ws_size').val(defaultWorkspace.size.value);
           }
           // Make the Workspace Volume Size readonly, if specified
-          if ('readOnly' in defaultWorkspace.size) {
+          if ('readOnly' in defaultWorkspace.size || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_size').attr({
               'readonly': defaultWorkspace.size.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.size.readOnly || defaultWorkspaceReadOnly
@@ -265,7 +265,7 @@ function setDefaultFormValues() {
             $('#ws_mount_path').val(defaultWorkspace.mountPath.value);
           }
           // Make the Workspace Volume MountPath readonly, if specified
-          if ('readOnly' in defaultWorkspace.mountPath) {
+          if ('readOnly' in defaultWorkspace.mountPath || 'readOnly' in formDefaults.workspaceVolume) {
             $('#ws_mount_path').attr({
               'readonly': defaultWorkspace.mountPath.readOnly || defaultWorkspaceReadOnly,
               'immutable': defaultWorkspace.mountPath.readOnly || defaultWorkspaceReadOnly
@@ -277,9 +277,13 @@ function setDefaultFormValues() {
   }
 
   if ('dataVolumes' in formDefaults) {
+      var dataVolumesReadOnly = formDefaults.dataVolumes.readOnly
       // Disable Add Volume button, if specified
       if ('readOnly' in formDefaults.dataVolumes) {
-        $('#add_volume').attr('readonly', formDefaults.dataVolumes.readOnly);
+        $('#add_volume').attr({
+          'disabled': dataVolumesReadOnly,
+          'immutable': dataVolumesReadOnly
+        });
       }
 
       // Set default Data Volumes - Disable if specified
@@ -294,20 +298,19 @@ function setDefaultFormValues() {
         if ('value' in defaultDataVolumes[i]) {
           vol = defaultDataVolumes[i].value;
         }
-        console.log(vol);
 
         if ('type' in vol) {
           $('#vol_type' + counter).val('');
           if ('value' in vol.type) {
             $('#vol_type' + counter).val(vol.type.value).trigger('change');
           }
-          if ('readOnly' in vol.type) {
+          if ('readOnly' in vol.type || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_type' + counter).attr({
-              'readonly': vol.type.readOnly,
-              'immutable': vol.type.readOnly
+              'readonly': vol.type.readOnly || dataVolumesReadOnly,
+              'immutable': vol.type.readOnly || dataVolumesReadOnly
             });
-            if ($('#vol_type').attr('readonly')) {
-              $('#vol_type').on('mousedown', function(e) {
+            if ($('#vol_type' + counter).attr('readonly')) {
+              $('#vol_type' + counter).on('mousedown', function(e) {
                 e.preventDefault(); this.blur(); window.focus();
               });
             }
@@ -319,10 +322,10 @@ function setDefaultFormValues() {
           if ('value' in vol.rokURL) {
             $('#vol_rok_url' + counter).val(vol.rokURL.value).trigger('change');
           }
-          if ('readOnly' in vol.rokURL) {
+          if ('readOnly' in vol.rokURL || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_rok_url' + counter).attr({
-              'readonly': vol.rokURL.readOnly,
-              'immutable': vol.name.readOnly
+              'readonly': vol.rokURL.readOnly || dataVolumesReadOnly,
+              'immutable': vol.rokURL.readOnly || dataVolumesReadOnly
             });
           }
         }
@@ -332,10 +335,10 @@ function setDefaultFormValues() {
           if ('value' in vol.name) {
             $('#vol_name' + counter).val(vol.name.value).trigger('focusout');
           }
-          if ('readOnly' in vol.name) {
+          if ('readOnly' in vol.name || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_name' + counter).attr({
-              'readonly': vol.name.readOnly,
-              'immutable': vol.name.readOnly
+              'readonly': vol.name.readOnly || dataVolumesReadOnly,
+              'immutable': vol.name.readOnly || dataVolumesReadOnly
             });
           }
         }
@@ -345,10 +348,10 @@ function setDefaultFormValues() {
           if ('value' in vol.size) {
             $('#vol_size' + counter).val(vol.size.value);
           }
-          if ('readOnly' in vol.size) {
+          if ('readOnly' in vol.size || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_size' + counter).attr({
-              'readonly': vol.size.readOnly,
-              'immutable': vol.size.readOnly
+              'readonly': vol.size.readOnly || dataVolumesReadOnly,
+              'immutable': vol.size.readOnly || dataVolumesReadOnly
             });
           }
         }
@@ -358,19 +361,19 @@ function setDefaultFormValues() {
           if ('value' in vol.mountPath) {
             $('#vol_mount_path' + counter).val(vol.mountPath.value);
           }
-          if ('readOnly' in vol.mountPath) {
+          if ('readOnly' in vol.mountPath || 'readOnly' in formDefaults.dataVolumes) {
             $('#vol_mount_path' + counter).attr({
-              'readonly': vol.mountPath.readOnly,
-              'immutable': vol.mountPath.readOnly
+              'readonly': vol.mountPath.readOnly || dataVolumesReadOnly,
+              'immutable': vol.mountPath.readOnly || dataVolumesReadOnly
             });
           }
         }
 
         // Disable Delete button, if specified
-        if ('readOnly' in defaultDataVolumes[i]) {
+        if ('readOnly' in formDefaults.dataVolumes) {
           $('#vol_delete_button' + counter).attr({
-            'readonly': defaultDataVolumes[i].readOnly,
-            'immutable': defaultDataVolumes[i].readOnly
+            'readonly': formDefaults.dataVolumes.readOnly,
+            'immutable': formDefaults.dataVolumes.readOnly
           });
         }
       }

--- a/kubeflow/jupyter/ui/rok/spawner.py
+++ b/kubeflow/jupyter/ui/rok/spawner.py
@@ -51,115 +51,176 @@ class KubeFormSpawner(spawner.KubeFormSpawner):
             form_defaults = self.spawner_ui_config['spawnerFormDefaults']
 
         # Manage Image
+        image_readonly = False
         if self._default_config_contains('image'):
             options['image'] = form_defaults['image']['value']
-        if 'image' in formdata and formdata['image'][0]:
-            options['image'] = formdata['image'][0].strip()
+            image_readonly = form_defaults['image'].get('readOnly', False)
+        if ('image' in formdata and formdata['image'][0]):
+            image_from_form = formdata['image'][0].strip()
+            if image_readonly:
+                # Provided image must be standard
+                if image_from_form in form_defaults['image']['options']:
+                    options['image'] = image_from_form
+            else:
+                # Provided image can be standard or custom
+                options['image'] = image_from_form
 
         # Manage CPU
+        cpu_readonly = False
         if self._default_config_contains('cpu'):
             options['cpu'] = form_defaults['cpu']['value']
-        if 'cpu' in formdata and formdata['cpu'][0]:
+            cpu_readonly = form_defaults['cpu'].get('readOnly', False)
+        if (not cpu_readonly and 'cpu' in formdata and formdata['cpu'][0]):
             options['cpu'] = formdata['cpu'][0].strip()
 
         # Manage Memory
+        memory_readonly = False
         if self._default_config_contains('memory'):
             options['memory'] = form_defaults['memory']['value']
-        if 'memory' in formdata and formdata['memory'][0]:
-            options['memory'] = formdata['memory'][0].strip()
+            memory_readonly = form_defaults['memory'].get('readOnly', False)
+        if (not memory_readonly and 'memory' in formdata and
+           formdata['memory'][0]):
+                options['memory'] = formdata['memory'][0].strip()
 
         # Manage Workspace Volume
         options['workspaceVolume'] = {}
         ws_volume = {}
 
+        ws_volume_readonly = False
         if self._default_config_contains('workspaceVolume'):
+            ws_volume_readonly = \
+                form_defaults['workspaceVolume'].get('readOnly', False)
+
             # The Workspace Volume is specified in `config.yaml`
-            if 'value' in form_defaults['workspaceVolume']:
-                default_ws_volume = form_defaults['workspaceVolume']['value']
+            default_ws_volume = form_defaults['workspaceVolume']['value']
 
-                # Get the default values from the YAML configuration files
-                if ('type' in default_ws_volume and
-                   'value' in default_ws_volume['type']):
-                        ws_volume['type'] = default_ws_volume['type']['value']
+            # Get and set the default values from the YAML configuration file,
+            # if present and not marked as readonly
+            ws_type_readonly = False
+            if ('type' in default_ws_volume and
+               'value' in default_ws_volume['type']):
+                    ws_volume['type'] = default_ws_volume['type']['value']
+                    ws_type_readonly = \
+                        default_ws_volume['type'].get('readOnly', False)
 
-                if ('rokURL' in default_ws_volume and
-                   'value' in default_ws_volume['rokURL']):
-                        ws_volume['rokURL'] = (
-                            default_ws_volume['rokURL']['value'])
+            ws_rok_url_readonly = False
+            if ('rokURL' in default_ws_volume and
+               'value' in default_ws_volume['rokURL']):
+                    ws_volume['rokURL'] = \
+                        default_ws_volume['rokURL']['value']
+                    ws_rok_url_readonly = \
+                        default_ws_volume['rokURL'].get('readOnly', False)
 
-                if ('name' in default_ws_volume and
-                   'value' in default_ws_volume['name']):
-                        ws_volume['name'] = default_ws_volume['name']['value']
+            ws_name_readonly = False
+            if ('name' in default_ws_volume and
+               'value' in default_ws_volume['name']):
+                    ws_volume['name'] = default_ws_volume['name']['value']
+                    ws_name_readonly = \
+                        default_ws_volume['name'].get('readOnly', False)
 
-                if ('size' in default_ws_volume and
-                   'value' in default_ws_volume['size']):
-                        ws_volume['size'] = (
-                            '%sGi' % default_ws_volume['size']['value'])
+            ws_size_readonly = False
+            if ('size' in default_ws_volume and
+               'value' in default_ws_volume['size']):
+                    ws_volume['size'] = \
+                        '%sGi' % default_ws_volume['size']['value']
+                    ws_size_readonly = \
+                        default_ws_volume['size'].get('readOnly', False)
 
-                if ('mountPath' in default_ws_volume and
-                   'value' in default_ws_volume['mountPath']):
-                        ws_volume['mountPath'] = (
-                            default_ws_volume['mountPath']['value'])
+            ws_mount_path_readonly = False
+            if ('mountPath' in default_ws_volume and
+               'value' in default_ws_volume['mountPath']):
+                    ws_volume['mountPath'] = \
+                        default_ws_volume['mountPath']['value']
+                    ws_mount_path_readonly = \
+                        default_ws_volume['mountPath'].get('readOnly', False)
 
-        # Get the Workspace Volume values from the form, if user specified them
-        if 'ws_type' in formdata and formdata['ws_type'][0]:
-            ws_volume['type'] = formdata['ws_type'][0].strip()
+        # Get and set the Workspace Volume values from the form, if present
+        # and not marked as readonly
+        if not ws_volume_readonly:
+            if (not ws_type_readonly and 'ws_type' in formdata and
+               formdata['ws_type'][0]):
+                    ws_volume['type'] = formdata['ws_type'][0].strip()
 
-        if 'ws_rok_url' in formdata and formdata['ws_rok_url'][0]:
-            ws_volume['rokURL'] = formdata['ws_rok_url'][0].strip()
+            if (not ws_rok_url_readonly and 'ws_rok_url' in formdata
+               and formdata['ws_rok_url'][0]):
+                    ws_volume['rokURL'] = \
+                        formdata['ws_rok_url'][0].strip()
 
-        if 'ws_name' in formdata and formdata['ws_name'][0]:
-            ws_volume['name'] = formdata['ws_name'][0].strip()
+            if (not ws_name_readonly and 'ws_name' in formdata and
+               formdata['ws_name'][0]):
+                    ws_volume['name'] = formdata['ws_name'][0].strip()
 
-        if 'ws_size' in formdata and formdata['ws_size'][0]:
-            ws_volume['size'] = '%sGi' % formdata['ws_size'][0].strip()
+            if (not ws_size_readonly and 'ws_size' in formdata and
+               formdata['ws_size'][0]):
+                    ws_volume['size'] = '%sGi' % formdata['ws_size'][0].strip()
 
-        if 'ws_mount_path' in formdata and formdata['ws_mount_path'][0]:
-            ws_volume['mountPath'] = formdata['ws_mount_path'][0].strip()
+            if (not ws_mount_path_readonly and 'ws_mount_path' in formdata and
+               formdata['ws_mount_path'][0]):
+                    ws_volume['mountPath'] = \
+                        formdata['ws_mount_path'][0].strip()
 
         options['workspaceVolume'] = ws_volume
 
         # Manage Data Volumes
         options['dataVolumes'] = []
+        data_volumes_readonly = False
+        if self._default_config_contains('dataVolumes'):
+            data_volumes_readonly = \
+                form_defaults['dataVolumes'].get('readOnly', False)
 
-        data_volumes_cnt = 0
-        # Deduce the total number of Data Volumes
-        for k, v in formdata.items():
-            if k.startswith('vol_type'):
-                data_volumes_cnt += 1
+        if data_volumes_readonly:
+            # Set Data Volumes as specified in the Spawner configuration file
+            for volume in form_defaults['dataVolumes']['value']:
+                data_volume = {}
+                for f in ['type', 'rokURL', 'name', 'size', 'mountPath']:
+                    data_volume[f] = volume['value'][f]['value']
+                data_volume['size'] += 'Gi'
+                options['dataVolumes'].append(data_volume)
+        else:
+            # Deduce the total number of Data Volumes
+            data_volumes_cnt = 0
+            for k, v in formdata.items():
+                if k.startswith('vol_type'):
+                    data_volumes_cnt += 1
 
-        for i in range(1, data_volumes_cnt + 1):
-            data_volume = {}
+            # Set Data Volumes as specified in the Spawner form
+            for i in range(1, data_volumes_cnt + 1):
+                data_volume = {}
 
-            # Get all Data Volume fields from the form
-            id = 'vol_type' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['type'] = formdata[id][0].strip()
+                # Get all Data Volume fields from the form
+                id = 'vol_type' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['type'] = formdata[id][0].strip()
 
-            id = 'vol_name' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['name'] = formdata[id][0].strip()
+                id = 'vol_name' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['name'] = formdata[id][0].strip()
 
-            id = 'vol_rok_url' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['rokURL'] = formdata[id][0].strip()
+                id = 'vol_rok_url' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['rokURL'] = formdata[id][0].strip()
 
-            id = 'vol_size' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['size'] = '%sGi' % formdata[id][0].strip()
+                id = 'vol_size' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['size'] = '%sGi' % formdata[id][0].strip()
 
-            id = 'vol_mount_path' + str(i)
-            if id in formdata and formdata[id][0]:
-                data_volume['mountPath'] = formdata[id][0].strip()
+                id = 'vol_mount_path' + str(i)
+                if id in formdata and formdata[id][0]:
+                    data_volume['mountPath'] = formdata[id][0].strip()
 
-            options['dataVolumes'].append(data_volume)
+                options['dataVolumes'].append(data_volume)
 
         # Manage Extra Resources
+        extra_resources_readonly = False
         if self._default_config_contains('extraResources'):
             options['extraResources'] = (
                 form_defaults['extraResources']['value'])
-        if 'extraResources' in formdata and formdata['extraResources'][0]:
-            options['extraResources'] = formdata['extraResources'][0].strip()
+            extra_resources_readonly = \
+                form_defaults['extraResources'].get('readOnly', False)
+        if (not extra_resources_readonly and 'extraResources' in formdata and
+           formdata['extraResources'][0]):
+                options['extraResources'] = \
+                    formdata['extraResources'][0].strip()
 
         return options
 


### PR DESCRIPTION
This PR provides various enhancements and fixes to the existng Jupyter Spawner. More specifically:

- Adds support for custom container Images in the JH Spawner UI, as suggested by @jlewi  - Fixes #2060 (see provided GIF below for a preview) 
- Updates the list of available container Images with the latest TF versions from [gcr.io](https://gcr.io/kubeflow-images-public/)
- Adds basic server-side validation for Spawner options values that are marked as readOnly in `config.yaml`. In a future PR, we plan to further improve the Spawner options validation and provide descriptive messages to the users in each case to provide a better UX (e.g. when a `readOnly` Spawner option gets mutated)
- Implements various fixes for the Spawner of existing JH Spawner UIs (`default` and `rok`)

![allow custom docker image](https://user-images.githubusercontent.com/14974598/49836477-76d97d80-fdab-11e8-8b37-778f46e6f954.gif)

@jlewi let us know for the next steps regarding the review of this PR in order to make it for the 0.4 release

This PR is currently marked as WIP, as we are peforming some more manual tests. However, there will are no breaking changes to it, so it makes sense to start the reviewing process ASAP.

@pdmack @kkasravi as you already know, we are always open to feedback on both structure and code

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2079)
<!-- Reviewable:end -->
