### PR TITLE
Add HorizontalPodAutoscaler to TF-Serving component

### DIFF
--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -25,7 +25,7 @@
     deployHorizontalPodAutoscaler: false,
     minReplicas: 2,
     maxReplicas: 8,
-
+    targetAverageUtilization: 60,
 
     serviceType: "ClusterIP",
 
@@ -266,7 +266,7 @@
             type: "Resource",
             resource: {
               name: "cpu",
-              targetAverageUtilization: 60,
+              targetAverageUtilization: $.params.targetAverageUtilization,
             },
           },
         ],

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -87,6 +87,9 @@
             // Default routing rule for the first version of model.
             if $.util.toBool($.params.deployIstio) && $.util.toBool($.params.firstVersion) then
               $.parts.defaultRouteRule,
+            // Configuration for HorizontalPodAutoscaler
+            if $.util.toBool($.params.deployHorizontalPodAutoscaler) then
+              $.parts.tfHorizontalPodAutoscaler,
           ] +
           // TODO(jlewi): It would be better to structure s3 as a mixin.
           // As an example it would be great to allow S3 and GCS parameters
@@ -111,12 +114,7 @@
             [
               $.parts.tfService,
               $.parts.tfDeployment,
-            ] +
-          if $.util.toBool($.params.deployHorizontalPodAutoscaler) then
-            [
-              $.parts.tfHorizontalPodAutoscaler,
-            ]
-          else [],
+            ],
   }.all,
 
   parts:: {
@@ -277,7 +275,7 @@
           name: $.params.name + "-" + $.params.version,
         },
       },
-    }, // tfHorizontalPodAutoscaler
+    },  // tfHorizontalPodAutoscaler
 
     tfService: {
       apiVersion: "v1",

--- a/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/kubeflow/tf-serving/tf-serving.libsonnet
@@ -115,7 +115,8 @@
           if $.util.toBool($.params.deployHorizontalPodAutoscaler) then
             [
               $.parts.tfHorizontalPodAutoscaler,
-            ],
+            ]
+          else [],
   }.all,
 
   parts:: {


### PR DESCRIPTION
Enable HorizontalPodAutoscaler in TF-Serving component.
Current implementation will let pods scale based on CPU usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2231)
<!-- Reviewable:end -->
