### PR TITLE
fixes 'kfctl downloading the kubeflow to a local cache should be idempotent'

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -77,7 +77,10 @@ func downloadToCache(platform string, appDir string, version string, useBasicAut
 	cacheDir := path.Join(appDir, kftypes.DefaultCacheDir)
 	// idempotency
 	if _, err := os.Stat(cacheDir); !os.IsNotExist(err) {
-		os.RemoveAll(cacheDir)
+		rmErr := os.RemoveAll(cacheDir)
+		if rmErr != nil {
+			return nil, fmt.Errorf("couldn't delete directory %v Error %v", cacheDir, rmErr)
+		}
 	}
 	cacheDirErr := os.Mkdir(cacheDir, os.ModePerm)
 	if cacheDirErr != nil {


### PR DESCRIPTION
fixes #2818

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2819)
<!-- Reviewable:end -->
