### PR TITLE
upgrade conda to 4.5.12 and stick with pip version 19.0.1 for now

### DIFF
--- a/components/contrib/rapidsai-notebook-image/Dockerfile
+++ b/components/contrib/rapidsai-notebook-image/Dockerfile
@@ -46,7 +46,7 @@ RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
     apt-get install -y google-cloud-sdk kubectl && \
     # Install to the existing RapidsAI conda env
     source activate rapids && \
-    pip install --upgrade pip && \
+    pip install --upgrade pip==19.0.1 && \
     pip --no-cache-dir install jupyterhub matplotlib
 
 # Install Tini - used as entrypoint for container

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -92,7 +92,7 @@ RUN cd /tmp && \
     chmod +x /usr/local/bin/tini
 
 # Install conda as jovyan user and check the md5 sum provided on the download site
-ENV MINICONDA_VERSION 4.4.10
+ENV MINICONDA_VERSION 4.5.12
 RUN cd /tmp && \
     mkdir -p $CONDA_DIR && \
     wget --quiet https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh && \
@@ -111,7 +111,7 @@ RUN cd /tmp && \
 # The image size can grow significantly.
 
 # Install base python3 packages
-RUN pip install --upgrade pip && \
+RUN pip install --upgrade pip==19.0.1 && \
     pip --no-cache-dir install \
     # Tensorflow
     ${TF_PACKAGE} \

--- a/components/tensorflow-notebook-image/install.sh
+++ b/components/tensorflow-notebook-image/install.sh
@@ -5,7 +5,7 @@ set -ex
 conda create -n py2 python=2
 
 source activate py2
-pip install --upgrade pip
+pip install --upgrade pip==19.0.1
 
 # TFX packages only supports python 2
 pip --no-cache-dir install \


### PR DESCRIPTION
- Don't upgrade `pip` blindly since it's known to have caused issues in the past.
- Upgrade `conda` to latest version `4.5.12` since the current version is ancient.