### PR TITLE
fix click_to_deploy test

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,7 +1,7 @@
 #
 # bootstrap_base
 #
-ARG GOLANG_VERSION=1.11.2
+ARG GOLANG_VERSION=1.11.5
 FROM golang:$GOLANG_VERSION as bootstrap_base
 
 RUN apt-get update

--- a/bootstrap/build_image.sh
+++ b/bootstrap/build_image.sh
@@ -17,6 +17,8 @@ until docker ps; do
   sleep 3
 done
 
+go version
+
 GO111MODULE=on go build -gcflags 'all=-N -l' -o bin/bootstrapper cmd/bootstrap/main.go
 
 rm -rf reg_tmp

--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -1045,7 +1045,7 @@ func (s *ksServer) Apply(ctx context.Context, req ApplyRequest) error {
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"activeCluster": {
 				CertificateAuthorityData: config.TLSClientConfig.CAData,
-				Server:                   config.Host,
+				Server: config.Host,
 			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
@@ -1173,10 +1173,8 @@ func checkDeploymentFinished(svc KsService, req CreateRequest, deployName string
 		time.Sleep(10 * time.Second)
 		status, errMsg, err = svc.GetDeploymentStatus(ctx, req, deployName)
 		if err != nil {
-			log.Errorf("Failed to get deployment status: %v", err)
-			deployReqCounter.WithLabelValues("INTERNAL").Inc()
-			deploymentFailure.WithLabelValues("INTERNAL").Inc()
-			return err
+			log.Warningf("Failed to get deployment status: %v\nWill retry...", err)
+			continue
 		}
 		if status == "DONE" {
 			if errMsg == "" {

--- a/bootstrap/cmd/bootstrap/app/ksServer.go
+++ b/bootstrap/cmd/bootstrap/app/ksServer.go
@@ -878,7 +878,7 @@ func (s *ksServer) CloneRepoToLocal(project string, token string) (string, error
 		return nil
 	}, bo)
 	if err != nil {
-		log.Errorf("Fail to create repo: %v", GetRepoName(project))
+		log.Errorf("Fail to create repo: %v. Error: %v", GetRepoName(project), err)
 		return "", err
 	}
 	err = os.Chdir(repoDir)

--- a/testing/workflows/components/click_deploy_test.jsonnet
+++ b/testing/workflows/components/click_deploy_test.jsonnet
@@ -244,7 +244,7 @@ local exitTemplates =
         "--bucket=" + bucket,
       ]),  // copy-artifacts,
 
-      dependencies: ["deploy-delete"],
+      dependencies: null,
     },
     {
       template:

--- a/testing/workflows/components/click_deploy_test.jsonnet
+++ b/testing/workflows/components/click_deploy_test.jsonnet
@@ -258,7 +258,7 @@ local exitTemplates =
           "-rf",
           testDir,
         ]),  // test-dir-delete
-      dependencies: ["copy-artifacts"],
+      dependencies: ["copy-artifacts", "deploy-delete"],
     },
   ];
 


### PR DESCRIPTION
- make `copy-artifacts` not depend on `deploy-delete` so that even delete failed we still have artifacts. @kunmingg Is this ok?
- when GetDeploymentStatus failed, retry
- update go version, and print out go version

for https://github.com/kubeflow/kubeflow/issues/2364

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2431)
<!-- Reviewable:end -->
