### PR TITLE
Namespace selector now only shows up when on activity page

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -118,12 +118,23 @@ export class MainPage extends PolymerElement {
     }
 
     /**
-     * Provide a logical OR functionality for the Polymer DOM
-     * @param {...boolean} a
+     * [MACRO] Provide a logical OR functionality for the Polymer DOM
+     * @param {...boolean} e
      * @return {boolean}
      */
     or(...e) {
         return e.some((i) => Boolean(i));
+    }
+
+    /**
+     * [MACRO] Provide a logical equals functionality for the Polymer DOM
+     * @param {...any} e
+     * @return {boolean}
+     */
+    equals(...e) {
+        const crit = e.shift();
+        if (!e.length) return true;
+        return e.every((e) => e === crit);
     }
 
     /**

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -29,7 +29,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}', force-narrow='[[or(inIframe, thi
                         a.link(tabindex='-1', href='/') Dashboard
                     paper-tab(page='activity', link)
                         a.link(tabindex='-1', href='/activity') Activity
-                aside#NamespaceSelector
+                aside#NamespaceSelector(hidden$='[[!equals(page, "activity")]]')
                     namespace-selector(query-params='{{queryParams}}')
         neon-animated-pages(selected='[[page]]', attr-for-selected='page',
                             entry-animation='fade-in-animation',


### PR DESCRIPTION
#### child of #2777 
## About 
- Namespace selector now only show on `Activity` and are disabled everywhere else

/assign @avdaredevil @prodonjs 
/cc: @rileyjbauer 
/area front-end
/area centraldashboard
/priority p1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2788)
<!-- Reviewable:end -->
