### PR TITLE
Update kubeflow components to v0.4.0

### DIFF
--- a/kubeflow/core/prototypes/centraldashboard.jsonnet
+++ b/kubeflow/core/prototypes/centraldashboard.jsonnet
@@ -3,7 +3,7 @@
 // @description centraldashboard Component
 // @shortDescription centraldashboard
 // @param name string Name
-// @optionalParam image string gcr.io/kubeflow-images-public/centraldashboard:v0.3.4 Image for the central dashboard
+// @optionalParam image string gcr.io/kubeflow-images-public/centraldashboard:v0.4.0 Image for the central dashboard
 
 local centraldashboard = import "kubeflow/core/centraldashboard.libsonnet";
 local instance = centraldashboard.new(env, params);

--- a/kubeflow/jupyter/ui/default/config.yaml
+++ b/kubeflow/jupyter/ui/default/config.yaml
@@ -21,23 +21,23 @@ spawnerFormDefaults:
   image:
     # The container Image for user's Notebook
     # Note that this value needs to be present in the options list below
-    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.3.1
+    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
     # The list of available container Images
     options:
-      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.3.1
+      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.4.0
   cpu:
     # CPU for user's Notebook
     value: '1.0'

--- a/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
@@ -5,7 +5,7 @@
 // @param name string Name to give to each of the components
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
-// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch-operator:v0.3.0-16-g8d71ff3 The image for the PyTorchJob controller
+// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch_operator:v0.4.0 The image for the PyTorchJob controller
 // @optionalParam pytorchDefaultImage string null The default image to use for pytorch
 // @optionalParam pytorchJobVersion string v1beta1 which version of the PyTorchJob operator to use
 // @optionalParam deploymentScope string cluster The scope at which pytorch-operator should be deployed - valid values are cluster, namespace.

--- a/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
@@ -5,7 +5,7 @@
 // @param name string Name to give to each of the components
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
-// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch_operator:v0.4.0 The image for the PyTorchJob controller
+// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch-operator:v0.4.0 The image for the PyTorchJob controller
 // @optionalParam pytorchDefaultImage string null The default image to use for pytorch
 // @optionalParam pytorchJobVersion string v1beta1 which version of the PyTorchJob operator to use
 // @optionalParam deploymentScope string cluster The scope at which pytorch-operator should be deployed - valid values are cluster, namespace.

--- a/kubeflow/tf-training/prototypes/tf-job-operator.jsonnet
+++ b/kubeflow/tf-training/prototypes/tf-job-operator.jsonnet
@@ -4,7 +4,7 @@
 // @shortDescription A TensorFlow job operator.
 // @param name string Name to give to each of the components
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
-// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:kubeflow-tf-operator-postsubmit-v2-785f416-272-7f3c The image for the TfJob controller.
+// @optionalParam tfJobImage string gcr.io/kubeflow-images-public/tf_operator:v0.4.0 The image for the TfJob controller.
 // @optionalParam tfDefaultImage string null The default image to use for TensorFlow.
 // @optionalParam tfJobUiServiceType string ClusterIP The service type for the UI.
 // @optionalParam tfJobVersion string v1beta1 which version of the TFJob operator to use

--- a/releasing/image_tags.yaml
+++ b/releasing/image_tags.yaml
@@ -4,6 +4,9 @@ images:
   - digest: sha256:9a410ef29484aa6d8b2acacbed8cc708bbf928436b67f1ab326eaf096424139a
     tags:
     - v0.3.0
+  - digest: sha256:3b0a17231c1e8f0c1f6b2eda70bb212998506008176ec0ab066ffc0e7c3854bc
+    tags:
+    - v0.4.0
 - name: gcr.io/kubeflow-images-public/chainer-operator
   versions:
   - digest: sha256:2cd5d5adbb97373f0ef978f39618cb43d214973aadee0d1b01dae61a9d0c48cc
@@ -28,6 +31,9 @@ images:
   - digest: sha256:33aa95a3aa0108d5bc631fa3f8a04e646d4eef08a0e8c4695842f92ef0c79027
     tags:
     - v0.3.0
+  - digest: sha256:a51b91ab69f61b709b747089bee34c692b9fdbf016f518a040696502a317ce26
+    tags:
+    - v0.4.0
 - name: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu
   versions:
   - digest: sha256:bd3d2ae9a4e07b2b58910e99a26676ab31f4ba5ae2a633fbde5ce8dee8b63024
