### PR TITLE
fixes 'kfctl generated yaml fails validation #2653'

### DIFF
--- a/kubeflow/argo/argo.libsonnet
+++ b/kubeflow/argo/argo.libsonnet
@@ -35,10 +35,10 @@
     local workflowController = {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
-      labels: {
-        app: "workflow-controller",
-      },
       metadata: {
+        labels: {
+          app: "workflow-controller",
+        },
         name: "workflow-controller",
         namespace: params.namespace,
       },
@@ -168,6 +168,12 @@
                 resources: {},
                 terminationMessagePath: "/dev/termination-log",
                 terminationMessagePolicy: "File",
+                readinessProbe: {
+                  httpGet: {
+                    path: "/",
+                    port: 8001,
+                  },
+                },
               },
             ],
             dnsPolicy: "ClusterFirst",
@@ -177,12 +183,6 @@
             serviceAccount: "argo-ui",
             serviceAccountName: "argo-ui",
             terminationGracePeriodSeconds: 30,
-            readinessProbe: {
-              httpGet: {
-                path: "/",
-                port: 8001,
-              },
-            },
           },
         },
       },

--- a/kubeflow/argo/tests/argo_test.jsonnet
+++ b/kubeflow/argo/tests/argo_test.jsonnet
@@ -51,10 +51,10 @@ local testCases = [
     expected: {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
-      labels: {
-        app: "workflow-controller",
-      },
       metadata: {
+        labels: {
+          app: "workflow-controller",
+        },
         name: "workflow-controller",
         namespace: "kubeflow",
       },
@@ -182,18 +182,18 @@ local testCases = [
                 image: "argoproj/argoui:v2.2.0",
                 imagePullPolicy: "IfNotPresent",
                 name: "argo-ui",
+                readinessProbe: {
+                  httpGet: {
+                    path: "/",
+                    port: 8001,
+                  },
+                },
                 resources: {},
                 terminationMessagePath: "/dev/termination-log",
                 terminationMessagePolicy: "File",
               },
             ],
             dnsPolicy: "ClusterFirst",
-            readinessProbe: {
-              httpGet: {
-                path: "/",
-                port: 8001,
-              },
-            },
             restartPolicy: "Always",
             schedulerName: "default-scheduler",
             securityContext: {},

--- a/kubeflow/common/ambassador.libsonnet
+++ b/kubeflow/common/ambassador.libsonnet
@@ -145,7 +145,7 @@
     ambassadorRoleBinding:: ambassadorRoleBinding,
 
     local ambassadorDeployment = {
-      apiVersion: "extensions/v1beta1",
+      apiVersion: "apps/v1beta1",
       kind: "Deployment",
       metadata: {
         name: "ambassador",
@@ -174,23 +174,7 @@
                   },
                 ],
                 image: params.ambassadorImage,
-                livenessProbe: {
-                  httpGet: {
-                    path: "/ambassador/v0/check_alive",
-                    port: 8877,
-                  },
-                  initialDelaySeconds: 30,
-                  periodSeconds: 30,
-                },
                 name: "ambassador",
-                readinessProbe: {
-                  httpGet: {
-                    path: "/ambassador/v0/check_ready",
-                    port: 8877,
-                  },
-                  initialDelaySeconds: 30,
-                  periodSeconds: 30,
-                },
                 resources: {
                   limits: {
                     cpu: 1,
@@ -200,6 +184,22 @@
                     cpu: "200m",
                     memory: "100Mi",
                   },
+                },
+                readinessProbe: {
+                  httpGet: {
+                    path: "/ambassador/v0/check_ready",
+                    port: 8877,
+                  },
+                  initialDelaySeconds: 30,
+                  periodSeconds: 30,
+                },
+                livenessProbe: {
+                  httpGet: {
+                    path: "/ambassador/v0/check_alive",
+                    port: 8877,
+                  },
+                  initialDelaySeconds: 30,
+                  periodSeconds: 30,
                 },
               },
             ],

