### PR TITLE
replace download k8s manifest with ksonnet entry

### DIFF
--- a/bootstrap/config/kfctl_basic_auth.yaml
+++ b/bootstrap/config/kfctl_basic_auth.yaml
@@ -30,6 +30,7 @@ components:
   - centraldashboard
   - cert-manager
   - cloud-endpoints
+  - gpu-driver
   - jupyter
   - jupyter-web-app
   - katib

--- a/bootstrap/config/kfctl_iap.yaml
+++ b/bootstrap/config/kfctl_iap.yaml
@@ -28,6 +28,7 @@ components:
   - centraldashboard
   - cert-manager
   - cloud-endpoints
+  - gpu-driver
   - iap-ingress
   - jupyter
   - jupyter-web-app

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/deckarep/golang-set"
 	"github.com/ghodss/yaml"
-	gogetter "github.com/hashicorp/go-getter"
 	configtypes "github.com/kubeflow/kubeflow/bootstrap/config"
 	kftypes "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps"
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps/kfdef/v1alpha1"
@@ -39,7 +38,7 @@ import (
 	"google.golang.org/api/serviceusage/v1"
 	"io"
 	"io/ioutil"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -62,8 +61,6 @@ const (
 	NETWORK_FILE      = "network.yaml"
 	GCFS_FILE         = "gcfs.yaml"
 	ISTIO_DIR         = "istio"
-	ISTIO_CRD         = "istio-crd.yaml"
-	ISTIO_INSTALL     = "istio-noauth.yaml"
 	ADMIN_SECRET_NAME = "admin-gcp-sa"
 	USER_SECRET_NAME  = "user-gcp-sa"
 	KUBEFLOW_OAUTH    = "kubeflow-oauth"
@@ -406,29 +403,10 @@ func (gcp *Gcp) updateDM(resources kftypes.ResourceEnum) error {
 	cred_cmd.Stdout = os.Stdout
 	log.Infof("Running get-credentials %v --zone=%v --project=%v ...", gcp.KfDef.Name,
 		gcp.KfDef.Spec.Zone, gcp.KfDef.Spec.Project)
-	if err = cred_cmd.Run(); err != nil {
+	if err := cred_cmd.Run(); err != nil {
 		return fmt.Errorf("Error when running gcloud container clusters get-credentials: %v", err)
 	}
 
-	k8sSpecsDir := path.Join(appDir, K8S_SPECS)
-	daemonsetPreloaded := filepath.Join(k8sSpecsDir, "daemonset-preloaded.yaml")
-	daemonsetPreloadedErr := utils.RunKubectlApply(daemonsetPreloaded)
-	if daemonsetPreloadedErr != nil {
-		return fmt.Errorf("could not create resources in daemonset-preloaded.yaml %v", daemonsetPreloadedErr)
-	}
-	adminClient := rest.CopyConfig(client)
-	adminClient.Impersonate.UserName = "admin"
-	adminClient.Impersonate.Groups = []string{"system:masters"}
-	rbacSetup := filepath.Join(k8sSpecsDir, "rbac-setup.yaml")
-	rbacSetupErr := utils.RunKubectlApply(rbacSetup, "--as=admin", "--as-group=system:masters")
-	if rbacSetupErr != nil {
-		return fmt.Errorf("could not create resources in rbac-setup.yaml %v", rbacSetupErr)
-	}
-	agents := filepath.Join(k8sSpecsDir, "agents.yaml")
-	agentsErr := utils.RunKubectlApply(agents)
-	if agentsErr != nil {
-		return fmt.Errorf("could not create resources in agents.yaml %v", agents)
-	}
 	return nil
 }
 
@@ -443,20 +421,6 @@ func (gcp *Gcp) Apply(resources kftypes.ResourceEnum) error {
 	updateDMErr := gcp.updateDM(resources)
 	if updateDMErr != nil {
 		return fmt.Errorf("gcp apply could not update deployment manager Error %v", updateDMErr)
-	}
-	// Install Istio
-	if gcp.Spec.UseIstio {
-		log.Infof("Installing istio...")
-		istioDir := path.Join(gcp.Spec.AppDir, ISTIO_DIR)
-		err := utils.RunKubectlApply(path.Join(istioDir, ISTIO_CRD))
-		if err != nil {
-			return fmt.Errorf("gcp apply could not install istio, Error %v", err)
-		}
-		err = utils.RunKubectlApply(path.Join(istioDir, ISTIO_INSTALL))
-		if err != nil {
-			return fmt.Errorf("gcp apply could not install istio, Error %v", err)
-		}
-		log.Infof("Done installing istio.")
 	}
 	// Insert secrets into the cluster
 	secretsErr := gcp.createSecrets()
@@ -681,65 +645,6 @@ func (gcp *Gcp) generateDMConfigs() error {
 	return nil
 }
 
-func (gcp *Gcp) downloadK8sManifests() error {
-	appDir := gcp.Spec.AppDir
-	k8sSpecsDir := path.Join(appDir, K8S_SPECS)
-	k8sSpecsDirErr := os.MkdirAll(k8sSpecsDir, os.ModePerm)
-	if k8sSpecsDirErr != nil {
-		return fmt.Errorf("cannot create directory %v Error %v", k8sSpecsDir, k8sSpecsDirErr)
-	}
-	daemonsetPreloaded := filepath.Join(k8sSpecsDir, "daemonset-preloaded.yaml")
-	url := "https://raw.githubusercontent.com/GoogleCloudPlatform/container-engine-accelerators/stable/nvidia-driver-installer/cos/daemonset-preloaded.yaml"
-	urlErr := gogetter.GetFile(daemonsetPreloaded, url)
-	if urlErr != nil {
-		return fmt.Errorf("couldn't download %v Error %v", url, urlErr)
-	}
-	rbacSetup := filepath.Join(k8sSpecsDir, "rbac-setup.yaml")
-	url = "https://storage.googleapis.com/stackdriver-kubernetes/stable/rbac-setup.yaml"
-	urlErr = gogetter.GetFile(rbacSetup, url)
-	if urlErr != nil {
-		return fmt.Errorf("couldn't download %v Error %v", url, urlErr)
-	}
-	agents := filepath.Join(k8sSpecsDir, "agents.yaml")
-	url = "https://storage.googleapis.com/stackdriver-kubernetes/stable/agents.yaml"
-	urlErr = gogetter.GetFile(agents, url)
-	if urlErr != nil {
-		return fmt.Errorf("couldn't download %v Error %v", url, urlErr)
-	}
-
-	// Download Istio manifests.
-	if gcp.Spec.UseIstio {
-		istioManifestDir := path.Join(appDir, ISTIO_DIR)
-		if err := os.Mkdir(istioManifestDir, os.ModePerm); err != nil {
-			return fmt.Errorf("cannot create directory %v Error %v", istioManifestDir, err)
-		}
-		repo := gcp.Spec.Repo
-		parentDir := path.Dir(repo)
-		// copy crd
-		sourceFile := filepath.Join(parentDir, "dependencies/istio/install/crds.yaml")
-		destFile := filepath.Join(istioManifestDir, ISTIO_CRD)
-		if err := gcp.copyFile(sourceFile, destFile); err != nil {
-			return fmt.Errorf("could not copy %v to %v Error %v", sourceFile, destFile, err)
-		}
-		// copy istio manifest
-		sourceFile = filepath.Join(parentDir, "dependencies/istio/install/istio-noauth.yaml")
-		destFile = filepath.Join(istioManifestDir, ISTIO_INSTALL)
-		if err := gcp.copyFile(sourceFile, destFile); err != nil {
-			return fmt.Errorf("could not copy %v to %v Error %v", sourceFile, destFile, err)
-		}
-	}
-
-	//TODO - copied from scripts/gke/util.sh. The rbac-setup command won't need admin since the user will be
-	// running as admin.
-	//  # Install the GPU driver. It has no effect on non-GPU nodes.
-	//  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/daemonset-preloaded.yaml
-	//  # Install Stackdriver Kubernetes agents.
-	//  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/rbac-setup.yaml --as=admin --as-group=system:masters
-	//  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/agents.yaml
-
-	return nil
-}
-
 func insertSecret(client *clientset.Clientset, secretName string, namespace string, data map[string][]byte) error {
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -891,19 +796,10 @@ func (gcp *Gcp) Generate(resources kftypes.ResourceEnum) error {
 		gcp.Spec.Email = account
 	}
 	switch resources {
-	case kftypes.K8S:
-		generateK8sSpecsErr := gcp.downloadK8sManifests()
-		if generateK8sSpecsErr != nil {
-			return fmt.Errorf("could not generate files under %v Error: %v", K8S_SPECS, generateK8sSpecsErr)
-		}
 	case kftypes.ALL:
 		gcpConfigFilesErr := gcp.generateDMConfigs()
 		if gcpConfigFilesErr != nil {
 			return fmt.Errorf("could not generate deployment manager configs under %v Error: %v", GCP_CONFIG, gcpConfigFilesErr)
-		}
-		generateK8sSpecsErr := gcp.downloadK8sManifests()
-		if generateK8sSpecsErr != nil {
-			return fmt.Errorf("could not generate files under %v Error: %v", K8S_SPECS, generateK8sSpecsErr)
 		}
 	case kftypes.PLATFORM:
 		gcpConfigFilesErr := gcp.generateDMConfigs()

--- a/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
+++ b/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ksonnet/ksonnet/pkg/client"
 	"github.com/ksonnet/ksonnet/pkg/component"
 	configtypes "github.com/kubeflow/kubeflow/bootstrap/config"
-	bootstrap "github.com/kubeflow/kubeflow/bootstrap/cmd/bootstrap/app"
 	kftypes "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps"
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps/kfdef/v1alpha1"
 	kfctlutils "github.com/kubeflow/kubeflow/bootstrap/pkg/utils"
@@ -117,27 +116,6 @@ func (ksApp *ksApp) Apply(resources kftypes.ResourceEnum) error {
 		if err != nil {
 			return fmt.Errorf("could not change directory to %v Error %v", ksApp.Spec.AppDir, err)
 		}
-	}
-	// Install Istio
-	if ksApp.Spec.UseIstio {
-		log.Infof("Installing istio...")
-		parentDir := path.Dir(ksApp.Spec.Repo)
-		err = bootstrap.CreateResourceFromFile(config, path.Join(parentDir, "dependencies/istio/install/crds.yaml"))
-		if err != nil {
-			log.Errorf("Failed to create istio CRD: %v", err)
-			return err
-		}
-		err = bootstrap.CreateResourceFromFile(config, path.Join(parentDir, "dependencies/istio/install/istio-noauth.yaml"))
-		if err != nil {
-			log.Errorf("Failed to create istio manifest: %v", err)
-			return err
-		}
-		err = bootstrap.CreateResourceFromFile(config, path.Join(parentDir, "dependencies/istio/kf-istio-resources.yaml"))
-		if err != nil {
-			log.Errorf("Failed to create kubeflow istio resource: %v", err)
-			return err
-		}
-		log.Infof("Done installing istio.")
 	}
 	clientConfig := kftypes.GetKubeConfig()
 	applyErr := ksApp.applyComponent([]string{"metacontroller"}, clientConfig)

--- a/kubeflow/gcp/gpu-driver.libsonnet
+++ b/kubeflow/gcp/gpu-driver.libsonnet
@@ -1,0 +1,130 @@
+{
+  local k = import "k.libsonnet",
+  new(_env, _params):: {
+    local params = _params + _env,
+
+    local daemonset = {
+      "apiVersion": "extensions/v1beta1",
+    	"kind": "DaemonSet",
+    	"metadata": {
+    		"name": "nvidia-driver-installer",
+    		"namespace": "kube-system",
+    		"labels": {
+    			"k8s-app": "nvidia-driver-installer"
+    		}
+    	},
+    	"spec": {
+    		"template": {
+    			"metadata": {
+    				"labels": {
+    					"name": "nvidia-driver-installer",
+    					"k8s-app": "nvidia-driver-installer"
+    				}
+    			},
+    			"spec": {
+    				"affinity": {
+    					"nodeAffinity": {
+    						"requiredDuringSchedulingIgnoredDuringExecution": {
+    							"nodeSelectorTerms": [
+    								{
+    									"matchExpressions": [
+    										{
+    											"key": "cloud.google.com/gke-accelerator",
+    											"operator": "Exists"
+    										}
+    									]
+    								}
+    							]
+    						}
+    					}
+    				},
+    				"tolerations": [
+    					{
+    						"operator": "Exists"
+    					}
+    				],
+    				"hostNetwork": true,
+    				"hostPID": true,
+    				"volumes": [
+    					{
+    						"name": "dev",
+    						"hostPath": {
+    							"path": "/dev"
+    						}
+    					},
+    					{
+    						"name": "nvidia-install-dir-host",
+    						"hostPath": {
+    							"path": "/home/kubernetes/bin/nvidia"
+    						}
+    					},
+    					{
+    						"name": "root-mount",
+    						"hostPath": {
+    							"path": "/"
+    						}
+    					}
+    				],
+    				"initContainers": [
+    					{
+    						"image": "cos-nvidia-installer:fixed",
+    						"imagePullPolicy": "Never",
+    						"name": "nvidia-driver-installer",
+    						"resources": {
+    							"requests": {
+    								"cpu": 0.15
+    							}
+    						},
+    						"securityContext": {
+    							"privileged": true
+    						},
+    						"env": [
+    							{
+    								"name": "NVIDIA_INSTALL_DIR_HOST",
+    								"value": "/home/kubernetes/bin/nvidia"
+    							},
+    							{
+    								"name": "NVIDIA_INSTALL_DIR_CONTAINER",
+    								"value": "/usr/local/nvidia"
+    							},
+    							{
+    								"name": "ROOT_MOUNT_DIR",
+    								"value": "/root"
+    							}
+    						],
+    						"volumeMounts": [
+    							{
+    								"name": "nvidia-install-dir-host",
+    								"mountPath": "/usr/local/nvidia"
+    							},
+    							{
+    								"name": "dev",
+    								"mountPath": "/dev"
+    							},
+    							{
+    								"name": "root-mount",
+    								"mountPath": "/root"
+    							}
+    						]
+    					}
+    				],
+    				"containers": [
+    					{
+    						"image": "gcr.io/google-containers/pause:2.0",
+    						"name": "pause"
+    					}
+    				]
+    			}
+    		}
+    	}
+    },
+    daemonset:: daemonset,
+
+    parts:: self,
+    all:: [
+      self.daemonset,
+    ],
+
+    list(obj=self.all):: k.core.v1.list.new(obj,),
+  },
+}

--- a/kubeflow/gcp/prototypes/gpu-driver.jsonnet
+++ b/kubeflow/gcp/prototypes/gpu-driver.jsonnet
@@ -1,0 +1,9 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.gpu-driver
+// @description Provides gpu-driver prototype in kubeflow gcp package
+// @shortDescription Gpu Driver.
+// @param name string Name for the component
+
+local gpuDriver = import "kubeflow/gcp/gpu-driver.libsonnet";
+local instance = gpuDriver.new(env, params);
+instance.list(instance.all)


### PR DESCRIPTION
The goal is to avoid shell out and run ```kubectl apply```:
To use gcp.go/ksonnet.go as a library, it need to support concurrent run and cannot use local kubeconfig. 

For stackdriver, will config with gcp/prometheus

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2772)
<!-- Reviewable:end -->