@@ -48,6 +54,19 @@ images:
       month: 10
       second: 27
       year: 2018
+  - digest: sha256:3e547beeeb4eaafd47ccdfb1ee72e80ba76ed88a5a6db7af64d893dde0cb028e
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 12:58:44-08:00'
+      day: 11
+      hour: 12
+      microsecond: 0
+      minute: 58
+      month: 12
+      second: 44
+      year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu
   versions:
   - digest: sha256:24a32e6a533a6e7d46a649cbff247ebd86dee078d37489035d9bc440a9e2487f
@@ -55,6 +74,19 @@ images:
     - latest
     - v20180301-pr317
     - v0.3.0
+  - digest: sha256:1cda81f21e8ea3fe3c1a753c7115388aaecf4f31e6611a04811bfe4e47b4539c
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:00:22-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 0
+      month: 12
+      second: 22
+      year: 2018
   - digest: sha256:ff7ee6e7a9aae82270bc3a6c00492a20afe5f005c9057058b3022d101eaa6cbe
     tags:
     - v-base-b321075-822
@@ -68,8 +100,81 @@ images:
       month: 10
       second: 39
       year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-cpu
+  versions:
+  - digest: sha256:eb7cedcd28ec47e94175bb27c516375ffbac05e46f02b6257762d89168711567
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:03:39-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 3
+      month: 12
+      second: 39
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-gpu
+  versions:
+  - digest: sha256:5a7d1b199a65b1e35db208dbb2de8566dfb5ce928ffc511d66d640ee2e56054c
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:04:18-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 4
+      month: 12
+      second: 18
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu
+  versions:
+  - digest: sha256:9d400875a7496f7047f630be018fcb31118e50b161a2c9826bd7bfeabde6e834
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 12:59:48-08:00'
+      day: 11
+      hour: 12
+      microsecond: 0
+      minute: 59
+      month: 12
+      second: 48
+      year: 2018
+- name: gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-gpu
+  versions:
+  - digest: sha256:d9176e3740a69e516b5029e669ddb353ab7a45ebe7f9c1c8cc339e92b7395647
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:15:28-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 15
+      month: 12
+      second: 28
+      year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu
   versions:
+  - digest: sha256:b062d728574c8daeb667c1a61a496c79be8c30cfbcc0feb443e5b5fc685923f4
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 12:57:38-08:00'
+      day: 11
+      hour: 12
+      microsecond: 0
+      minute: 57
+      month: 12
+      second: 38
+      year: 2018
   - digest: sha256:f7fbde2e30a81d87df8987efb55ffeb9d3eb8d8436e9f4e4179a5aaf1557a860
     tags:
     - latest
@@ -140,6 +245,19 @@ images:
       month: 10
       second: 1
       year: 2018
+  - digest: sha256:f932fc3b9f1492ffa8bca2026e2e9ffb9ba40f96cc46b82dd639991e7ebed90a
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:03:13-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 3
+      month: 12
+      second: 13
+      year: 2018
   - digest: sha256:5743117cd1a7ed5976cf02b889db75437e3d37886a3fb32bb3bfdf59b3d067d3
     tags:
     - latest
@@ -184,18 +302,18 @@ images:
       month: 7
       second: 49
       year: 2018
-  - digest: sha256:c62d2057a83dbc87461b1a36672897ed03543ec51a94464e2dea3539083c78e2
+  - digest: sha256:6e89d0c567fd6ab17a050034f58fc213a42840c162834d8dad14d27c67636bad
     tags:
-    - v-base-b321075-822
-    - v0.3.1
+    - v-base-d1ee37b-955
+    - v0.4.0
     timestamp:
-      datetime: '2018-10-18 13:29:24-07:00'
-      day: 18
+      datetime: '2018-12-11 13:00:00-08:00'
+      day: 11
       hour: 13
       microsecond: 0
-      minute: 29
-      month: 10
-      second: 24
+      minute: 0
+      month: 12
+      second: 0
       year: 2018
   - digest: sha256:8582e9b65e3e3d1fa16e91d89e2a2cb981a03008223c137dd842311ec496da90
     tags:
@@ -210,6 +328,19 @@ images:
       minute: 11
       month: 9
       second: 50
