### PR TITLE
fix workflow name

### DIFF
--- a/bootstrap/test_delete.sh
+++ b/bootstrap/test_delete.sh
@@ -15,7 +15,7 @@ gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS
 
 gcloud container clusters get-credentials ${CLUSTER} --zone ${ZONE} --project kubeflow-ci
 # delete test namespace
-kubectl delete namespace ${NAMESPACE}
+kubectl delete namespace ${NAMESPACE} || echo "Failed to delete namespace"
 
 for i in 1 2 3 4 5; do
   gcloud -q deployment-manager deployments delete ${DEPLOYMENT} --project=kubeflow-ci-deployment && break || sleep 30

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -25,7 +25,7 @@ workflows:
     - testing/*
     params:
       installIstio: true
-      workflowName: deployapp
+      workflowName: deployapp-istio
   # kfctl test runs tests on gke.
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: kfctl_test


### PR DESCRIPTION
Also, make test_delete catch error on delete namespace (which happens when previous step failed and namespace is not created)

/cc @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2492)
<!-- Reviewable:end -->
