### PR TITLE
use golang:1.11.2 as base image; more ksonnet 0.13.1 API change

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -26,21 +26,20 @@ ENV PATH /go/bin:/usr/local/go/bin:$PATH
 # use go modules
 ENV GO111MODULE=on
 
-COPY go.mod .
-COPY go.sum .
+COPY . .
 RUN go mod download
+RUN go build -gcflags 'all=-N -l' -o bin/bootstrapper cmd/bootstrap/main.go
 
 #
-# bootstrap_build
+# bootstrap
 #
-FROM bootstrap_base as bootstrap_build
+FROM golang:$GOLANG_VERSION as bootstrap
 ARG registries
 
 COPY $registries /opt/registries
-COPY . $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap
 
-RUN go build -gcflags 'all=-N -l' -o bin/bootstrapper cmd/bootstrap/main.go
-RUN cp $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/bin/bootstrapper /opt/kubeflow
+RUN mkdir -p /opt/kubeflow
+COPY --from=bootstrap_base $GOPATH/src/github.com/kubeflow/kubeflow/bootstrap/bin/bootstrapper /opt/kubeflow/
 
 COPY config/default.yaml /opt/kubeflow/
 COPY image_registries.yaml /opt/kubeflow/
@@ -48,27 +47,9 @@ RUN mkdir -p /opt/bootstrap
 RUN mkdir -p /opt/versioned_registries
 RUN chmod a+rx /opt/kubeflow/bootstrapper
 
-#
-# bootstrap
-#
-FROM golang:alpine as bootstrap
-
-RUN apk update && apk add --no-cache libc6-compat socat
-ENV GOPATH /go
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
-RUN mkdir -p /go/bin
 RUN mkdir -p /opt/kubeflow
 WORKDIR /opt/kubeflow
-
-
-COPY --from=bootstrap_build /opt/registries /opt/registries
-COPY --from=bootstrap_build /opt/kubeflow/bootstrapper /opt/kubeflow/
-
-COPY --from=bootstrap_build /opt/kubeflow/default.yaml /opt/kubeflow/
-COPY --from=bootstrap_build /opt/kubeflow/image_registries.yaml /opt/kubeflow/
-RUN mkdir -p /opt/bootstrap
-RUN mkdir -p /opt/versioned_registries
-RUN chmod a+rx /opt/kubeflow/bootstrapper
 
 EXPOSE 8080
 