+      year: 2018
+  - digest: sha256:c62d2057a83dbc87461b1a36672897ed03543ec51a94464e2dea3539083c78e2
+    tags:
+    - v-base-b321075-822
+    - v0.3.1
+    timestamp:
+      datetime: '2018-10-18 13:29:24-07:00'
+      day: 18
+      hour: 13
+      microsecond: 0
+      minute: 29
+      month: 10
+      second: 24
       year: 2018
   - digest: sha256:9bbd319374e73f7632e0ffe4d8b52c5280c2c8ea00032629c91e03121d1ab4c3
     tags:
@@ -227,6 +358,19 @@ images:
       year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu
   versions:
+  - digest: sha256:c66a4d81e46a641806e8d8c87f6d950417973d4bc440cde4492d6478ada094b8
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:04:46-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 4
+      month: 12
+      second: 46
+      year: 2018
   - digest: sha256:eea72345728b29cfe77d859c3a4c7907fea2ccf71947f5580080592dc31a4017
     tags:
     - latest
@@ -240,33 +384,6 @@ images:
       minute: 8
       month: 6
       second: 8
-      year: 2018
-  - digest: sha256:6a81400e8a08568e6f622660affad5ce48d6e512eb7967a79ee632732b2a6156
-    tags:
-    - v-base-b321075-822
-    - v0.3.1
-    timestamp:
-      datetime: '2018-10-18 13:33:13-07:00'
-      day: 18
-      hour: 13
-      microsecond: 0
-      minute: 33
-      month: 10
-      second: 13
-      year: 2018
-  - digest: sha256:8a601b729df6dab2ccd2c59a284ccce42dc2b035fae85d7354ecdc0c761f6da7
-    tags:
-    - latest
-    - v20180707-5a11c84d
-    - v0.2.1
-    timestamp:
-      datetime: '2018-07-07 09:29:40-07:00'
-      day: 7
-      hour: 9
-      microsecond: 0
-      minute: 29
-      month: 7
-      second: 40
       year: 2018
   - digest: sha256:c30a0067bfdc53aaae6b0bc87ea5c6a59005c3d282319a5ec8d605bca36b143c
     tags:
@@ -282,8 +399,49 @@ images:
       month: 9
       second: 33
       year: 2018
+  - digest: sha256:8a601b729df6dab2ccd2c59a284ccce42dc2b035fae85d7354ecdc0c761f6da7
+    tags:
+    - latest
+    - v20180707-5a11c84d
+    - v0.2.1
+    timestamp:
+      datetime: '2018-07-07 09:29:40-07:00'
+      day: 7
+      hour: 9
+      microsecond: 0
+      minute: 29
+      month: 7
+      second: 40
+      year: 2018
+  - digest: sha256:6a81400e8a08568e6f622660affad5ce48d6e512eb7967a79ee632732b2a6156
+    tags:
+    - v-base-b321075-822
+    - v0.3.1
+    timestamp:
+      datetime: '2018-10-18 13:33:13-07:00'
+      day: 18
+      hour: 13
+      microsecond: 0
+      minute: 33
+      month: 10
+      second: 13
+      year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu
   versions:
+  - digest: sha256:1bdc75e21e30ad4a06d868002bc70ea991e0998a8cb2306bdcaae90aa3fbb317
+    tags:
+    - latest
+    - v20180301-pr317
+    - v0.3.0
+    timestamp:
+      datetime: '2018-09-26 15:10:13-07:00'
+      day: 26
+      hour: 15
+      microsecond: 0
+      minute: 10
+      month: 9
+      second: 13
+      year: 2018
   - digest: sha256:8df95a6e81610595347c6cb00be6fe06f1504933392deea848181463a42cc0e4
     tags:
     - v-base-b321075-822
@@ -296,20 +454,6 @@ images:
       minute: 35
       month: 10
       second: 30
-      year: 2018
-  - digest: sha256:ee61d16658d6baa0bb6f18ad0d456de66d3931b2f0484bbd185f4af96170f5d6
-    tags:
-    - latest
-    - v20180707-5a11c84d
-    - v0.2.1
-    timestamp:
-      datetime: '2018-07-07 09:23:39-07:00'
-      day: 7
-      hour: 9
-      microsecond: 0
-      minute: 23
-      month: 7
-      second: 39
       year: 2018
   - digest: sha256:dadb6730d9aadb7b024e3ebe0c4c76ff46e4b56f0c12367db3afbd4c1a732550
     tags:
@@ -325,35 +469,61 @@ images:
       month: 6
       second: 37
       year: 2018
