### PR TITLE
Updated jupyter image paths to point to the latest ones

### DIFF
--- a/kubeflow/jupyter/config.yaml
+++ b/kubeflow/jupyter/config.yaml
@@ -21,25 +21,25 @@ spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
     # If readonly, this value must be a member of the list below
-    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v-base-97b94c0-1202
+    value: gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v-base-74ac37c-1214
     # The list of available standard container Images
     options:
-      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-gpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v-base-97b94c0-1202
-      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-gpu:v-base-97b94c0-1202
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-gpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v-base-74ac37c-1214
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-gpu:v-base-74ac37c-1214
     # By default, custom container Images are allowed
     # Uncomment the following line to only enable standard container Images
     readOnly: false


### PR DESCRIPTION
Paths are updated following [this pr](https://github.com/kubeflow/kubeflow/pull/2627)
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2638)
<!-- Reviewable:end -->
