### PR TITLE
Update tf-serving.libsonnet for replicas

### DIFF
--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -5,6 +5,7 @@
   params:: {
     name: null,
     numGpus: 0,
+    replicas: 1,
     labels: {
       app: $.params.name,
     },
@@ -214,6 +215,7 @@
       },
       spec: {
         template: {
+          replicas: $.params.replicas,
           metadata: $.parts.tfServingMetadata,
           spec: {
             containers: [


### PR DESCRIPTION
Added replicas parameters in tf-serving.libsonnet so that multiple tf-serving pods can be deployed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2113)
<!-- Reviewable:end -->
