### PR TITLE
Extend Katib documentation to use not in GKE

### DIFF
--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -11,33 +11,33 @@
   - [Pytorch-operator](#pytorch-operator)
   - [Katib](#katib)
   - [Cleanups](#cleanups)
-- [Deploying Katib not in GKE](#deploying-katib-not-in-gke)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 ## Quickstart
 
-For running Katib you have to install tf-job operator and pytorch operator package.
+For running Katib you have to install tfjob operator and pytorch operator package.
 
 In your Ksonnet app root, run the following
 
 ```
 export KF_ENV=default
+ks env set ${KF_ENV} --namespace=kubeflow
 ks registry add kubeflow github.com/kubeflow/kubeflow/tree/master/kubeflow
 ```
 
-### TF-job operator
+### TFjob operator
 
-For installing tf-job operator, run the following
+For installing tfjob operator, run the following
 
 ```
 ks pkg install kubeflow/tf-training
-ks pkg install kubeflow/core
+ks pkg install kubeflow/common
 ks generate tf-job-operator tf-job-operator
 ks apply ${KF_ENV} -c tf-job-operator
 ```
 
-### Pytorch-operator
+### Pytorch operator
 For installing pytorch operator, run the following
 
 ```
@@ -55,18 +55,6 @@ ks pkg install kubeflow/katib
 ks generate katib katib
 ks apply ${KF_ENV} -c katib
 ```
-
-### Cleanups
-
-Delete installed components
-
-```
-ks delete ${KF_ENV} -c katib
-ks delete ${KF_ENV} -c pytorch-operator
-ks delete ${KF_ENV} -c tf-job-operator
-```
-
-## Deploying Katib not in GKE
 
 If you want to use Katib not in GKE and you don't have StorageClass for dynamic volume provisioning at your cluster, you have to create persistent volume to bound your persistent volume claim.
 
@@ -95,7 +83,17 @@ Create this pv after deploying Katib package
 kubectl create -f pv.yaml
 ```
 
-Delete this pv after cleanup Katib components
+### Cleanups
+
+Delete installed components
+
+```
+ks delete ${KF_ENV} -c katib
+ks delete ${KF_ENV} -c pytorch-operator
+ks delete ${KF_ENV} -c tf-job-operator
+```
+
+If you create pv for Katib delete it
 
 ```
 kubectl delete -f pv.yaml

--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -11,6 +11,7 @@
   - [Pytorch-operator](#pytorch-operator)
   - [Katib](#katib)
   - [Cleanups](#cleanups)
+- [Deploying Katib not in GKE](#deploying-katib-not-in-gke)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -58,7 +58,7 @@ ks apply ${KF_ENV} -c katib
 
 If you want to use Katib not in GKE and you don't have StorageClass for dynamic volume provisioning at your cluster, you have to create persistent volume to bound your persistent volume claim.
 
-This is yaml file for persistent volume:
+This is yaml file for persistent volume
 
 ```yaml
 apiVersion: v1
@@ -80,7 +80,7 @@ spec:
 Create this pv after deploying Katib package
 
 ```
-kubectl create -f pv.yaml
+kubectl create -f katib-mysql-pv.yaml
 ```
 
 ### Cleanups
@@ -96,7 +96,7 @@ ks delete ${KF_ENV} -c tf-job-operator
 If you create pv for Katib delete it
 
 ```
-kubectl delete -f pv.yaml
+kubectl delete -f katib-mysql-pv.yaml
 ```
 
 Please refer to the official docs for

--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -7,8 +7,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Quickstart](#quickstart)
-  - [TF-job operator](#tf-job-operator)
-  - [Pytorch-operator](#pytorch-operator)
+  - [TF operator](#tf-operator)
+  - [Pytorch operator](#pytorch-operator)
   - [Katib](#katib)
   - [Cleanups](#cleanups)
 
@@ -16,7 +16,7 @@
 
 ## Quickstart
 
-For running Katib, you have to install tfjob operator and pytorch operator package.
+For running Katib, you have to install tf operator and pytorch operator package.
 
 In your Ksonnet app root, run the following
 
@@ -26,9 +26,9 @@ ks env set ${KF_ENV} --namespace=kubeflow
 ks registry add kubeflow github.com/kubeflow/kubeflow/tree/master/kubeflow
 ```
 
-### TFjob operator
+### TF operator
 
-For installing tfjob operator, run the following
+For installing tf operator, run the following
 
 ```
 ks pkg install kubeflow/tf-training
@@ -56,7 +56,7 @@ ks generate katib katib
 ks apply ${KF_ENV} -c katib
 ```
 
-If you want to use Katib not in GKE and you don't have StorageClass for dynamic volume provisioning at your cluster, you have to create persistent volume to bound your persistent volume claim.
+If you want to use Katib not in GKE and you don't have StorageClass for dynamic volume provisioning at your cluster, you have to create persistent volume to bound your persistent volume claim. For additional information about persistent volume, visit Kubernetes [documentation](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
 
 This is yaml file for persistent volume
 

--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -16,7 +16,7 @@
 
 ## Quickstart
 
-For running Katib you have to install tfjob operator and pytorch operator package.
+For running Katib, you have to install tfjob operator and pytorch operator package.
 
 In your Ksonnet app root, run the following
 
@@ -80,7 +80,7 @@ spec:
 Create this pv after deploying Katib package
 
 ```
-kubectl create -f katib-mysql-pv.yaml
+kubectl create -f https://raw.githubusercontent.com/kubeflow/katib/master/manifests/pv/pv.yaml
 ```
 
 ### Cleanups
@@ -93,10 +93,10 @@ ks delete ${KF_ENV} -c pytorch-operator
 ks delete ${KF_ENV} -c tf-job-operator
 ```
 
-If you create pv for Katib delete it
+If you create pv for Katib, delete it
 
 ```
-kubectl delete -f katib-mysql-pv.yaml
+kubectl delete -f https://raw.githubusercontent.com/kubeflow/katib/master/manifests/pv/pv.yaml
 ```
 
 Please refer to the official docs for

--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -11,6 +11,7 @@
   - [Pytorch-operator](#pytorch-operator)
   - [Katib](#katib)
   - [Cleanups](#cleanups)
+  - [Deploying Katib not in GKE](#deploy-katib-not-in-GKE)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -63,6 +64,40 @@ Delete installed components
 ks delete ${KF_ENV} -c katib
 ks delete ${KF_ENV} -c pytorch-operator
 ks delete ${KF_ENV} -c tf-job-operator
+```
+## Deploying Katib not in GKE
+
+If you want to use Katib not in GKE and you don't have StorageClass for dynamic volume provisioning at your cluster, you have to create persistent volume to bound your persistent volume claim.
+
+This is yaml file for persistent volume:
+
+```yaml
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: katib-mysql
+  labels:
+    type: local
+    app: katib
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: /data/katib
+```
+
+Create this pv after deploying Katib package
+
+```
+kubectl create -f pv.yaml
+```
+
+Delete this pv after cleanup Katib components
+
+```
+kubectl delete -f pv.yaml
 ```
 
 Please refer to the official docs for

--- a/kubeflow/katib/README.md
+++ b/kubeflow/katib/README.md
@@ -11,7 +11,6 @@
   - [Pytorch-operator](#pytorch-operator)
   - [Katib](#katib)
   - [Cleanups](#cleanups)
-  - [Deploying Katib not in GKE](#deploy-katib-not-in-GKE)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -65,6 +64,7 @@ ks delete ${KF_ENV} -c katib
 ks delete ${KF_ENV} -c pytorch-operator
 ks delete ${KF_ENV} -c tf-job-operator
 ```
+
 ## Deploying Katib not in GKE
 
 If you want to use Katib not in GKE and you don't have StorageClass for dynamic volume provisioning at your cluster, you have to create persistent volume to bound your persistent volume claim.


### PR DESCRIPTION
I added some information inside Katib package README. 
How to deploy Katib not in GKE if you don't have StorageClass inside your cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2260)
<!-- Reviewable:end -->
