### PR TITLE
add selector for minio deploy

### DIFF
--- a/kubeflow/pipeline/minio.libsonnet
+++ b/kubeflow/pipeline/minio.libsonnet
@@ -38,6 +38,11 @@
         namespace: namespace,
       },
       spec: {
+        selector: {
+          matchLabels: {
+            app: "minio",
+          },
+        },
         strategy: {
           type: "Recreate",
         },


### PR DESCRIPTION
Otherwise I saw 
```
ERROR handle object: patching object from cluster: merging object with existing state: Deployment.apps "minio" is invalid: spec.template.metadata.labels: Invalid value: map[string]string{"app":"minio"}: `selector` does not match template `labels`
```
when doing upgrade

Ref https://stackoverflow.com/questions/48582951/deployment-invalid-spec-template-metadata-labels-invalid-value

/assign @neuromage

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2466)
<!-- Reviewable:end -->
