### PR TITLE
Fix check install to use param for type as well as which check 

### DIFF
--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -16,7 +16,7 @@ usage() {
 }
 
 check_install() {
-  if ! which "${1}" &>/dev/null && ! type -a ks &>/dev/null ; then
+  if ! which "${1}" &>/dev/null && ! type -a "${1}" &>/dev/null ; then
     echo "You don't have ${1} installed. Please install ${1}."
     exit 1
   fi


### PR DESCRIPTION
(previously hard coded to ks when falling back to type check) - closes https://github.com/kubeflow/kubeflow/issues/2162

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2163)
<!-- Reviewable:end -->
