### PR TITLE
Add missing alsologtostderr flag to mpi-operator args

### DIFF
--- a/kubeflow/mpi-job/mpi-operator.libsonnet
+++ b/kubeflow/mpi-job/mpi-operator.libsonnet
@@ -273,6 +273,7 @@ local k = import "k.libsonnet";
                 name: "mpi-operator",
                 image: image,
                 args: [
+                  "-alsologtostderr",
                   "--gpus-per-node",
                   std.toString(gpusPerNode),
                   "--kubectl-delivery-image",


### PR DESCRIPTION
mpi-operator doesn't log to std by default, this `kubectl logs` doesn't retrieve the logs. 

See `alsologtostderr` flag is also set in [mpi-operator.yaml](https://github.com/kubeflow/mpi-operator/blob/master/deploy/3-mpi-operator.yaml#L23).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2793)
<!-- Reviewable:end -->
