### PR TITLE
Fix katib repo for the docker registry which doesn't support sub namespace

### DIFF
--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -40,6 +40,7 @@ createEnv() {
   echo KUBEFLOW_VERSION=${KUBEFLOW_VERSION:-"master"} >> ${ENV_FILE}
   echo KUBEFLOW_KS_DIR=${KUBEFLOW_KS_DIR:-"$(pwd)/ks_app"} >> ${ENV_FILE}
   echo KUBEFLOW_DOCKER_REGISTRY=${KUBEFLOW_DOCKER_REGISTRY:-""} >> ${ENV_FILE}
+  echo DOCKER_REGISTRY_KATIB_NAMESPACE=${DOCKER_REGISTRY_KATIB_NAMESPACE:-""} >> ${ENV_FILE}
 
   # Namespace where kubeflow is deployed
   echo K8S_NAMESPACE=${K8S_NAMESPACE:-"kubeflow"} >> ${ENV_FILE}
@@ -56,6 +57,7 @@ createEnv() {
     ack)
       echo KUBEFLOW_PLATFORM=ack >> ${ENV_FILE}
       echo KUBEFLOW_DOCKER_REGISTRY=registry.aliyuncs.com >> ${ENV_FILE}
+      echo DOCKER_REGISTRY_KATIB_NAMESPACE=katib >> ${ENV_FILE}
       ;;
     gcp)
       echo KUBEFLOW_PLATFORM=gke >> ${ENV_FILE}

--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -134,4 +134,10 @@ customizeKsAppWithDockerImage() {
     find ${KUBEFLOW_KS_DIR} -name "*.libsonnet" -o -name "*.jsonnet" | xargs sed -i -e "s%gcr.io%$KUBEFLOW_DOCKER_REGISTRY%g"
     find ${KUBEFLOW_KS_DIR} -name "*.libsonnet" -o -name "*.jsonnet" | xargs sed -i -e "s%quay.io%$KUBEFLOW_DOCKER_REGISTRY%g"
   fi
+
+  # The katib images like gcr.io/kubeflow-images-public/katib/tfevent-metrics-collector:v0.4.0 uses sub namespace kubeflow-images-public/katib in 
+  # gcr.io repo, but it's not supported by other docker image repo. We need to consider how to support it in other docker repos.
+  if [[ ! -z "$DOCKER_REGISTRY_KATIB_NAMESPACE" ]]; then
+    find ${KUBEFLOW_KS_DIR} -name "*.libsonnet" -o -name "*.jsonnet" | xargs sed -i -e "s%kubeflow-images-public/katib%$DOCKER_REGISTRY_KATIB_NAMESPACE%g"
+  fi
 }


### PR DESCRIPTION
The katib images like `gcr.io/kubeflow-images-public/katib/tfevent-metrics-collector:v0.4.0` uses sub namespace `kubeflow-images-public/katib` in `gcr.io`, but it's not supported by other docker image repo. We need to consider how to support it in other docker repos.

We will use the environment variable `DOCKER_REGISTRY_KATIB_NAMESPACE ` to replace `kubeflow-images-public/katib` if the variable is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2237)
<!-- Reviewable:end -->
