### PR TITLE
Temporary change to pin kubeflow to the latest verified tf-operator commit 

### DIFF
--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -647,7 +647,7 @@
               ["/usr/local/bin/checkout.sh", srcRootDir],
               env_vars=[{
                 name: "EXTRA_REPOS",
-                value: "kubeflow/tf-operator@HEAD;kubeflow/testing@HEAD",
+                value: "kubeflow/tf-operator@4652bad;kubeflow/testing@HEAD",
               }],
             ),
             buildTemplate("test-dir-delete", [


### PR DESCRIPTION
This is a temporary change so that we could merge [this PR](https://github.com/kubeflow/tf-operator/pull/945), which renames python top level package in tf-operator repo.  Once merged, it likely breaks kubeflow checkout tests since the tf-operator imports in external repos no longer are correct. 
To avoid this probelm, we temporarily pin checkout test to the latest tf-operator commit and will resume it once all import renaming in external repos are resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2555)
<!-- Reviewable:end -->
