### PR TITLE
kfctl interface in gcp.go/ksonnet.go for deploy app

### DIFF
--- a/bootstrap/config/kfctl_basic_auth.yaml
+++ b/bootstrap/config/kfctl_basic_auth.yaml
@@ -5,7 +5,6 @@
 repo: /path/to/local/tmp/containing/kubeflow
 packages:
   - argo
-  - application
   - common
   - examples
   - gcp
@@ -23,7 +22,6 @@ packages:
   - tf-training
 components:
   - ambassador
-  - application
   - argo
   - basic-auth
   - basic-auth-ingress
@@ -57,10 +55,6 @@ componentParams:
       # TODO change value on the fly: replace with user-provide parameters. This need to be fully qualified domain name to use with ingress.
       value: <deployName>.endpoints.<Project>.cloud.goog
       initRequired: true
-
-  application:
-    - name: components
-      value: <list-of-components>
   cloud-endpoints:
     - name: secretName
       value: admin-gcp-sa

--- a/bootstrap/config/kfctl_default.yaml
+++ b/bootstrap/config/kfctl_default.yaml
@@ -5,7 +5,6 @@
 repo: /path/to/local/tmp/containing/kubeflow
 packages:
   - argo
-  - application
   - common
   - examples
   - gcp
@@ -23,7 +22,6 @@ packages:
   - tf-training
 components:
   - ambassador
-  - application
   - argo
   - centraldashboard
   - jupyter-web-app
@@ -36,9 +34,6 @@ components:
   - tensorboard
   - tf-job-operator
 componentParams:
-  application:
-    - name: components
-      value: <list-of-components>
   ambassador:
     - name: ambassadorServiceType
       value: NodePort

--- a/bootstrap/config/kfctl_iap.yaml
+++ b/bootstrap/config/kfctl_iap.yaml
@@ -4,7 +4,6 @@
 # TODO change repo on the fly: set it to local tmp dir containing kubeflow registry
 repo: /path/to/local/tmp/containing/kubeflow
 packages:
-  - application
   - argo
   - common
   - examples
@@ -23,7 +22,6 @@ packages:
   - tf-training
 components:
   - ambassador
-  - application
   - argo
   - centraldashboard
   - cert-manager
@@ -56,9 +54,6 @@ componentParams:
       # TODO change value on the fly: replace with user-provide parameters. This need to be fully qualified domain name to use with ingress.
       value: <deployName>.endpoints.<project>.cloud.goog
       initRequired: true
-  application:
-    - name: components
-      value: <list-of-components>
   cloud-endpoints:
     - name: secretName
       value: admin-gcp-sa

--- a/bootstrap/pkg/apis/apps/group.go
+++ b/bootstrap/pkg/apis/apps/group.go
@@ -51,8 +51,7 @@ const (
 	DefaultAppLabel   = "app.kubernetes.io/name"
 	KUBEFLOW_USERNAME = "KUBEFLOW_USERNAME"
 	KUBEFLOW_PASSWORD = "KUBEFLOW_PASSWORD"
-	// TODO: switch to bootstrap/k8sSpec/v1.11.7/api/openapi-spec/swagger.json
-	DefaultSwaggerFile = "releasing/releaser/lib/v1.9.7/swagger.json"
+	DefaultSwaggerFile = "bootstrap/k8sSpec/v1.11.7/api/openapi-spec/swagger.json"
 )
 
 type ResourceEnum string
@@ -179,7 +178,7 @@ func GetConfig() *rest.Config {
 	overrides := &clientcmd.ConfigOverrides{}
 	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides).ClientConfig()
 	if err != nil {
-		log.Fatalf("could not open %v Error %v", loadingRules.ExplicitPath, err)
+		log.Warnf("could not open %v Error %v", loadingRules.ExplicitPath, err)
 	}
 	return config
 }
