### PR TITLE
Update kubespawner property name

### DIFF
--- a/kubeflow/jupyter/ui/default/spawner.py
+++ b/kubeflow/jupyter/ui/default/spawner.py
@@ -252,10 +252,11 @@ class KubeFormSpawner(KubeSpawner):
     return options
 
   @property
-  def singleuser_image_spec(self):
+  def image(self):
     return self.user_options['image']
 
-  image_spec = singleuser_image_spec
+  image_spec = image
+  singleuser_image_spec = image
 
   @property
   def cpu_guarantee(self):


### PR DESCRIPTION
kubespawner deprecated the `image_spec` property name in 0.10, in favor of just a plain `image` property name. Update the `KubeFormSpawner` property with that naming, and proxy the deprecated names to the new property.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2508)
<!-- Reviewable:end -->
