### PR TITLE
Serve Pytorch v1beta2 and v1beta1 crd

### DIFF
--- a/kubeflow/pytorch-job/prototypes/pytorch-job.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-job.jsonnet
@@ -8,7 +8,7 @@
 // @optionalParam numMasters number 1 The number of masters to use
 // @optionalParam numWorkers number 1 The number of workers to use
 // @optionalParam numGpus number 0 The number of GPUs to attach to workers.
-// @optionalParam jobVersion string v1beta1 The pytorch operator version to use
+// @optionalParam jobVersion string v1beta2 The pytorch operator version to use
 
 local k = import "k.libsonnet";
 

--- a/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
+++ b/kubeflow/pytorch-job/prototypes/pytorch-operator.jsonnet
@@ -5,9 +5,8 @@
 // @param name string Name to give to each of the components
 // @optionalParam disks string null Comma separated list of Google persistent disks to attach to jupyter environments.
 // @optionalParam cloud string null String identifying the cloud to customize the deployment for.
-// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch-operator:v0.5.0-rc.1-1-g6807802 The image for the PyTorchJob controller
+// @optionalParam pytorchJobImage string gcr.io/kubeflow-images-public/pytorch-operator:v0.5.0-rc.1-6-gd09eb65 The image for the PyTorchJob controller
 // @optionalParam pytorchDefaultImage string null The default image to use for pytorch
-// @optionalParam pytorchJobVersion string v1beta1 which version of the PyTorchJob operator to use
 // @optionalParam deploymentScope string cluster The scope at which pytorch-operator should be deployed - valid values are cluster, namespace.
 // @optionalParam deploymentNamespace string null The namespace to which pytorch-operator should be scoped. If deploymentScope is set to cluster, this is ignored.
 

