### PR TITLE
Create cloud sql database for ml pipeline 

### DIFF
--- a/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -89,6 +89,7 @@ resources:
     # This is the name of the GCP static ip address reserved for your domain.
     # Each Kubeflow deployment in your project should use one unique ipName among all configs.
     ipName: kubeflow-ip
+    # TODO(IronPan): Enable cloud sql when Kubeflow Pipelines integrate with cloud sql
     enable_cloudsql: false
     database:
       name: mlpipeline

--- a/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
+++ b/deployment/gke/deployment_manager_configs/cluster-kubeflow.yaml
@@ -89,3 +89,8 @@ resources:
     # This is the name of the GCP static ip address reserved for your domain.
     # Each Kubeflow deployment in your project should use one unique ipName among all configs.
     ipName: kubeflow-ip
+    enable_cloudsql: false
+    database:
+      name: mlpipeline
+    dbUser:
+      user: root

--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -14,6 +14,7 @@ limitations under the License.
 
 {% set NAME_PREFIX = env['deployment'] %}
 {% set CLUSTER_NAME = NAME_PREFIX %}
+{% set SQL_INSTANCE_NAME =  env['deployment'] + '-mysql' %}
 {% set CPU_POOL = NAME_PREFIX + '-cpu-pool-' + properties['pool-version'] %}
 {% set GPU_POOL = NAME_PREFIX + '-gpu-pool-' + properties['pool-version'] %}
 {% set VM_OAUTH_SCOPES = ['https://www.googleapis.com/auth/logging.write', 
@@ -173,3 +174,49 @@ resources:
   type: compute.v1.globalAddress
   properties:
     description: "Static IP for Kubeflow ingress."
+
+{% if properties['enable_cloudsql'] %}
+- name: {{ SQL_INSTANCE_NAME }}
+  type: sqladmin.v1beta4.instance
+  properties:
+    backendType: SECOND_GEN
+    instanceType: CLOUD_SQL_INSTANCE
+    databaseVersion: {{ properties['cloudsql']['databaseVersion'] }}
+    region: {{ properties['cloudsql']['region'] }}
+    settings:
+      tier: {{ properties['cloudsql']['tier'] }}
+      dataDiskSizeGb: {{ properties['cloudsql']['dataDiskSizeGb'] }}
+      dataDiskType: {{ properties['cloudsql']['dataDiskType'] }}
+      storageAutoResize: true
+      replicationType: SYNCHRONOUS
+      locationPreference:
+        zone: {{ properties['cloudsql']['zone'] }}
+      {% if properties['databaseFlags'] %}
+      databaseFlags: {{ properties['databaseFlags'] }}
+      {% endif %}
+      activationPolicy: ALWAYS
+      backupConfiguration:
+        enabled: true
+        binaryLogEnabled: true
+        startTime: {{ properties['cloudsql']['backupStartTime'] }}
+      ipConfiguration:
+        privateNetwork: projects/{{ env['project'] }}/global/networks/default
+        authorizedNetworks: {{ properties['cloudsql']['authorizedNetworks'] }}
+
+- name: {{ SQL_INSTANCE_NAME }}-db
+  type: sqladmin.v1beta4.database
+  properties:
+    name: {{ properties['database']['name'] }}
+    instance: $(ref.{{ SQL_INSTANCE_NAME }}.name)
+    charset: {{ properties['database']['charset'] }}
+
+- name: {{ SQL_INSTANCE_NAME }}-db-root
+  type: sqladmin.v1beta4.user
+  properties:
+    name: {{ properties['dbUser']['name'] }}
+    host:  "{{ properties['dbUser']['host'] }}"
+    instance: $(ref.{{ SQL_INSTANCE_NAME }}.name)
+  metadata:
+    dependsOn:
+      - {{ SQL_INSTANCE_NAME }}-db
+{% endif %}

--- a/deployment/gke/deployment_manager_configs/cluster.jinja.schema
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja.schema
@@ -32,3 +32,81 @@ properties:
     type: integer
     description: Initial number of nodes desired in the cluster.
     default: 4
+
+  cloudsql:
+    type: object
+    default:
+      properties: 
+    properties:
+      databaseVersion:
+        type: string
+        description: MYSQL_5_7 or MYSQL_5_6
+        default: MYSQL_5_6
+      dataDiskSizeGb:
+        type: integer
+        minimum: 10
+        maximum: 1000
+        default: 10
+      dataDiskType:
+        type: string
+        decription: PD_SSD or PD_HDD
+        default: PD_SSD
+      backupStartTime:
+        type: string
+        description: HH:MM in 24 hour format
+        default: 00:00
+      tier:
+        type: string
+        description: https://cloud.google.com/sql/pricing#2nd-gen-pricing
+        default: db-n1-highmem-4
+      region:
+        type: string
+        description: i.e. us-central1
+        default: us-central1
+      zone:
+        type: string
+        description: i.e. us-central1-a
+        default: us-central1-a
+      authorizedNetworks:
+        type: array
+        description: An array of allowed CIDR blocks
+        items:
+          type: string
+
+  databaseFlags: 
+    type: array
+    description: An array of https://cloud.google.com/sql/docs/mysql/flags
+    items:
+      type: object
+      required:
+        - name
+        - value 
+      properties:
+        name: 
+          type: string 
+        value:
+          type: 
+            - integer
+            - string
+  
+  dbUser:
+    type: object
+    properties:
+      name:
+        type: string
+        default: root
+      host:
+        type: string
+        default: '%'
+  
+  database: 
+    type: object
+    required:
+      - name
+    properties:
+      name: 
+        type: string
+      charset:
+        type: string
+        description: https://dev.mysql.com/doc/refman/5.7/en/charset.html
+        default: utf8

--- a/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
+++ b/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
@@ -28,6 +28,7 @@ bindings:
   - roles/dataflow.admin
   - roles/ml.admin
   - roles/dataproc.editor
+  - roles/cloudsql.admin
 - members:
   - set-kubeflow-vm-service-account
   roles:

--- a/scripts/gke/util.sh
+++ b/scripts/gke/util.sh
@@ -28,7 +28,8 @@ gcpInitProject() {
     endpoints.googleapis.com \
     file.googleapis.com \
     ml.googleapis.com \
-    iam.googleapis.com --project=${PROJECT}
+    iam.googleapis.com \
+    sqladmin.googleapis.com --project=${PROJECT}
 
   # Set IAM Admin Policy
   gcloud projects add-iam-policy-binding ${PROJECT} \


### PR DESCRIPTION
Pipeline would use cloud sql for GCP scenarios. This change would give user the option to create a cloud sql instance, database and a root user as part of deployment.

The sql instance will have private IP enabled 
https://github.com/kubeflow/kubeflow/pull/2123/files#diff-a9c1d9db18e6d68f99216458ba3ab83fR203
so it can be accessed by GKE cluster by private IP. 
https://cloud.google.com/sql/docs/mysql/connect-kubernetes-engine#private-ip

This feature is currently disabled by a flag. 
https://github.com/kubeflow/kubeflow/pull/2123/files#diff-a9c1d9db18e6d68f99216458ba3ab83fR178
Will turn it on when pipeline fully integrate with cloud sql

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2123)
<!-- Reviewable:end -->
