### PR TITLE
add status tag to deployments_failure; exclude failure caused by quota or permission issue

### DIFF
--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -65,7 +65,7 @@ type KsService interface {
 	ConfigCluster(context.Context, CreateRequest) error
 	BindRole(context.Context, string, string, string) error
 	InsertDeployment(context.Context, CreateRequest) (*deploymentmanager.Deployment, error)
-	GetDeploymentStatus(context.Context, CreateRequest) (string, error)
+	GetDeploymentStatus(context.Context, CreateRequest) (string, string, error)
 	ApplyIamPolicy(context.Context, ApplyIamRequest) error
 	GetProjectLock(string) *sync.Mutex
 }
@@ -242,10 +242,11 @@ var (
 		},
 		[]string{"status"},
 	)
-	deploymentFailure = prometheus.NewCounter(prometheus.CounterOpts{
+	deploymentFailure = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "deployments_failure",
 		Help: "Number of failed Kubeflow deployments",
-	})
+	}, []string{"status"})
+
 	serviceHeartbeat = prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "service_heartbeat",
 		Help: "Heartbeat signal every 10 seconds indicating pods are alive.",
@@ -1082,14 +1083,21 @@ func finishDeployment(svc KsService, req CreateRequest, dmDeploy *deploymentmana
 	ctx = context.WithValue(ctx, StartTime, time.Now())
 	for retry := 0; retry < 60; retry++ {
 		time.Sleep(10 * time.Second)
-		status, err = svc.GetDeploymentStatus(ctx, req)
+		status, errMsg, err := svc.GetDeploymentStatus(ctx, req)
 		if err != nil {
 			log.Errorf("Failed to get deployment status: %v", err)
 			deployReqCounter.WithLabelValues("INTERNAL").Inc()
-			deploymentFailure.Inc()
+			deploymentFailure.WithLabelValues("INTERNAL").Inc()
 			return
 		}
 		if status == "DONE" {
+			if errMsg != "" {
+				log.Errorf("Deployment manager returned error message: %v", errMsg)
+				// Mark status "INVALID_ARGUMENT" as most deployment manager failures are caused by insufficient quota or permission.
+				// Error messages are available from UI, and should be resolvable by retries.
+				deployReqCounter.WithLabelValues("INVALID_ARGUMENT").Inc()
+				return
+			}
 			clusterDeploymentLatencies.Observe(timeSinceStart(ctx).Seconds())
 			log.Infof("Deployment is done")
 			break
@@ -1099,7 +1107,7 @@ func finishDeployment(svc KsService, req CreateRequest, dmDeploy *deploymentmana
 	if status != "DONE" {
 		log.Errorf("Deployment status is not done: %v", status)
 		deployReqCounter.WithLabelValues("INTERNAL").Inc()
-		deploymentFailure.Inc()
+		deploymentFailure.WithLabelValues("INTERNAL").Inc()
 		return
 	}
 
@@ -1114,14 +1122,14 @@ func finishDeployment(svc KsService, req CreateRequest, dmDeploy *deploymentmana
 	if err != nil {
 		log.Errorf("Failed to update IAM: %v", err)
 		deployReqCounter.WithLabelValues("INTERNAL").Inc()
-		deploymentFailure.Inc()
+		deploymentFailure.WithLabelValues("INTERNAL").Inc()
 		return
 	}
 
 	log.Infof("Configuring cluster...")
 	if err = svc.ConfigCluster(ctx, req); err != nil {
 		deployReqCounter.WithLabelValues("INTERNAL").Inc()
-		deploymentFailure.Inc()
+		deploymentFailure.WithLabelValues("INTERNAL").Inc()
 		return
 	}
 
@@ -1130,7 +1138,7 @@ func finishDeployment(svc KsService, req CreateRequest, dmDeploy *deploymentmana
 	if err != nil {
 		log.Errorf("Failed to create app: %v", err)
 		deployReqCounter.WithLabelValues("INTERNAL").Inc()
-		deploymentFailure.Inc()
+		deploymentFailure.WithLabelValues("INTERNAL").Inc()
 		return
 	}
 

--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -252,6 +252,15 @@ var (
 		Help: "Heartbeat signal every 10 seconds indicating pods are alive.",
 	})
 
+	deployReqCounterUser = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "deploy_requests_user",
+		Help: "Number of user requests for deployments",
+	})
+	kfDeploymentsDoneUser = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "kubeflow_deployments_done_user",
+		Help: "Number of successfully finished Kubeflow user deployments",
+	})
+
 	// Gauge metrics
 	deployReqCounterRaw = prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "deploy_requests_raw",
@@ -280,6 +289,8 @@ func init() {
 	prometheus.MustRegister(deployReqCounter)
 	prometheus.MustRegister(clusterDeploymentLatencies)
 	prometheus.MustRegister(kfDeploymentLatencies)
+	prometheus.MustRegister(deployReqCounterUser)
+	prometheus.MustRegister(kfDeploymentsDoneUser)
 	prometheus.MustRegister(deployReqCounterRaw)
 	prometheus.MustRegister(kfDeploymentsDoneRaw)
 	prometheus.MustRegister(deploymentFailure)
@@ -1145,6 +1156,7 @@ func finishDeployment(svc KsService, req CreateRequest, dmDeploy *deploymentmana
 	deployReqCounter.WithLabelValues("OK").Inc()
 	if req.Project != "kubeflow-prober-deploy" {
 		kfDeploymentsDoneRaw.Inc()
+		kfDeploymentsDoneUser.Inc()
 	}
 	kfDeploymentLatencies.Observe(timeSinceStart(ctx).Seconds())
 }
@@ -1163,6 +1175,7 @@ func makeDeployEndpoint(svc KsService) endpoint.Endpoint {
 		r := &basicServerResponse{}
 		if req.Project != "kubeflow-prober-deploy" {
 			deployReqCounterRaw.Inc()
+			deployReqCounterUser.Inc()
 		}
 		if err := req.Validate(); err != nil {
 			r.Err = err.Error()


### PR DESCRIPTION
1. reduce false alerts.
2. reformat prometheus metrics and unify tags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2215)
<!-- Reviewable:end -->
