### PR TITLE
remove load sample job from pipeline config

### DIFF
--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -5,7 +5,6 @@
     $.parts(namespace).role,
     $.parts(namespace).service,
     $.parts(namespace).deploy(apiImage),
-    $.parts(namespace).loadSampleJob(apiImage),
     $.parts(namespace).pipelineRunnerServiceAccount,
     $.parts(namespace).pipelineRunnerRole,
     $.parts(namespace).pipelineRunnerRoleBinding,
@@ -179,46 +178,6 @@
         },
       },
     },  // deploy
-
-    loadSampleJob(image): {
-      apiVersion: "batch/v1",
-      kind: "Job",
-      metadata: {
-        name: "ml-pipelines-load-samples",
-        namespace: namespace,
-      },
-      spec: {
-        template: {
-          spec: {
-            restartPolicy: "Never",
-            containers: [
-              {
-                name: "ml-pipelines-load-samples",
-                image: image,
-                imagePullPolicy: "Always",
-                command: ["apiserver"],
-                args: [
-                  "--config=/config",
-                  "--sampleconfig=/config/sample_config.json",
-                ],
-                env: [
-                  {
-                    name: "POD_NAMESPACE",
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: "metadata.namespace",
-                      },
-                    },
-                  },
-                ],
-              },
-            ],
-            serviceAccountName: "ml-pipeline",
-          },
-        },
-        backoffLimit: 2,
-      },
-    },  // loadSampleJob
 
     pipelineRunnerServiceAccount: {
       apiVersion: "v1",


### PR DESCRIPTION
Avoid using job to load samples into pipeline system. 
The K8s Job doesn't work well because it's immutable once created, ksonnet throw an error of "merging object with existing state failure" in case of upgrading the system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2254)
<!-- Reviewable:end -->
