### PR TITLE
fix test name on testgrid

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -11,6 +11,8 @@ workflows:
     - bootstrap/*
     - kubeflow/*
     - testing/*
+    params:
+      workflowName: deployapp
   # kfctl test runs tests on gke.
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: kfctl_test
@@ -27,6 +29,7 @@ workflows:
     params:
       platform: gke
       gkeApiVersion: v1
+      workflowName: kfctl
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: kfctl_test
     name: kfctl-beta
@@ -40,11 +43,14 @@ workflows:
     params:
       platform: gke
       gkeApiVersion: v1beta1
+      workflowName: kfctl-beta
   # Run unittests
   # TODO(jlewi): Need to add step to run go and python unittests
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: unit_tests
     name: unittests
+    params:
+      workflowName: unittest
   # TODO(jlewi): We should be running the minikube workflow
   # on presubmit when the minikube E2E test itself changes
   # so we verify the test is working before submitting
@@ -63,6 +69,7 @@ workflows:
       - periodic
     params:
       platform: minikube
+      workflowName: e2e-minikube
     include_dirs:
       # Run on presubmit if any files used by minikube change
       - kubeflow/core/*
@@ -82,6 +89,8 @@ workflows:
       - kubeflow/tf-serving/*
       - components/k8s-model-server/*
       - testing/*
+    params:
+      workflowName: tfserving
 
   # Image Auto Release workflows.
   # The workflows below are related to auto building our Docker images.

--- a/testing/test_tf_serving.py
+++ b/testing/test_tf_serving.py
@@ -90,12 +90,14 @@ def main():
     "--result_path",
     type=str,
     help=("The expected result."))
+  parser.add_argument(
+    "--workflow_name", default="tfserving", type=str, help="The name of the workflow.")
 
   args = parser.parse_args()
 
   t = test_util.TestCase()
   t.class_name = "Kubeflow"
-  t.name = "tf-serving-image-" + args.service_name
+  t.name = args.workflow_name + "-" + args.service_name
 
   start = time.time()
 

--- a/testing/workflows/components/click_deploy_test.jsonnet
+++ b/testing/workflows/components/click_deploy_test.jsonnet
@@ -212,6 +212,7 @@ local dagTemplates = [
         "--namespace=" + name,
         "--artifacts_dir=" + artifactsDir,
         "--iap_wait_min=15",
+        "--workflow_name=" + params.workflowName,
       ],
       working_dir=testDir
     ),

--- a/testing/workflows/components/kfctl_test.jsonnet
+++ b/testing/workflows/components/kfctl_test.jsonnet
@@ -151,7 +151,7 @@ local componentTests = util.kfTests {
   testDir: testDir,
   kubeConfig: kubeConfig,
   image: image,
-  workflow_name: params.workflowName,
+  workflowName: params.workflowName,
   buildTemplate+: {
     argoTemplate+: {
       container+: {

--- a/testing/workflows/components/kfctl_test.jsonnet
+++ b/testing/workflows/components/kfctl_test.jsonnet
@@ -151,7 +151,7 @@ local componentTests = util.kfTests {
   testDir: testDir,
   kubeConfig: kubeConfig,
   image: image,
-  workflow_name: name,
+  workflow_name: params.workflowName,
   buildTemplate+: {
     argoTemplate+: {
       container+: {

--- a/testing/workflows/components/params.libsonnet
+++ b/testing/workflows/components/params.libsonnet
@@ -12,6 +12,7 @@
       prow: "JOB_NAME=kubeflow-presubmit-test,JOB_TYPE=presubmit,PULL_NUMBER=209,REPO_NAME=kubeflow,REPO_OWNER=kubeflow,BUILD_NUMBER=997a",
       prow_env: "JOB_NAME=kubeflow-gke-deploy-test,JOB_TYPE=presubmit,PULL_NUMBER=4,REPO_NAME=kubeflow,REPO_OWNER=jlewi,BUILD_NUMBER=3a8b",
       gkeApiVersion: "",
+      workflowName: "",
     },
     gke_deploy: {
       bucket: "kubeflow-ci_temp",
@@ -28,6 +29,7 @@
       prow_env: "",
       deleteKubeflow: true,
       gkeApiVersion: "v1",
+      workflowName: "kfctl",
     },
     click_deploy_test: {
       bucket: "kubeflow-ci_temp",
@@ -35,6 +37,7 @@
       namespace: "kubeflow-test-infra",
       prow_env: "",
       gkeApiVersion: "v1",
+      workflowName: "deployapp",
     },
     unit_tests: {
       bucket: "kubeflow-ci_temp",
@@ -42,6 +45,7 @@
       namespace: "kubeflow-test-infra",
       prow_env: "",
       gkeApiVersion: "",
+      workflowName: "unittest",      
     },
     tfserving: {
       commit: "master",
@@ -49,6 +53,7 @@
       namespace: "kubeflow-test-infra",
       prow_env: "REPO_OWNER=kubeflow,REPO_NAME=kubeflow,PULL_BASE_SHA=master",
       gkeApiVersion: "",
+      workflowName: "tfserving",
     },
   },
 }

--- a/testing/workflows/components/tfserving.libsonnet
+++ b/testing/workflows/components/tfserving.libsonnet
@@ -162,6 +162,7 @@
             "--namespace=" + stepsNamespace,
             "--artifacts_dir=" + artifactsDir,
             "--service_name=" + serviceName,
+            "--workflow_name=" + params.workflowName,
             "--input_path=" + srcDir + "/components/k8s-model-server/test-data/mnist_input.json",
             "--result_path=" + srcDir + "/components/k8s-model-server/test-data/mnist_result.json",
           ],
@@ -237,6 +238,7 @@
         "--namespace=" + stepsNamespace,
         "--test_dir=" + testDir,
         "--artifacts_dir=" + artifactsDir,
+        "--workflow_name=" + params.workflowName,
       ];
       local deploy_tf_serving_command = deploy_tf_serving_command_base + [
         "--deploy_name=mnist-cpu",
@@ -369,6 +371,7 @@
                 "--namespace=" + stepsNamespace,
                 "--test_dir=" + testDir,
                 "--artifacts_dir=" + artifactsDir,
+                "--workflow_name=" + params.workflowName,
                 "teardown",
               ]
             ),  // teardown

--- a/testing/workflows/components/workflows.jsonnet
+++ b/testing/workflows/components/workflows.jsonnet
@@ -10,4 +10,4 @@ local name = params.name;
 
 local prowEnv = workflows.parseEnv(params.prow_env);
 local bucket = params.bucket;
-std.prune(k.core.v1.list.new([workflows.parts(namespace, name).e2e(prowEnv, bucket, params.platform)]))
+std.prune(k.core.v1.list.new([workflows.parts(namespace, name).e2e(prowEnv, bucket, params.platform, params.workflowName)]))

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -59,7 +59,7 @@
     // name and platform should be given unique values.
     name: "somename",
     platform: "gke",
-    workflow_name: "",
+    workflowName: "",
 
     // In order to refer to objects between the current and outer-most object, we use a variable to create a name for that level:
     local tests = self,
@@ -240,7 +240,7 @@
             "--test_dir=" + tests.testDir,
             "--artifacts_dir=" + tests.artifactsDir,
             "--deploy_name=test-argo-deploy",
-            "--workflow_name=" + tests.workflow_name,
+            "--workflow_name=" + tests.workflowName,
             "deploy_argo",
           ],
         },
@@ -260,7 +260,7 @@
             "--test_dir=" + tests.testDir,
             "--artifacts_dir=" + tests.artifactsDir,
             "--deploy_name=test-katib",
-            "--workflow_name=" + tests.workflow_name,
+            "--workflow_name=" + tests.workflowName,
             "test_katib",
           ],
         },
@@ -279,7 +279,7 @@
             "--test_dir=" + tests.testDir,
             "--artifacts_dir=" + tests.artifactsDir,
             "--deploy_name=pytorch-job",
-            "--workflow_name=" + tests.workflow_name,
+            "--workflow_name=" + tests.workflowName,
             "deploy_pytorchjob",
             "--params=image=pytorch/pytorch:v0.2,num_workers=1",
           ],
@@ -369,7 +369,7 @@
     //
     // Create a new .jsonnet file for minikube and define the workflow there.
     // Reuse kfTests above to add the actual tests to that file.
-    e2e(prow_env, bucket, platform="minikube"):
+    e2e(prow_env, bucket, platform="minikube", workflowName="workflow"):
       // The name for the workspace to run the steps in
       local stepsNamespace = "kubeflow";
       // mountPath is the directory where the volume to store the test data
@@ -656,7 +656,7 @@
               "--namespace=" + stepsNamespace,
               "--test_dir=" + testDir,
               "--artifacts_dir=" + artifactsDir,
-              "--workflow_name=" + name,
+              "--workflow_name=" + workflowName,
               "deploy_minikube",
               "--vm_name=" + vmName,
               "--zone=" + zone,
@@ -669,7 +669,7 @@
               "--namespace=" + stepsNamespace,
               "--test_dir=" + testDir,
               "--artifacts_dir=" + artifactsDir,
-              "--workflow_name=" + name,
+              "--workflow_name=" + workflowName,
               "teardown_minikube",
               "--vm_name=" + vmName,
               "--zone=" + zone,
@@ -733,7 +733,7 @@
               "--test_dir=" + testDir,
               "--artifacts_dir=" + artifactsDir,
               "--deploy_name=pytorch-job",
-              "--workflow_name=" + name,
+              "--workflow_name=" + workflowName,
               "deploy_pytorchjob",
               "--params=image=pytorch/pytorch:v0.2,num_workers=1",
             ]),  // pytorchjob-deploy
@@ -754,7 +754,7 @@
               "--test_dir=" + testDir,
               "--artifacts_dir=" + artifactsDir,
               "--deploy_name=test-argo-deploy",
-              "--workflow_name=" + name,
+              "--workflow_name=" + workflowName,
               "deploy_argo",
             ]),  // test-argo-deploy
           ],  // templates


### PR DESCRIPTION
for https://github.com/kubeflow/testing/issues/301

The test name on testgrid has requirement:
1. kfctl and kfctl-beta both running at the same time, the test name cannot collide
2. cannot use the name of workflow which is specific per run, e.g. kubeflow-presubmit-kubeflow-e2e-minikube-2447-0c1503a-5646-cec4

So I am creating a new param, workflowName, for each e2e test. kfctl and kfctl-beta will have different workflowName with this.

/cc @jlewi 
/cc @richardsliu 

/hold
waiting for the presubmit result

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2462)
<!-- Reviewable:end -->
