### PR TITLE
Updated TFMA and TFDV versions of Jupyter images

### DIFF
--- a/components/tensorflow-notebook-image/versions/1.11.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.11.0/version-config.json
@@ -2,5 +2,6 @@
   "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.11.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.11.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "2.8.0",
+  "TFDV_VERSION": "2.8.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.11.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.11.0/version-config.json
@@ -2,6 +2,6 @@
   "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.11.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.11.0-cp27-none-linux_x86_64.whl",
-  "TFMA_VERSION": "2.8.0",
-  "TFDV_VERSION": "2.8.0"
+  "TFMA_VERSION": "0.11.0",
+  "TFDV_VERSION": "0.11.0"
 }

--- a/components/tensorflow-notebook-image/versions/1.11.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.11.0gpu/version-config.json
@@ -2,5 +2,7 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.11.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.11.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "2.8.0",
+  "TFDV_VERSION": "2.8.0"
 }
+

--- a/components/tensorflow-notebook-image/versions/1.11.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.11.0gpu/version-config.json
@@ -2,7 +2,7 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.11.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.11.0-cp27-none-linux_x86_64.whl",
-  "TFMA_VERSION": "2.8.0",
-  "TFDV_VERSION": "2.8.0"
+  "TFMA_VERSION": "0.11.0",
+  "TFDV_VERSION": "0.11.0"
 }
 

--- a/components/tensorflow-notebook-image/versions/1.12.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.12.0/version-config.json
@@ -2,5 +2,7 @@
   "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "2.10.0",
+  "TFDV_VERSION": "2.10.0"
 }
+

--- a/components/tensorflow-notebook-image/versions/1.12.0/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.12.0/version-config.json
@@ -2,7 +2,7 @@
   "BASE_IMAGE": "ubuntu:18.04@sha256:de774a3145f7ca4f0bd144c7d4ffb2931e06634f11529653b23eba85aef8e378",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow-1.12.0-cp27-none-linux_x86_64.whl",
-  "TFMA_VERSION": "2.10.0",
-  "TFDV_VERSION": "2.10.0"
+  "TFMA_VERSION": "0.12.0",
+  "TFDV_VERSION": "0.12.0"
 }
 

--- a/components/tensorflow-notebook-image/versions/1.12.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.12.0gpu/version-config.json
@@ -2,5 +2,7 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.12.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.12.0-cp27-none-linux_x86_64.whl",
-  "INSTALL_TFMA": "yes"
+  "TFMA_VERSION": "2.10.0",
+  "TFDV_VERSION": "2.10.0"
 }
+

--- a/components/tensorflow-notebook-image/versions/1.12.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.12.0gpu/version-config.json
@@ -2,7 +2,7 @@
   "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.12.0-cp36-cp36m-linux_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://storage.googleapis.com/tensorflow/linux/gpu/tensorflow_gpu-1.12.0-cp27-none-linux_x86_64.whl",
-  "TFMA_VERSION": "2.10.0",
-  "TFDV_VERSION": "2.10.0"
+  "TFMA_VERSION": "0.12.0",
+  "TFDV_VERSION": "0.12.0"
 }
 


### PR DESCRIPTION
Addressing [this issue](https://github.com/kubeflow/kubeflow/issues/2551)
Built and tested the images locally. Jupyter notebook of Python 2 could successfully import TFMA and TFDV packages. 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2666)
<!-- Reviewable:end -->
