### PR TITLE
Stop setting JupyterHub parameters and pull config from PR branch.

### DIFF
--- a/bootstrap/config/kfctl_basic_auth.yaml
+++ b/bootstrap/config/kfctl_basic_auth.yaml
@@ -63,9 +63,6 @@ componentParams:
   cloud-endpoints:
     - name: secretName
       value: admin-gcp-sa
-  jupyter:
-    - name: platform
-      value: gke
   ambassador:
     - name: ambassadorServiceType
       value: NodePort

--- a/bootstrap/config/kfctl_default.yaml
+++ b/bootstrap/config/kfctl_default.yaml
@@ -39,9 +39,6 @@ componentParams:
   application:
     - name: components
       value: <list-of-components>
-  jupyter:
-    - name: platform
-      value: none
   ambassador:
     - name: ambassadorServiceType
       value: NodePort

--- a/testing/kfctl/kfctl_go_test.py
+++ b/testing/kfctl/kfctl_go_test.py
@@ -32,8 +32,9 @@ def test_build_kfctl_go(app_path, project):
   build_dir = os.path.join(root, "bootstrap")
 
   # Need to activate account for scopes.
-  util.run(["gcloud", "auth", "activate-service-account",
-            "--key-file=" + os.environ["GOOGLE_APPLICATION_CREDENTIALS"]])
+  if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
+    util.run(["gcloud", "auth", "activate-service-account",
+              "--key-file=" + os.environ["GOOGLE_APPLICATION_CREDENTIALS"]])
 
   # We need to use retry builds because when building in the test cluster
   # we see intermittent failures pulling dependencies
@@ -44,20 +45,37 @@ def test_build_kfctl_go(app_path, project):
   os.environ["KUBEFLOW_USERNAME"] = "kf-test-user"
   os.environ["KUBEFLOW_PASSWORD"] = str(uuid.uuid4().hex)
 
+  version = "master"
+  if os.getenv("PULL_NUMBER"):
+    version = "pull/{0}".format(os.getenv("PULL_NUMBER"))
+
   # username and password are passed as env vars and won't appear in the logs
   run_with_retries([kfctl_path, "init", app_path, "-V", "--platform=gcp",
-                         "--use_basic_auth", "--skip-init-gcp-project",
+                         "--version=" + version,
+                         "--use_basic_auth",
+                         "--skip-init-gcp-project",
                          "--disable_usage_report",
                          "--project=" + project], cwd=parent_dir)
 
-  # TODO(jlewi): We need to specify a valid email otherwise we get an error
-  # when trying to apply the IAM policy.
+  # We need to specify a valid email because
+  #  1. We need to create appropriate RBAC rules to allow the current user
+  #     to create the required K8s resources.
+  #  2. Setting the IAM policy will fail if the email is invalid.
+  email = util.run(["gcloud", "config", "get-value", "account"])
+
+  if not email:
+    raise ValueError("Could not determine GCP account being used.")
+
   run_with_retries([kfctl_path, "generate", "-V", "all",
-                    "--email=kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com"],
+                    "--email=" + email],
                     cwd=app_path)
 
   # We need to use retries because if we don't we see random failures
   # where kfctl just appears to die.
+  #
+  # TODO(https://github.com/kubeflow/kubeflow/issues/2791): Running with
+  # retries will mask failures like kubeflow/kubeflow#2791 that will succeed
+  # on retry. We should fix the test so that we don't mask those errors.
   run_with_retries([kfctl_path, "apply", "-V", "all"], cwd=app_path)
 
 if __name__ == "__main__":


### PR DESCRIPTION
* Fix #2796; stop installing the jupyter component (jupyterhub) and
  trying to set parameters on that component.

* In presubmits we need to pull the config file listing the ksonnet packages,
  and components to configure from the PR branch and not master.

* To support local running of the test, only activate the service account if
GOOGLE_APPLICATION_CREDENTIALS is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2798)
<!-- Reviewable:end -->
