### PR TITLE
Added 'google-api-python-client' to the jupyterhub image

### DIFF
--- a/components/jupyterhub/docker/Dockerfile
+++ b/components/jupyterhub/docker/Dockerfile
@@ -15,6 +15,7 @@
 FROM jupyterhub/jupyterhub:0.9
 
 RUN pip install  --no-cache-dir \
+                 google-api-python-client \
                  jupyterhub-kubespawner==0.9.0 \
                  jupyterhub-dummyauthenticator \
                  jhub_remote_user_authenticator \


### PR DESCRIPTION
This commit fixes issue (#1932)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2268)
<!-- Reviewable:end -->
