### PR TITLE
Add the TF 1.11 & TF 1.12 Jupyter images to the spawner drop down box.

### DIFF
--- a/kubeflow/jupyter/ui/default/config.yaml
+++ b/kubeflow/jupyter/ui/default/config.yaml
@@ -38,6 +38,10 @@ spawnerFormDefaults:
       - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.4.0
       - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
       - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-gpu:v0.4.0
     # By default, custom container Images are allowed
     # Uncomment the following line to only enable standard container Images
     #readOnly: true

--- a/kubeflow/jupyter/ui/default/config.yaml
+++ b/kubeflow/jupyter/ui/default/config.yaml
@@ -21,7 +21,7 @@ spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
     # If readonly, this value must be a member of the list below
-    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
+    value: gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0
     # The list of available standard container Images
     options:
       - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v0.4.0

--- a/kubeflow/jupyter/ui/rok/config.yaml
+++ b/kubeflow/jupyter/ui/rok/config.yaml
@@ -11,7 +11,7 @@ spawnerFormDefaults:
     # The URL of a Jupyter Lab, already snapshotted in Rok
     value: ''
   image:
-    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
+    value: gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0
     options:
       - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v0.4.0
       - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu:v0.4.0

--- a/kubeflow/jupyter/ui/rok/config.yaml
+++ b/kubeflow/jupyter/ui/rok/config.yaml
@@ -11,22 +11,26 @@ spawnerFormDefaults:
     # The URL of a Jupyter Lab, already snapshotted in Rok
     value: ''
   image:
-    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.3.1
+    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
     options:
-      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.3.1
-      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.3.1
+      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.4.1-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-gpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.4.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-gpu:v0.4.0      
     # By default, custom container Images are allowed
     # Uncomment the following line to only enable standard container Images
     #readOnly: true


### PR DESCRIPTION
* Upgrade the images in the Arrikto ROK UI as well; it looks as though
  they hadn't been updated to the 0.4 images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2180)
<!-- Reviewable:end -->
