### PR TITLE
Add PD params back to prototypes

### DIFF
--- a/kubeflow/pipeline/pipeline.libsonnet
+++ b/kubeflow/pipeline/pipeline.libsonnet
@@ -12,9 +12,6 @@
     mysqlPvName: null,
     minioPvName: null,
     nfsPvName: null,
-    mysqlPd: null,
-    minioPd: null,
-    nfsPd: null,
   },
 
   parts:: {

--- a/kubeflow/pipeline/prototypes/pipeline.jsonnet
+++ b/kubeflow/pipeline/prototypes/pipeline.jsonnet
@@ -3,6 +3,9 @@
 // @description a Kubeflow pipeline deployment.
 // @shortDescription Kubeflow pipeline
 // @param name string Name to give to each of the components
+// @optionalParam mysqlPd string null GCE PD name to host mysql DB
+// @optionalParam minioPd string null GCE PD name to host minio
+// @optionalParam nfsPd string null GCE PD name to host NFS
 
 local k = import "k.libsonnet";
 local pipelineBase = import "kubeflow/pipeline/pipeline.libsonnet";

--- a/kubeflow/pipeline/storage.libsonnet
+++ b/kubeflow/pipeline/storage.libsonnet
@@ -8,17 +8,17 @@
   all(namespace, mysqlPvName=null, minioPvName=null, nfsPvName=null, mysqlPd=null, minioPd=null, nfsPd=null):: [
     $.parts(namespace).mysqlPvc(mysqlPd,mysqlPvName),
   ] +
-  [ if (nfsPvName != null) || (nfsPd!= null)
+  [ if (nfsPvName != "null") || (nfsPd!= "null")
     then $.parts(namespace).nfsServerPvc(nfsPd,nfsPvName)
     else $.parts(namespace).minioPvc(minioPd,minioPvName),
   ] +
-  [ if mysqlPd != null
+  [ if mysqlPd != "null"
     then $.parts(namespace).mysqlPv(mysqlPd),
   ] +
-  [ if minioPd != null
+  [ if minioPd != "null"
     then $.parts(namespace).minioPv(minioPd),
   ] +
-  [ if nfsPd != null
+  [ if nfsPd != "null"
     then $.parts(namespace).nfsServerPv(nfsPd),
   ],
   parts(namespace):: {
@@ -66,10 +66,10 @@
         } +
         // if GCE PD or PV is provided, use mysql-pv volume
         // Otherwise create PVC through default StorageClass
-        if (mysqlPvName != null) || (mysqlPd != null)  then {
+        if (mysqlPvName != null) || (mysqlPd != "null")  then {
          storageClassName: "",
          volumeName:
-           if mysqlPd != null
+           if mysqlPd != "null"
            then "mysql-pv"
            else mysqlPvName,
         } else {}
@@ -119,10 +119,10 @@
         } +
         // if GCE PD or PV is provided, use minio-pv volume
         // Otherwise create PVC through default StorageClass
-        if (minioPvName != null) || (minioPd != null)  then {
+        if (minioPvName != null) || (minioPd != "null")  then {
          storageClassName: "",
          volumeName:
-           if minioPd != null
+           if minioPd != "null"
            then "minio-pv"
            else minioPvName,
         } else {}
@@ -175,10 +175,10 @@
         } +
         // if GCE PD or PV is provided, use mysql-pv volume
         // Otherwise create PVC through default StorageClass
-        if (nfsPvName != null) || (nfsPd != null)  then {
+        if (nfsPvName != null) || (nfsPd != "null")  then {
          storageClassName: "",
          volumeName:
-           if nfsPd != null
+           if nfsPd != "null"
            then "nfs-server-pv"
            else nfsPvName,
         }


### PR DESCRIPTION
It's more user friendly to have them in prototypes so that we could define them during `ks generate`.  This shouldn't have impact on the project to upgrade pipelines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2525)
<!-- Reviewable:end -->
