### PR TITLE
Deploy NFS only when explicitly set the nfs parameter

### DIFF
--- a/kubeflow/pipeline/all.libsonnet
+++ b/kubeflow/pipeline/all.libsonnet
@@ -26,10 +26,11 @@
     local mysqlPd = params.mysqlPd,
     local minioPd = params.minioPd,
     local nfsPd = params.nfsPd,
-    nfs:: if (minioPvName == "null") && (minioPd== "null") then
+    nfs:: if (nfsPvName != "null") || (nfsPd != "null") then
              nfs.all(namespace, nfsImage)
            else [],
-    all:: minio.all(namespace, minioImage, minioPd, minioPvName) +
+    local minioPvcName = if (nfsPvName != "null") || (nfsPd != "null") then "nfs-pvc" else "minio-pvc",
+    all:: minio.all(namespace, minioImage, minioPvcName) +
           mysql.all(namespace, mysqlImage) +
           pipeline_apiserver.all(namespace, apiImage) +
           pipeline_scheduledworkflow.all(namespace, scheduledWorkflowImage) +

--- a/kubeflow/pipeline/minio.libsonnet
+++ b/kubeflow/pipeline/minio.libsonnet
@@ -1,7 +1,7 @@
 {
-  all(namespace, minioImage, minioPd, minioPvName):: [
+  all(namespace, minioImage, minioPvcName):: [
     $.parts(namespace).service,
-    $.parts(namespace).deploy(minioImage, minioPd, minioPvName),
+    $.parts(namespace).deploy(minioImage, minioPvcName),
     $.parts(namespace).secret,
   ],
 
@@ -30,7 +30,7 @@
       },
     },  //service
 
-    deploy(image, minioPd, minioPvName): {
+    deploy(image, minioPvcName): {
       apiVersion: "apps/v1beta1",
       kind: "Deployment",
       metadata: {
@@ -52,7 +52,7 @@
               {
                 name: "data",
                 persistentVolumeClaim: {
-                  claimName: if (minioPvName != "null") || (minioPd != "null") then "minio-pvc" else "nfs-pvc",
+                  claimName: minioPvcName,
                 },
               },
             ],

--- a/kubeflow/pipeline/storage.libsonnet
+++ b/kubeflow/pipeline/storage.libsonnet
@@ -8,9 +8,9 @@
   all(namespace, mysqlPvName=null, minioPvName=null, nfsPvName=null, mysqlPd=null, minioPd=null, nfsPd=null):: [
     $.parts(namespace).mysqlPvc(mysqlPd,mysqlPvName),
   ] +
-  [ if (minioPvName != "null") || (minioPd!= "null")
-    then $.parts(namespace).minioPvc(minioPd,minioPvName)
-    else $.parts(namespace).nfsServerPvc(nfsPd,nfsPvName),
+  [ if (nfsPvName != "null") || (nfsPd!= "null")
+    then $.parts(namespace).nfsServerPvc(nfsPd,nfsPvName)
+    else $.parts(namespace).minioPvc(minioPd,minioPvName),
   ] +
   [ if mysqlPd != "null"
     then $.parts(namespace).mysqlPv(mysqlPd),


### PR DESCRIPTION
NFS will be deployed only when explicitly set nfsPvName or nfsPd. 
By default NFS won't be deployed. Minio will use minioPvName, minioPd or PVC provisioned by default storageclass.

fix https://github.com/kubeflow/kubeflow/issues/2443

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2446)
<!-- Reviewable:end -->