--- a/kubeflow/pytorch-job/pytorch-operator.libsonnet
+++ b/kubeflow/pytorch-job/pytorch-operator.libsonnet
@@ -1,26 +1,17 @@
 {
   all(params, env):: [
-                       $.parts(params, env).configMap(params.pytorchDefaultImage),
-                       $.parts(params, env).serviceAccount,
-                       $.parts(params, env).operatorRole(params.deploymentScope, params.deploymentNamespace),
-                       $.parts(params, env).operatorRoleBinding(params.deploymentScope, params.deploymentNamespace),
-                     ] +
-
-                     if params.pytorchJobVersion == "v1beta2" then
-                       [
-                         $.parts(params, env).crdV1beta2,
-                         $.parts(params, env).pytorchJobDeployV1beta2(params.pytorchJobImage, params.deploymentScope, params.deploymentNamespace),
-                       ]
-                     else
-                       [
-                         $.parts(params, env).crdV1beta1,
-                         $.parts(params, env).pytorchJobDeployV1beta1(params.pytorchJobImage, params.deploymentScope, params.deploymentNamespace),
-                       ],
+    $.parts(params, env).configMap(params.pytorchDefaultImage),
+    $.parts(params, env).serviceAccount,
+    $.parts(params, env).operatorRole(params.deploymentScope, params.deploymentNamespace),
+    $.parts(params, env).operatorRoleBinding(params.deploymentScope, params.deploymentNamespace),
+    $.parts(params, env).crd,
+    $.parts(params, env).pytorchJobDeploy(params.pytorchJobImage, params.deploymentScope, params.deploymentNamespace),
+  ],
 
   parts(params, env):: {
     local namespace = env.namespace,
 
-    crdV1beta2: {
+    crd: {
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",
       metadata: {
@@ -48,6 +39,18 @@
             JSONPath: ".metadata.creationTimestamp",
             name: "Age",
             type: "date",
+          },
+        ],
+        versions: [
+          {
+            name: "v1beta2",
+            served: true,
+            storage: true,
+          },
+          {
+            name: "v1beta1",
+            served: true,
+            storage: false,
           },
         ],
         validation: {
@@ -84,56 +87,7 @@
       },
     },
 
-    crdV1beta1: {
-      apiVersion: "apiextensions.k8s.io/v1beta1",
-      kind: "CustomResourceDefinition",
-      metadata: {
-        name: "pytorchjobs.kubeflow.org",
-      },
-      spec: {
-        group: "kubeflow.org",
-        version: "v1beta1",
-        scope: "Namespaced",
-        names: {
-          kind: "PyTorchJob",
-          singular: "pytorchjob",
-          plural: "pytorchjobs",
-        },
-        validation: {
-          openAPIV3Schema: {
-            properties: {
-              spec: {
-                properties: {
-                  pytorchReplicaSpecs: {
-                    properties: {
-                      Worker: {
-                        properties: {
-                          replicas: {
-                            type: "integer",
-                            minimum: 1,
-                          },
-                        },
-                      },
-                      Master: {
-                        properties: {
-                          replicas: {
-                            type: "integer",
-                            minimum: 1,
-                            maximum: 1,
-                          },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-
-    pytorchJobDeployV1beta2(image, deploymentScope, deploymentNamespace): {
+    pytorchJobDeploy(image, deploymentScope, deploymentNamespace): {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
       metadata: {
@@ -205,81 +159,7 @@
           },
         },
       },
-    },  // pytorchJobDeployV1beta2
-
-    pytorchJobDeployV1beta1(image, deploymentScope, deploymentNamespace): {
-      apiVersion: "extensions/v1beta1",
-      kind: "Deployment",
-      metadata: {
-        name: "pytorch-operator",
-        namespace: namespace,
-      },
-      spec: {
-        replicas: 1,
-        template: {
-          metadata: {
-            labels: {
-              name: "pytorch-operator",
-            },
-          },
-          spec: {
-            containers: [
-              {
-                command: std.prune([
-                  "/pytorch-operator.v1beta1",
-                  "--alsologtostderr",
-                  "-v=1",
-                  if deploymentScope == "namespace" then ("--namespace=" + deploymentNamespace),
-                ]),
-                env: std.prune([
-                  {
-                    name: "MY_POD_NAMESPACE",
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: "metadata.namespace",
-                      },
-                    },
-                  },
-                  {
-                    name: "MY_POD_NAME",
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: "metadata.name",
-                      },
-                    },
-                  },
-                  if deploymentScope == "namespace" then {
-                    name: "KUBEFLOW_NAMESPACE",
-                    valueFrom: {
-                      fieldRef: {
-                        fieldPath: "metadata.namespace",
-                      },
-                    },
-                  },
-                ]),
-                image: image,
-                name: "pytorch-operator",
-                volumeMounts: [
-                  {
-                    mountPath: "/etc/config",
-                    name: "config-volume",
-                  },
-                ],
-              },
-            ],
-            serviceAccountName: "pytorch-operator",
-            volumes: [
-              {
-                configMap: {
-                  name: "pytorch-operator-config",
-                },
-                name: "config-volume",
-              },
-            ],
-          },
-        },
-      },
-    },  // pytorchJobDeployV1beta1
+    },  // pytorchJobDeploy
 
     // Default value for
     defaultControllerConfig(pytorchDefaultImage):: if pytorchDefaultImage != "" && pytorchDefaultImage != "null" then

--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -4,30 +4,22 @@
 
 local pyjob = import "../pytorch-operator.libsonnet";
 local testSuite = import "kubeflow/common/testsuite.libsonnet";
-local paramsv1beta2 = {
+local params = {
   image: "pyControllerImage",
   deploymentScope: "cluster",
   deploymentNamespace: "null",
   pyjobVersion: "v1beta2",
-};
-local paramsv1beta1 = {
-  image: "pyControllerImage",
-  deploymentScope: "cluster",
-  deploymentNamespace: "null",
-  pyjobVersion: "v1beta1",
 };
 
 local env = {
   namespace: "test-kf-001",
 };
 
-local pyjobCrdV1beta2 = pyjob.parts(paramsv1beta2, env).crdV1beta2;
-local pyjobCrdV1beta1 = pyjob.parts(paramsv1beta1, env).crdV1beta1;
+local pyjobCrd = pyjob.parts(params, env).crdV1beta2;
 
-local pytorchJobDeployV1alpha1 = pyjob.parts(paramsv1beta2, env).pytorchJobDeployV1alpha1;
-local pytorchJobDeployV1beta1 = pyjob.parts(paramsv1beta1, env).pytorchJobDeployV1beta1;
+local pytorchJobDeploy = pyjob.parts(params, env).pytorchJobDeploy;
 
-local expectedCrdV1beta2 = {
+local expectedCrd = {
   apiVersion: "apiextensions.k8s.io/v1beta1",
   kind: "CustomResourceDefinition",
   metadata: {
@@ -88,69 +80,29 @@ local expectedCrdV1beta2 = {
       },
     },
     version: "v1beta2",
+    versions: [
+      {
+        name: "v1beta2",
+        served: true,
+        storage: true,
+      },
+      {
+        name: "v1beta1",
+        served: true,
+        storage: false,
+      },
+    ],
   },
 };
 
-local expectedCrdV1beta1 = {
-  apiVersion: "apiextensions.k8s.io/v1beta1",
-  kind: "CustomResourceDefinition",
-  metadata: {
-    name: "pytorchjobs.kubeflow.org",
-  },
-  spec: {
-    group: "kubeflow.org",
-    scope: "Namespaced",
-    names: {
-      kind: "PyTorchJob",
-      plural: "pytorchjobs",
-      singular: "pytorchjob",
-    },
-    validation: {
-      openAPIV3Schema: {
-        properties: {
-          spec: {
-            properties: {
-              pytorchReplicaSpecs: {
-                properties: {
-                  Master: {
-                    properties: {
-                      replicas: {
-                        minimum: 1,
-                        maximum: 1,
-                        type: "integer",
-                      },
-                    },
-                  },
-                  Worker: {
-                    properties: {
-                      replicas: {
-                        minimum: 1,
-                        type: "integer",
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    version: "v1beta1",
-  },
-};
 
 local testCases = [
   {
-    actual: pyjob.parts(paramsv1beta2, env).crdV1beta2,
-    expected: expectedCrdV1beta2,
+    actual: pyjob.parts(params, env).crd,
+    expected: expectedCrd,
   },
   {
-    actual: pyjob.parts(paramsv1beta2, env).crdV1beta1,
-    expected: expectedCrdV1beta1,
-  },
-  {
-    actual: pyjob.parts(paramsv1beta2, env).pytorchJobDeployV1beta1(paramsv1beta1.image, paramsv1beta1.deploymentScope, paramsv1beta1.deploymentNamespace),
+    actual: pyjob.parts(params, env).pytorchJobDeploy(params.image, params.deploymentScope, params.deploymentNamespace),
     expected: {
       apiVersion: "extensions/v1beta1",
       kind: "Deployment",
@@ -170,7 +122,7 @@ local testCases = [
             containers: [
               {
                 command: [
-                  "/pytorch-operator.v1beta1",
+                  "/pytorch-operator.v1beta2",
                   "--alsologtostderr",
                   "-v=1",
                 ],


### PR DESCRIPTION
Serve both v1beta1 and v1beta2 crd of Pytorch operator. v1beta2 is made as default

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2677)
<!-- Reviewable:end -->
