### PR TITLE
Adding pytorch operator to non gcp platforms

### DIFF
--- a/scripts/gke/util.sh
+++ b/scripts/gke/util.sh
@@ -249,7 +249,6 @@ gcpKsApply() {
   ks apply default -c cloud-endpoints
   ks apply default -c cert-manager
   ks apply default -c iap-ingress
-  ks apply default -c pytorch-operator
 
   popd
 }

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -140,6 +140,7 @@ ksApply() {
   ks apply default -c jupyter
   ks apply default -c centraldashboard
   ks apply default -c tf-job-operator
+  ks apply default -c pytorch-operator
   ks apply default -c metacontroller
   ks apply default -c spartakus
   ks apply default -c argo


### PR DESCRIPTION
Pytorch operator installation by kfctl is added to all platforms

Related: #2212

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2225)
<!-- Reviewable:end -->
