### PR TITLE
Use command array in mpi job prototype

### DIFF
--- a/kubeflow/mpi-job/prototypes/mpi-job-custom.jsonnet
+++ b/kubeflow/mpi-job/prototypes/mpi-job-custom.jsonnet
@@ -22,7 +22,7 @@ local args = params.args;
 local containerCommand =
   if command != "null" then
     {
-      command: command,
+      command: std.split(command, ","),
     }
   else {};
 local containerArgs =

--- a/kubeflow/mpi-job/prototypes/mpi-job-simple.jsonnet
+++ b/kubeflow/mpi-job/prototypes/mpi-job-simple.jsonnet
@@ -20,7 +20,7 @@ local args = params.args;
 local containerCommand =
   if command != "null" then
     {
-      command: command,
+      command: std.split(command, ","),
     }
   else {};
 local containerArgs =


### PR DESCRIPTION
Meet this problem when I  `yaml.Unmarshal(manifest, &mpiJob)`

```
error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go struct field Container.command of type []string"

```

MPI job spec template uses corev1.PodTemplateSpec. Commands and Args are both `[]string` type. 

https://github.com/kubernetes/api/blob/369c77d0cd027d5cb8eebabebfb64d38b21538a0/core/v1/types.go#L2065-L2080

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2434)
<!-- Reviewable:end -->