-  - digest: sha256:1bdc75e21e30ad4a06d868002bc70ea991e0998a8cb2306bdcaae90aa3fbb317
+  - digest: sha256:ee61d16658d6baa0bb6f18ad0d456de66d3931b2f0484bbd185f4af96170f5d6
     tags:
     - latest
-    - v20180301-pr317
-    - v0.3.0
+    - v20180707-5a11c84d
+    - v0.2.1
     timestamp:
-      datetime: '2018-09-26 15:10:13-07:00'
-      day: 26
-      hour: 15
+      datetime: '2018-07-07 09:23:39-07:00'
+      day: 7
+      hour: 9
       microsecond: 0
-      minute: 10
-      month: 9
-      second: 13
+      minute: 23
+      month: 7
+      second: 39
+      year: 2018
+  - digest: sha256:160383f1bfc246ac9021900a9e44f4cfd8bf83aeccf82cd9518125197bcf8e7a
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:00:15-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 0
+      month: 12
+      second: 15
       year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu
   versions:
-  - digest: sha256:e1ffb27e9b831f5ad7db447e5cb1b4b6ecc135a3b95cbf7b4226fcf8f184be3b
+  - digest: sha256:bc343131c6ef4bdf29f7e54b945438b756b969aab1d786e16553b5209ca4e4b8
     tags:
     - latest
-    - v20180619-c79194b3
-    - v0.2.0
+    - v20180707-5a11c84d
+    - v0.2.1
     timestamp:
-      datetime: '2018-06-19 10:35:55-07:00'
-      day: 19
-      hour: 10
+      datetime: '2018-07-07 09:26:14-07:00'
+      day: 7
+      hour: 9
       microsecond: 0
-      minute: 35
-      month: 6
-      second: 55
+      minute: 26
+      month: 7
+      second: 14
+      year: 2018
+  - digest: sha256:55818d555f26811bd0e3e7249e2a11c37e3a619e16c1033dae3da9ac245bdb13
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:29:19-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 29
+      month: 12
+      second: 19
       year: 2018
   - digest: sha256:6f4348ffb5bc3c78acf2895f56fc58ba4406d93449baadffdf927671d121637e
     tags:
@@ -382,22 +552,35 @@ images:
       month: 9
       second: 28
       year: 2018
-  - digest: sha256:bc343131c6ef4bdf29f7e54b945438b756b969aab1d786e16553b5209ca4e4b8
+  - digest: sha256:e1ffb27e9b831f5ad7db447e5cb1b4b6ecc135a3b95cbf7b4226fcf8f184be3b
     tags:
     - latest
-    - v20180707-5a11c84d
-    - v0.2.1
+    - v20180619-c79194b3
+    - v0.2.0
     timestamp:
-      datetime: '2018-07-07 09:26:14-07:00'
-      day: 7
-      hour: 9
+      datetime: '2018-06-19 10:35:55-07:00'
+      day: 19
+      hour: 10
       microsecond: 0
-      minute: 26
-      month: 7
-      second: 14
+      minute: 35
+      month: 6
+      second: 55
       year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu
   versions:
+  - digest: sha256:290798da8685d93f988a3f18983fdc361b58e5e3d0b33e591d8ee7a0f381b032
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:00:51-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 0
+      month: 12
+      second: 51
+      year: 2018
   - digest: sha256:01d4be10c25c9b44a3818eedb603eb97dcfbdb8368a1c6186780a142889e3687
     tags:
     - latest
@@ -481,6 +664,19 @@ images:
       minute: 29
       month: 7
       second: 0
+      year: 2018
+  - digest: sha256:e93bee9d389bf43d473c297f5e76bfdfb3e1bcf922a1e5e3745ec7fd0e7c4b75
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:46:08-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 46
+      month: 12
+      second: 8
       year: 2018
   - digest: sha256:2495fd5a62e6e1746255d0973f455171f5d939655bcb839b203c38032bf1f3e2
     tags:
@@ -567,6 +763,19 @@ images:
       month: 10
       second: 39
       year: 2018
+  - digest: sha256:c331adb72b4b49c99e593d587ed34b1da450a2739d05e40910eb8b1f4f05f66c
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 12:58:48-08:00'
+      day: 11
+      hour: 12
+      microsecond: 0
+      minute: 58
+      month: 12
+      second: 48
+      year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu
   versions:
   - digest: sha256:2db8d824f0528d0576b2d61e3d5b6c14ede523e9dd6e97335680fc73f1e013b8
