### PR TITLE
Improve the delete_deployment script.

### DIFF
--- a/scripts/gke/delete_role_bindings.py
+++ b/scripts/gke/delete_role_bindings.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+#
+# A simple script to delete all role bindings for the service
+# accounts created as part of a Kubeflow deployment
+# This is an effort to deal with
+# https://github.com/kubeflow/kubeflow/issues/953
+import argparse
+import logging
+import json
+import subprocess
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+    "--project", default=None, type=str, help=("The project."))
+  parser.add_argument(
+    "--service_account",
+    type=str,
+    help=("The service account."))
+
+  args = parser.parse_args()
+  output = subprocess.check_output(["gcloud", "projects", "get-iam-policy",
+                                    "--format=json", args.project,])
+
+  bindings = json.loads(output)
+  roles = []
+  entry = "serviceAccount:" + args.service_account
+  for b in bindings["bindings"]:
+    if entry in b["members"]:
+      roles.append(b["role"])
+  # TODO(jlewi): Can we issue a single gcloud command.
+  for r in roles:
+    command =[
+          "gcloud", "projects", "remove-iam-policy-binding",
+          args.project,
+          "--member", entry,
+          "--role", r,
+        ]
+    print(" ".join(command))
+    subprocess.call(command)

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -496,7 +496,7 @@ main() {
       if [[ "${PLATFORM}" == "gcp" ]]; then
         if [[ -d "${KUBEFLOW_DM_DIR}" ]]; then
           pushd ${KUBEFLOW_DM_DIR}
-          ${DIR}/gke/delete_deployment.sh ${PROJECT} ${DEPLOYMENT_NAME} ${CONFIG_FILE}
+          ${DIR}/gke/delete_deployment.sh --project=${PROJECT} --deployment=${DEPLOYMENT_NAME} --zone=${ZONE}
           popd
         fi
       fi


### PR DESCRIPTION
* Take named command line arguments rather than positional arguments
* Add and use delete_role_bindings.py to delete all bindings associated
  with the service accounts. This way we don't depend on the IAM patch
  file being present. That only works if you have the kfctl app directory.

* Set exit status explicitly.

Related to: #953 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2344)
<!-- Reviewable:end -->
