### PR TITLE
Launch trtserver so that CUDA driver compatibility is enabled

### DIFF
--- a/kubeflow/nvidia-inference-server/nvidia-inference-server.libsonnet
+++ b/kubeflow/nvidia-inference-server/nvidia-inference-server.libsonnet
@@ -28,10 +28,8 @@
       name: $.params.name,
       image: $.params.image,
       imagePullPolicy: "IfNotPresent",
-      command: [
-        "trtserver",
-      ],
       args: [
+        "trtserver",
         "--model-store=" + $.params.modelRepositoryPath,
       ],
       ports: [


### PR DESCRIPTION
The container entrypoint must run to ensure driver compatibility is
enabled correctly. Fix spec to not use "command" so that container
launch runs entrypoint.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2726)
<!-- Reviewable:end -->
