### PR TITLE
   Check the name of the deployment is < 25 characters on GCP

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -258,6 +258,14 @@ main() {
       echo "usage: kfctl init <name>"
       exit 1
     fi
+    if [ ${#DEPLOYMENT_NAME} -gt 25 ]; then
+      echo "Name ${DEPLOYMENT_NAME} should not be longer than 25 characters" 
+      exit 1
+    fi
+    if [[ ${DEPLOYMENT_NAME} == *.*  ]]; then
+      echo "Name should not contain '.'"
+      exit 1
+    fi
     if [ -d ${DEPLOYMENT_NAME} ]; then
       echo "Directory ${DEPLOYMENT_NAME} already exists"
       exit 1


### PR DESCRIPTION
 This patch attemps to address issue 2189 by checking that
 DEPLOYMENT_NAME is less than 25 characters, and that it does
 not contain a '.'.

Fixes: #2189

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2191)
<!-- Reviewable:end -->
