### PR TITLE
Update aws parameters in serving and dashboard

### DIFF
--- a/kubeflow/tensorboard/aws.libsonnet
+++ b/kubeflow/tensorboard/aws.libsonnet
@@ -37,10 +37,6 @@
               value: params.s3AwsRegion,
             },
             {
-              name: "S3_REGION",
-              value: params.s3AwsRegion,
-            },
-            {
               name: "S3_USE_HTTPS",
               value: params.s3UseHttps,
             },

--- a/kubeflow/tensorboard/prototypes/tensorboard-aws.jsonnet
+++ b/kubeflow/tensorboard/prototypes/tensorboard-aws.jsonnet
@@ -14,7 +14,7 @@
 // @optionalParam s3AwsRegion string us-west-1 S3 region
 // @optionalParam s3UseHttps string true Whether or not to use https
 // @optionalParam s3VerifySsl string true Whether or not to verify https certificates for S3 connections
-// @optionalParam s3Endpoint string http://s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint
+// @optionalParam s3Endpoint string s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint
 
 local subtype = import "kubeflow/tensorboard/aws.libsonnet";
 local basetype = import "kubeflow/tensorboard/tensorboard.libsonnet";

--- a/kubeflow/tensorboard/tests/tensorboard-aws_test.jsonnet
+++ b/kubeflow/tensorboard/tests/tensorboard-aws_test.jsonnet
@@ -107,10 +107,6 @@ std.assertEqual(
                   value: "us-west1-a",
                 },
                 {
-                  name: "S3_REGION",
-                  value: "us-west1-a",
-                },
-                {
                   name: "S3_USE_HTTPS",
                   value: "true",
                 },

--- a/kubeflow/tf-serving/prototypes/tf-serving-aws.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-aws.jsonnet
@@ -1,24 +1,27 @@
 // @apiVersion 0.1
-// @name io.ksonnet.pkg.tf-serving-aws
+// @name io.ksonnet.pkg.tf-serving-deployment-aws
 // @description TensorFlow serving
 // @shortDescription A TensorFlow serving deployment
 // @param name string Name to give to each of the components
-// @optionalParam serviceType string ClusterIP The k8s service type for tf serving.
 // @optionalParam numGpus string 0 Number of gpus to use
 // @optionalParam deployHttpProxy string false Whether to deploy http proxy
-// @optionalParam modelBasePath string gs://kubeflow-examples-data/mnist The model path
-// @optionalParam modelName string mnist The model name
-// @optionalParam defaultCpuImage string tensorflow/serving:1.8.0 The default model server image (cpu)
-// @optionalParam defaultGpuImage string tensorflow/serving:1.10.0-gpu The default model server image (gpu)
+// @optionalParam injectIstio string false Whether to inject istio sidecar; should be true or false.
+// @optionalParam enablePrometheus string true Whether to enable prometheus endpoint (requires TF 1.11)
+// @optionalParam modelBasePath string s3://kubeflow-examples-data/mnist The model path
+// @optionalParam modelName string null The model name
+// @optionalParam versionName string v1 The version name
+// @optionalParam defaultCpuImage string tensorflow/serving:1.11.1 The default model server image (cpu)
+// @optionalParam defaultGpuImage string tensorflow/serving:1.11.1-gpu The default model server image (gpu)
 // @optionalParam httpProxyImage string gcr.io/kubeflow-images-public/tf-model-server-http-proxy:v20180723 Http proxy image
 // @optionalParam s3Enable string false Whether to enable S3
+// Following parameters are needed only if s3Enable is true
 // @optionalParam s3SecretName string null Name of the k8s secrets containing S3 credentials
 // @optionalParam s3SecretAccesskeyidKeyName string AWS_ACCESS_KEY_ID Name of the key in the k8s secret containing AWS_ACCESS_KEY_ID
 // @optionalParam s3SecretSecretaccesskeyKeyName string AWS_SECRET_ACCESS_KEY Name of the key in the k8s secret containing AWS_SECRET_ACCESS_KEY
 // @optionalParam s3AwsRegion string us-west-1 S3 region
 // @optionalParam s3UseHttps string true Whether or not to use https
 // @optionalParam s3VerifySsl string true Whether or not to verify https certificates for S3 connections
-// @optionalParam s3Endpoint string http://s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint
+// @optionalParam s3Endpoint string s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint
 
 local k = import "k.libsonnet";
 local deployment = k.apps.v1beta1.deployment;
@@ -44,7 +47,6 @@ local tfDeployment = base.tfDeployment +
                                    valueFrom: { secretKeyRef: { name: params.s3SecretName, key: params.s3SecretSecretaccesskeyKeyName } },
                                  },
                                  { name: "AWS_REGION", value: params.s3AwsRegion },
-                                 { name: "S3_REGION", value: params.s3AwsRegion },
                                  { name: "S3_USE_HTTPS", value: params.s3UseHttps },
                                  { name: "S3_VERIFY_SSL", value: params.s3VerifySsl },
                                  { name: "S3_ENDPOINT", value: params.s3Endpoint },
@@ -55,5 +57,5 @@ local tfDeployment = base.tfDeployment +
                      );
 util.list([
   tfDeployment,
-  base.tfService,
+  base.tfservingConfig,
 ],)


### PR DESCRIPTION
1. Update tf serving aws prototype to use same pattern as gcp in order to reuse template. (Right now it's broken since k8s service was move out from tf-serving-template.libsonnet)
2. Remove useless parameters

Website are updated correspondingly. 
https://github.com/kubeflow/website/pull/362

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2097)
<!-- Reviewable:end -->
