### PR TITLE
Add jupyter-web-app to kfctl

### DIFF
--- a/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go
+++ b/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go
@@ -89,6 +89,7 @@ var DefaultComponents = []string{
 	"katib",
 	"metacontroller",
 	"notebooks",
+	"notebook-controller",
 	"openvino",
 	"pipeline",
 	"profiles",

--- a/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go
+++ b/bootstrap/pkg/apis/apps/ksonnet/v1alpha1/application_types.go
@@ -85,6 +85,7 @@ var DefaultComponents = []string{
 	"argo",
 	"centraldashboard",
 	"jupyter",
+	"jupyter-web-app",
 	"katib",
 	"metacontroller",
 	"notebooks",

--- a/components/jupyter-web-app/OWNERS
+++ b/components/jupyter-web-app/OWNERS
@@ -1,0 +1,5 @@
+approvers:
+  - ioandr
+  - kimwnasptd
+reviewers:
+  - vkoukis


### PR DESCRIPTION
Fix for #2481 
`make test-known-platforms-generate` from bootstrap creates the kubeflow apps with `jupyter-web-app` component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2500)
<!-- Reviewable:end -->
