### PR TITLE
Update Jupyter WebApp redirect URL and libsonnet

### DIFF
--- a/components/jupyter-web-app/default/kubeflow/jupyter/static/js/notebooks.js
+++ b/components/jupyter-web-app/default/kubeflow/jupyter/static/js/notebooks.js
@@ -56,7 +56,7 @@ function deleteNotebook(ns, nb) {
 };
 
 function connectNotebook(ns, nb) {
-  window.open(`/${ns}/${nb}`, "_blank");
+  window.open(`/notebook/${ns}/${nb}`, "_blank");
 };
 
 function createNotebook(ns) {

--- a/components/jupyter-web-app/rok/kubeflow/rokui/static/js/notebooks.js
+++ b/components/jupyter-web-app/rok/kubeflow/rokui/static/js/notebooks.js
@@ -56,7 +56,7 @@ function deleteNotebook(ns, nb) {
 };
 
 function connectNotebook(ns, nb) {
-  window.open(`/${ns}/${nb}`, "_blank");
+  window.open(`/notebook/${ns}/${nb}`, "_blank");
 };
 
 function createNotebook(ns) {

--- a/kubeflow/jupyter/jupyter-web-app.libsonnet
+++ b/kubeflow/jupyter/jupyter-web-app.libsonnet
@@ -83,6 +83,7 @@
       kind: "Service",
       metadata: {
         name: params.name,
+        namespace: params.namespace,
         labels: {
           run: params.name
         },
@@ -119,6 +120,7 @@
       kind: "Deployment",
       metadata: {
         name: params.name,
+        namespace: params.namespace,
         labels: {
           app: params.name,
         },


### PR DESCRIPTION
Following on changes from #2463, the UI must redirect to `/notebook/<namespace>/<name>`. Also a small fix in the `.libsonnet`, needed for #2481.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2490)
<!-- Reviewable:end -->
