### PR TITLE
Undefined name: 'false' --> 'False'

### DIFF
--- a/testing/test_jsonnet.py
+++ b/testing/test_jsonnet.py
@@ -81,7 +81,7 @@ def run(test_files_dirs, jsonnet_path_args, test_case):
                 "Result was: %s. Output will be treated as a boolean", output)
               test_passed = parsed
             else:
-              test_passed = parsed.get("pass", false)
+              test_passed = parsed.get("pass", False)
 
             if not test_passed:
               test_case.add_failure_info('{} test failed'.format(test_file))


### PR DESCRIPTION
_Undefined names_ have the potential to raise NameError at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/kubeflow/kubeflow on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./docs/gke/iap_request.py:140:25: F821 undefined name 'signer_email'
                        signer_email))
                        ^
./components/tensorflow-notebook-image/jupyter_notebook_config.py:23:5: F821 undefined name 'get_config'
c = get_config()
    ^
./kubeflow/jupyter/jupyter_config.py:27:1: F821 undefined name 'c'
c.JupyterHub.ip = '0.0.0.0'
^
./kubeflow/jupyter/jupyter_config.py:28:1: F821 undefined name 'c'
c.JupyterHub.hub_ip = '0.0.0.0'
^
./kubeflow/jupyter/jupyter_config.py:31:1: F821 undefined name 'c'
c.JupyterHub.cleanup_servers = False
^
./kubeflow/jupyter/jupyter_config.py:37:1: F821 undefined name 'c'
c.JupyterHub.spawner_class = spawner.KubeFormSpawner
^
./kubeflow/jupyter/jupyter_config.py:39:1: F821 undefined name 'c'
c.KubeSpawner.cmd = 'start-singleuser.sh'
^
./kubeflow/jupyter/jupyter_config.py:40:1: F821 undefined name 'c'
c.KubeSpawner.args = ['--allow-root']
^
./kubeflow/jupyter/jupyter_config.py:42:1: F821 undefined name 'c'
c.KubeSpawner.start_timeout = 60 * 30
^
./kubeflow/jupyter/jupyter_config.py:44:1: F821 undefined name 'c'
c.KubeSpawner.http_timeout = 60 * 5
^
./kubeflow/jupyter/jupyter_config.py:47:1: F821 undefined name 'c'
c.KubeSpawner.singleuser_uid = 1000
^
./kubeflow/jupyter/jupyter_config.py:48:1: F821 undefined name 'c'
c.KubeSpawner.singleuser_fs_gid = 100
^
./kubeflow/jupyter/jupyter_config.py:49:1: F821 undefined name 'c'
c.KubeSpawner.singleuser_working_dir = '/home/jovyan'
^
./kubeflow/jupyter/jupyter_config.py:55:5: F821 undefined name 'c'
    c.KubeSpawner.singleuser_uid = int(env_uid)
    ^
./kubeflow/jupyter/jupyter_config.py:58:5: F821 undefined name 'c'
    c.KubeSpawner.singleuser_fs_gid = int(env_gid)
    ^
./kubeflow/jupyter/jupyter_config.py:73:5: F821 undefined name 'c'
    c.KubeSpawner.modify_pod_hook = modify_pod_hook
    ^
./kubeflow/jupyter/jupyter_config.py:83:1: F821 undefined name 'c'
c.KubeSpawner.storage_pvc_ensure = False
^
./kubeflow/jupyter/jupyter_config.py:84:1: F821 undefined name 'c'
c.KubeSpawner.user_storage_pvc_ensure = False
^
./kubeflow/jupyter/jupyter_config.py:102:1: F821 undefined name 'c'
c.KubeSpawner.volumes = volumes
^
./kubeflow/jupyter/jupyter_config.py:103:1: F821 undefined name 'c'
c.KubeSpawner.volume_mounts = volume_mounts
^
./kubeflow/jupyter/jupyter_config.py:115:1: F821 undefined name 'c'
c.KubeSpawner.service_account = 'jupyter-notebook'
^
./kubeflow/jupyter/jupyter_config.py:116:1: F821 undefined name 'c'
c.KubeSpawner.singleuser_service_account = 'jupyter-notebook'
^
./kubeflow/jupyter/jupyter_config.py:119:5: F821 undefined name 'c'
    c.JupyterHub.authenticator_class = RemoteUserAuthenticator
    ^
./kubeflow/jupyter/jupyter_config.py:120:5: F821 undefined name 'c'
    c.RemoteUserAuthenticator.header_name = 'x-goog-authenticated-user-email'
    ^
./kubeflow/jupyter/jupyter_config.py:122:5: F821 undefined name 'c'
    c.JupyterHub.authenticator_class = 'dummyauthenticator.DummyAuthenticator'
    ^
./kubeflow/jupyter/jupyter_config.py:125:5: F821 undefined name 'c'
    c.KubeSpawner.default_url = '/lab'
    ^
./kubeflow/jupyter/jupyter_config.py:128:1: F821 undefined name 'c'
c.KubeSpawner.extra_spawner_config = {
^
./testing/test_tf_serving.py:48:14: F821 undefined name 'xrange'
    for i in xrange(len(a)):
             ^
./testing/test_jsonnet.py:84:48: F821 undefined name 'false'
              test_passed = parsed.get("pass", false)
                                               ^
29    F821 undefined name 'get_config'
29
```

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2227)
<!-- Reviewable:end -->
