### PR TITLE
Adds Kferror interface

### DIFF
--- a/bootstrap/pkg/apis/kferrors.go
+++ b/bootstrap/pkg/apis/kferrors.go
@@ -1,0 +1,17 @@
+// Copyright 2018 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package apis
+
+import ()

--- a/bootstrap/pkg/apis/kferrors.go
+++ b/bootstrap/pkg/apis/kferrors.go
@@ -14,4 +14,19 @@
 
 package apis
 
-import ()
+import (
+	"fmt"
+)
+
+// KfError stands for Kubeflow error. This is the standard error interface
+// for Kubeflow components.
+type KfError struct {
+	// Code is the HTTP response status code.
+	Code    int    `json:"code"`
+	Message string `json:"message,omitempty"`
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf(" (kubeflow.error): Code %d with message: %v",
+		e.Code, e.Message)
+}

--- a/bootstrap/pkg/apis/kferrors.go
+++ b/bootstrap/pkg/apis/kferrors.go
@@ -18,6 +18,15 @@ import (
 	"fmt"
 )
 
+type StatusCode int
+
+const (
+	OK               StatusCode = 200
+	INVALID_ARGUMENT StatusCode = 400
+	INTERNAL_ERROR   StatusCode = 500
+	UNKNOWN          StatusCode = 520
+)
+
 // KfError stands for Kubeflow error. This is the standard error interface
 // for Kubeflow components.
 type KfError struct {

--- a/bootstrap/pkg/apis/kferrors.go
+++ b/bootstrap/pkg/apis/kferrors.go
@@ -26,7 +26,7 @@ type KfError struct {
 	Message string `json:"message,omitempty"`
 }
 
-func (e *Error) Error() string {
+func (e *KfError) Error() string {
 	return fmt.Sprintf(" (kubeflow.error): Code %d with message: %v",
 		e.Code, e.Message)
 }


### PR DESCRIPTION
Relates #2712

We will use this error interface to carry error information and status code used for monitoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2769)
<!-- Reviewable:end -->
