### PR TITLE
Don't grant cloudservices account IAM admin priveleges.

### DIFF
--- a/scripts/gke/util.sh
+++ b/scripts/gke/util.sh
@@ -29,11 +29,6 @@ gcpInitProject() {
     file.googleapis.com \
     ml.googleapis.com \
     iam.googleapis.com --project=${PROJECT}
-
-  # Set IAM Admin Policy
-  gcloud projects add-iam-policy-binding ${PROJECT} \
-    --member serviceAccount:${PROJECT_NUMBER}@cloudservices.gserviceaccount.com \
-    --role roles/resourcemanager.projectIamAdmin
 }
 
 generateDMConfigs() {


### PR DESCRIPTION
* Originally we were using deployment manager to set IAM permissions.
* DM uses the cloud services account so we needed to grant the account IAM
  permissions.

* We no longer use DM to set IAM permissions; in part because we don't want
  to give cloudservice so much permisison.

Fix #1140 flakiness caused by setting the IAM policy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2101)
<!-- Reviewable:end -->
