### PR TITLE
new deploy API following Open API format

### DIFF
--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -20,54 +20,253 @@ tags:
 schemes:
 - "https"
 paths:
-  /projects/{project}/deployments:
+  /projects/{project}/configs:
     post:
       tags:
-      - "deployment"
-      summary: "Create a new kubeflow deployment on GCP"
-      description: ""
-      operationId: "createDeployment"
+        - "config"
+      summary: "Create a new kubeflow config entry on source repo"
+      security:
+        - BearerToken: []
+      operationId: "createConfig"
       consumes:
-      - "application/json"
+        - "application/json"
       produces:
-      - "application/json"
+        - "application/json"
       parameters:
-      - in: "path"
-        name: "project"
-        description: "Project needs to be created"
-        required: true
-        type: "string"
-      - in: "body"
-        name: "body"
-        description: "Deployment needs to be created"
-        required: true
-        schema:
-          $ref: "#/definitions/CreateDeployment"
-      responses:
-        200:
-          description: "successful operation"
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "body"
+          name: "body"
+          description: "Config needs to be created"
+          required: true
           schema:
-            $ref: "#/definitions/CreateOperation"
+            $ref: "#/definitions/KfConfig"
+      responses:
         405:
           description: "Invalid input"
           schema:
-            $ref: "#/definitions/InvalidInput"
+            $ref: "#/definitions/ErrorMessage"
+    get:
+      tags:
+        - "config"
+      summary: "List kubeflow config entries in target project"
+      security:
+        - BearerToken: []
+      operationId: "listConfigs"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "Kubeflow config entries"
+          schema:
+            $ref: "#/definitions/KfConfigEntries"
+        405:
+          description: "Invalid input"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+  /projects/{project}/configs/{config}/version/{version}/file:
+    get:
+      tags:
+        - "config"
+      summary: "Get kubeflow config entry file"
+      security:
+        - BearerToken: []
+      operationId: "getConfigFile"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "config"
+          description: "config entry name"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "version"
+          description: "config entry kubeflow version"
+          required: true
+          type: "string"
+        - in: "query"
+          name: "filepath"
+          description: "file relative path"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "Kubeflow config entries"
+          schema:
+            $ref: "#/definitions/KfConfigFile"
+        404:
+          description: "Entry not found"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+        405:
+          description: "Invalid input"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+    put:
+      tags:
+        - "config"
+      description: "Update kubeflow config entry file"
+      security:
+        - BearerToken: []
+      operationId: "putConfigFile"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "config"
+          description: "config entry name"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "version"
+          description: "config entry kubeflow version"
+          required: true
+          type: "string"
+        - in: "body"
+          name: "body"
+          description: "file object to update"
+          required: true
+          schema:
+            $ref: "#/definitions/KfConfigFile"
+      responses:
+        405:
+          description: "Invalid input"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+  /projects/{project}/deployments:
+    post:
+      tags:
+        - "deployment"
+      summary: "Create a new kubeflow deployment on GCP"
+      security:
+        - BearerToken: []
+      operationId: "createDeployment"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "body"
+          name: "body"
+          description: "Deployment name"
+          required: true
+          schema:
+            $ref: "#/definitions/KfDeployment"
+      responses:
+        405:
+          description: "Invalid input"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+  /projects/{project}/deployments/{deployment}:
+    get:
+      tags:
+        - "deployment"
+      description: "Get kubeflow deployment status"
+      security:
+        - BearerToken: []
+      operationId: "getDeployment"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "deployment"
+          description: "Deployment name"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "deployment status"
+          schema:
+            $ref: "#/definitions/KfDeployment"
+        405:
+          description: "Invalid input"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
 definitions:
-  CreateDeployment:
+  BasicAuthIngress:
+    type: "object"
+    properties:
+      username:
+        type: "string"
+      passwordHash:
+        type: "string"
+  DeploymentMetadata:
     type: "object"
     properties:
       name:
         type: "string"
-      version:
-        type: "string"
       namespace:
         type: "string"
-      zone:
+      version:
         type: "string"
       email:
         type: "string"