--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -377,7 +377,7 @@ func (s *ksServer) CreateApp(ctx context.Context, request CreateRequest, dmDeplo
 	if err == nil {
 		log.Infof("App %v exists in project %v", request.Name, request.Project)
 		options := map[string]interface{}{
-			actions.OptionApp:     a.App,
+			actions.OptionAppRoot: a.App.Root(),
 			actions.OptionEnvName: envName,
 			actions.OptionServer:  config.Host,
 		}
@@ -440,9 +440,9 @@ func (s *ksServer) CreateApp(ctx context.Context, request CreateRequest, dmDeplo
 		request.AppConfig.Registries[idx].RegUri = RegUri
 		log.Infof("App %v add registry %v URI %v", request.Name, registry.Name, registry.RegUri)
 		options := map[string]interface{}{
-			actions.OptionApp:  a.App,
-			actions.OptionName: registry.Name,
-			actions.OptionURI:  request.AppConfig.Registries[idx].RegUri,
+			actions.OptionAppRoot: a.App.Root(),
+			actions.OptionName:    registry.Name,
+			actions.OptionURI:     request.AppConfig.Registries[idx].RegUri,
 			// Version doesn't actually appear to be used by the add function.
 			actions.OptionVersion: "",
 			// Looks like override allows us to override existing registries; we shouldn't
@@ -609,12 +609,12 @@ func (s *ksServer) appGenerate(kfApp kApp.App, appConfig *AppConfig) error {
 					full := fmt.Sprintf("%v/%v", registry.Name, pkgName)
 					log.Infof("Installing package %v", full)
 
-					if _, found := libs[pkgName]; found {
+					if _, found := libs[full]; found {
 						log.Infof("Package %v already exists", pkgName)
 						continue
 					}
 					err := actions.RunPkgInstall(map[string]interface{}{
-						actions.OptionApp:     kfApp,
+						actions.OptionAppRoot: kfApp.Root(),
 						actions.OptionPkgName: full,
 						actions.OptionName:    pkgName,
 						actions.OptionForce:   false,
@@ -633,12 +633,12 @@ func (s *ksServer) appGenerate(kfApp kApp.App, appConfig *AppConfig) error {
 		full := fmt.Sprintf("%v/%v", pkg.Registry, pkg.Name)
 		log.Infof("Installing package %v", full)
 
-		if _, found := libs[pkg.Name]; found {
+		if _, found := libs[full]; found {
 			log.Infof("Package %v already exists", pkg.Name)
 			continue
 		}
 		err := actions.RunPkgInstall(map[string]interface{}{
-			actions.OptionApp:     kfApp,
+			actions.OptionAppRoot: kfApp.Root(),
 			actions.OptionPkgName: full,
 			actions.OptionName:    pkg.Name,
 			actions.OptionForce:   false,
@@ -672,10 +672,10 @@ func (s *ksServer) appGenerate(kfApp kApp.App, appConfig *AppConfig) error {
 	// Apply Params
 	for _, p := range appConfig.Parameters {
 		err = actions.RunParamSet(map[string]interface{}{
-			actions.OptionApp:   kfApp,
-			actions.OptionName:  p.Component,
-			actions.OptionPath:  p.Name,
-			actions.OptionValue: p.Value,
+			actions.OptionAppRoot: kfApp.Root(),
+			actions.OptionName:    p.Component,
+			actions.OptionPath:    p.Name,
+			actions.OptionValue:   p.Value,
 		})
 		if err != nil {
 			return fmt.Errorf("Error when setting Parameters %v for Component %v: %v", p.Name, p.Component, err)
@@ -692,7 +692,7 @@ func (s *ksServer) createComponent(kfApp kApp.App, args []string) error {
 	if exists, _ := afero.Exists(s.fs, componentPath); !exists {
 		log.Infof("Creating Component: %v ...", componentName)
 		err := actions.RunPrototypeUse(map[string]interface{}{
-			actions.OptionApp:       kfApp,
+			actions.OptionAppRoot:   kfApp.Root(),
 			actions.OptionArguments: args,
 		})
 		if err != nil {
@@ -744,10 +744,10 @@ func (s *ksServer) autoConfigureApp(kfApp *kApp.App, appConfig *AppConfig, names
 			}
 
 			err = actions.RunParamSet(map[string]interface{}{
-				actions.OptionApp:   *kfApp,
-				actions.OptionName:  component.Name,
-				actions.OptionPath:  "jupyterNotebookPVCMount",
-				actions.OptionValue: pvcMount,
+				actions.OptionAppRoot: (*kfApp).Root(),
+				actions.OptionName:    component.Name,
+				actions.OptionPath:    "jupyterNotebookPVCMount",
+				actions.OptionValue:   pvcMount,
 			})
 
 			if err != nil {
@@ -988,7 +988,7 @@ func (s *ksServer) Apply(ctx context.Context, req ApplyRequest) error {
 	}
 
 	applyOptions := map[string]interface{}{
-		actions.OptionApp: targetApp.App,
+		actions.OptionAppRoot: targetApp.App.Root(),
 		actions.OptionClientConfig: &client.Config{
 			Overrides: &clientcmd.ConfigOverrides{},
 			Config:    clientcmd.NewDefaultClientConfig(cfg, &clientcmd.ConfigOverrides{}),


### PR DESCRIPTION
We have lots dependencies which alpine doesn't include, so actually could be easier use golang:1.11.2 as base. Increase image size by 300M but build faster and test simpler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2258)
<!-- Reviewable:end -->
