### PR TITLE
split debug case into separate docker file so we don't expose port unnecessary

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -41,7 +41,7 @@ COPY . $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap
 
 RUN go build -gcflags 'all=-N -l' -o bin/bootstrapper cmd/bootstrap/main.go
 RUN cp $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/bin/bootstrapper /opt/kubeflow
-COPY dlv.sh /opt/kubeflow/
+
 COPY config/default.yaml /opt/kubeflow/
 COPY image_registries.yaml /opt/kubeflow/
 RUN mkdir -p /opt/bootstrap
@@ -60,20 +60,19 @@ RUN mkdir -p /go/bin
 RUN mkdir -p /opt/kubeflow
 WORKDIR /opt/kubeflow
 
-COPY --from=bootstrap_build $GOPATH/bin/dlv $GOPATH/bin/dlv
+
 COPY --from=bootstrap_build /opt/registries /opt/
 COPY --from=bootstrap_build /opt/registries /opt/
 COPY --from=bootstrap_build /opt/kubeflow/bootstrapper /opt/kubeflow/
-COPY --from=bootstrap_build /opt/kubeflow/dlv.sh /opt/kubeflow/
+
 COPY --from=bootstrap_build /opt/kubeflow/default.yaml /opt/kubeflow/
 COPY --from=bootstrap_build /opt/kubeflow/image_registries.yaml /opt/kubeflow/
 RUN mkdir -p /opt/bootstrap
 RUN mkdir -p /opt/versioned_registries
 RUN chmod a+rx /opt/kubeflow/bootstrapper
-RUN chmod a+rx $GOPATH/bin/dlv
 
 EXPOSE 8080
-EXPOSE 2345
+
 
 # Set default values for USER, USER_ID, GROUP_ID
 # The startup script will create the user and su to that user.

--- a/bootstrap/DockerfileDebug
+++ b/bootstrap/DockerfileDebug
@@ -1,6 +1,13 @@
 ARG KFCTL_IMAGE
 
-FROM KFCTL_IMAGE
+ARG GOLANG_VERSION=1.11.2
+FROM golang:$GOLANG_VERSION as debug_util
+
+# install debugger
+RUN go get -u github.com/derekparker/delve/cmd/dlv
+
+FROM $KFCTL_IMAGE
+COPY --from=debug_util $GOPATH/bin/dlv $GOPATH/bin/dlv
 RUN chmod a+rx $GOPATH/bin/dlv
 COPY dlv.sh /opt/kubeflow/
 

--- a/bootstrap/DockerfileDebug
+++ b/bootstrap/DockerfileDebug
@@ -1,0 +1,7 @@
+ARG KFCTL_IMAGE
+
+FROM KFCTL_IMAGE
+RUN chmod a+rx $GOPATH/bin/dlv
+COPY dlv.sh /opt/kubeflow/
+
+EXPOSE 2345


### PR DESCRIPTION
DockerfileDebug should be for debug only and always executed manually on local

Example build cmd:
```
docker build -f DockerfileDebug --build-arg KFCTL_IMAGE=XXXX -t gcr.io/kubeflow-images-public/bootstrapperdebug:test0 .
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2242)
<!-- Reviewable:end -->
