### PR TITLE
fix artifact dir

### DIFF
--- a/testing/workflows/components/click_deploy_test.jsonnet
+++ b/testing/workflows/components/click_deploy_test.jsonnet
@@ -210,7 +210,7 @@ local dagTemplates = [
         "-m",
         "testing.test_deploy_app",
         "--namespace=" + name,
-        "--artifacts_dir=" + outputDir,
+        "--artifacts_dir=" + artifactsDir,
         "--iap_wait_min=15",
       ],
       working_dir=testDir


### PR DESCRIPTION
junit_kubeflow-deploy-bootstrapper.xml is at wrong location.
```
gsutil ls gs://kubernetes-jenkins/logs/kubeflow-riodic-master/761
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/build-log.txt
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/finished.json
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/junit_kubeflow-deploy-bootstrapper.xml
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/started.json
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/artifacts/

gsutil ls gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/artifacts
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/artifacts/junit_jsonnet-test-suite.xml
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/artifacts/junit_jupyter-test.xml
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/artifacts/junit_kubeflow-deploy-deploy-argo-test-argo-deploy.xml
gs://kubernetes-jenkins/logs/kubeflow-periodic-master/761/artifacts/junit_kubeflow-deploy-deploy-minikube.xml
...
```

/cc @kunmingg 
/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2449)
<!-- Reviewable:end -->
