### PR TITLE
Obtain build version from ENV

### DIFF
--- a/components/centraldashboard/.eslintrc.json
+++ b/components/centraldashboard/.eslintrc.json
@@ -8,6 +8,7 @@
         "google"
     ],
     "globals": {
+        "BUILD_VERSION": "readonly",
         "VERSION": "readonly",
         "DEVMODE": "readonly",
         "Atomics": "readonly",

--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -6,6 +6,9 @@ COPY app/ ./app
 COPY public/ ./public
 COPY webpack.config.js *.json ./
 
+ARG kubeflowversion
+ENV BUILD_VERSION=$kubeflowversion
+
 RUN npm install && npm run build && npm prune --production
 
 EXPOSE 8082

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -87,7 +87,7 @@ export class MainPage extends PolymerElement {
             },
             sidebarItemIndex: {type: Number, value: 0},
             iframeUrl: {type: String, value: ''},
-            buildVersion: {type: String, value: '0.5.0'},
+            buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
             inIframe: {type: Boolean, value: false, readOnly: true},
             _devMode: {type: Boolean, value: DEVMODE},

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -17,7 +17,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}', force-narrow='[[or(inIframe, thi
         footer.footer
             section.privacy Privacy
             section.build build version&nbsp;
-                span(title="Build: v[[buildVersion]] | Dashboard: v[[dashVersion]]") v[[buildVersion]]
+                span(title="Build: [[buildVersion]] | Dashboard: v[[dashVersion]]") [[buildVersion]]
     app-header-layout(fullbleed)
         app-header(slot='header')
             app-toolbar(blue$='[[inIframe]]')

--- a/components/centraldashboard/webpack.config.js
+++ b/components/centraldashboard/webpack.config.js
@@ -12,6 +12,7 @@ const TerserPlugin = require('terser-webpack-plugin');
 const ENV = process.env.NODE_ENV || 'development';
 const NODE_MODULES = /\/node_modules\//;
 const PKG_VERSION = require('./package.json').version;
+const BUILD_VERSION = process.env.BUILD_VERSION || `v${PKG_VERSION}`;
 const SRC = resolve(__dirname, 'public');
 const COMPONENTS = resolve(SRC, 'components');
 const DESTINATION = resolve(__dirname, 'dist', 'public');
@@ -29,8 +30,10 @@ const POLYFILLS = [
     },
 ];
 
-// Rules for processing Polymer components to allow
-// external Pug templates and CSS files.
+/**
+ * Rules for processing Polymer components to allow external Pug templates
+ * and CSS files.
+ */
 const COMPONENT_RULES = [
     {
         test: /\.pug$/,
@@ -150,6 +153,7 @@ module.exports = {
         new CleanWebpackPlugin([DESTINATION]),
         new CopyWebpackPlugin(POLYFILLS),
         new DefinePlugin({
+            BUILD_VERSION: JSON.stringify(BUILD_VERSION),
             VERSION: JSON.stringify(PKG_VERSION),
             DEVMODE: JSON.stringify(ENV == 'development'),
         }),


### PR DESCRIPTION
*Fixes last open item on #2512* 

This change adds an additional variable defined at build time by webpack based on the value of the `BUILD_VERSION` environment variable. When building the Docker container via `make`, the `kubeflowversion` argument is already set to the most recent tag in the repository. This change assigns that build-time argument to the environment variable and the container and uses it to display the Kubeflow version. If the environment variable is not set, the dashboard's version from package.json is shown.

![Screenshot from 2019-03-22 10-47-40](https://user-images.githubusercontent.com/6835846/54831015-f2db3f80-4c8f-11e9-850c-5e05c7bfb591.png)

/assign @avdaredevil
/area centraldashboard
/area front-end

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2779)
<!-- Reviewable:end -->
