### PR TITLE
increase the number of mktemp template variables in download.sh

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -12,7 +12,7 @@ fi
 KUBEFLOW_TAG=${KUBEFLOW_TAG:-master}
 
 # Create a local copy of the Kubeflow source repo
-TMPDIR=$(mktemp -d /tmp/tmp.kubeflow-repo-XXXX)
+TMPDIR=$(mktemp -d /tmp/tmp.kubeflow-repo-XXXXXX)
 curl -L -o ${TMPDIR}/kubeflow.tar.gz https://github.com/kubeflow/kubeflow/archive/${KUBEFLOW_TAG}.tar.gz
 tar -xzvf ${TMPDIR}/kubeflow.tar.gz -C ${TMPDIR}
 # GitHub seems to strip out the v in the file name.


### PR DESCRIPTION
The call to mktemp in the download.sh script results in an error similar to the following when running the script from Alpine, in my case I was using busybox:

```
mktemp: Invalid argument
```

Which is easily reproducible outside of the download.sh script:
```
bash-4.3# mktemp -d /tmp/tmp.kubeflow-repo-XXXX
mktemp: Invalid argument
```

Once the number of template variables was increased to _at least_ 6 places, the error was resolved:
```
bash-4.3# mktemp -d /tmp/tmp.kubeflow-repo-XXXXXX
/tmp/tmp.kubeflow-repo-XckJMKj
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2304)
<!-- Reviewable:end -->
