### PR TITLE
Removing prune for Subresource field in CRD

### DIFF
--- a/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
@@ -14,4 +14,4 @@
 local k = import "k.libsonnet";
 local operator = import "kubeflow/pytorch-job/pytorch-operator.libsonnet";
 
-std.prune(k.core.v1.list.new(operator.all(params, env)))
+k.core.v1.list.new(operator.all(params, env))


### PR DESCRIPTION
Prune is removed for enabling subresource field in CRD

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2598)
<!-- Reviewable:end -->
