### PR TITLE
Add optional parameter ambassadorNodePort

### DIFF
--- a/kubeflow/common/ambassador.libsonnet
+++ b/kubeflow/common/ambassador.libsonnet
@@ -20,6 +20,10 @@
             name: "ambassador",
             port: 80,
             targetPort: 80,
+            [if (params.ambassadorServiceType == 'NodePort') &&
+                (params.ambassadorNodePort >= 30000) &&
+                (params.ambassadorNodePort <= 32767)
+             then 'nodePort']: params.ambassadorNodePort,
           },
         ],
         selector: {

--- a/kubeflow/common/prototypes/ambassador.jsonnet
+++ b/kubeflow/common/prototypes/ambassador.jsonnet
@@ -4,7 +4,8 @@
 // @shortDescription Ambassador
 // @param name string Name
 // @optionalParam platform string none supported platforms {none|gke|minikube}
-// @optionalParam ambassadorServiceType string ClusterIP The service type for the API Gateway.
+// @optionalParam ambassadorServiceType string ClusterIP The service type for the API Gateway {ClusterIP|NodePort|LoadBalancer}.
+// @optionalParam ambassadorNodePort number 0 Optional nodePort to use when ambassadorServiceType is NodePort {30000-32767}.
 // @optionalParam ambassadorImage string quay.io/datawire/ambassador:0.37.0 The image for the API Gateway.
 // @optionalParam replicas number 3 The number of replicas.
 


### PR DESCRIPTION
Used to set the ambassador service nodePort only when ambassadorServiceType is NodePort and ambassadorNodePort is within the valid range [30000-32767]. By default this parameter is set to 0. If ambassadorServiceType is NodePort and ambassadorNodePort is outside the valid range, then Kubernetes will automatically assign an available nodePort.

Contributes to closing the following issues:
#630
#1525

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2511)
<!-- Reviewable:end -->
