### PR TITLE
Attempt to fix spark-operator and argo-deploy test flakiness.

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -77,7 +77,9 @@ workflows:
     component: workflows
     name: kubeflow-e2e-minikube
     job_types:
-      - presubmit
+      # TODO(https://github.com/kubeflow/kubeflow/issues/2703): Reenable minikube on presubmit
+      # when the test is fixed.
+      # - presubmit
       - postsubmit
       - periodic
     params:

--- a/testing/workflows/components/kfctl_test.jsonnet
+++ b/testing/workflows/components/kfctl_test.jsonnet
@@ -301,7 +301,9 @@ local dagTemplates = [
       ],
       working_dir=appDir + "/ks_app"
     ),
-    dependencies: ["install-spark-operator"],
+    // Need to wait on kfctl-apply-k8s because that step creates
+    // the ksonnet environment.
+    dependencies: ["install-spark-operator", "kfctl-apply-k8s"],
   },  // generate-spark-operator
   {
     template: buildTemplate(

--- a/testing/workflows/components/workflows.libsonnet
+++ b/testing/workflows/components/workflows.libsonnet
@@ -247,26 +247,27 @@
         },  // run tests
         dependencies: ["wait-for-kubeflow"],
       },  // tf-job-test-v1b2
-      {
-
-        template: tests.buildTemplate {
-          name: "test-argo-deploy",
-          command: [
-            "python",
-            "-m",
-            "testing.test_deploy",
-            "--project=kubeflow-ci",
-            "--github_token=$(GITHUB_TOKEN)",
-            "--namespace=" + tests.stepsNamespace,
-            "--test_dir=" + tests.testDir,
-            "--artifacts_dir=" + tests.artifactsDir,
-            "--deploy_name=test-argo-deploy",
-            "--workflow_name=" + tests.workflowName,
-            "deploy_argo",
-          ],
-        },
-        dependencies: ["wait-for-kubeflow"],
-      },  // test-argo-deploy
+      // TODO(https://github.com/kubeflow/kubeflow/issues/1407): argo-deploy is flaky so disable it.
+      // {
+      //
+      //  template: tests.buildTemplate {
+      //    name: "test-argo-deploy",
+      //    command: [
+      //      "python",
+      //      "-m",
+      //      "testing.test_deploy",
+      //      "--project=kubeflow-ci",
+      //      "--github_token=$(GITHUB_TOKEN)",
+      //      "--namespace=" + tests.stepsNamespace,
+      //      "--test_dir=" + tests.testDir,
+      //      "--artifacts_dir=" + tests.artifactsDir,
+      //      "--deploy_name=test-argo-deploy",
+      //      "--workflow_name=" + tests.workflowName,
+      //      "deploy_argo",
+      //    ],
+      //  },
+      //  dependencies: ["wait-for-kubeflow"],
+      //},  // test-argo-deploy
       {
 
         template: tests.buildTemplate {


### PR DESCRIPTION
* Don't try to apply the spark-operator until after calling kfctl apply k8s
  because the ksonnet environment gets created during the step.

Fix #2693 

* Disable argo deploy test because it is flaky #1407 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2694)
<!-- Reviewable:end -->