--- a/kubeflow/common/tests/ambassador_test.jsonnet
+++ b/kubeflow/common/tests/ambassador_test.jsonnet
@@ -159,71 +159,72 @@ local testCases = [
   },
   {
     actual: instance.parts.ambassadorDeployment,
-    expected: {
-      apiVersion: "extensions/v1beta1",
-      kind: "Deployment",
-      metadata: {
-        name: "ambassador",
-        namespace: "kubeflow",
-      },
-      spec: {
-        replicas: 3,
-        template: {
-          metadata: {
-            labels: {
-              service: "ambassador",
+    expected:
+      {
+        apiVersion: "apps/v1beta1",
+        kind: "Deployment",
+        metadata: {
+          name: "ambassador",
+          namespace: "kubeflow",
+        },
+        spec: {
+          replicas: 3,
+          template: {
+            metadata: {
+              labels: {
+                service: "ambassador",
+              },
+              namespace: "kubeflow",
             },
-            namespace: "kubeflow",
-          },
-          spec: {
-            containers: [
-              {
-                env: [
-                  {
-                    name: "AMBASSADOR_NAMESPACE",
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: "metadata.namespace",
+            spec: {
+              containers: [
+                {
+                  env: [
+                    {
+                      name: "AMBASSADOR_NAMESPACE",
+                      valueFrom: {
+                        fieldRef: {
+                          fieldPath: "metadata.namespace",
+                        },
                       },
                     },
+                  ],
+                  image: "quay.io/datawire/ambassador:0.37.0",
+                  livenessProbe: {
+                    httpGet: {
+                      path: "/ambassador/v0/check_alive",
+                      port: 8877,
+                    },
+                    initialDelaySeconds: 30,
+                    periodSeconds: 30,
                   },
-                ],
-                image: "quay.io/datawire/ambassador:0.37.0",
-                livenessProbe: {
-                  httpGet: {
-                    path: "/ambassador/v0/check_alive",
-                    port: 8877,
+                  name: "ambassador",
+                  readinessProbe: {
+                    httpGet: {
+                      path: "/ambassador/v0/check_ready",
+                      port: 8877,
+                    },
+                    initialDelaySeconds: 30,
+                    periodSeconds: 30,
                   },
-                  initialDelaySeconds: 30,
-                  periodSeconds: 30,
+                  resources: {
+                    limits: {
+                      cpu: 1,
+                      memory: "400Mi",
+                    },
+                    requests: {
+                      cpu: "200m",
+                      memory: "100Mi",
+                    },
+                  },
                 },
-                name: "ambassador",
-                readinessProbe: {
-                  httpGet: {
-                    path: "/ambassador/v0/check_ready",
-                    port: 8877,
-                  },
-                  initialDelaySeconds: 30,
-                  periodSeconds: 30,
-                },
-                resources: {
-                  limits: {
-                    cpu: 1,
-                    memory: "400Mi",
-                  },
-                  requests: {
-                    cpu: "200m",
-                    memory: "100Mi",
-                  },
-                },
-              },
-            ],
-            restartPolicy: "Always",
-            serviceAccountName: "ambassador",
+              ],
+              restartPolicy: "Always",
+              serviceAccountName: "ambassador",
+            },
           },
         },
       },
-    },
   },
 ];
 

--- a/kubeflow/pipeline/pipeline-viewercrd.libsonnet
+++ b/kubeflow/pipeline/pipeline-viewercrd.libsonnet
@@ -31,7 +31,6 @@
           app: app_label,
         },
         name: viewer_controller_role,
-        namespace: namespace,
       },
       rules: [
         {


### PR DESCRIPTION
Running 
```
kfctl init ~/kubeflow
cd ~/kubeflow
kfctl generate all
cd ks_app
ks show default -c application -c metacontroller >default.yaml
kubectl apply -f default.yaml
```

will return validation errors of misplaced or incorrect yaml specs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2674)
<!-- Reviewable:end -->
