### PR TITLE
Add NotFoundView to catch invalid paths

### DIFF
--- a/components/centraldashboard/.eslintrc.json
+++ b/components/centraldashboard/.eslintrc.json
@@ -10,7 +10,6 @@
     "globals": {
         "BUILD_VERSION": "readonly",
         "VERSION": "readonly",
-        "DEVMODE": "readonly",
         "Atomics": "readonly",
         "SharedArrayBuffer": "readonly"
     },

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -4310,7 +4310,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4331,12 +4332,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4351,17 +4354,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4478,7 +4484,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4490,6 +4497,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4504,6 +4512,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4511,12 +4520,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4535,6 +4546,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4615,7 +4627,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4627,6 +4640,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4712,7 +4726,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4748,6 +4763,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4767,6 +4783,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4810,12 +4827,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -91,8 +91,8 @@ export class MainPage extends PolymerElement {
             buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
             inIframe: {type: Boolean, value: false, readOnly: true},
-            notFoundInIframe: {type: Boolean, value: false},
-            _devMode: {type: Boolean, value: DEVMODE},
+            hideTabs: {type: Boolean, value: false, readOnly: true},
+            notFoundInIframe: {type: Boolean, value: false, readOnly: true},
         };
     }
 
@@ -157,7 +157,7 @@ export class MainPage extends PolymerElement {
      */
     _routePageChanged(newPage) {
         let isIframe = false;
-        this.notFoundInIframe = false;
+        this._setNotFoundInIframe(false);
         switch (newPage) {
         case 'activity':
             this.sidebarItemIndex = 0;
@@ -176,9 +176,11 @@ export class MainPage extends PolymerElement {
             this.page = 'not_found';
             // Handles case when an iframed page requests an invalid route
             if (window.location !== window.parent.location) {
-                this.notFoundInIframe = true;
+                this._setNotFoundInIframe(true);
             }
         }
+        this._setHideTabs(!(this.page === 'activity' ||
+            this.page === 'dashboard'));
         this._setInIframe(isIframe);
         // If iframe <-> [non-frame OR other iframe]
         if (isIframe !== this.inIframe || isIframe) {

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -157,11 +157,13 @@ export class MainPage extends PolymerElement {
      */
     _routePageChanged(newPage) {
         let isIframe = false;
-        this._setNotFoundInIframe(false);
+        let notFoundInIframe = false;
+        let hideTabs = true;
         switch (newPage) {
         case 'activity':
             this.sidebarItemIndex = 0;
             this.page = 'activity';
+            hideTabs = false;
             break;
         case '_': // iframe case
             this._setIframeFromRoute(this.subRouteData.path);
@@ -170,17 +172,18 @@ export class MainPage extends PolymerElement {
         case '':
             this.sidebarItemIndex = 0;
             this.page = 'dashboard';
+            hideTabs = false;
             break;
         default:
             this.sidebarItemIndex = -1;
             this.page = 'not_found';
             // Handles case when an iframed page requests an invalid route
             if (window.location !== window.parent.location) {
-                this._setNotFoundInIframe(true);
+                notFoundInIframe = true;
             }
         }
-        this._setHideTabs(!(this.page === 'activity' ||
-            this.page === 'dashboard'));
+        this._setNotFoundInIframe(notFoundInIframe);
+        this._setHideTabs(hideTabs);
         this._setInIframe(isIframe);
         // If iframe <-> [non-frame OR other iframe]
         if (isIframe !== this.inIframe || isIframe) {

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -32,6 +32,7 @@ import template from './main-page.pug';
 import './namespace-selector.js';
 import './dashboard-view.js';
 import './activity-view.js';
+import './not-found-view.js';
 
 /**
  * Entry point for application UI.
@@ -164,9 +165,13 @@ export class MainPage extends PolymerElement {
             this._setIframeFromRoute(this.subRouteData.path);
             isIframe = true;
             break;
-        default:
+        case '':
             this.sidebarItemIndex = 0;
             this.page = 'dashboard';
+            break;
+        default:
+            this.sidebarItemIndex = -1;
+            this.page = 'not_found';
         }
         this._setInIframe(isIframe);
         // If iframe <-> [non-frame OR other iframe]
@@ -187,8 +192,8 @@ export class MainPage extends PolymerElement {
             this.iframeUrl = this.menuLinks[menuLinkIndex].iframeUrl;
             this.sidebarItemIndex = menuLinkIndex + 1;
         } else {
-            this.sidebarItemIndex = 0;
-            this.page = 'dashboard';
+            this.sidebarItemIndex = -1;
+            this.page = 'not_found';
         }
     }
 }

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -91,6 +91,7 @@ export class MainPage extends PolymerElement {
             buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
             inIframe: {type: Boolean, value: false, readOnly: true},
+            notFoundInIframe: {type: Boolean, value: false},
             _devMode: {type: Boolean, value: DEVMODE},
         };
     }
@@ -156,6 +157,7 @@ export class MainPage extends PolymerElement {
      */
     _routePageChanged(newPage) {
         let isIframe = false;
+        this.notFoundInIframe = false;
         switch (newPage) {
         case 'activity':
             this.sidebarItemIndex = 0;
@@ -172,6 +174,10 @@ export class MainPage extends PolymerElement {
         default:
             this.sidebarItemIndex = -1;
             this.page = 'not_found';
+            // Handles case when an iframed page requests an invalid route
+            if (window.location !== window.parent.location) {
+                this.notFoundInIframe = true;
+            }
         }
         this._setInIframe(isIframe);
         // If iframe <-> [non-frame OR other iframe]

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -1,4 +1,6 @@
-app-drawer-layout.flex(narrow='{{narrowMode}}', force-narrow='[[or(inIframe, thinView)]]', thin$='[[thinView]]')
+app-drawer-layout.flex(narrow='{{narrowMode}}',
+        force-narrow='[[or(inIframe, thinView, notFoundInIframe)]]',
+        thin$='[[thinView]]')
     app-location(route='{{route}}', query-params='{{queryParams}}')
     app-route(route='{{route}}', pattern='/:page', data='{{routeData}}',
         tail='{{subRouteData}}')
@@ -20,7 +22,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}', force-narrow='[[or(inIframe, thi
             section.build build version&nbsp;
                 span(title="Build: [[buildVersion]] | Dashboard: v[[dashVersion]]") [[buildVersion]]
     app-header-layout(fullbleed)
-        app-header(slot='header')
+        app-header(slot='header', hides, hidden$='[[notFoundInIframe]]')
             app-toolbar(blue$='[[inIframe]]')
                 aside#Narrow-Slider(hides, hidden$='[[!narrowMode]]')
                     paper-icon-button#Menu(icon='menu', drawer-toggle)

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -41,4 +41,6 @@ app-drawer-layout.flex(narrow='{{narrowMode}}', force-narrow='[[or(inIframe, thi
                 activity-view(namespace='[[queryParams.ns]]')
             neon-animatable#iframe-page(page='iframe')
                 iframe#PageFrame.flex(src='[[iframeUrl]]')
+            neon-animatable(page='not_found')
+                not-found-view(path="[[route.path]]")
     iron-media-query(query='(max-width: 900px)', query-matches='{{thinView}}')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -27,7 +27,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 aside#Narrow-Slider(hides, hidden$='[[!narrowMode]]')
                     paper-icon-button#Menu(icon='menu', drawer-toggle)
                     figure.Logo
-                paper-tabs.bottom(selected='[[page]]', attr-for-selected='page', hides, hidden$='[[inIframe]]')
+                paper-tabs.bottom(selected='[[page]]', attr-for-selected='page',
+                        hides, hidden$='[[hideTabs]]')
                     paper-tab(page='dashboard', link)
                         a.link(tabindex='-1', href='/') Dashboard
                     paper-tab(page='activity', link)

--- a/components/centraldashboard/public/components/not-found-view.js
+++ b/components/centraldashboard/public/components/not-found-view.js
@@ -1,0 +1,35 @@
+import {html, PolymerElement} from '@polymer/polymer';
+
+export class NotFoundView extends PolymerElement {
+    static get template() {
+        return html`
+            <style>
+                :host {
+                    background: #f1f3f4;
+                    color: var(--google-grey-500);
+                    font-style: italic;
+                    font-size: 2em;
+                    font-family: Google Sans;
+                    padding: 1em;
+                    text-align: center;
+                    align-self: center;
+                    position: absolute;
+                    top: 50%;
+                    transform: translateY(-50%);
+                }
+            </style>
+            <p>Sorry, <strong>[[path]]</strong> is not a valid page</p>
+        `;
+    }
+
+    /**
+      * Object describing property-related metadata used by Polymer features
+      */
+    static get properties() {
+        return {
+            path: String,
+        };
+    }
+}
+
+window.customElements.define('not-found-view', NotFoundView);

--- a/components/centraldashboard/webpack.config.js
+++ b/components/centraldashboard/webpack.config.js
@@ -155,7 +155,6 @@ module.exports = {
         new DefinePlugin({
             BUILD_VERSION: JSON.stringify(BUILD_VERSION),
             VERSION: JSON.stringify(PKG_VERSION),
-            DEVMODE: JSON.stringify(ENV == 'development'),
         }),
         new HtmlWebpackPlugin({
             filename: resolve(DESTINATION, 'index.html'),


### PR DESCRIPTION
Fixes #2759.

This PR adds a not-found view that stylistically matches the look of the message on the Activity page before a Namespace is selected.

![Screenshot from 2019-03-22 09-24-25](https://user-images.githubusercontent.com/6835846/54825567-4d6e9e80-4c84-11e9-8558-480df12691d0.png)

Here are some screencasts of the behavior:
- This shows the primary behavior running locally on the Webpack Dev Server. If a user explicitly navigates to an unknown route, the view is shown indicating that the page is invalid.
  - https://screencast.googleplex.com/cast/NDc4OTAzMjM0NTE0MTI0OHxlOWI4YzdkMy0zMA
- This shows the behavior when deployed in a Kubeflow cluster on GKE. The behavior is the same.
  - https://screencast.googleplex.com/cast/NjAwMjAwMzc4ODQzMTM2MHxmZDI5OWFjNC1jYw

It should no longer be possible to land on the dashboard unless using the base URL of the cluster.

With respect to the iframe-inception behavior, I believe that should only be possible when running the Webpack Dev Server via `npm run dev` since it rewrites all all incoming requests to the entry point (index.html). I experimented with adding additional entries to the `proxy` object to see if I could proxy those paths to a working GKE cluster but it doesn't work properly due to same-origin issues. That might be different if you were working with a cluster on your local machine. In any case, I don't think that's a huge issue at the moment since it only affects development and can't occur in cluster.

/assign @avdaredevil 
/area front-end
/area centraldashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2778)
<!-- Reviewable:end -->