+      zone:
+        type: "string"
+  KfDeployment:
+    type: "object"
+    properties:
+      metadata:
+        $ref: "#/definitions/DeploymentMetadata"
       sAClientId:
         type: "string"
+      status:
+        type: "string"
+  ErrorMessage:
+    type: "object"
+    properties:
+      errorMessage:
+        type: "string"
+  IapIngress:
+    type: "object"
+    properties:
+      clientId:
+        type: "string"
+      clientSecret:
+        type: "string"
+  KfConfig:
+    type: "object"
+    properties:
+      metadata:
+        $ref: "#/definitions/DeploymentMetadata"
       extraComponents:
         type: "array"
         items:
@@ -82,6 +281,21 @@ definitions:
         $ref: "#/definitions/BasicAuthIngress"
       storageOption:
         $ref: "#/definitions/StorageOption"
+  KfConfigEntries:
+    type: "object"
+    properties:
+      configs:
+        type: "array"
+        items:
+          $ref: "#/definitions/DeploymentMetadata"
+  KfConfigFile:
+    type: "object"
+    properties:
+      file:
+        type: "string"
+        format: "byte"
+      filepath:
+        type: "string"
   Parameter:
     type: "object"
     properties:
@@ -91,42 +305,14 @@ definitions:
         type: "string"
       value:
         type: "string"
-  IapIngress:
-    type: "object"
-    properties:
-      clientId:
-        type: "string"
-      clientSecret:
-        type: "string"
-  BasicAuthIngress:
-    type: "object"
-    properties:
-      username:
-        type: "string"
-      passwordHash:
-        type: "string"
   StorageOption:
     type: "object"
     properties:
       createPersistentStorage:
         type: "boolean"
-  ApiResponse:
-    type: "object"
-    properties:
-      code:
-        type: "integer"
-        format: "int32"
-      type:
-        type: "string"
-      message:
-        type: "string"
-  CreateOperation:
-    type: "object"
-    properties:
-      operationId:
-        type: "string"
-  InvalidInput:
-    type: "object"
-    properties:
-      errorMessage:
-        type: "string"
+securityDefinitions:
+  BearerToken:
+    description: "Bearer Token authentication"
+    type: apiKey
+    name: "authorization"
+    in: "header"

--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -106,7 +106,7 @@ paths:
           type: "string"
         - in: "path"
           name: "version"
-          description: "config entry kubeflow version"
+          description: "kubeflow git version that config entry based on"
           required: true
           type: "string"
       responses:
@@ -144,7 +144,7 @@ paths:
           type: "string"
         - in: "path"
           name: "version"
-          description: "config entry kubeflow version"
+          description: "kubeflow git version that config entry based on"
           required: true
           type: "string"
         - in: "query"
@@ -188,7 +188,7 @@ paths:
           type: "string"
         - in: "path"
           name: "version"
-          description: "config entry kubeflow version"
+          description: "kubeflow git version that config entry based on"
           required: true
           type: "string"
         - in: "body"
@@ -318,6 +318,7 @@ definitions:
         type: "string"
   DeploymentMetadata:
     type: "object"
+    description: "kubeflow Deployment share same metadata as kubeflow config"
     properties:
       name:
         type: "string"
@@ -340,7 +341,13 @@ definitions:
           sAClientId:
             type: "string"
       status:
-        type: "string"
+        type: "object"
+        properties:
+          message:
+            type: "string"
+          condition:
+            description: "Status of the condition, one of Healthy, Unhealthy, Unknown."
+            type: "string"
   ErrorMessage:
     type: "object"
     properties:
@@ -376,7 +383,15 @@ definitions:
           storageOption:
             $ref: "#/definitions/StorageOption"
       status:
-        type: "string"
+        type: "object"
+        properties:
+          version:
+            type: "string"
+          message:
+            type: "string"
+          condition:
+            description: "Status of the condition, one of Clean, Dirty, Unknown."
+            type: "string"
   KfConfigEntries:
     type: "object"
     properties:

--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -9,7 +9,6 @@ info:
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-host: "https://www.kubeflow.org/"
 basePath: "/kfctl/v1"
 tags:
 - name: "deployment"

--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -10,7 +10,7 @@ info:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 host: "https://www.kubeflow.org/"
-basePath: "/kfctl"
+basePath: "/kfctl/v1"
 tags:
 - name: "deployment"
   description: "A kubeflow deployment on GCP"
@@ -20,7 +20,7 @@ tags:
 schemes:
 - "https"
 paths:
-  /e2eDeploy:
+  /projects/{project}/deployments:
     post:
       tags:
       - "deployment"
@@ -32,9 +32,14 @@ paths:
       produces:
       - "application/json"
       parameters:
+      - in: "path"
+        name: "project"
+        description: "Project needs to be created"
+        required: true
+        type: "string"
       - in: "body"
         name: "body"
-        description: "Pet object that needs to be added to the store"
+        description: "Deployment needs to be created"
         required: true
         schema:
           $ref: "#/definitions/CreateDeployment"
@@ -53,19 +58,13 @@ definitions:
     properties:
       name:
         type: "string"
+      version:
+        type: "string"
       namespace:
-        type: "string"
-      cluster:
-        type: "string"
-      project:
         type: "string"
       zone:
         type: "string"
-      token:
-        type: "string"
       email:
-        type: "string"
-      ipName:
         type: "string"
       sAClientId:
         type: "string"

--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -1,0 +1,133 @@
+swagger: "2.0"
+info:
+  description: "Deployment API."
+  version: "1.0.0"
+  title: "Kubeflow Deployment"
+  termsOfService: "https://www.kubeflow.org/"
+  contact:
+    email: "kubeflow-engineering@google.com"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "https://www.kubeflow.org/"
+basePath: "/kfctl"
+tags:
+- name: "deployment"
+  description: "A kubeflow deployment on GCP"
+  externalDocs:
+    description: "Find out more"
+    url: "https://www.kubeflow.org/docs/started/getting-started-gke/"
+schemes:
+- "https"
+paths:
+  /e2eDeploy:
+    post:
+      tags:
+      - "deployment"
+      summary: "Create a new kubeflow deployment on GCP"
+      description: ""
+      operationId: "createDeployment"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/CreateDeployment"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/CreateOperation"
+        405:
+          description: "Invalid input"
+          schema:
+            $ref: "#/definitions/InvalidInput"
+definitions:
+  CreateDeployment:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      namespace:
+        type: "string"
+      cluster:
+        type: "string"
+      project:
+        type: "string"
+      zone:
+        type: "string"
+      token:
+        type: "string"
+      email:
+        type: "string"
+      ipName:
+        type: "string"
+      sAClientId:
+        type: "string"
+      extraComponents:
+        type: "array"
+        items:
+          type: "string"
+      parameters:
+        type: "array"
+        items:
+          $ref: "#/definitions/Parameter"
+      iapIngress:
+        $ref: "#/definitions/IapIngress"
+      basicAuthIngress:
+        $ref: "#/definitions/BasicAuthIngress"
+      storageOption:
+        $ref: "#/definitions/StorageOption"
+  Parameter:
+    type: "object"
+    properties:
+      component:
+        type: "string"
+      name:
+        type: "string"
+      value:
+        type: "string"
+  IapIngress:
+    type: "object"
+    properties:
+      clientId:
+        type: "string"
+      clientSecret:
+        type: "string"
+  BasicAuthIngress:
+    type: "object"
+    properties:
+      username:
+        type: "string"
+      passwordHash:
+        type: "string"
+  StorageOption:
+    type: "object"
+    properties:
+      createPersistentStorage:
+        type: "boolean"
+  ApiResponse:
+    type: "object"
+    properties:
+      code:
+        type: "integer"
+        format: "int32"
+      type:
+        type: "string"
+      message:
+        type: "string"
+  CreateOperation:
+    type: "object"
+    properties:
+      operationId:
+        type: "string"
+  InvalidInput:
+    type: "object"
+    properties:
+      errorMessage:
+        type: "string"

