### PR TITLE
Enabling EFS on AWS for Tensorboard

### DIFF
--- a/kubeflow/tensorboard/aws.libsonnet
+++ b/kubeflow/tensorboard/aws.libsonnet
@@ -10,45 +10,70 @@
 
   tbDeployment::
     super.tbDeployment +
+    deployment.mixin.spec.template.spec.withVolumesMixin(
+      if params.efsEnabled then (
+        [{
+          name: params.efsVolumeName,
+          persistentVolumeClaim: {
+            claimName: params.efsPvcName,
+          },
+        }]
+      ) else [],
+    ) +
     deployment.mapContainers(
       function(c) {
         result:: c + c.withEnvMixin(
-          [
-            {
-              name: "AWS_ACCESS_KEY_ID",
-              valueFrom: {
-                secretKeyRef: {
-                  name: params.s3SecretName,
-                  key: params.s3SecretAccesskeyidKeyName,
+          if params.s3Enabled then (
+            [
+              {
+                name: "AWS_ACCESS_KEY_ID",
+                valueFrom: {
+                  secretKeyRef: {
+                    name: params.s3SecretName,
+                    key: params.s3SecretAccesskeyidKeyName,
+                  },
                 },
               },
-            },
-            {
-              name: "AWS_SECRET_ACCESS_KEY",
-              valueFrom: {
-                secretKeyRef: {
-                  name: params.s3SecretName,
-                  key: params.s3SecretSecretaccesskeyKeyName,
+              {
+                name: "AWS_SECRET_ACCESS_KEY",
+                valueFrom: {
+                  secretKeyRef: {
+                    name: params.s3SecretName,
+                    key: params.s3SecretSecretaccesskeyKeyName,
+                  },
                 },
               },
-            },
-            {
-              name: "AWS_REGION",
-              value: params.s3AwsRegion,
-            },
-            {
-              name: "S3_USE_HTTPS",
-              value: params.s3UseHttps,
-            },
-            {
-              name: "S3_VERIFY_SSL",
-              value: params.s3VerifySsl,
-            },
-            {
-              name: "S3_ENDPOINT",
-              value: params.s3Endpoint,
-            },
-          ]
+              {
+                name: "AWS_REGION",
+                value: params.s3AwsRegion,
+              },
+              {
+                name: "S3_REGION",
+                value: params.s3AwsRegion,
+              },
+              {
+                name: "S3_USE_HTTPS",
+                value: params.s3UseHttps,
+              },
+              {
+                name: "S3_VERIFY_SSL",
+                value: params.s3VerifySsl,
+              },
+              {
+                name: "S3_ENDPOINT",
+                value: params.s3Endpoint,
+              },
+            ]
+          ) else [],
+        ) + c.withVolumeMountsMixin(
+          if params.efsEnabled then (
+            [
+              {
+                mountPath: params.efsMountPath,
+                name: params.efsVolumeName,
+              },
+            ]
+          ) else [],
         ),
       }.result,
     ),

--- a/kubeflow/tensorboard/prototypes/tensorboard-aws.jsonnet
+++ b/kubeflow/tensorboard/prototypes/tensorboard-aws.jsonnet
@@ -8,6 +8,7 @@
 // @optionalParam servicePort number 9000 Name of the servicePort
 // @optionalParam serviceType string ClusterIP The service type for tensorboard service
 // @optionalParam defaultTbImage string tensorflow/tensorflow:1.8.0 default tensorboard image to use
+// @optionalParam s3Enabled string false Wether or not to use S3
 // @optionalParam s3SecretName string null Name of the k8s secrets containing S3 credentials
 // @optionalParam s3SecretAccesskeyidKeyName string null Name of the key in the k8s secret containing AWS_ACCESS_KEY_ID
 // @optionalParam s3SecretSecretaccesskeyKeyName string null Name of the key in the k8s secret containing AWS_SECRET_ACCESS_KEY
@@ -15,6 +16,10 @@
 // @optionalParam s3UseHttps string true Whether or not to use https
 // @optionalParam s3VerifySsl string true Whether or not to verify https certificates for S3 connections
 // @optionalParam s3Endpoint string s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint
+// @optionalParam efsEnabled string false Wether or not to use EFS
+// @optionalParam efsPvcName string null Name of the Persistent Volume Claim used for EFS
+// @optionalParam efsVolumeName string null Name of the Volume to mount to the pod
+// @optionalParam efsMountPath string null Where to mount the EFS Volume
 
 local subtype = import "kubeflow/tensorboard/aws.libsonnet";
 local basetype = import "kubeflow/tensorboard/tensorboard.libsonnet";

--- a/kubeflow/tensorboard/prototypes/tensorboard-aws.jsonnet
+++ b/kubeflow/tensorboard/prototypes/tensorboard-aws.jsonnet
@@ -8,7 +8,7 @@
 // @optionalParam servicePort number 9000 Name of the servicePort
 // @optionalParam serviceType string ClusterIP The service type for tensorboard service
 // @optionalParam defaultTbImage string tensorflow/tensorflow:1.8.0 default tensorboard image to use
-// @optionalParam s3Enabled string false Wether or not to use S3
+// @optionalParam s3Enabled string false Whether or not to use S3
 // @optionalParam s3SecretName string null Name of the k8s secrets containing S3 credentials
 // @optionalParam s3SecretAccesskeyidKeyName string null Name of the key in the k8s secret containing AWS_ACCESS_KEY_ID
 // @optionalParam s3SecretSecretaccesskeyKeyName string null Name of the key in the k8s secret containing AWS_SECRET_ACCESS_KEY
@@ -16,7 +16,7 @@
 // @optionalParam s3UseHttps string true Whether or not to use https
 // @optionalParam s3VerifySsl string true Whether or not to verify https certificates for S3 connections
 // @optionalParam s3Endpoint string s3.us-west-1.amazonaws.com URL for your s3-compatible endpoint
-// @optionalParam efsEnabled string false Wether or not to use EFS
+// @optionalParam efsEnabled string false Whether or not to use EFS
 // @optionalParam efsPvcName string null Name of the Persistent Volume Claim used for EFS
 // @optionalParam efsVolumeName string null Name of the Volume to mount to the pod
 // @optionalParam efsMountPath string null Where to mount the EFS Volume

--- a/kubeflow/tensorboard/tests/tensorboard-aws_test.jsonnet
+++ b/kubeflow/tensorboard/tests/tensorboard-aws_test.jsonnet
@@ -8,6 +8,7 @@ local params = {
   servicePort: "9000",
   serviceType: "LoadBalancer",
   defaultTbImage: "tensorflow/tensorflow:1.9.0",
+  s3Enabled: true,
   s3SecretName: "foo",
   s3SecretAccesskeyidKeyName: "bar",
   s3SecretSecretaccesskeyKeyName: "baz",
@@ -15,6 +16,10 @@ local params = {
   s3UseHttps: "true",
   s3VerifySsl: "true",
   s3Endpoint: "null",
+  efsEnabled: true,
+  efsPvcName: "qux",
+  efsVolumeName: "quux",
+  efsMountPath: "/quuz",
 };
 local env = {
   namespace: "test-kf-001",
@@ -107,6 +112,10 @@ std.assertEqual(
                   value: "us-west1-a",
                 },
                 {
+                  name: "S3_REGION",
+                  value: "us-west1-a",
+                },
+                {
                   name: "S3_USE_HTTPS",
                   value: "true",
                 },
@@ -136,6 +145,20 @@ std.assertEqual(
                   cpu: "1",
                   memory: "1Gi",
                 },
+              },
+              volumeMounts: [
+                {
+                  mountPath: "/quuz",
+                  name: "quux",
+                },
+              ],
+            },
+          ],
+          volumes: [
+            {
+              name: "quux",
+              persistentVolumeClaim: {
+                claimName: "qux",
               },
             },
           ],


### PR DESCRIPTION
Allowing the use of [AWS EFS](https://aws.amazon.com/efs/) for the Tensorboard deployment on AWS.
Previously, only S3 parameters were available.

With these changes, provided you have a Persistent Volume Claim with an EFS resource on your cluster (using [efs-provisioner](https://github.com/kubernetes-incubator/external-storage/tree/master/aws/efs)), you can make Tensorboard read from EFS.

You can still use S3, of course. They are not mutually exclusive (use the flags `efsEnabled` and `s3Enabled`, both can be `true` at the same time).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2569)
<!-- Reviewable:end -->
