### PR TITLE
Add extra permissions to ClusterRole 'pipeline-runner'

### DIFF
--- a/kubeflow/pipeline/pipeline-apiserver.libsonnet
+++ b/kubeflow/pipeline/pipeline-apiserver.libsonnet
@@ -230,6 +230,20 @@
           verbs: [
             "create",
             "delete",
+            "get",
+          ],
+        },
+        {
+          apiGroups: [
+            "snapshot.storage.k8s.io",
+          ],
+          resources: [
+            "volumesnapshots",
+          ],
+          verbs: [
+            "create",
+            "delete",
+            "get",
           ],
         },
         {


### PR DESCRIPTION
Hello,

as part of our work on kubeflow/pipelines#801. we need to include a few extra permissions to the service account which runs the pipeline (`pipeline-runner`) so it can `create`, `get` and `delete` `PVC`s and `VolumeSnapshot`s.

It can already `create` and `delete` `PVC`s, so we update the rule to add the verb `get`. We also make a new rule entry referring to `VolumeSnapshot` resources with the verbs `create`, `delete` and `get`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2556)
<!-- Reviewable:end -->
