### PR TITLE
Update private IP configuration with new GKE API

### DIFF
--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -76,8 +76,9 @@ resources:
       ipAllocationPolicy:
         createSubnetwork: true
         useIpAliases: true
-      masterIpv4CidrBlock: {{ properties['securityConfig']['masterIpv4CidrBlock'] }}
-      privateCluster: true
+      privateClusterConfig:
+        masterIpv4CidrBlock: {{ properties['securityConfig']['masterIpv4CidrBlock'] }}
+        enablePrivateNodes: true
       masterAuthorizedNetworksConfig:
         enabled: {{ properties['securityConfig']['masterAuthorizedNetworksConfigEnabled'] }}
         {% if properties['securityConfig']['masterAuthorizedNetworksConfigEnabled'] %}


### PR DESCRIPTION
The change is based on the new GKE API spec
https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1beta1/projects.locations.clusters#privateclusterconfig

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2085)
<!-- Reviewable:end -->
