### PR TITLE
fixes "Cloud Endpoints Controller not working on mmaster"

### DIFF
--- a/kubeflow/gcp/cloud-endpoints.libsonnet
+++ b/kubeflow/gcp/cloud-endpoints.libsonnet
@@ -189,7 +189,7 @@
         hooks: {
           sync: {
             webhook: {
-              url: "http://cloud-endpoints-controller." + params.namespace + "/sync"
+              url: "http://cloud-endpoints-controller." + params.namespace + "/sync",
             },
           },
         },

--- a/kubeflow/gcp/cloud-endpoints.libsonnet
+++ b/kubeflow/gcp/cloud-endpoints.libsonnet
@@ -173,7 +173,7 @@
       },
       spec: {
         generateSelector: true,
-        resyncPeriodSeconds: 2
+        resyncPeriodSeconds: 2,
         parentResource: {
           apiVersion: "ctl.isla.solutions/v1",
           resource: "cloudendpoints",

--- a/kubeflow/gcp/cloud-endpoints.libsonnet
+++ b/kubeflow/gcp/cloud-endpoints.libsonnet
@@ -173,6 +173,7 @@
       },
       spec: {
         generateSelector: true,
+        resyncPeriodSeconds: 2
         parentResource: {
           apiVersion: "ctl.isla.solutions/v1",
           resource: "cloudendpoints",

--- a/kubeflow/gcp/cloud-endpoints.libsonnet
+++ b/kubeflow/gcp/cloud-endpoints.libsonnet
@@ -3,7 +3,6 @@
   new(_env, _params):: {
     local params = _params + _env {
       cloudEndpointsImage: "gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1",
-      metacontrollerImage: "metacontroller/metacontroller:v0.3.0",
     },
 
     local endpointsCRD = {

--- a/kubeflow/gcp/tests/cloud-endpoints_test.jsonnet
+++ b/kubeflow/gcp/tests/cloud-endpoints_test.jsonnet
@@ -1,0 +1,232 @@
+local cloudEndpoints = import "kubeflow/gcp/cloud-endpoints.libsonnet";
+
+local params = {
+  name: "cloud-endpoints",
+  secretName: "admin-gcp-sa",
+  secretKey: "admin-gcp-sa.json",
+};
+local env = {
+  namespace: "kf-001",
+};
+
+local instance = cloudEndpoints.new(env, params);
+
+std.assertEqual(
+  instance.parts.endpointsCRD,
+  {
+    apiVersion: "apiextensions.k8s.io/v1beta1",
+    kind: "CustomResourceDefinition",
+    metadata: {
+      name: "cloudendpoints.ctl.isla.solutions",
+    },
+    spec: {
+      group: "ctl.isla.solutions",
+      names: {
+        kind: "CloudEndpoint",
+        plural: "cloudendpoints",
+        shortNames: [
+          "cloudep",
+          "ce",
+        ],
+        singular: "cloudendpoint",
+      },
+      scope: "Namespaced",
+      version: "v1",
+    },
+  }
+) &&
+
+std.assertEqual(
+  instance.parts.endpointsClusterRole,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRole",
+    metadata: {
+      name: "cloud-endpoints-controller",
+    },
+    rules: [
+      {
+        apiGroups: [
+          "",
+        ],
+        resources: [
+          "services",
+          "configmaps"
+        ],
+        verbs: [
+          "get",
+          "list",
+        ],
+      },
+      {
+        apiGroups: [
+          "extensions",
+        ],
+        resources: [
+          "ingresses",
+        ],
+        verbs: [
+          "get",
+          "list",
+        ],
+      },
+    ],
+  }
+) &&
+
+std.assertEqual(
+  instance.parts.endpointsClusterRoleBinding,
+  {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRoleBinding",
+    metadata: {
+      name: "cloud-endpoints-controller",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "cloud-endpoints-controller",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: "cloud-endpoints-controller",
+        namespace: "kf-001",
+      },
+    ],
+  }
+) &&
+
+std.assertEqual(
+  instance.parts.endpointsService,
+  {
+    apiVersion: "v1",
+    kind: "Service",
+    metadata: {
+      name: "cloud-endpoints-controller",
+      namespace: "kf-001",
+    },
+    spec: {
+      ports: [
+        {
+          name: "http",
+          port: 80,
+        },
+      ],
+      selector: {
+        app: "cloud-endpoints-controller",
+      },
+      type: "ClusterIP",
+    },
+  }
+) &&
+
+std.assertEqual(
+  instance.parts.endpointsServiceAccount,
+  {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      name: "cloud-endpoints-controller",
+      namespace: "kf-001",
+    },
+  }
+) &&
+
+std.assertEqual(
+  instance.parts.endpointsDeploy,
+  {
+    apiVersion: "apps/v1beta1",
+    kind: "Deployment",
+    metadata: {
+      name: "cloud-endpoints-controller",
+      namespace: "kf-001",
+    },
+    spec: {
+      replicas: 1,
+      template: {
+        metadata: {
+          labels: {
+            app: "cloud-endpoints-controller",
+          },
+        },
+        spec: {
+          containers: [
+            {
+              env: [
+                {
+                  name: "GOOGLE_APPLICATION_CREDENTIALS",
+                  value: "/var/run/secrets/sa/admin-gcp-sa.json",
+                },
+              ],
+              image: "gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1",
+              imagePullPolicy: "Always",
+              name: "cloud-endpoints-controller",
+              readinessProbe: {
+                failureThreshold: 2,
+                httpGet: {
+                  path: "/healthz",
+                  port: 80,
+                  scheme: "HTTP",
+                },
+                periodSeconds: 5,
+                successThreshold: 1,
+                timeoutSeconds: 5,
+              },
+              volumeMounts: [
+                {
+                  mountPath: "/var/run/secrets/sa",
+                  name: "sa-key",
+                  readOnly: true,
+                },
+              ],
+            },
+          ],
+          serviceAccountName: "cloud-endpoints-controller",
+          terminationGracePeriodSeconds: 5,
+          volumes: [
+            {
+              name: "sa-key",
+              secret: {
+                secretName: "admin-gcp-sa",
+              },
+            },
+          ],
+        },
+      },
+    },
+  }
+) &&
+
+std.assertEqual(
+  instance.parts.endpointsCompositeController,
+  {
+    apiVersion: "metacontroller.k8s.io/v1alpha1",
+    kind: "CompositeController",
+    metadata: {
+      name: "cloud-endpoints-controller",
+    },
+    spec: {
+      childResources: [],
+      clientConfig: {
+        service: {
+          caBundle: "...",
+          name: "cloud-endpoints-controller",
+          namespace: "kf-001",
+        },
+      },
+      generateSelector: true,
+      hooks: {
+        sync: {
+          webhook: {
+            url: "http://cloud-endpoints-controller.kf-001/sync",
+          },
+        },
+      },
+      parentResource: {
+        apiVersion: "ctl.isla.solutions/v1",
+        resource: "cloudendpoints",
+      },
+    },
+  }
+)

--- a/kubeflow/gcp/tests/cloud-endpoints_test.jsonnet
+++ b/kubeflow/gcp/tests/cloud-endpoints_test.jsonnet
@@ -216,6 +216,7 @@ std.assertEqual(
         },
       },
       generateSelector: true,
+      resyncPeriodSeconds: 2,
       hooks: {
         sync: {
           webhook: {

--- a/kubeflow/gcp/tests/cloud-endpoints_test.jsonnet
+++ b/kubeflow/gcp/tests/cloud-endpoints_test.jsonnet
@@ -51,7 +51,7 @@ std.assertEqual(
         ],
         resources: [
           "services",
-          "configmaps"
+          "configmaps",
         ],
         verbs: [
           "get",

--- a/testing/workflows/components/unit_tests.jsonnet
+++ b/testing/workflows/components/unit_tests.jsonnet
@@ -115,6 +115,7 @@ local dagTemplates = [
       "--test_files_dirs=" +
       srcDir + "/kubeflow/application/tests" + "," +
       srcDir + "/kubeflow/core/tests" + "," +
+      srcDir + "/kubeflow/gcp/tests" + "," +
       srcDir + "/kubeflow/jupyter/tests" + "," +
       srcDir + "/kubeflow/examples/tests" + "," +
       srcDir + "/kubeflow/openvino/tests" + "," +


### PR DESCRIPTION
fixes #2120

cloud-endpoints (from https://github.com/danisla/cloud-endpoints-controller) was uprevv'd to 0.2.1 and is compatible with metacontroller 0.3, however the manifests in kubeflow/gcp/cloud-endpoints.libsonnet weren't uprevv'd to work with the image(gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1) and there were redundant manifests that are already deployed in kubeflow/metacontroller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2122)
<!-- Reviewable:end -->
