### PR TITLE
sync-notebook needs to look for a Deployment kind that is version independent

### DIFF
--- a/kubeflow/jupyter/notebooks.libsonnet
+++ b/kubeflow/jupyter/notebooks.libsonnet
@@ -35,6 +35,7 @@
       },
       data: {
         "sync-notebook.jsonnet": (importstr "sync-notebook.jsonnet"),
+        "util.libsonnet": (importstr "kubeflow/jupyter/util.libsonnet"),
       },
     },
     notebooksConfigMap:: notebooksConfigMap,

--- a/kubeflow/jupyter/tests/notebooks_test.jsonnet
+++ b/kubeflow/jupyter/tests/notebooks_test.jsonnet
@@ -73,6 +73,7 @@ std.assertEqual(
     apiVersion: "v1",
     data: {
       "sync-notebook.jsonnet": (importstr "../sync-notebook.jsonnet"),
+      "util.libsonnet": (importstr "kubeflow/jupyter/util.libsonnet"),
     },
     kind: "ConfigMap",
     metadata: {

--- a/kubeflow/jupyter/util.libsonnet
+++ b/kubeflow/jupyter/util.libsonnet
@@ -1,4 +1,6 @@
 // Some useful routines.
+// Duplicating kubeflow/common/util.libsonnet for unit tests to work.
+// For lambda metacontroller it's available via ConfigMap.
 {
   local k = import "k.libsonnet",
   local util = self,


### PR DESCRIPTION
Signed-off-by: Abhilash Pallerlamudi <stp.abhi@gmail.com>

Fix #2185

**Problem**: Metacontroller deletes notebook deployment if there is a version mismatch between the Deployment created and the Deployment specified.

**Fix**: sync-notebook needs to look for a Deployment kind that is version independent.

**Details**: https://github.com/kubeflow/kubeflow/issues/2185#issuecomment-450441261

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2194)
<!-- Reviewable:end -->