### PR TITLE
Fix OWNERs file for gcp package.

### DIFF
--- a/kubeflow/gcp/OWNERS
+++ b/kubeflow/gcp/OWNERS
@@ -1,7 +1,7 @@
 approvers:
   - abhi-g
   - jlewi
-  - kunming
-  - llunnn
+  - kunmingg
+  - lluunn 
   - r2d4
   - richardsliu


### PR DESCRIPTION
* Some GitHub ids were misspelled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2202)
<!-- Reviewable:end -->
