### PR TITLE
Fix the check if directory named ${DEPLOYMENT_NAME} exists

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -242,12 +242,6 @@ main() {
     DEPLOYMENT_NAME=${WHAT}
     parseArgs $*
 
-    mkdir -p ${DEPLOYMENT_NAME}
-    # Most commands expect to be executed from the app directory
-    cd ${DEPLOYMENT_NAME}
-    createEnv
-
-    source ${ENV_FILE}
     # TODO(jlewi): Should we default to directory name?
     # TODO(jlewi): This doesn't work if user doesn't provide name we will end up
     # interpreting parameters as the name. To fix this we need to check name doesn't start with --
@@ -261,6 +255,22 @@ main() {
       exit 1
     fi
 
+    # Check that DEPLOYMENT_NAME is not a path e.g. /a/b/c
+    BASE_DEPLOYMENT_NAME=$(basename ${DEPLOYMENT_NAME})
+
+    if [ "${BASE_DEPLOYMENT_NAME}" != "${DEPLOYMENT_NAME}" ]; then
+      echo "usage: kfctl init <name>"
+      echo "<name> should be the name for the deployment; not a path"
+      exit 1
+    fi
+
+    mkdir -p ${DEPLOYMENT_NAME}
+    # Most commands expect to be executed from the app directory
+    cd ${DEPLOYMENT_NAME}
+    createEnv
+
+    source ${ENV_FILE}
+    
     if [ -z "${PLATFORM}" ]; then
       echo "--platform must be provided"
       echo "usage: kfctl init <PLATFORM>"


### PR DESCRIPTION
* kfctl init ${DEPLOYMENT_NAME} will create a directory named ${DEPLOYMENT_NAME}.
* We want to check if that directory already exists and if it does return an
  error; we don't want to overwrite the contents.

* There was a bug in the code though and we were checking if the directory
  exists after creating the directory ${DEPLOYMENT_NAME} and cd'ing into it
  so it wasn't having any effect.

* Check if init is passed a path rather than a name and if it is return error.

* Fix #2009

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2115)
<!-- Reviewable:end -->
