### PR TITLE
Enable stackdriver agents for GKE  by default.

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -12,8 +12,12 @@ set -xe
 
 ENV_FILE="env.sh"
 SKIP_INIT_PROJECT=false
-CLUSTER_VERSION="1.10"
-GKE_API_VERSION="v1"
+
+# To enable GKE beta features we need to use the v1beta1 API.
+# https://cloud.google.com/kubernetes-engine/docs/reference/api-organization#beta
+# We currently use this by default so we can enable the new stackdriver
+# logging agents.
+GKE_API_VERSION="v1beta1"
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null && pwd)"
 source "${DIR}/util.sh"
@@ -84,11 +88,6 @@ createEnv() {
       echo CONFIG_FILE=${CONFIG_FILE:-"cluster-kubeflow.yaml"} >> ${ENV_FILE}
 
       echo PROJECT_NUMBER=${PROJECT_NUMBER} >> ${ENV_FILE}
-
-      # "1.X": picks the highest valid patch+gke.N patch in the 1.X version
-      # https://cloud.google.com/kubernetes-engine/docs/reference/rest/v1/projects.zones.clusters
-      echo "Setting cluster version to ${CLUSTER_VERSION}"
-      echo CLUSTER_VERSION=${CLUSTER_VERSION} >> ${ENV_FILE}
 
       echo GKE_API_VERSION=${GKE_API_VERSION} >> ${ENV_FILE}
       ;;


### PR DESCRIPTION
* We want to enable the stackdriver monitoring agents by default. This allows
  pod logs to be fetched by pod label which is very valuable.

* To enable this we need to use the v1beta1 API for GKE
https://cloud.google.com/kubernetes-engine/docs/reference/api-organization#beta

* Remove the field CLUSTER_VERSION from kfctl.sh
  This was added in #1888 but it doesn't look like it was actually being
  use to set the CLUSTER_VERSION; it looks like cluster-version is set
  in the deployment manager config cluster-kubeflow.yaml

* I think the changes will be rolled out to click to deploy as soon as we cut a new release with the updated DM configs and push that to click to deploy.

Fix to #1757

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2118)
<!-- Reviewable:end -->
