### PR TITLE
Consistent formatting of prototype docs

### DIFF
--- a/kubeflow/README.md
+++ b/kubeflow/README.md
@@ -1,20 +1,18 @@
+# Kubeflow Ksonnet Registry
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Kubeflow Ksonnet Registry](#kubeflow-ksonnet-registry)
-  - [Overview](#overview)
-  - [Usage](#usage)
-  - [Library-specific Documentation](#library-specific-documentation)
+- [Overview](#overview)
+- [Usage](#usage)
+- [Library-specific Documentation](#library-specific-documentation)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# Kubeflow Ksonnet Registry
 
 ## Overview
 
 This directory contains the Kubeflow ksonnet [registry][2]. If you are unfamiliar with ksonnet, we recommend browsing [the official site][1] to gain more context.
-
 
 ## Usage
 

--- a/kubeflow/application/prototypes/README.md
+++ b/kubeflow/application/prototypes/README.md
@@ -1,3 +1,16 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Overview](#overview)
+- [Sample script](#sample-script)
+- [Expected output](#expected-output)
+  - [both the ApplicationCRD and the Application will be emitted with the other components](#both-the-applicationcrd-and-the-application-will-be-emitted-with-the-other-components)
+  - [all namespace scoped resources are created](#all-namespace-scoped-resources-are-created)
+- [Expected Application yaml](#expected-application-yaml)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Overview
 
 The application component creates an Application Kind based on the 

--- a/kubeflow/argo/README.md
+++ b/kubeflow/argo/README.md
@@ -1,28 +1,22 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [Argo](#argo)
-  - [Quickstart](#quickstart)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # Argo
 
 > Prototypes for deploying Argo and running Argo Workflows
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-* [Quickstart](#quickstart)
-* [Using Prototypes](#using-prototypes)
-  * [io.ksonnet.pkg.argo](#io.ksonnet.pkg.argo)
+- [Quickstart](#quickstart)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Quickstart
 
 *The following commands use the `io.ksonnet.pkg.argo` prototype to deploy the Argo Workflow operator on your Kubernetes cluster*
 
-First, create a cluster and install the ksonnet CLI (see root-level [README.md](rootReadme)).
+First, create a cluster and install the ksonnet CLI (see root-level [README.md](../../README.md)).
 
-If you haven't yet created a [ksonnet application](linkToSomewhere), do so using `ks init <app-name>`.
+If you haven't yet created a [ksonnet application](https://ksonnet.io/docs/tutorial#1-initialize-your-app), do so using `ks init <app-name>`.
 
 Finally, in the ksonnet application directory, run the following:
 
@@ -39,5 +33,3 @@ $ ks prototype use io.ksonnet.pkg.argo argo \
 # Apply to server.
 $ ks apply default -c argo
 ```
-
-[rootReadme]: https://github.com/ksonnet/mixins

--- a/kubeflow/chainer-job/README.md
+++ b/kubeflow/chainer-job/README.md
@@ -1,12 +1,24 @@
 # chainer-job
 
-Prototypes for running Chainer jobs.
+> Prototypes for running Chainer jobs.
 
-* [Quickstart](#quickstart)
-* [Using Prototypes](#using-prototypes)
-  * [io.ksonnet.pkg.chainer-operator](#io.ksonnet.pkg.chainer-operator)
-  * [io.ksonnet.pkg.chainer-job-simple](#io.ksonnet.pkg.chainer-job-simple)
-  * [io.ksonnet.pkg.chainer-job](#io.ksonnet.pkg.chainer-job)
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Quickstart](#quickstart)
+- [Using the library](#using-the-library)
+  - [io.ksonnet.pkg.chainer-operator](#ioksonnetpkgchainer-operator)
+    - [Example](#example)
+    - [Parameters](#parameters)
+  - [io.ksonnet.pkg.chainer-job-simple](#ioksonnetpkgchainer-job-simple)
+    - [Example](#example-1)
+    - [Parameters](#parameters-1)
+  - [io.ksonnet.pkg.chainer-job](#ioksonnetpkgchainer-job)
+    - [Example](#example-2)
+    - [Parameters](#parameters-2)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Quickstart
 

--- a/kubeflow/common/README.md
+++ b/kubeflow/common/README.md
@@ -1,3 +1,5 @@
+# common
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
@@ -5,7 +7,5 @@
 - [common](#common)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
-# common
 
 This ksonnet package contains kubeflow common prototypes such as ambassador, spartakus, etc. You can install this using `ks pkg install kubeflow/common`. `ks prototype list` should list the available prototypes. `ks prototype describe <name>` should describe the prototype.

--- a/kubeflow/credentials-pod-preset/README.md
+++ b/kubeflow/credentials-pod-preset/README.md
@@ -1,10 +1,19 @@
 # Credentials Pod Presets
 
-This package contains Kubernetes [PodPresets](https://kubernetes.io/docs/concepts/workloads/pods/podpreset/) for injecting credentials into Pods.
+> This package contains Kubernetes [PodPresets](https://kubernetes.io/docs/concepts/workloads/pods/podpreset/) for injecting credentials into Pods.
 
 > Note: Pod Presets are namespace-scoped. A separate Pod Preset needs to be created for every namespace that needs credentials injected into pods.
 
-# Google Cloud Service Account Credentials
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Google Cloud Service Account Credentials](#google-cloud-service-account-credentials)
+  - [Testing the pod preset](#testing-the-pod-preset)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Google Cloud Service Account Credentials
 
 This is useful for injecting GCP Service Account Credentials into pods by using labels. Currently PodPresets is in alpha on GCP, so make sure that you are creating a GKE cluster with alpha features [enabled](https://cloud.google.com/kubernetes-engine/docs/concepts/alpha-clusters).
 
@@ -57,7 +66,7 @@ KS_ENV=default
 ks apply ${KS_ENV} -c ${COMPONENT_NAME}
 ```
 
-## Testing the pod preset
+### Testing the pod preset
 
 Any pod which has the label `inject_gcp_service_account: ${SERVICE_ACCOUNT}` and created in the `${NAMESPACE}` will be injected with the `${SERVICE_ACCOUNT}` credentials.
 

--- a/kubeflow/gcp/README.md
+++ b/kubeflow/gcp/README.md
@@ -1,11 +1,12 @@
+# gcp
+
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [core](#core)
+- [gcp](#gcp)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# gcp
 
-This ksonnet package contains GCP specific prototypes. 
+> This ksonnet package contains GCP specific prototypes. 

--- a/kubeflow/jupyter/prototypes/README.md
+++ b/kubeflow/jupyter/prototypes/README.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Goals](#goals)
+- [Design](#design)
+  - [User Interaction](#user-interaction)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Goals
 
 - provide a k8 native mechanism to spawning jupyter notebooks for users

--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -1,4 +1,20 @@
-# Katib Quickstart
+# Katib
+
+> Hyperparameter Tuning on Kubernetes
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Quickstart](#quickstart)
+  - [TF-job operator](#tf-job-operator)
+  - [Pytorch-operator](#pytorch-operator)
+  - [Katib](#katib)
+  - [Cleanups](#cleanups)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Quickstart
 
 For running Katib you have to install tf-job operator and pytorch operator package.
 
@@ -9,7 +25,7 @@ export KF_ENV=default
 ks registry add kubeflow github.com/kubeflow/kubeflow/tree/master/kubeflow
 ```
 
-## TF-job operator
+### TF-job operator
 
 For installing tf-job operator, run the following
 
@@ -20,7 +36,7 @@ ks generate tf-job-operator tf-job-operator
 ks apply ${KF_ENV} -c tf-job-operator
 ```
 
-## Pytorch-operator
+### Pytorch-operator
 For installing pytorch operator, run the following
 
 ```
@@ -29,7 +45,7 @@ ks generate pytorch-operator pytorch-operator
 ks apply ${KF_ENV} -c pytorch-operator
 ```
 
-## Katib
+### Katib
 
 Finally, you can install Katib
 
@@ -39,7 +55,7 @@ ks generate katib katib
 ks apply ${KF_ENV} -c katib
 ```
 
-## Cleanups
+### Cleanups
 
 Delete installed components
 

--- a/kubeflow/mpi-job/README.md
+++ b/kubeflow/mpi-job/README.md
@@ -5,6 +5,24 @@ standard designed by a group of researchers from academia and industry to
 function on a wide variety of parallel computing architectures. It can be used
 to run allreduce-style distributed training.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Quickstart](#quickstart)
+- [Using the library](#using-the-library)
+  - [io.ksonnet.pkg.mpi-operator](#ioksonnetpkgmpi-operator)
+    - [Example](#example)
+    - [Parameters](#parameters)
+  - [io.ksonnet.pkg.mpi-job-simple](#ioksonnetpkgmpi-job-simple)
+    - [Example](#example-1)
+    - [Parameters](#parameters-1)
+  - [io.ksonnet.pkg.mpi-job-custom](#ioksonnetpkgmpi-job-custom)
+    - [Example](#example-2)
+    - [Parameters](#parameters-2)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Quickstart
 
 *The following commands use the `io.ksonnet.pkg.mpi-job-simple` prototype to

--- a/kubeflow/mxnet-job/README.md
+++ b/kubeflow/mxnet-job/README.md
@@ -1,4 +1,17 @@
-# MXNet Training
+# MXNet-job
+
+> Prototypes for running MXNet jobs.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installing MXNet Operator](#installing-mxnet-operator)
+- [Verify that MXNet support is included in your Kubeflow deployment](#verify-that-mxnet-support-is-included-in-your-kubeflow-deployment)
+- [Creating a MXNet Job](#creating-a-mxnet-job)
+- [Monitoring a MXNet Job](#monitoring-a-mxnet-job)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Installing MXNet Operator
 

--- a/kubeflow/new-package-stub/README.md
+++ b/kubeflow/new-package-stub/README.md
@@ -1,0 +1,20 @@
+# new-package-stub
+
+> My short description.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Quickstart](#quickstart)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Quickstart
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+incididunt ut laboreet dolore magna aliqua. Ut enim ad minim veniam, quis
+nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
+eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident,
+sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/kubeflow/nvidia-inference-server/README.md
+++ b/kubeflow/nvidia-inference-server/README.md
@@ -1,9 +1,26 @@
 # nvidia-inference-server
 
-NVIDIA Inference Server is a REST and GRPC service for deep-learning
+> NVIDIA Inference Server is a REST and GRPC service for deep-learning
 inferencing of TensorRT, TensorFlow and Caffe2 models. The server is
 optimized deploy machine and deep learning algorithms on both GPUs and
 CPUs at scale.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Setup](#setup)
+  - [Google Cloud and Ksonnet](#google-cloud-and-ksonnet)
+- [Create Cluster](#create-cluster)
+- [Google Cloud Console](#google-cloud-console)
+- [Enable CUDA on the GPU Nodes](#enable-cuda-on-the-gpu-nodes)
+- [NVIDIA Inference Server Image](#nvidia-inference-server-image)
+- [Model Repository](#model-repository)
+- [Kubernetes Generation and Deploy](#kubernetes-generation-and-deploy)
+- [Using the Inference Server](#using-the-inference-server)
+- [Cleanup](#cleanup)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 These instructions detail how to set up a GKE cluster suitable for
 running the NVIDIA Inference server and how to use the

--- a/kubeflow/openmpi/README.md
+++ b/kubeflow/openmpi/README.md
@@ -1,6 +1,6 @@
 # Open MPI
 
-Prototypes for running Open MPI jobs with Kubernetes.
+> Prototypes for running Open MPI jobs with Kubernetes.
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->

--- a/kubeflow/pachyderm/README.md
+++ b/kubeflow/pachyderm/README.md
@@ -1,5 +1,19 @@
 # Pachyderm
 
+> Pachyderm lets you deploy and manage multi-stage, language-agnostic data pipelines while maintaining complete reproducibility and provenance.
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Quickstart](#quickstart)
+  - [Using GCP](#using-gcp)
+  - [Local mode](#local-mode)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+## Quickstart
+
 To deploy pachyderm
 
 ```shell
@@ -27,7 +41,7 @@ but this ksonnet package currently only supports
 1. local
 1. GCP
 
-## Using GCP
+### Using GCP
 
 You can use Google Cloud Storage to store the actual data versioned
 by Pachyderm. This is recommended because
@@ -65,7 +79,7 @@ ks param set ${COMPONENT_NAME} backend gcp
 ks apply ${ENVIRONMENT} -c ${COMPONENT_NAME}
 ```
 
-## Local mode
+### Local mode
 
 Local mode should **only** be used 
 	

--- a/kubeflow/profiles/prototypes/README.md
+++ b/kubeflow/profiles/prototypes/README.md
@@ -1,3 +1,13 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Goals](#goals)
+- [Design](#design)
+  - [Data Structures](#data-structures)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 ## Goals
 
 - Provide a self-serve environment for data-scientists to create one or more protected namespaces where 

--- a/kubeflow/pytorch-job/README.md
+++ b/kubeflow/pytorch-job/README.md
@@ -2,19 +2,28 @@
 
 > Prototypes for running PyTorch jobs.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-* [Quickstart](#quickstart)
-* [Using Prototypes](#using-prototypes)
-  * [io.ksonnet.pkg.pytorch-operator](#io.ksonnet.pkg.pytorch-operator)
-  * [io.ksonnet.pkg.pytorch-job](#io.ksonnet.pkg.pytorch-job)
+- [Quickstart](#quickstart)
+- [Using the library](#using-the-library)
+  - [io.ksonnet.pkg.pytorch-operator](#ioksonnetpkgpytorch-operator)
+    - [Example](#example)
+    - [Parameters](#parameters)
+  - [io.ksonnet.pkg.pytorch-job](#ioksonnetpkgpytorch-job)
+    - [Example](#example-1)
+    - [Parameters](#parameters-1)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Quickstart
 
 *The following commands use the `io.ksonnet.pkg.pytorch-job` prototype to generate Kubernetes YAML for pytorch-job, and then deploys it to your Kubernetes cluster.*
 
-First, create a cluster and install the ksonnet CLI (see root-level [README.md](rootReadme)).
+First, create a cluster and install the ksonnet CLI (see root-level [README.md](../../README.md)).
 
-If you haven't yet created a [ksonnet application](linkToSomewhere), do so using `ks init <app-name>`.
+If you haven't yet created a [ksonnet application](https://ksonnet.io/docs/tutorial#1-initialize-your-app), do so using `ks init <app-name>`.
 
 Finally, in the ksonnet application directory, run the following:
 

--- a/kubeflow/tf-serving/README.md
+++ b/kubeflow/tf-serving/README.md
@@ -1,32 +1,26 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
-
-- [tf-serving](#tf-serving)
-  - [Quickstart](#quickstart)
-  - [Using the library](#using-the-library)
-    - [io.ksonnet.pkg.tf-serving](#ioksonnetpkgtf-serving)
-      - [Example](#example)
-      - [Parameters](#parameters)
-
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
-
 # tf-serving
 
 > TensorFlow serving is a server for TensorFlow models.
 
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-* [Quickstart](#quickstart)
-* [Using Prototypes](#using-prototypes)
-  * [io.ksonnet.pkg.tf-serving](#io.ksonnet.pkg.tf-serving)
+- [Quickstart](#quickstart)
+- [Using the library](#using-the-library)
+  - [io.ksonnet.pkg.tf-serving](#ioksonnetpkgtf-serving)
+    - [Example](#example)
+    - [Parameters](#parameters)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Quickstart
 
 *The following commands use the `io.ksonnet.pkg.tf-serving` prototype to generate Kubernetes YAML for tf-serving, and then deploys it to your Kubernetes cluster.*
 
-First, create a cluster and install the ksonnet CLI (see root-level [README.md](rootReadme)).
+First, create a cluster and install the ksonnet CLI (see root-level [README.md](../../README.md)).
 
-If you haven't yet created a [ksonnet application](linkToSomewhere), do so using `ks init <app-name>`.
+If you haven't yet created a [ksonnet application](https://ksonnet.io/docs/tutorial#1-initialize-your-app), do so using `ks init <app-name>`.
 
 Finally, in the ksonnet application directory, run the following:
 
@@ -68,6 +62,3 @@ The available options to pass prototype are:
 
 * `--name=<name>`: Name to give to each of the components [string]
 * `--model_path=<model_path>`: Path to the model. This can be a GCS path. [string]
-
-
-[rootReadme]: https://github.com/ksonnet/mixins

--- a/kubeflow/weaveflux/README.md
+++ b/kubeflow/weaveflux/README.md
@@ -1,11 +1,18 @@
 # WeaveFlux
 
-Weaveworks Flux is an integration allowing Kubeflow users to leverage [Weaveworks&#174; Flux]("https://github.com/weaveworks/flux) for GitOps. This utilizes the [stand-alone]("https://github.com/weaveworks/flux/tree/master/site/standalone") implementation. Being stand-alone, most of the maintenance is manual. If you are looking for a more managed solution, we recommend you look at [Weave Cloud&#174;]("https://www.weave.works/product/cloud/").
+> Weaveworks Flux is an integration allowing Kubeflow users to leverage [Weaveworks&#174; Flux]("https://github.com/weaveworks/flux) for GitOps. This utilizes the [stand-alone]("https://github.com/weaveworks/flux/tree/master/site/standalone") implementation. Being stand-alone, most of the maintenance is manual. If you are looking for a more managed solution, we recommend you look at [Weave Cloud&#174;]("https://www.weave.works/product/cloud/").
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Installation](#installation)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Installation
 
 We have packaged Weaveworks&#174; Flux as a ksonnet package as to fit with the overall architecture of Kubeflow. We will pick up from the installation guide found [here]("https://github.com/kubeflow/kubeflow#setup").
-
 
 
 ```


### PR DESCRIPTION
The readme in the prototypes directory was quite inconsistent, though very similar. This PR lines them all up. Many don't have Readme's, so it adds a readme to the prototype stub too, in the hopes devs fill these in.

    - Consistently use doctoc where-ever there are READMEs in the
      prototype directory:
      1. Header
      2. [optional] Summary
      3. TOC
      4. Body
    - Fix several dead links
    - Add README to prototype stub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2221)
<!-- Reviewable:end -->
