### PR TITLE
add config file entries for deployment on GCP

### DIFF
--- a/bootstrap/config/kfctl_basic_auth.yaml
+++ b/bootstrap/config/kfctl_basic_auth.yaml
@@ -1,0 +1,43 @@
+# Config entry used for deploying on GCP with basic auth enabled
+# Load this file as object (KsonnetSpec)[https://github.com/kubeflow/kubeflow/blob/master/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go#L201]
+# All TODO fields need to be changed following user's input before apply
+# TODO change repo on the fly: set it to local tmp dir containing kubeflow registry
+repo: /path/to/local/tmp/containing/kubeflow
+components:
+  - metacontroller
+  - jupyter
+  - ambassador
+  - centraldashboard
+  - tf-job-operator
+  - cloud-endpoints
+  - cert-manager
+  - basic-auth-ingress
+  - pytorch-operator
+  - argo
+  - katib
+  - pipeline
+  - basic-auth
+parameters:
+  cloud-endpoints:
+    - name: secretName
+      value: admin-gcp-sa
+  cert-manager:
+    - name: acmeEmail
+      # TODO change value on the fly: use your email for ssl cert
+      value: johnDoe@acme.com
+  basic-auth-ingress:
+    - name: ipName
+      # TODO change value on the fly: value of ipName need to match resource name in deployment entry.
+      value: ipName
+    - name: hostname
+      # TODO change value on the fly: replace with user-provide parameters. This need to be fully qualified domain name to use with ingress.
+      value: <deployName>.endpoints.<Project>.cloud.goog
+  jupyter:
+    - name: platform
+      value: gke
+  ambassador:
+    - name: platform
+      value: gke
+    - name: ambassadorServiceType
+      value: NodePort
+platform: gcp

--- a/bootstrap/config/kfctl_iap.yaml
+++ b/bootstrap/config/kfctl_iap.yaml
@@ -1,0 +1,42 @@
+# Config entry used for deploying on GCP with IAP enabled
+# Load this file as object (KsonnetSpec)[https://github.com/kubeflow/kubeflow/blob/master/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go#L201]
+# All TODO fields need to be changed following user's input before apply
+# TODO change repo on the fly: set it to local tmp dir containing kubeflow registry
+repo: /path/to/local/tmp/containing/kubeflow
+components:
+  - metacontroller
+  - jupyter
+  - ambassador
+  - centraldashboard
+  - tf-job-operator
+  - cloud-endpoints
+  - cert-manager
+  - iap-ingress
+  - pytorch-operator
+  - argo
+  - katib
+  - pipeline
+parameters:
+  cloud-endpoints:
+    - name: secretName
+      value: admin-gcp-sa
+  cert-manager:
+    - name: acmeEmail
+      # TODO change value on the fly: use your email for ssl cert
+      value: johnDoe@acme.com
+  iap-ingress:
+    - name: ipName
+      # TODO change value on the fly: value of ipName need to match resource name in deployment entry.
+      value: ipName
+    - name: hostname
+      # TODO change value on the fly: replace with user-provide parameters. This need to be fully qualified domain name to use with ingress.
+      value: <deployName>.endpoints.<Project>.cloud.goog
+  jupyter:
+    - name: jupyterHubAuthenticator
+      value: iap
+    - name: platform
+      value: gke
+  ambassador:
+    - name: platform
+      value: gke
+platform: gcp


### PR DESCRIPTION
Define ksonnet app used by kfctl to deploy kubeflow on GCP
Provide 2 entries:
* IAP
* Basic Auth

File can be loaded as [KsonnetSpec](https://github.com/kubeflow/kubeflow/blob/master/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go#L201)

Package is not provided as [default pkg set](https://github.com/kubeflow/kubeflow/blob/master/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go#L63) should be good now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2482)
<!-- Reviewable:end -->
