### PR TITLE
argo s3 artifact repository configuration added

### DIFF
--- a/kubeflow/argo/argo.libsonnet
+++ b/kubeflow/argo/argo.libsonnet
@@ -229,7 +229,39 @@
     local workflowControllerConfigmap = {
       apiVersion: "v1",
       data: {
-        config: @"executorImage: " + params.executorImage,
+        config: std.format(|||
+                             {
+                             executorImage: %s,
+                             artifactRepository:
+                             {
+                                 s3: {
+                                     bucket: %s,
+                                     keyPrefix: %s,
+                                     endpoint: %s,
+                                     insecure: %s,
+                                     accessKeySecret: {
+                                         name: %s,
+                                         key: %s
+                                     },
+                                     secretKeySecret: {
+                                         name: %s,
+                                         key: %s
+                                     }
+                                 }
+                             }
+                             }
+                           |||,
+                           [
+                             params.executorImage,
+                             params.artifactRepositoryBucket,
+                             params.artifactRepositoryKeyPrefix,
+                             params.artifactRepositoryEndpoint,
+                             params.artifactRepositoryInsecure,
+                             params.artifactRepositoryAccessKeySecretName,
+                             params.artifactRepositoryAccessKeySecretKey,
+                             params.artifactRepositorySecretKeySecretName,
+                             params.artifactRepositorySecretKeySecretKey,
+                           ]),
       },
       kind: "ConfigMap",
       metadata: {

--- a/kubeflow/argo/prototypes/argo.jsonnet
+++ b/kubeflow/argo/prototypes/argo.jsonnet
@@ -6,6 +6,14 @@
 // @optionalParam workflowControllerImage string argoproj/workflow-controller:v2.2.0 workflowControllerImage
 // @optionalParam uiImage string argoproj/argoui:v2.2.0 uiImage
 // @optionalParam executorImage string argoproj/argoexec:v2.2.0 executorImage
+// @optionalParam artifactRepositoryKeyPrefix string artifacts artifactRepositoryKeyPrefix
+// @optionalParam artifactRepositoryEndpoint string minio-service.kubeflow:9000 artifactRepositoryEndpoint
+// @optionalParam artifactRepositoryBucket string mlpipeline artifactRepositoryBucket
+// @optionalParam artifactRepositoryInsecure string true artifactRepositoryInsecure
+// @optionalParam artifactRepositoryAccessKeySecretName string mlpipeline-minio-artifact artifactRepositoryAccessKeySecretName
+// @optionalParam artifactRepositoryAccessKeySecretKey string accesskey artifactRepositoryAccessKeySecretKey
+// @optionalParam artifactRepositorySecretKeySecretName string mlpipeline-minio-artifact artifactRepositorySecretKeySecretName
+// @optionalParam artifactRepositorySecretKeySecretKey string secretkey artifactRepositorySecretKeySecretKey
 
 local argo = import "kubeflow/argo/argo.libsonnet";
 local instance = argo.new(env, params);


### PR DESCRIPTION
Now Argo deployed with  with `kfctl.sh` cannot handle workflows with artifactory configuration.

This PR updating Argo ksonnet configuration to include s3 minio repository in workflow controller configmap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2238)
<!-- Reviewable:end -->
