### PR TITLE
add in-cluster nfs 

### DIFF
--- a/kubeflow/pipeline/all.libsonnet
+++ b/kubeflow/pipeline/all.libsonnet
@@ -2,6 +2,7 @@
   parts(_env, _params):: {
     local params = _env + _params,
 
+    local nfs = import "kubeflow/pipeline/nfs.libsonnet",
     local minio = import "kubeflow/pipeline/minio.libsonnet",
     local mysql = import "kubeflow/pipeline/mysql.libsonnet",
     local pipeline_apiserver = import "kubeflow/pipeline/pipeline-apiserver.libsonnet",
@@ -15,10 +16,12 @@
     local scheduledWorkflowImage = params.scheduledWorkflowImage,
     local persistenceAgentImage = params.persistenceAgentImage,
     local uiImage = params.uiImage,
+    local nfsImage = params.nfsImage,
     local mysqlImage = params.mysqlImage,
     local minioImage = params.minioImage,
     all:: minio.all(namespace, minioImage) +
           mysql.all(namespace, mysqlImage) +
+          nfs.all(namespace, nfsImage) +
           pipeline_apiserver.all(namespace, apiImage) +
           pipeline_scheduledworkflow.all(namespace, scheduledWorkflowImage) +
           pipeline_persistenceagent.all(namespace, persistenceAgentImage) +

--- a/kubeflow/pipeline/minio.libsonnet
+++ b/kubeflow/pipeline/minio.libsonnet
@@ -1,31 +1,11 @@
 {
   all(namespace, minioImage):: [
-    $.parts(namespace).pvc,
     $.parts(namespace).service,
     $.parts(namespace).deploy(minioImage),
     $.parts(namespace).secret,
   ],
 
   parts(namespace):: {
-    pvc: {
-      apiVersion: "v1",
-      kind: "PersistentVolumeClaim",
-      metadata: {
-        name: "minio-pv-claim",
-        namespace: namespace,
-      },
-      spec: {
-        accessModes: [
-          "ReadWriteOnce",
-        ],
-        resources: {
-          requests: {
-            storage: "10Gi",
-          },
-        },
-      },
-    },  //pvc
-
     service: {
       apiVersion: "v1",
       kind: "Service",
@@ -72,7 +52,7 @@
               {
                 name: "data",
                 persistentVolumeClaim: {
-                  claimName: "minio-pv-claim",
+                  claimName: "nfs-pvc",
                 },
               },
             ],
@@ -83,6 +63,7 @@
                   {
                     name: "data",
                     mountPath: "/data",
+                    subPath: "minio",
                   },
                 ],
                 image: image,

--- a/kubeflow/pipeline/nfs.libsonnet
+++ b/kubeflow/pipeline/nfs.libsonnet
@@ -1,0 +1,190 @@
+{
+  all(namespace, nfsImage):: [
+    // Instead of creating a PV, use default storage class instead.
+    // $.parts(namespace).nfsServerPv,
+    $.parts(namespace).nfsServerPvc,
+    $.parts(namespace).nfsServerDeployment(nfsImage),
+    $.parts(namespace).nfsServerService,
+    $.parts(namespace).nfsPv,
+    $.parts(namespace).nfsPvc,
+  ],
+  parts(namespace):: {
+    nfsServerPv: {
+      apiVersion: "v1",
+      kind: "PersistentVolume",
+      metadata: {
+        name: "nfs-server-pv",
+        namespace: namespace,
+        labels: {
+          app: "nfs-server-pv",
+        },
+      },
+      spec: {
+        capacity: {
+          storage: "200Gi",
+        },
+        accessModes: [
+          "ReadWriteOnce",
+        ],
+        gcePersistentDisk: {
+          pdName: "mypd",
+          fsType: "ext4",
+        },
+      },
+    }, // nfsServerPv
+
+    nfsServerPvc: {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: "nfs-server-pvc",
+        namespace: namespace,
+        labels: {
+          app: "nfs-server-pvc",
+        },
+      },
+      spec: {
+        accessModes: [
+          "ReadWriteOnce",
+        ],
+        resources: {
+          requests: {
+            storage: "20Gi",
+          },
+        },
+      },
+    }, //nfsServerPvc
+
+    nfsServerDeployment(image): {
+      apiVersion: "apps/v1beta2",
+      kind: "Deployment",
+      metadata: {
+        name: "nfs-server",
+        namespace: namespace,
+      },
+      spec: {
+        selector: {
+          matchLabels: {
+            role: "nfs-server",
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              role: "nfs-server",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                name: "nfs-server",
+                image: image,
+                ports: [
+                  {
+                    name: "nfs",
+                    containerPort: 2049,
+                  },
+                  {
+                    name: "mountd",
+                    containerPort: 20048,
+                  },
+                  {
+                    name: "rpcbind",
+                    containerPort: 111,
+                  },
+                ],
+                securityContext: {
+                  privileged: true,
+                },
+                volumeMounts: [
+                  {
+                    mountPath: "/exports",
+                    name: "nfs-server-pvc",
+                  },
+                ],
+              },
+            ],
+            volumes: [
+              {
+                name: "nfs-server-pvc",
+                persistentVolumeClaim: {
+                  claimName: "nfs-server-pvc",
+                },
+              },
+            ],
+          },
+        },
+      },
+    }, //nfsServerDeployment
+
+    nfsServerService: {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        name: "nfs-server",
+        namespace: namespace,
+      },
+      spec: {
+        ports: [
+          {
+            name: "nfs",
+            port: 2049,
+          },
+          {
+            name: "mountd",
+            port: 20048,
+          },
+          {
+            name: "rpcbind",
+            port: 111,
+          },
+        ],
+        selector: {
+          role: "nfs-server",
+        },
+      },
+    }, //nfsServerService
+
+    nfsPv: {
+      apiVersion: "v1",
+      kind: "PersistentVolume",
+      metadata: {
+        name: "nfs-pv",
+        namespace: namespace,
+      },
+      spec: {
+        capacity: {
+          storage: "20Gi",
+        },
+        accessModes: [
+          "ReadWriteMany",
+        ],
+        nfs: {
+          server: "nfs-server." + namespace + ".svc.cluster.local",
+          path: "/",
+        },
+      },
+    }, // nfsPv
+
+    nfsPvc: {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: "nfs-pvc",
+        namespace: namespace,
+      },
+      spec: {
+        accessModes: [
+          "ReadWriteMany",
+        ],
+        storageClassName: "",
+        volumeName: "nfs-pv",
+        resources: {
+          requests: {
+            storage: "20Gi"
+          },
+        },
+      },
+    },
+  }, //nfsPvc
+}

--- a/kubeflow/pipeline/prototypes/pipeline.jsonnet
+++ b/kubeflow/pipeline/prototypes/pipeline.jsonnet
@@ -9,6 +9,7 @@
 // @optionalParam uiImage string gcr.io/ml-pipeline/frontend:0.1.7 UI docker image
 // @optionalParam mysqlImage string mysql:5.6 mysql image
 // @optionalParam minioImage string minio/minio:RELEASE.2018-02-09T22-40-05Z minio image
+// @optionalParam nfsImage string k8s.gcr.io/volume-nfs:0.8 nfs image
 
 local k = import "k.libsonnet";
 local all = import "kubeflow/pipeline/all.libsonnet";


### PR DESCRIPTION
- Add in-cluster NFS that uses default storageclass in the cluster.
- switch minio to use in-cluster NFS

NFS ensure that the nfs-pvc is a RWM PVC that can be reused for other pipeline components to mount PV in the future. This will be the first step to deprecate minio in favor of K8s PV.

TODO: Since we don't expose functionality to allow user specify permanent storage, we use the default storageclass. The data will still be gone if cluster is deleted. As next step, expose this configuration as parameter to kfctl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2328)
<!-- Reviewable:end -->
