### PR TITLE
Pytorch v1beta2 support

### DIFF
--- a/kubeflow/pytorch-job/prototypes/pytorch-job.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-job.jsonnet
@@ -67,7 +67,7 @@ else
 
 local masterSpec = replicaSpec("MASTER", num_masters, args, image);
 
-local job = if jobVersion == "v1beta1" || jobVersion == "v1alpha2" then {
+local job = if jobVersion == "v1beta1" || jobVersion == "v1beta2" then {
   apiVersion: "kubeflow.org/" + jobVersion,
   kind: "PyTorchJob",
   metadata: {

--- a/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
@@ -5,7 +5,7 @@
 // @param name string Name to give to each of the components
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
-// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch-operator:v0.4.0 The image for the PyTorchJob controller
+// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch-operator:v0.5.0-rc.1-1-g6807802 The image for the PyTorchJob controller
 // @optionalParam pytorchDefaultImage string null The default image to use for pytorch
 // @optionalParam pytorchJobVersion string v1beta1 which version of the PyTorchJob operator to use
 // @optionalParam deploymentScope string cluster The scope at which pytorch-operator should be deployed - valid values are cluster, namespace.

--- a/kubeflow/pytorch-job/pytorch-operator.libsonnet
+++ b/kubeflow/pytorch-job/pytorch-operator.libsonnet
@@ -6,21 +6,21 @@
                        $.parts(params, env).operatorRoleBinding(params.deploymentScope, params.deploymentNamespace),
                      ] +
 
-                     if params.pytorchJobVersion == "v1beta1" then
+                     if params.pytorchJobVersion == "v1beta2" then
                        [
-                         $.parts(params, env).crdV1beta1,
-                         $.parts(params, env).pytorchJobDeployV1beta1(params.pytorchJobImage, params.deploymentScope, params.deploymentNamespace),
+                         $.parts(params, env).crdV1beta2,
+                         $.parts(params, env).pytorchJobDeployV1beta2(params.pytorchJobImage, params.deploymentScope, params.deploymentNamespace),
                        ]
                      else
                        [
-                         $.parts(params, env).crdV1alpha2,
-                         $.parts(params, env).pytorchJobDeployV1alpha2(params.pytorchJobImage, params.deploymentScope, params.deploymentNamespace),
+                         $.parts(params, env).crdV1beta1,
+                         $.parts(params, env).pytorchJobDeployV1beta1(params.pytorchJobImage, params.deploymentScope, params.deploymentNamespace),
                        ],
 
   parts(params, env):: {
     local namespace = env.namespace,
 
-    crdV1alpha2: {
+    crdV1beta2: {
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",
       metadata: {
@@ -29,11 +29,14 @@
       spec: {
         group: "kubeflow.org",
         scope: "Namespaced",
-        version: "v1alpha2",
+        version: "v1beta2",
         names: {
           kind: "PyTorchJob",
           singular: "pytorchjob",
           plural: "pytorchjobs",
+        },
+        subresources: {
+          status: {},
         },
         validation: {
           openAPIV3Schema: {
@@ -118,7 +121,7 @@
       },
     },
 
-    pytorchJobDeployV1alpha2(image, deploymentScope, deploymentNamespace): {
+    pytorchJobDeployV1beta2(image, deploymentScope, deploymentNamespace): {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
       metadata: {
@@ -137,7 +140,7 @@
             containers: [
               {
                 command: std.prune([
-                  "/pytorch-operator.v2",
+                  "/pytorch-operator.v1beta2",
                   "--alsologtostderr",
                   "-v=1",
                   if deploymentScope == "namespace" then ("--namespace=" + deploymentNamespace),
@@ -190,7 +193,7 @@
           },
         },
       },
-    },  // pytorchJobDeployV1alpha2
+    },  // pytorchJobDeployV1beta2
 
     pytorchJobDeployV1beta1(image, deploymentScope, deploymentNamespace): {
       apiVersion: "extensions/v1beta1",
@@ -316,6 +319,7 @@
           ],
           resources: [
             "pytorchjobs",
+            "pytorchjobs/status",
           ],
           verbs: [
             "*",

--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -2,13 +2,13 @@
 // You can run the test as follows
 // jsonnet eval ./kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet --jpath ./kubeflow --jpath ./testing/workflows/lib/v1.7.0/
 
-local testSuite = import "kubeflow/common/testsuite.libsonnet";
 local pyjob = import "../pytorch-operator.libsonnet";
-local paramsv1alpha2 = {
+local testSuite = import "kubeflow/common/testsuite.libsonnet";
+local paramsv1beta2 = {
   image: "pyControllerImage",
   deploymentScope: "cluster",
   deploymentNamespace: "null",
-  pyjobVersion: "v1alpha2",
+  pyjobVersion: "v1beta2",
 };
 local paramsv1beta1 = {
   image: "pyControllerImage",
@@ -21,13 +21,13 @@ local env = {
   namespace: "test-kf-001",
 };
 
-local pyjobCrdV1alpha2 = pyjob.parts(paramsv1alpha2, env).crdV1alpha2;
-local pyjobCrdV1beta = pyjob.parts(paramsv1beta1, env).crdV1beta1;
+local pyjobCrdV1beta2 = pyjob.parts(paramsv1beta2, env).crdV1beta2;
+local pyjobCrdV1beta1 = pyjob.parts(paramsv1beta1, env).crdV1beta1;
 
-local pytorchJobDeployV1alpha1 = pyjob.parts(paramsv1alpha2, env).pytorchJobDeployV1alpha1;
+local pytorchJobDeployV1alpha1 = pyjob.parts(paramsv1beta2, env).pytorchJobDeployV1alpha1;
 local pytorchJobDeployV1beta1 = pyjob.parts(paramsv1beta1, env).pytorchJobDeployV1beta1;
 
-local expectedCrdV1alpha2 = {
+local expectedCrdV1beta2 = {
   apiVersion: "apiextensions.k8s.io/v1beta1",
   kind: "CustomResourceDefinition",
   metadata: {
@@ -72,7 +72,7 @@ local expectedCrdV1alpha2 = {
         },
       },
     },
-    version: "v1alpha2",
+    version: "v1beta2",
   },
 };
 
@@ -127,15 +127,15 @@ local expectedCrdV1beta1 = {
 
 local testCases = [
   {
-    actual: pyjob.parts(paramsv1alpha2, env).crdV1alpha2,
-    expected: expectedCrdV1alpha2,
+    actual: pyjob.parts(paramsv1beta2, env).crdV1beta2,
+    expected: expectedCrdV1beta2,
   },
   {
-    actual: pyjob.parts(paramsv1alpha2, env).crdV1beta1,
+    actual: pyjob.parts(paramsv1beta2, env).crdV1beta1,
     expected: expectedCrdV1beta1,
   },
   {
-    actual: pyjob.parts(paramsv1alpha2, env).pytorchJobDeployV1beta1(paramsv1beta1.image, paramsv1beta1.deploymentScope, paramsv1beta1.deploymentNamespace),
+    actual: pyjob.parts(paramsv1beta2, env).pytorchJobDeployV1beta1(paramsv1beta1.image, paramsv1beta1.deploymentScope, paramsv1beta1.deploymentNamespace),
     expected: {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",

--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -41,6 +41,9 @@ local expectedCrdV1beta2 = {
       plural: "pytorchjobs",
       singular: "pytorchjob",
     },
+    subresources: {
+      status: {},
+    },
     validation: {
       openAPIV3Schema: {
         properties: {


### PR DESCRIPTION
Adding Pytorch v1beta2 CRD with status sub resource

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2532)
<!-- Reviewable:end -->
