### PR TITLE
ks init: --skip-default-registries + append ${KS_INIT_EXTRA_ARGS}

### DIFF
--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -46,7 +46,7 @@ createKsApp() {
   pushd .
   # Create the ksonnet app
   cd $(dirname "${KUBEFLOW_KS_DIR}")
-  ks init $(basename "${KUBEFLOW_KS_DIR}")
+  eval ks init $(basename "${KUBEFLOW_KS_DIR}") --skip-default-registries ${KS_INIT_EXTRA_ARGS}
   cd "${KUBEFLOW_KS_DIR}"
 
   # Remove the default environment; The cluster might not exist yet


### PR DESCRIPTION

## What are the goals of this PR ?

Fix  #1615

## How are the goals of the PR achieved ?

+ Avoid downloading from default registries, add --skip-default-registries to the ks init command here
https://github.com/kubeflow/kubeflow/blob/master/scripts/util.sh#L49

+ Define an extra environment variable ${KS_INIT_EXTRA_ARGS} to contain additional arguments to pass to the ks init command so that folks can specify additional arguments if needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2100)
<!-- Reviewable:end -->
