### PR TITLE
Fix param set on ipName and hostname

### DIFF
--- a/bootstrap/pkg/client/gcp/gcp.go
+++ b/bootstrap/pkg/client/gcp/gcp.go
@@ -842,7 +842,7 @@ func (gcp *Gcp) Generate(resources kftypes.ResourceEnum, options map[string]inte
 	if hostname == "" {
 		hostname = gcp.GcpApp.Name + ".endpoints." + gcp.GcpApp.Spec.Project + ".cloud.goog"
 	}
-	if val, ok := options[string(kftypes.USE_BASIC_AUTH)]; ok && val.(bool) {
+	if gcp.GcpApp.Spec.UseBasicAuth {
 		nv = gcp.GcpApp.Spec.ComponentParams["basic-auth-ingress"]
 		setNameVal(&nv, "ipName", ipName, true)
 		setNameVal(&nv, "hostname", hostname, true)


### PR DESCRIPTION
Fixes #2701

`useBasicAuth` is not an option in `kfctl generate`.  it's available in app spec, though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2702)
<!-- Reviewable:end -->