@@ -199,7 +198,7 @@ func GetKubeConfig() *clientcmdapi.Config {
 	kubeconfig := KubeConfigPath()
 	config, configErr := clientcmd.LoadFromFile(kubeconfig)
 	if configErr != nil {
-		log.Fatalf("could not load config Error: %v", configErr)
+		log.Warnf("could not load config Error: %v", configErr)
 	}
 	return config
 }

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -135,7 +135,7 @@ func getPlatform(kfdef *kfdefs.KfDef) (kftypes.KfApp, error) {
 	case string(kftypes.MINIKUBE):
 		return minikube.GetKfApp(kfdef), nil
 	case string(kftypes.GCP):
-		return gcp.GetKfApp(kfdef), nil
+		return gcp.GetKfApp(kfdef)
 	default:
 		log.Infof("** loading %v.so for platform %v **", kfdef.Spec.Platform, kfdef.Spec.Platform)
 		return kftypes.LoadKfApp(kfdef)

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -97,7 +97,10 @@ func GetKfApp(kfdef *kfdefs.KfDef) (kftypes.KfApp, error) {
 	}
 	ts, err := google.DefaultTokenSource(ctx, iam.CloudPlatformScope)
 	if err != nil {
-		return nil, fmt.Errorf("Get token error: %v", err)
+		return nil, &kfapis.KfError{
+			Code: int(kfapis.INVALID_ARGUMENT),
+			Message: fmt.Sprintf("Get token error: %v", err),
+		}
 	}
 	_gcp := &Gcp{
 		KfDef:       *kfdef,
@@ -130,7 +133,7 @@ func GetAccount() (string, error) {
 }
 
 func (gcp *Gcp) writeConfigFile() error {
-	buf, bufErr := yaml.Marshal(gcp)
+	buf, bufErr := yaml.Marshal(gcp.KfDef)
 	if bufErr != nil {
 		return bufErr
 	}
@@ -960,7 +963,7 @@ func (gcp *Gcp) createSecrets() error {
 // Remind: Need to be thread-safe: this entry is share among kfctl and deploy app
 func (gcp *Gcp) Generate(resources kftypes.ResourceEnum) error {
 	if gcp.Spec.Email == "" {
-		return fmt.Errorf("--email not specified and cannot get gcloud value.")
+		return fmt.Errorf("email not specified.")
 	}
 	switch resources {
 	case kftypes.ALL:

--- a/bootstrap/pkg/utils/k8utils.go
+++ b/bootstrap/pkg/utils/k8utils.go
@@ -28,8 +28,6 @@ import (
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
-	"os"
-	"os/exec"
 	"strings"
 	"sync"
 
@@ -194,18 +192,6 @@ func patchOrCreate(mapping *meta.RESTMapping, config *rest.Config, group string,
 		err = createResource(mapping, config, group, version, namespace, data)
 	}
 	return err
-}
-
-// TODO(#2391): Should remove use of kubectl apply.
-func RunKubectlApply(filename string, args ...string) error {
-	cmdargs := []string{"apply", "--validate=false", "-f", filename}
-	for _, arg := range args {
-		cmdargs = append(cmdargs, arg)
-	}
-	cmd := exec.Command("kubectl", cmdargs...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stdout
-	return cmd.Run()
 }
 
 // CreateResourceFromFile creates resources from a file, just like `kubectl create -f filename`

--- a/testing/workflows/components/kfctl_go_test.jsonnet
+++ b/testing/workflows/components/kfctl_go_test.jsonnet
@@ -85,7 +85,7 @@ local prowDict = {
 // We use separate kubeConfig files for separate clusters
 local buildTemplate(step_name, command, working_dir=null, env_vars=[], sidecars=[]) = {
   name: step_name,
-  activeDeadlineSeconds: 2400,  // Set 40 minute timeout for each template
+  activeDeadlineSeconds: 3000,  // Set 50 minute timeout for each template
   workingDir: working_dir,
   container: {
     command: command,

--- a/testing/workflows/components/kfctl_go_test.jsonnet
+++ b/testing/workflows/components/kfctl_go_test.jsonnet
@@ -85,7 +85,7 @@ local prowDict = {
 // We use separate kubeConfig files for separate clusters
 local buildTemplate(step_name, command, working_dir=null, env_vars=[], sidecars=[]) = {
   name: step_name,
-  activeDeadlineSeconds: 2700,  // Set 30 minute timeout for each template
+  activeDeadlineSeconds: 2400,  // Set 40 minute timeout for each template
   workingDir: working_dir,
   container: {
     command: command,


### PR DESCRIPTION
* remove gcloud dependency from gcp.go,
* remove kubectl dependency from ksonnet.go,
* parameterize auth method for gcp.go and ksonnet.go.

so kfctl and deploy app can use same code with their own auth methdo.

New interface example:
Generate() and Apply() need to be called by deploy app, it need to satisfy:
* no dependency on ENV var
* no dependency on local config like gcloud or kube config
* need to be thread safe
* only do disk read/write within it's own app dir.

Now for kfctl we prepare auth config in GetKfApp()

Have to remove application to avoid concurrent label edit.
Will hard code label for v0.5 and use application component once kustomize.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2801)
<!-- Reviewable:end -->
