### PR TITLE
Add mpijobs and pods/log in kubebench rbac

### DIFF
--- a/kubeflow/kubebench/kubebench-rbac.libsonnet
+++ b/kubeflow/kubebench/kubebench-rbac.libsonnet
@@ -27,6 +27,7 @@ local k = import "k.libsonnet";
           resources: [
             "tfjobs",
             "pytorchjobs",
+            "mpijobs",
           ],
           verbs: [
             "*",
@@ -72,6 +73,7 @@ local k = import "k.libsonnet";
           resources: [
             "configmaps",
             "pods",
+            "pods/log",
             "pods/exec",
             "services",
             "endpoints",


### PR DESCRIPTION
Grant kubebench service account permission to operate mpijobs and fetch pod logs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2442)
<!-- Reviewable:end -->