--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -11,22 +11,22 @@ info:
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
 basePath: "/kfctl/v1"
 tags:
-- name: "deployment"
-  description: "A kubeflow deployment on GCP"
-  externalDocs:
-    description: "Find out more"
-    url: "https://www.kubeflow.org/docs/started/getting-started-gke/"
+  - name: "deployment"
+    description: "A kubeflow deployment on GCP"
+    externalDocs:
+      description: "Find out more"
+      url: "https://www.kubeflow.org/docs/started/getting-started-gke/"
 schemes:
-- "https"
+  - "https"
 paths:
   /projects/{project}/configs:
     post:
       tags:
-        - "configEntry"
+        - "KfConfig"
       summary: "Create a new kubeflow config entry on source repo"
       security:
         - BearerToken: []
-      operationId: "createConfigEntry"
+      operationId: "createKfConfig"
       consumes:
         - "application/json"
       produces:
@@ -35,6 +35,11 @@ paths:
         - in: "path"
           name: "project"
           description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "query"
+          name: "email"
+          description: "Email of user who make the request"
           required: true
           type: "string"
         - in: "body"
@@ -56,11 +61,11 @@ paths:
           description: "Internal Server Error"
     get:
       tags:
-        - "configEntry"
+        - "KfConfig"
       summary: "List kubeflow config entries in target project"
       security:
         - BearerToken: []
-      operationId: "listConfigEntries"
+      operationId: "listKfConfigs"
       consumes:
         - "application/json"
       produces:
@@ -80,15 +85,15 @@ paths:
           description: "Unauthorized"
         500:
           description: "Internal Server Error"
-  /projects/{project}/configs/{config}/version/{version}:
+  /projects/{project}/configs/{config}/kfversion/{kfversion}:
     delete:
       tags:
-        - "configEntry"
+        - "KfConfig"
       summary: "Delete kubeflow config entry"
       description: "internal use only, alpha stage"
       security:
         - BearerToken: []
-      operationId: "deleteConfigEntry"
+      operationId: "deleteKfConfig"
       consumes:
         - "application/json"
       produces:
@@ -105,7 +110,7 @@ paths:
           required: true
           type: "string"
         - in: "path"
-          name: "version"
+          name: "kfversion"
           description: "kubeflow git version that config entry based on"
           required: true
           type: "string"
@@ -118,7 +123,7 @@ paths:
           description: "Entry not found"
         500:
           description: "Internal Server Error"
-  /projects/{project}/configs/{config}/version/{version}/file:
+  /projects/{project}/configs/{config}/kfversion/{kfversion}/file:
     get:
       tags:
         - "configFile"
@@ -143,7 +148,7 @@ paths:
           required: true
           type: "string"
         - in: "path"
-          name: "version"
+          name: "kfversion"
           description: "kubeflow git version that config entry based on"
           required: true
           type: "string"
@@ -187,7 +192,7 @@ paths:
           required: true
           type: "string"
         - in: "path"
-          name: "version"
+          name: "kfversion"
           description: "kubeflow git version that config entry based on"
           required: true
           type: "string"
@@ -224,6 +229,11 @@ paths:
         - in: "path"
           name: "project"
           description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "query"
+          name: "email"
+          description: "Email of user who make the request and should have access to kubeflow service"
           required: true
           type: "string"
         - in: "body"
@@ -316,7 +326,7 @@ definitions:
         type: "string"
       passwordHash:
         type: "string"
-  DeploymentMetadata:
+  Metadata:
     type: "object"
     description: "kubeflow Deployment share same metadata as kubeflow config"
     properties:
@@ -324,20 +334,16 @@ definitions:
         type: "string"
       namespace:
         type: "string"
-      version:
-        type: "string"
-      email:
-        type: "string"
-      zone:
-        type: "string"
   KfDeployment:
     type: "object"
     properties:
       metadata:
-        $ref: "#/definitions/DeploymentMetadata"
+        $ref: "#/definitions/Metadata"
       spec:
         type: "object"
         properties:
+          kfConfigRef:
+            $ref: "#/definitions/KfConfigRef"
           sAClientId:
             type: "string"
       status:
@@ -364,10 +370,12 @@ definitions:
     type: "object"
     properties:
       metadata:
-        $ref: "#/definitions/DeploymentMetadata"
+        $ref: "#/definitions/Metadata"
       spec:
         type: "object"
         properties:
+          kfConfigRef:
+            $ref: "#/definitions/KfConfigRef"
           extraComponents:
             type: "array"
             items:
@@ -385,7 +393,7 @@ definitions:
       status:
         type: "object"
         properties:
-          version:
+          kfversion:
             type: "string"
           message:
             type: "string"
@@ -398,7 +406,7 @@ definitions:
       configs:
         type: "array"
         items:
-          $ref: "#/definitions/DeploymentMetadata"
+          $ref: "#/definitions/KfConfigRef"
   KfConfigFile:
     type: "object"
     properties:
@@ -406,6 +414,15 @@ definitions:
         type: "string"
         format: "byte"
       filepath:
+        type: "string"
+  KfConfigRef:
+    type: "object"
+    description: "kubeflow config location in source repo of target project"
+    properties:
+      name:
+        type: "string"
+      kfversion:
+        description: "kubeflow git version that config entry based on"
         type: "string"
   Parameter:
     type: "object"

--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -22,11 +22,11 @@ paths:
   /projects/{project}/configs:
     post:
       tags:
-        - "config"
+        - "configEntry"
       summary: "Create a new kubeflow config entry on source repo"
       security:
         - BearerToken: []
-      operationId: "createConfig"
+      operationId: "createConfigEntry"
       consumes:
         - "application/json"
       produces:
@@ -44,17 +44,23 @@ paths:
           schema:
             $ref: "#/definitions/KfConfig"
       responses:
-        405:
-          description: "Invalid input"
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        403:
+          description: "Forbidden"
           schema:
             $ref: "#/definitions/ErrorMessage"
+        500:
+          description: "Internal Server Error"
     get:
       tags:
-        - "config"
+        - "configEntry"
       summary: "List kubeflow config entries in target project"
       security:
         - BearerToken: []
-      operationId: "listConfigs"
+      operationId: "listConfigEntries"
       consumes:
         - "application/json"
       produces:
@@ -67,17 +73,55 @@ paths:
           type: "string"
       responses:
         200:
-          description: "Kubeflow config entries"
+          description: "OK"
           schema:
             $ref: "#/definitions/KfConfigEntries"
-        405:
-          description: "Invalid input"
-          schema:
-            $ref: "#/definitions/ErrorMessage"
+        401:
+          description: "Unauthorized"
+        500:
+          description: "Internal Server Error"
+  /projects/{project}/configs/{config}/version/{version}:
+    delete:
+      tags:
+        - "configEntry"
+      summary: "Delete kubeflow config entry"
+      description: "internal use only, alpha stage"
+      security:
+        - BearerToken: []
+      operationId: "deleteConfigEntry"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "config"
+          description: "config entry name"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "version"
+          description: "config entry kubeflow version"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Entry not found"
+        500:
+          description: "Internal Server Error"
   /projects/{project}/configs/{config}/version/{version}/file:
     get:
       tags:
-        - "config"
+        - "configFile"
       summary: "Get kubeflow config entry file"
       description: "internal use only, alpha stage"
       security:
@@ -110,20 +154,18 @@ paths:
           type: "string"
       responses:
         200:
-          description: "Kubeflow config entries"
+          description: "OK"
           schema:
             $ref: "#/definitions/KfConfigFile"
+        401:
+          description: "Unauthorized"
         404:
           description: "Entry not found"
-          schema:
-            $ref: "#/definitions/ErrorMessage"
-        405:
-          description: "Invalid input"
-          schema:
-            $ref: "#/definitions/ErrorMessage"
+        500:
+          description: "Internal Server Error"
     put:
       tags:
-        - "config"
+        - "configFile"
       summary: "Update kubeflow config entry file"
       description: "internal use only, alpha stage"
       security:
@@ -156,10 +198,16 @@ paths:
           schema:
             $ref: "#/definitions/KfConfigFile"
       responses:
-        405:
-          description: "Invalid input"
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        403:
+          description: "Forbidden"
           schema:
             $ref: "#/definitions/ErrorMessage"
+        500:
+          description: "Internal Server Error"
   /projects/{project}/deployments:
     post:
       tags:
@@ -185,10 +233,16 @@ paths:
           schema:
             $ref: "#/definitions/KfDeployment"
       responses:
-        405:
-          description: "Invalid input"
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        403:
+          description: "Forbidden"
           schema:
             $ref: "#/definitions/ErrorMessage"
+        500:
+          description: "Internal Server Error"
   /projects/{project}/deployments/{deployment}:
     get:
       tags:
@@ -214,13 +268,46 @@ paths:
           type: "string"
       responses:
         200:
-          description: "deployment status"
+          description: "OK"
           schema:
             $ref: "#/definitions/KfDeployment"
-        405:
-          description: "Invalid input"
-          schema:
-            $ref: "#/definitions/ErrorMessage"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Entry not found"
+        500:
+          description: "Internal Server Error"
+    delete:
+      tags:
+        - "deployment"
+      description: "Delete a kubeflow deployment instance"
+      security:
+        - BearerToken: []
+      operationId: "deleteDeployment"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "project"
+          description: "gcp project string id"
+          required: true
+          type: "string"
+        - in: "path"
+          name: "deployment"
+          description: "Deployment name"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Entry not found"
+        500:
+          description: "Internal Server Error"
 definitions:
   BasicAuthIngress:
     type: "object"

--- a/bootstrap/api/swagger.yaml
+++ b/bootstrap/api/swagger.yaml
@@ -79,6 +79,7 @@ paths:
       tags:
         - "config"
       summary: "Get kubeflow config entry file"
+      description: "internal use only, alpha stage"
       security:
         - BearerToken: []
       operationId: "getConfigFile"
@@ -123,7 +124,8 @@ paths:
     put:
       tags:
         - "config"
-      description: "Update kubeflow config entry file"
+      summary: "Update kubeflow config entry file"
+      description: "internal use only, alpha stage"
       security:
         - BearerToken: []
       operationId: "putConfigFile"
@@ -245,8 +247,11 @@ definitions:
     properties:
       metadata:
         $ref: "#/definitions/DeploymentMetadata"
-      sAClientId:
-        type: "string"
+      spec:
+        type: "object"
+        properties:
+          sAClientId:
+            type: "string"
       status:
         type: "string"
   ErrorMessage:
@@ -266,20 +271,25 @@ definitions:
     properties:
       metadata:
         $ref: "#/definitions/DeploymentMetadata"
-      extraComponents:
-        type: "array"
-        items:
-          type: "string"
-      parameters:
-        type: "array"
-        items:
-          $ref: "#/definitions/Parameter"
-      iapIngress:
-        $ref: "#/definitions/IapIngress"
-      basicAuthIngress:
-        $ref: "#/definitions/BasicAuthIngress"
-      storageOption:
-        $ref: "#/definitions/StorageOption"
+      spec:
+        type: "object"
+        properties:
+          extraComponents:
+            type: "array"
+            items:
+              type: "string"
+          parameters:
+            type: "array"
+            items:
+              $ref: "#/definitions/Parameter"
+          iapIngress:
+            $ref: "#/definitions/IapIngress"
+          basicAuthIngress:
+            $ref: "#/definitions/BasicAuthIngress"
+          storageOption:
+            $ref: "#/definitions/StorageOption"
+      status:
+        type: "string"
   KfConfigEntries:
     type: "object"
     properties:


### PR DESCRIPTION
New deployment API supports 2 types of entries:
* config entry
each entry maps to a set of config files stored in source repo or Github which can fully define a deployment entry. 
* deployment entry
each entry maps to a kubeflow instance on GCP which include resources like GKE, Endpoint, Storage, Service Account, IAM bindings. Deployment entry is created following definition in the corresponding config entry.

Goals of new API include simplify reuse configs and support configs customization. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2564)
<!-- Reviewable:end -->
