### PR TITLE
Update dashboard image to point to newest build

### DIFF
--- a/kubeflow/common/prototypes/centraldashboard.jsonnet
+++ b/kubeflow/common/prototypes/centraldashboard.jsonnet
@@ -3,7 +3,7 @@
 // @description centraldashboard Component
 // @shortDescription centraldashboard
 // @param name string Name
-// @optionalParam image string gcr.io/kubeflow-images-public/centraldashboard:v0.4.0 Image for the central dashboard
+// @optionalParam image string gcr.io/kubeflow-images-public/centraldashboard:v20190222-v0.4.0-rc.1-152-g1de09b7a Image for the central dashboard
 
 local centraldashboard = import "kubeflow/common/centraldashboard.libsonnet";
 local instance = centraldashboard.new(env, params);


### PR DESCRIPTION
Fixes: #2524 
Child of #2359

##About
This change just updates the default image for the dashboard to the version build from #2359.

/cc @abhi-g 
/assign @jlewi 
/assign @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2540)
<!-- Reviewable:end -->
