### PR TITLE
set jupyterHubAuthenticator explicitly even for default values

### DIFF
--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -283,7 +283,6 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
 
     const state = this.state;
     const email = await Gapi.getSignedInEmail();
-    let iapIdx = 0;
     for (let i = 0, len = this._configSpec.defaultApp.parameters.length; i < len; i++) {
       const p = this._configSpec.defaultApp.parameters[i];
       if (p.name === 'ipName') {
@@ -299,11 +298,10 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
       }
 
       if (p.name === 'jupyterHubAuthenticator') {
-        iapIdx = i;
+        if (this.state.clientId === '' || this.state.clientSecret === '') {
+          p.value = 'null';
+        }
       }
-    }
-    if (this.state.clientId === '' || this.state.clientSecret === '') {
-      this._configSpec.defaultApp.parameters.splice(iapIdx, 1);
     }
     this._configSpec.defaultApp.registries[0].version = this.state.kfversion;
 


### PR DESCRIPTION
As reusing deploy name will reuse app config of previous deploy, we should set ```jupyterHubAuthenticator``` explicitly even the value is default value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2235)
<!-- Reviewable:end -->