@@ -610,6 +819,19 @@ images:
       month: 7
       second: 53
       year: 2018
+  - digest: sha256:541d8604090b55ae87d01010bd1e015b37827b178d8676a13d6ecee892733ef6
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:05:48-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 5
+      month: 12
+      second: 48
+      year: 2018
   - digest: sha256:6b928a95e2109eb45d078fce8a757c2218a2965f653a6ed1a492ee5cf497c012
     tags:
     - latest
@@ -626,6 +848,19 @@ images:
       year: 2018
 - name: gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu
   versions:
+  - digest: sha256:f4c83e9aba38e60c07329ddf26984ea93ac752915e45496fba79b5d648a827c9
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:26:19-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 26
+      month: 12
+      second: 19
+      year: 2018
   - digest: sha256:94c6d15c49dfa8999f850ab08a12be72d9333a766b2551ced53d45af5eb9f8d9
     tags:
     - latest
@@ -659,6 +894,19 @@ images:
       month: 10
       second: 31
       year: 2018
+  - digest: sha256:cb1c4a51c041925ef14f6558da25d5eaa769b74305cc1c089541435b57c0e679
+    tags:
+    - v-base-d1ee37b-955
+    - v0.4.0
+    timestamp:
+      datetime: '2018-12-11 13:04:27-08:00'
+      day: 11
+      hour: 13
+      microsecond: 0
+      minute: 4
+      month: 12
+      second: 27
+      year: 2018
   - digest: sha256:15e1f791e814d35f9434cd73eb0d13497faedb0930ec341db71b56e8dbc1f20a
     tags:
     - latest
@@ -672,3 +920,6 @@ images:
   - digest: sha256:9007f398a8da9287e4693f7cb01e711c94d1404e8bf91885837fdd5fe3cca35
     tags:
     - v0.3.0
+  - digest: sha256:95a360e82bb3ed76f4c31b8d463e4d342e1b8023d20d6650f8653599bf4b57ab
+    tags:
+    - v0.4.0

--- a/releasing/update_components.sh
+++ b/releasing/update_components.sh
@@ -38,7 +38,7 @@ elif [ "${COMPONENT}" == "pytorch-operator" ]; then
   echo "Updating PyTorch operator..."
   python scripts/update_prototype.py \
     --file=${ROOT_DIR}/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet \
-    --values=pytorchJobImage=gcr.io/kubeflow-images-public/pytorch_operator:${TAG}
+    --values=pytorchJobImage=gcr.io/kubeflow-images-public/pytorch-operator:${TAG}
   echo "Done."
 
 elif [ "${COMPONENT}" == "katib" ]; then

--- a/releasing/update_components.sh
+++ b/releasing/update_components.sh
@@ -67,7 +67,7 @@ elif [ "${COMPONENT}" == "centraldashboard" ]; then
 elif [ "${COMPONENT}" == "jupyter-notebooks" ]; then
   echo "Updating Jupyter notebooks..."
   sed -i "s/tensorflow-\([0-9\.]*\)-notebook-\(.*\):v[0-9\.]*/tensorflow-\1-notebook-\2:${TAG}/" \
-    kubeflow/core/ui/default/config.yaml
+    kubeflow/jupyter/ui/default/config.yaml
   echo "Done."
 
 else

--- a/releasing/update_image_tags.sh
+++ b/releasing/update_image_tags.sh
@@ -21,8 +21,8 @@ export PYTHONPATH=${PYTHONPATH}:${ROOT_DIR}/../git_kubeflow-testing/py
 
 # TODO(richardsliu): Current postsubmits apply this tag to all TF notebook images.
 # We should fix our postsubmit jobs such that each postsubmit generates an unique tag based on commit hash.
-JUPYTER_TAG=v-base-b321075-822
-RELEASE=v0.3.1
+JUPYTER_TAG=v-base-d1ee37b-955
+RELEASE=v0.4.0
 
 # Fetch shas for Jupyter images
 python ${ROOT_DIR}/releasing/add_image_shas.py --pattern=.*tensorflow.*1.*notebook.*:${JUPYTER_TAG} \


### PR DESCRIPTION
Updating the following kubeflow components to v0.4.0:
- tf-operator
- pytorch-operator
- centraldashboard
- Jupyter notebook images

Katib was recently updated (see https://github.com/kubeflow/kubeflow/pull/2064) so it is not included here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2112)
<!-- Reviewable:end -->
