### PR TITLE
Change the IAP fields to match their parent's width.

### DIFF
--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -168,10 +168,10 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
           <label style={{ minHeight: 20 }} >Skip IAP</label>
         </Row>
         <Row style={{ minHeight: 0 }}>
-          <Input style={IapElementStyle(this.state.iap)} name="clientId" label="IAP Oauth Client ID" spellCheck={false} value={this.state.clientId} onChange={this._handleChange.bind(this)} />
+          <Input style={IapElementStyle(this.state.iap)} name="clientId" label="IAP Oauth Client ID" fullWidth={true} spellCheck={false} value={this.state.clientId} onChange={this._handleChange.bind(this)} />
         </Row>
         <Row style={{ minHeight: 0 }}>
-          <Input style={IapElementStyle(this.state.iap)} name="clientSecret" label="IAP Oauth Client Secret" spellCheck={false} value={this.state.clientSecret} onChange={this._handleChange.bind(this)} />
+          <Input style={IapElementStyle(this.state.iap)} name="clientSecret" label="IAP Oauth Client Secret" fullWidth={true} spellCheck={false} value={this.state.clientSecret} onChange={this._handleChange.bind(this)} />
         </Row>
         <Row style={{ minHeight: 20}}>
           <Text style={{ fontSize: '1.1em', margin: '2% 11%' }}>GKE Zone: </Text>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/3463757/49968206-fb2a1e80-fed9-11e8-927e-49d6e94efde9.png)

After:
![screenshot 2018-12-13 at 1 21 55 pm](https://user-images.githubusercontent.com/3463757/49968376-80adce80-feda-11e8-8b4e-097da37bd027.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2087)
<!-- Reviewable:end -->
