### PR TITLE
Adding additional printer columns to display status

### DIFF
--- a/kubeflow/pytorch-job/pytorch-operator.libsonnet
+++ b/kubeflow/pytorch-job/pytorch-operator.libsonnet
@@ -38,6 +38,18 @@
         subresources: {
           status: {},
         },
+        additionalPrinterColumns: [
+          {
+            JSONPath: ".status.conditions[-1:].type",
+            name: "State",
+            type: "string",
+          },
+          {
+            JSONPath: ".metadata.creationTimestamp",
+            name: "Age",
+            type: "date",
+          },
+        ],
         validation: {
           openAPIV3Schema: {
             properties: {

--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -44,6 +44,18 @@ local expectedCrdV1beta2 = {
     subresources: {
       status: {},
     },
+    additionalPrinterColumns: [
+      {
+        JSONPath: ".status.conditions[-1:].type",
+        name: "State",
+        type: "string",
+      },
+      {
+        JSONPath: ".metadata.creationTimestamp",
+        name: "Age",
+        type: "date",
+      },
+    ],
     validation: {
       openAPIV3Schema: {
         properties: {

--- a/kubeflow/tf-training/tests/tf-job_test.jsonnet
+++ b/kubeflow/tf-training/tests/tf-job_test.jsonnet
@@ -31,6 +31,18 @@ std.assertEqual(
       subresources: {
         status: {},
       },
+      additionalPrinterColumns: [
+        {
+          JSONPath: ".status.conditions[-1:].type",
+          name: "State",
+          type: "string",
+        },
+        {
+          JSONPath: ".metadata.creationTimestamp",
+          name: "Age",
+          type: "date",
+        },
+      ],
       validation: {
         openAPIV3Schema: {
           properties: {

--- a/kubeflow/tf-training/tf-job-operator.libsonnet
+++ b/kubeflow/tf-training/tf-job-operator.libsonnet
@@ -67,6 +67,18 @@
         subresources: {
           status: {},
         },
+        additionalPrinterColumns: [
+          {
+            JSONPath: ".status.conditions[-1:].type",
+            name: "State",
+            type: "string",
+          },
+          {
+            JSONPath: ".metadata.creationTimestamp",
+            name: "Age",
+            type: "date",
+          },
+        ],
         validation: { openAPIV3Schema: openAPIV3Schema },
         versions: [
           {
@@ -79,7 +91,7 @@
             served: true,
             storage: false,
           },
-	],
+        ],
       },
     },
     tfJobCrd:: tfJobCrd,


### PR DESCRIPTION
Display status field for kubectl get tfjobs/pytorchjobs. This outputs the type from the last condition in the status field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2609)
<!-- Reviewable:end -->
