### PR TITLE
fixes 'kfctl Incorrect ksonnet OptionServer is specified when no platform is provided'

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -74,6 +74,10 @@ func downloadToCache(platform string, appDir string, version string, useBasicAut
 		}
 	}
 	cacheDir := path.Join(appDir, kftypes.DefaultCacheDir)
+	// idempotency
+	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
+		os.RemoveAll(cacheDir)
+	}
 	cacheDirErr := os.Mkdir(cacheDir, os.ModePerm)
 	if cacheDirErr != nil {
 		return nil, fmt.Errorf("couldn't create directory %v Error %v", cacheDir, cacheDirErr)

--- a/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
+++ b/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
@@ -447,16 +447,18 @@ func (ksApp *ksApp) initKs() error {
 	}
 	ksApp.KsEnvName = KsEnvName
 	k8sSpec := ksApp.Spec.ServerVersion
+	host := "127.0.0.1"
 	if k8sSpec == "" {
-		k8sSpec = kftypes.GetServerVersion(kftypes.GetClientset(kftypes.GetConfig()))
+		config := kftypes.GetConfig()
+		host = config.Host
+		k8sSpec = kftypes.GetServerVersion(kftypes.GetClientset(config))
 	}
 	options := map[string]interface{}{
 		actions.OptionFs:                    afero.NewOsFs(),
 		actions.OptionName:                  ksApp.KsName,
 		actions.OptionEnvName:               ksApp.KsEnvName,
 		actions.OptionNewRoot:               newRoot,
-		// Using local host appears to fool ksonnet on init. We will add a new environment later.
-		actions.OptionServer:                "127.0.0.1",
+		actions.OptionServer:                host,
 		actions.OptionSpecFlag:              k8sSpec,
 		actions.OptionNamespace:             ksApp.Namespace,
 		actions.OptionSkipDefaultRegistries: true,

--- a/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
+++ b/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
@@ -452,6 +452,9 @@ func (ksApp *ksApp) initKs() error {
 		config := kftypes.GetConfig()
 		host = config.Host
 		k8sSpec = kftypes.GetServerVersion(kftypes.GetClientset(config))
+		if k8sSpec == "" {
+			return fmt.Errorf("could not find kubernetes version info")
+		}
 	}
 	options := map[string]interface{}{
 		actions.OptionFs:                    afero.NewOsFs(),


### PR DESCRIPTION
fixes #2761

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2763)
<!-- Reviewable:end -->
