### PR TITLE
Fix minikube setup script's df inference

### DIFF
--- a/scripts/setup-minikube.sh
+++ b/scripts/setup-minikube.sh
@@ -152,7 +152,11 @@ infer_minikube_settings() {
 
   # disk
   local dd=40
-  dd=$(df -h . | awk '{print $4}' | tail -1 | sed 's/[A-Za-z]//g')
+  if [[ $PLATFORM == $LINUX ]]; then
+    dd=$(df -BG . | awk '{print $4}' | tail -1 | sed 's/[A-Za-z]//g')
+  elif [[ $PLATFORM == $OSX ]]; then
+    dd=$(df -g . | awk '{print $4}' | tail -1 | sed 's/[A-Za-z]//g')
+  fi
   if (($dd < 40)); then
     echo -e "${YELLOW}WARNING: Low available disk space.${NC}"
   fi


### PR DESCRIPTION
The minikube setup script infers the amount of disk that's available. It does so through a `dd -h`. This can produce fractions, which will make the code fail. E.g. when i have `1.7Tb` free, the value will be `1.7`, which will be compared to `40`, which will break, like so, as bash cannot perform floating point arithmetic.
```
((: 1.7 < 40: syntax error: invalid arithmetic operator (error token is ".7 < 40")
```

The patch here makes sure that `df` only returns integers in Gigabytes.

I have proposed a patch for this in this PR, but in general, I think the current approach taken, where we check the last mount's free space using `tail -1` is not a good approach at all. I would even consider removing the test, and make it configurable.

I think the above concern is to address later, and get this patch in asap. Tested to work on MacOS and Ubuntu 18.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2354)
<!-- Reviewable:end -->
