### PR TITLE
TF-Serving Service: Added param for custom HTTP and GRPC port

### DIFF
--- a/kubeflow/tf-serving/prototypes/tf-serving-service.jsonnet
+++ b/kubeflow/tf-serving/prototypes/tf-serving-service.jsonnet
@@ -8,6 +8,8 @@
 // @optionalParam trafficRule string v1:100 The traffic rule, in the format of version:percentage,version:percentage,..
 // @optionalParam injectIstio string false Whether to inject istio sidecar; should be true or false.
 // @optionalParam enablePrometheus string true Whether to enable prometheus endpoint (requires TF 1.11)
+// @optionalParam portHTTP string 8500 Port to use for tf-serving HTTP
+// @optionalParam portGRPC string 9000 Port to use for tf-serving GRPC
 
 local k = import "k.libsonnet";
 local tfservingService = import "kubeflow/tf-serving/tf-serving-service-template.libsonnet";

--- a/kubeflow/tf-serving/tf-serving-service-template.libsonnet
+++ b/kubeflow/tf-serving/tf-serving-service-template.libsonnet
@@ -50,12 +50,12 @@
         ports: [
           {
             name: "grpc-tf-serving",
-            port: 9000,
+            port: params.portGRPC,
             targetPort: 9000,
           },
           {
             name: "http-tf-serving",
-            port: 8500,
+            port: params.portHTTP,
             targetPort: 8500,
           },
         ],


### PR DESCRIPTION
I have added a new param for the HTTP and GRPC port of the ksonnet tf-serving service prototype. This makes it easier to change it from the defaults, since e.g. Azure only allows traffic on port 80 to the external IP of an Service. 

Port can be changed via:

```
ks param set $COMPONENT portHTTP 80
ks param set $COMPONENT portGRPC 90
```

Since this is my first Pull Request, feel free to correct me on anything :-)

Thanks
Marcel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2340)
<!-- Reviewable:end -->
