### PR TITLE
Add aws platform option

### DIFF
--- a/deployment/aws/infra_configs/iam_alb_ingress_policy.json
+++ b/deployment/aws/infra_configs/iam_alb_ingress_policy.json
@@ -1,0 +1,103 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": [
+          "acm:DescribeCertificate",
+          "acm:ListCertificates",
+          "acm:GetCertificate"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "ec2:AuthorizeSecurityGroupIngress",
+          "ec2:CreateSecurityGroup",
+          "ec2:CreateTags",
+          "ec2:DeleteTags",
+          "ec2:DeleteSecurityGroup",
+          "ec2:DescribeInstances",
+          "ec2:DescribeInstanceStatus",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "ec2:DescribeTags",
+          "ec2:DescribeVpcs",
+          "ec2:ModifyInstanceAttribute",
+          "ec2:ModifyNetworkInterfaceAttribute",
+          "ec2:RevokeSecurityGroupIngress"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "elasticloadbalancing:AddTags",
+          "elasticloadbalancing:CreateListener",
+          "elasticloadbalancing:CreateLoadBalancer",
+          "elasticloadbalancing:CreateRule",
+          "elasticloadbalancing:CreateTargetGroup",
+          "elasticloadbalancing:DeleteListener",
+          "elasticloadbalancing:DeleteLoadBalancer",
+          "elasticloadbalancing:DeleteRule",
+          "elasticloadbalancing:DeleteTargetGroup",
+          "elasticloadbalancing:DeregisterTargets",
+          "elasticloadbalancing:DescribeListeners",
+          "elasticloadbalancing:DescribeLoadBalancers",
+          "elasticloadbalancing:DescribeLoadBalancerAttributes",
+          "elasticloadbalancing:DescribeRules",
+          "elasticloadbalancing:DescribeSSLPolicies",
+          "elasticloadbalancing:DescribeTags",
+          "elasticloadbalancing:DescribeTargetGroups",
+          "elasticloadbalancing:DescribeTargetGroupAttributes",
+          "elasticloadbalancing:DescribeTargetHealth",
+          "elasticloadbalancing:ModifyListener",
+          "elasticloadbalancing:ModifyLoadBalancerAttributes",
+          "elasticloadbalancing:ModifyRule",
+          "elasticloadbalancing:ModifyTargetGroup",
+          "elasticloadbalancing:ModifyTargetGroupAttributes",
+          "elasticloadbalancing:RegisterTargets",
+          "elasticloadbalancing:RemoveTags",
+          "elasticloadbalancing:SetIpAddressType",
+          "elasticloadbalancing:SetSecurityGroups",
+          "elasticloadbalancing:SetSubnets",
+          "elasticloadbalancing:SetWebACL"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "iam:GetServerCertificate",
+          "iam:ListServerCertificates"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "waf-regional:GetWebACLForResource",
+          "waf-regional:GetWebACL",
+          "waf-regional:AssociateWebACL",
+          "waf-regional:DisassociateWebACL"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "tag:GetResources",
+          "tag:TagResources"
+        ],
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": [
+          "waf:GetWebACL"
+        ],
+        "Resource": "*"
+      }
+    ]
+  }

--- a/deployment/aws/infra_configs/iam_cloudwatch_policy.json
+++ b/deployment/aws/infra_configs/iam_cloudwatch_policy.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "*",
+            "Effect": "Allow"
+        }
+    ]
+}

--- a/kubeflow/aws/OWNERS
+++ b/kubeflow/aws/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - jeffwan
+  - jlewi

--- a/kubeflow/aws/README.md
+++ b/kubeflow/aws/README.md
@@ -1,0 +1,12 @@
+# aws
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [aws](#aws)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+
+> This ksonnet package contains AWS specific prototypes.

--- a/kubeflow/aws/aws-alb-ingress-controller.libsonnet
+++ b/kubeflow/aws/aws-alb-ingress-controller.libsonnet
@@ -39,7 +39,7 @@
       subjects: [
         {
           kind: "ServiceAccount",
-          name: "alb-ingress",
+          name: "alb-ingress-controller",
           namespace: params.namespace,
         },
       ],
@@ -112,8 +112,8 @@
             restartPolicy: "Always",
             securityContext: {},
             terminationGracePeriodSeconds: 30,
-            serviceAccountName: "alb-ingress",
-            serviceAccount: "alb-ingress",
+            serviceAccountName: "alb-ingress-controller",
+            serviceAccount: "alb-ingress-controller",
           },
         },
       },

--- a/kubeflow/aws/aws-alb-ingress-controller.libsonnet
+++ b/kubeflow/aws/aws-alb-ingress-controller.libsonnet
@@ -1,0 +1,134 @@
+{
+  local k = import "k.libsonnet",
+  new(_env, _params):: {
+    local params = _params + _env,
+
+    local albIngressClusterRole = {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "alb-ingress-controller",
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+      rules: [
+        {
+          apiGroups: ["", "extensions"],
+          resources: ["configmaps", "endpoints", "events", "ingresses", "ingresses/status", "services"],
+          verbs: ["create", "get", "list", "update", "watch", "patch"],
+        },
+        {
+          apiGroups: ["", "extensions"],
+          resources: ["nodes", "pods", "secrets", "services", "namespaces"],
+          verbs: ["get", "list", "watch"],
+        },
+      ],
+    }, // albIngressClusterRole
+    albIngressClusterRole:: albIngressClusterRole,
+
+    local albIngressClusterRoleBinding = {
+      kind: "ClusterRoleBinding",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "alb-ingress-controller",
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "alb-ingress",
+          namespace: params.namespace,
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "alb-ingress-controller",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+    }, // albIngressClusterRoleBinding
+    albIngressClusterRoleBinding:: albIngressClusterRoleBinding,
+
+    local albIngressServiceAccount = {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "alb-ingress-controller",
+        namespace: params.namespace,
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+    },  // albIngressServiceAccount
+    albIngressServiceAccount:: albIngressServiceAccount,
+
+    local albIngressDeploy = {
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: {
+        name: "alb-ingress-controller",
+        namespace: params.namespace,
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+      spec: {
+        replicas: 1,
+        selector: {
+          matchLabels: {
+            app: "alb-ingress-controller"
+          },
+        },
+        strategy: {
+          rollingUpdate: {
+            maxSurge: 1,
+            maxUnavailable: 1
+          },
+          type: "RollingUpdate"
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "alb-ingress-controller",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                args: [
+                  "--ingress-class=alb",
+                  "--cluster-name=" + params.clusterName,
+                ],
+                name: "alb-ingress-controller",
+                image: params.albIngressControllerImage,
+                imagePullPolicy: "Always",
+                resources: {},
+                terminationMessagePath: "/dev/termination-log"
+              },
+            ],
+            dnsPolicy: "ClusterFirst",
+            restartPolicy: "Always",
+            securityContext: {},
+            terminationGracePeriodSeconds: 30,
+            serviceAccountName: "alb-ingress",
+            serviceAccount: "alb-ingress",
+          },
+        },
+      },
+    },  // albIngressDeploy
+    albIngressDeploy:: albIngressDeploy,
+
+    parts:: self,
+    local all = [
+      self.albIngressClusterRole,
+      self.albIngressClusterRoleBinding,
+      self.albIngressServiceAccount,
+      self.albIngressDeploy,
+    ],
+    all:: all,
+
+    list(obj=self.all):: k.core.v1.list.new(obj,),
+  },
+}

--- a/kubeflow/aws/aws-alb-ingress-controller.libsonnet
+++ b/kubeflow/aws/aws-alb-ingress-controller.libsonnet
@@ -40,7 +40,7 @@
         {
           kind: "ServiceAccount",
           name: "alb-ingress-controller",
-          namespace: params.namespace,
+          namespace: kube-system,
         },
       ],
       roleRef: {
@@ -56,7 +56,7 @@
       kind: "ServiceAccount",
       metadata: {
         name: "alb-ingress-controller",
-        namespace: params.namespace,
+        namespace: kube-system,
         labels: {
           app: "alb-ingress-controller"
         },
@@ -69,7 +69,7 @@
       kind: "Deployment",
       metadata: {
         name: "alb-ingress-controller",
-        namespace: params.namespace,
+        namespace: kube-system,
         labels: {
           app: "alb-ingress-controller"
         },

--- a/kubeflow/aws/aws-alb-ingress-controller.libsonnet
+++ b/kubeflow/aws/aws-alb-ingress-controller.libsonnet
@@ -40,7 +40,7 @@
         {
           kind: "ServiceAccount",
           name: "alb-ingress-controller",
-          namespace: kube-system,
+          namespace: "kube-system",
         },
       ],
       roleRef: {
@@ -56,7 +56,7 @@
       kind: "ServiceAccount",
       metadata: {
         name: "alb-ingress-controller",
-        namespace: kube-system,
+        namespace: "kube-system",
         labels: {
           app: "alb-ingress-controller"
         },
@@ -69,7 +69,7 @@
       kind: "Deployment",
       metadata: {
         name: "alb-ingress-controller",
-        namespace: kube-system,
+        namespace: "kube-system",
         labels: {
           app: "alb-ingress-controller"
         },

--- a/kubeflow/aws/aws-efs-pv.libsonnet
+++ b/kubeflow/aws/aws-efs-pv.libsonnet
@@ -36,7 +36,8 @@
         accessModes: [
           "ReadWriteMany",
         ],
-        storageClassName: "",
+        storageClassName: "nfs-storage",
+        volumeName: params.name,
         resources: {
           requests: {
             storage: params.storageCapacity,
@@ -65,11 +66,11 @@
                 command: [
                   "chmod",
                   "777",
-                  "/kubeflow-gcfs",
+                  "/kubeflow-efs",
                 ],
                 volumeMounts: [
                   {
-                    mountPath: "/kubeflow-gcfs",
+                    mountPath: "/kubeflow-efs",
                     name: params.name,
                   },
                 ],

--- a/kubeflow/aws/aws-efs-pv.libsonnet
+++ b/kubeflow/aws/aws-efs-pv.libsonnet
@@ -1,0 +1,103 @@
+{
+  local k = import "k.libsonnet",
+  new(_env, _params):: {
+    local params = _params + _env,
+
+    local persistentVolume = {
+      apiVersion: "v1",
+      kind: "PersistentVolume",
+      metadata: {
+        name: params.name,
+        namespace: params.namespace,
+      },
+      spec: {
+        capacity: {
+          storage: params.storageCapacity,
+        },
+        accessModes: [
+          "ReadWriteMany",
+        ],
+        nfs: {
+          server: params.serverIP,
+          path: params.path,
+        },
+      },
+    },
+    persistentVolume:: persistentVolume,
+
+    local persistentVolumeClaim = {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: params.name,
+        namespace: params.namespace,
+      },
+      spec: {
+        accessModes: [
+          "ReadWriteMany",
+        ],
+        storageClassName: "",
+        resources: {
+          requests: {
+            storage: params.storageCapacity,
+          },
+        },
+      },
+    },
+    persistentVolumeClaim:: persistentVolumeClaim,
+
+    // Set 777 permissions on the EFS so that non-root users
+    // like jovyan can use that NFS share
+    local efsPersmissions = {
+      apiVersion: "batch/v1",
+      kind: "Job",
+      metadata: {
+        name: "set-efs-permissions",
+        namespace: params.namespace,
+      },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                name: "set-efs-permissions",
+                image: params.image,
+                command: [
+                  "chmod",
+                  "777",
+                  "/kubeflow-gcfs",
+                ],
+                volumeMounts: [
+                  {
+                    mountPath: "/kubeflow-gcfs",
+                    name: params.name,
+                  },
+                ],
+              },
+            ],
+            restartPolicy: "OnFailure",
+            volumes: [
+              {
+                name: params.name,
+                persistentVolumeClaim: {
+                  claimName: params.name,
+                  readOnly: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+    efsPersmissions:: efsPersmissions,
+
+    parts:: self,
+    all:: [
+      self.persistentVolume,
+      self.persistentVolumeClaim,
+      self.efsPersmissions,
+    ],
+
+    list(obj=self.all):: k.core.v1.list.new(obj,),
+  },
+}

--- a/kubeflow/aws/aws-fsx-csi-driver.libsonnet
+++ b/kubeflow/aws/aws-fsx-csi-driver.libsonnet
@@ -1,0 +1,249 @@
+{
+  local k = import "k.libsonnet",
+  new(_env, _params):: {
+    local params = _params + _env,
+
+    local csiControllerServiceAccount = {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "fsx-csi-controller-sa",
+        namespace: params.namespace,
+      },
+    },  // csiControllerServiceAccount
+    csiControllerServiceAccount:: csiControllerServiceAccount,
+
+    local csiProvisionerClusterRole = {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-external-provisioner-clusterrole",
+      },
+      rules: [
+        {
+          apiGroups: [""],
+          resources: ["persistentvolumes"],
+          verbs: ["get", "list", "watch", "create", "delete"],
+        },
+        {
+          apiGroups: [""],
+          resources: ["persistentvolumeclaims"],
+          verbs: ["get", "list", "watch", "update"],
+        },
+        {
+          apiGroups: ["storage.k8s.io"],
+          resources: ["storageclasses"],
+          verbs: ["get", "list", "watch"],
+        },
+        {
+          apiGroups: [""],
+          resources: ["events"],
+          verbs: ["get", "list", "watch", "create", "update", "patch"],
+        },
+      ],
+    }, // csiProvisionerClusterRole
+    csiProvisionerClusterRole:: csiProvisionerClusterRole,
+
+    local csiProvisionerClusterRoleBinding = {
+      kind: "ClusterRoleBinding",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-provisioner-binding",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "fsx-csi-controller-sa",
+          namespace: params.namespace,
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "csi-fsx-external-provisioner-clusterrole",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+    }, // csiProvisionerClusterRoleBinding
+    csiProvisionerClusterRoleBinding:: csiProvisionerClusterRoleBinding,
+
+    local csiAttacherClusterRole = {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-external-attacher-clusterrole",
+      },
+      rules: [
+        {
+          apiGroups: [""],
+          resources: ["persistentvolumes"],
+          verbs: ["get", "list", "watch", "update"],
+        },
+        {
+          apiGroups: [""],
+          resources: ["nodes"],
+          verbs: ["get", "list", "watch"],
+        },
+        {
+          apiGroups: ["storage.k8s.io"],
+          resources: ["volumeattachments"],
+          verbs: ["get", "list", "watch", "update"],
+        },
+      ],
+    }, // csiFSxAttacherClusterRole
+    csiAttacherClusterRole:: csiAttacherClusterRole,
+
+    local csiAttacherClusterRoleBinding = {
+      kind: "ClusterRoleBinding",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-attacher-binding",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "fsx-csi-controller-sa",
+          namespace: params.namespace,
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "csi-fsx-external-attacher-clusterrole",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+    }, // csiAttacherClusterRoleBinding
+    csiAttacherClusterRoleBinding:: csiAttacherClusterRoleBinding,
+
+    local csiControllerDeploy = {
+      apiVersion: "apps/v1beta1",
+      kind: "StatefulSet",
+      metadata: {
+        name: "fsx-csi-controller",
+        namespace: params.namespace,
+      },
+      spec: {
+        serviceAccount: "fsx-csi-controller",
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              app: "fsx-csi-controller",
+            },
+          },
+          spec: {
+            serviceAccount: "csi-controller-sa",
+            priorityClassName: "system-cluster-critical",
+
+            tolerations: [
+              {
+                key: "CriticalAddonsOnly",
+                operator: "Exists"
+              },
+            ],
+            containers: [
+              {
+                name: "fsx-plugin",
+                image: params.csiControllerImage,
+                args: [
+                  "--endpoint=$(CSI_ENDPOINT)",
+                  "--logtostderr",
+                  "--v=5"
+                ],
+                env: [
+                  {
+                    name: "CSI_ENDPOINT",
+                    value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+                  },
+                  {
+                    name: "AWS_ACCESS_KEY_ID",
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: "aws-secret",
+                        key: "key_id",
+                      },
+                    },
+                  },
+                  {
+                    name: "AWS_SECRET_ACCESS_KEY",
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: "aws-secret",
+                        key: "access_key",
+                      },
+                    },
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "socket-dir",
+                    mountPath: "/var/lib/csi/sockets/pluginproxy/",
+                  },
+                ],
+              },
+              {
+                name: "fsx-csi-provisioner",
+                image: params.csiProvisionerImage,
+                args: [
+                  "--provisioner=fsx.csi.aws.com",
+                  "--csi-address=$(ADDRESS)",
+                  "--connection-timeout=5m",
+                  "--v=5"
+                ],
+                env: [
+                  {
+                    name: "ADDRESS",
+                    value: "/var/lib/csi/sockets/pluginproxy/csi.sock",
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "socket-dir",
+                    mountPath: "/var/lib/csi/sockets/pluginproxy/",
+                  },
+                ],
+              },
+              {
+                name: "fsx-csi-attacher",
+                image: params.csiAttacherImage,
+                args: [
+                  "--csi-address=$(ADDRESS)",
+                  "--v=5"
+                ],
+                env: [
+                  {
+                    name: "ADDRESS",
+                    value: "/var/lib/csi/sockets/pluginproxy/csi.sock",
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "socket-dir",
+                    mountPath: "/var/lib/csi/sockets/pluginproxy/",
+                  },
+                ],
+              },
+            ],
+            volumes: [
+              {
+                name: "socket-dir",
+                emptyDir: {},
+              },
+            ],
+          },
+        },
+      },
+    },  // csiControllerDeploy
+    csiControllerDeploy:: csiControllerDeploy,
+
+    parts:: self,
+    local all = [
+      self.csiControllerServiceAccount,
+      self.csiProvisionerClusterRole,
+      self.csiProvisionerClusterRoleBinding,
+      self.csiAttacherClusterRole,
+      self.csiAttacherClusterRoleBinding,
+      self.csiControllerDeploy,
+    ],
+    all:: all,
+
+    list(obj=self.all):: k.core.v1.list.new(obj,),
+  },
+}

--- a/kubeflow/aws/aws-fsx-csi-driver.libsonnet
+++ b/kubeflow/aws/aws-fsx-csi-driver.libsonnet
@@ -157,7 +157,7 @@
                     valueFrom: {
                       secretKeyRef: {
                         name: "aws-secret",
-                        key: "key_id",
+                        key: "AWS_ACCESS_KEY_ID",
                       },
                     },
                   },
@@ -166,7 +166,7 @@
                     valueFrom: {
                       secretKeyRef: {
                         name: "aws-secret",
-                        key: "access_key",
+                        key: "AWS_SECRET_ACCESS_KEY",
                       },
                     },
                   },

--- a/kubeflow/aws/istio-ingress.libsonnet
+++ b/kubeflow/aws/istio-ingress.libsonnet
@@ -99,7 +99,7 @@
                 params.CognitoAppClientId,
               ],
               "issuer": "https://cognito-idp." + params.CoginitoRegion + ".amazonaws.com/" + params.CognitoUserPoolId,
-              "jwksUri": "https://cognito-idp." + params.CoginitoRegion + ".amazonaws.com/" + + params.CognitoUserPoolId + "/.well-known/jwks.json",
+              "jwksUri": "https://cognito-idp." + params.CoginitoRegion + ".amazonaws.com/" + params.CognitoUserPoolId + "/.well-known/jwks.json",
               "jwtHeaders": [
                 // double confirm headers in documentation
                 "x-amzn-cognito-jwt-assertion"
@@ -155,7 +155,7 @@
       self.ingress,
     ] + if params.enableJwtChecking then [
       self.policy,
-    ],
+    ] else [],
 
     list(obj=self.all):: k.core.v1.list.new(obj,),
   },

--- a/kubeflow/aws/istio-ingress.libsonnet
+++ b/kubeflow/aws/istio-ingress.libsonnet
@@ -1,0 +1,162 @@
+{
+  local k = import "k.libsonnet",
+  local util = import "kubeflow/common/util.libsonnet",
+  new(_env, _params):: {
+    local params = _params + _env {
+      disableJwtChecking: util.toBool(_params.disableJwtChecking),
+      hostname: if std.objectHas(_params, "hostname") then _params.hostname else "null",
+      istioTls: util.toBool(_params.istioTls),
+    },
+
+    local kubeflowGateway = {
+      apiVersion: "networking.istio.io/v1alpha3",
+      kind: "Gateway",
+      metadata: {
+        name: "kubeflow-gateway",
+        namespace: params.namespace,
+      },
+      spec: {
+        selector: {
+          istio: "ingressgateway"
+        },
+        servers: [
+          {
+            port: {
+              number: 80,
+              name: "http",
+              protocol: "HTTP"
+            },
+            hosts: [
+              "*"
+            ],
+          },
+        ],
+      },
+    }, // kubeflowGateway
+    gateway:: kubeflowGateway,
+
+    local kubeflowRoutes = {
+      apiVersion: "networking.istio.io/v1alpha3",
+      kind: "VirtualService",
+      metadata: {
+        name: "kubeflow-routes",
+        namespace: params.namespace,
+      },
+      spec: {
+        hosts: [
+          "*",
+        ],
+        gateways: [
+          "kubeflow-gateway",
+        ],
+        http: [
+          {
+            "match": [
+              {
+                "uri": {
+                  "prefix": "/"
+                }
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "ambassador",
+                  "port": {
+                    "number": 80
+                  }
+                }
+              }
+            ]
+          }
+        ],
+      },
+    }, // kubeflowRoutes
+    virtualService:: kubeflowRoutes,
+
+    local policy = {
+      apiVersion: "authentication.istio.io/v1alpha1",
+      kind: "Policy",
+      metadata: {
+        name: "istio-jwt",
+        namespace: params.istioNamespace,
+      },
+      spec: {
+        "targets": [
+          {
+            "name": "istio-ingressgateway",
+            "ports": [
+              {
+                "number": 80
+              }
+            ]
+          }
+        ],
+        "origins": [
+          {
+            "jwt": {
+              "audiences": [
+                params.CognitoAppClientId,
+              ],
+              "issuer": "https://cognito-idp." + params.CoginitoRegion + ".amazonaws.com/" + params.CognitoUserPoolId,
+              "jwksUri": "https://cognito-idp." + params.CoginitoRegion + ".amazonaws.com/" + + params.CognitoUserPoolId + "/.well-known/jwks.json",
+              "jwtHeaders": [
+                // double confirm headers in documentation
+                "x-amzn-cognito-jwt-assertion"
+              ],
+            }
+          }
+        ],
+        "principalBinding": "USE_ORIGIN"
+      },
+    },
+    policy:: policy,
+
+    local ingress = {
+      apiVersion: "extensions/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "istio-ingress",
+        namespace: params.istioNamespace,
+        annotations: {
+          "kubernetes.io/ingress.class": "alb",
+          "alb.ingress.kubernetes.io/scheme": "internet-facing",
+        } + if params.istioTls then {
+          "alb.ingress.kubernetes.io/certificate-arn": params.certArn,
+          "alb.ingress.kubernetes.io/listen-ports":  '[{"HTTP": 80}, {"HTTPS":443}]',
+        } else {},
+      },
+      spec: {
+        rules: [
+          {
+            [if params.hostname != "null" then "host"]: params.hostname,
+            http: {
+              paths: [
+                {
+                  backend: {
+                    serviceName: "istio-ingressgateway",
+                    servicePort: 80,
+                  },
+                  path: "/*",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },  // ingress
+    ingress:: ingress,
+
+
+    parts:: self,
+    all:: [
+      self.gateway,
+      self.virtualService,
+      self.ingress,
+    ] + if params.disableJwtChecking then [
+      self.policy,
+    ],
+
+    list(obj=self.all):: k.core.v1.list.new(obj,),
+  },
+}

--- a/kubeflow/aws/istio-ingress.libsonnet
+++ b/kubeflow/aws/istio-ingress.libsonnet
@@ -3,7 +3,7 @@
   local util = import "kubeflow/common/util.libsonnet",
   new(_env, _params):: {
     local params = _params + _env {
-      disableJwtChecking: util.toBool(_params.disableJwtChecking),
+      enableJwtChecking: util.toBool(_params.enableJwtChecking),
       hostname: if std.objectHas(_params, "hostname") then _params.hostname else "null",
       istioTls: util.toBool(_params.istioTls),
     },
@@ -153,7 +153,7 @@
       self.gateway,
       self.virtualService,
       self.ingress,
-    ] + if params.disableJwtChecking then [
+    ] + if params.enableJwtChecking then [
       self.policy,
     ],
 

--- a/kubeflow/aws/parts.yaml
+++ b/kubeflow/aws/parts.yaml
@@ -1,0 +1,35 @@
+{
+   "name": "aws",
+   "apiVersion": "0.0.1",
+   "kind": "ksonnet.io/parts",
+   "description": "Core components of Kubeflow.\n",
+   "author": "kubeflow team <kubeflow-team@google.com>",
+   "contributors": [
+      {
+         "name": "Jiaxin Shan",
+         "email": "shjiaxin@amazon.com"
+      }
+   ],
+   "repository": {
+      "type": "git",
+      "url": "https://github.com/kubeflow/kubeflow"
+   },
+   "bugs": {
+      "url": "https://github.com/kubeflow/kubeflow/issues"
+   },
+   "keywords": [
+      "kubeflow",
+      "tensorflow"
+   ],
+   "quickStart": {
+      "prototype": "io.ksonnet.pkg.kubeflow",
+      "componentName": "aws",
+      "flags": {
+         "name": "aws",
+         "namespace": "default",
+         "disks": ""
+      },
+      "comment": "AWS specific Kubeflow components."
+   },
+   "license": "Apache 2.0"
+}

--- a/kubeflow/aws/prototypes/aws-alb-ingress-controller.jsonnet
+++ b/kubeflow/aws/prototypes/aws-alb-ingress-controller.jsonnet
@@ -1,0 +1,12 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.aws-alb-ingress-controller
+// @description Provides alb-ingress-controller prototypes for creating AWS Application Load Balancer.
+// @shortDescription Application Load Balancer creation.
+// @param name string Name for the component
+// @param namespace string Namespace for the component
+// @param clusterName string Kubernetes Cluster Name
+// @optionalParam albIngressControllerImage string docker.io/amazon/aws-alb-ingress-controller:v1.1.0 ALB Ingress Controller Image.
+
+local albIngressController = import "kubeflow/aws/aws-alb-ingress-controller.libsonnet";
+local instance = albIngressController.new(env, params);
+instance.list(instance.all)

--- a/kubeflow/aws/prototypes/aws-alb-ingress-controller.jsonnet
+++ b/kubeflow/aws/prototypes/aws-alb-ingress-controller.jsonnet
@@ -1,10 +1,10 @@
 // @apiVersion 0.1
 // @name io.ksonnet.pkg.aws-alb-ingress-controller
 // @description Provides alb-ingress-controller prototypes for creating AWS Application Load Balancer.
-// @shortDescription Application Load Balancer creation.
+// @shortDescription Application Load Balancer Ingress Controller.
 // @param name string Name for the component
-// @param namespace string Namespace for the component
 // @param clusterName string Kubernetes Cluster Name
+// @optionalParam namespace string kube-system Namespace for the component
 // @optionalParam albIngressControllerImage string docker.io/amazon/aws-alb-ingress-controller:v1.1.0 ALB Ingress Controller Image.
 
 local albIngressController = import "kubeflow/aws/aws-alb-ingress-controller.libsonnet";

--- a/kubeflow/aws/prototypes/aws-efs-pv.jsonnet
+++ b/kubeflow/aws/prototypes/aws-efs-pv.jsonnet
@@ -1,0 +1,13 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.aws-efs-pv
+// @description Creates PV and PVC based on AWS EFS
+// @shortDescription Creates PV and PVC based on AWS EFS
+// @param name string Name for the component
+// @optionalParam storageCapacity string 1T Storage Capacity
+// @optionalParam path string /kubeflow Path in NFS server
+// @param serverIP string AWS EFS Server IP
+// @optionalParam image string gcr.io/kubeflow-images-public/ubuntu:18.04 The docker image to use
+
+local aws_efs_pv = import "kubeflow/aws/aws_efs_pv.libsonnet";
+local instance = aws_efs_pv.new(env, params);
+instance.list(instance.all)

--- a/kubeflow/aws/prototypes/aws-fsx-csi-driver.jsonnet
+++ b/kubeflow/aws/prototypes/aws-fsx-csi-driver.jsonnet
@@ -1,0 +1,13 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.aws-fsx-csi-driver
+// @description CSI driver for AWS FSx for Lustre
+// @shortDescription FSx CSI driver
+// @param name string Name for the component
+// @param namespace string Namespace for the component
+// @optionalParam csiControllerImage string amazon/aws-fsx-csi-driver:latest The CSI controller image to use
+// @optionalParam csiProvisionerImage string quay.io/k8scsi/csi-provisioner:v0.4.2 The CSI controller image to use
+// @optionalParam csiAttacherImage string quay.io/k8scsi/csi-attacher:v0.4.2 The CSI controller image to use
+
+local aws_fsx_csi_driver = import "kubeflow/aws/aws-fsx-csi-driver.libsonnet";
+local instance = aws_fsx_csi_driver.new(env, params);
+instance.list(instance.all)

--- a/kubeflow/aws/prototypes/istio-ingress.jsonnet
+++ b/kubeflow/aws/prototypes/istio-ingress.jsonnet
@@ -1,0 +1,20 @@
+// @apiVersion 0.1
+// @name io.ksonnet.pkg.istio-ingress
+// @description Provides ingress prototypes for setting up ALB on AWS.
+// @shortDescription Ingress for ALB on AWS and Istio Gateway and VirtualServices
+// @param name string Name for the component
+// @optionalParam namespace string kubeflow The namespace where Kubeflow is installed
+// @optionalParam istioNamespace string istio-system The namespace where Istio is installed
+// @optionalParam hostname string null The hostname associated with this ingress. Eg: mykubeflow.example.com
+// @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.
+// @optionalParam istioTls string false Enabel Istio TLS.
+// @optionalParam oauthSecretName string kubeflow-oauth The name of the secret containing the OAuth client_id and client_secret.
+// @optionalParam disableJwtChecking string true Disable JWT checking.
+// @optionalParam certArn string acm-cert AWS Certificate Manager certicate arn.
+// @optionalParam CognitoAppClientId string false Cognito App client Id
+// @optionalParam CognitoUserPoolId string false Cognito User Pool Id
+// @optionalParam CoginitoRegion string false Cognito User Pool Region
+
+local istioIngress = import "kubeflow/aws/istio-ingress.libsonnet";
+local instance = istioIngress.new(env, params);
+instance.list(instance.all)

--- a/kubeflow/aws/prototypes/istio-ingress.jsonnet
+++ b/kubeflow/aws/prototypes/istio-ingress.jsonnet
@@ -9,7 +9,7 @@
 // @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.
 // @optionalParam istioTls string false Enabel Istio TLS.
 // @optionalParam oauthSecretName string kubeflow-oauth The name of the secret containing the OAuth client_id and client_secret.
-// @optionalParam enableJwtChecking string true Enable JWT checking.
+// @optionalParam enableJwtChecking string false Enable JWT checking.
 // @optionalParam certArn string acm-cert AWS Certificate Manager certicate arn.
 // @optionalParam CognitoAppClientId string false Cognito App client Id
 // @optionalParam CognitoUserPoolId string false Cognito User Pool Id

--- a/kubeflow/aws/prototypes/istio-ingress.jsonnet
+++ b/kubeflow/aws/prototypes/istio-ingress.jsonnet
@@ -9,7 +9,7 @@
 // @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.
 // @optionalParam istioTls string false Enabel Istio TLS.
 // @optionalParam oauthSecretName string kubeflow-oauth The name of the secret containing the OAuth client_id and client_secret.
-// @optionalParam disableJwtChecking string true Disable JWT checking.
+// @optionalParam enableJwtChecking string true Enable JWT checking.
 // @optionalParam certArn string acm-cert AWS Certificate Manager certicate arn.
 // @optionalParam CognitoAppClientId string false Cognito App client Id
 // @optionalParam CognitoUserPoolId string false Cognito User Pool Id

--- a/kubeflow/aws/tests/aws-alb-ingress-controller_test.jsonnet
+++ b/kubeflow/aws/tests/aws-alb-ingress-controller_test.jsonnet
@@ -1,0 +1,145 @@
+local testSuite = import "kubeflow/common/testsuite.libsonnet";
+local albIngressController = import "kubeflow/aws/aws-alb-ingress-controller.libsonnet";
+
+local params = {
+  name: "aws-alb-ingress-controller",
+  clusterName: "eks-test-cluster",
+  namespace: "kube-system",
+  albIngressControllerImage: "docker.io/amazon/aws-alb-ingress-controller:v1.1.0",
+};
+
+local env = {
+    namespace: "kubeflow",
+};
+
+
+local instance = albIngressController.new(env, params);
+
+local testCases = [
+  {
+    actual: instance.parts.albIngressClusterRole,
+    expected: {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "alb-ingress-controller",
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+      rules: [
+        {
+          apiGroups: ["", "extensions"],
+          resources: ["configmaps", "endpoints", "events", "ingresses", "ingresses/status", "services"],
+          verbs: ["create", "get", "list", "update", "watch", "patch"],
+        },
+        {
+          apiGroups: ["", "extensions"],
+          resources: ["nodes", "pods", "secrets", "services", "namespaces"],
+          verbs: ["get", "list", "watch"],
+        },
+      ],
+    },
+
+  },
+  {
+    actual: instance.parts.albIngressClusterRoleBinding,
+    expected: {
+      kind: "ClusterRoleBinding",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "alb-ingress-controller",
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "alb-ingress-controller",
+          namespace: "kube-system",
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "alb-ingress-controller",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+      
+    },
+  },
+  {
+    actual: instance.parts.albIngressServiceAccount,
+    expected: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "alb-ingress-controller",
+        namespace: "kube-system",
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+    },
+
+  },
+  {
+    actual: instance.parts.albIngressDeploy,
+    expected: {
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: {
+        name: "alb-ingress-controller",
+        namespace: "kube-system",
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+      spec: {
+        replicas: 1,
+        selector: {
+          matchLabels: {
+            app: "alb-ingress-controller"
+          },
+        },
+        strategy: {
+          rollingUpdate: {
+            maxSurge: 1,
+            maxUnavailable: 1
+          },
+          type: "RollingUpdate"
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "alb-ingress-controller",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                args: [
+                  "--ingress-class=alb",
+                  "--cluster-name=eks-test-cluster",
+                ],
+                name: "alb-ingress-controller",
+                image: "docker.io/amazon/aws-alb-ingress-controller:v1.1.0",
+                imagePullPolicy: "Always",
+                resources: {},
+                terminationMessagePath: "/dev/termination-log"
+              },
+            ],
+            dnsPolicy: "ClusterFirst",
+            restartPolicy: "Always",
+            securityContext: {},
+            terminationGracePeriodSeconds: 30,
+            serviceAccountName: "alb-ingress-controller",
+            serviceAccount: "alb-ingress-controller",
+          },
+        },
+      },
+    },
+  },
+];
+
+testSuite.run(testCases)

--- a/kubeflow/aws/tests/aws-efs-pv_test.jsonnet
+++ b/kubeflow/aws/tests/aws-efs-pv_test.jsonnet
@@ -1,0 +1,110 @@
+local testSuite = import "kubeflow/common/testsuite.libsonnet";
+local awsEfsPv = import "kubeflow/aws/aws-efs-pv.libsonnet";
+
+local params = {
+  name: "aws-efs-pv",
+  storageCapacity: "1T",
+  path: "/kubeflow",
+  serverIP: "10.10.10.10",
+  image: "gcr.io/kubeflow-images-public/ubuntu:18.04",
+};
+local env = {
+  namespace: "kf-001",
+};
+
+local instance = awsEfsPv.new(env, params);
+
+local testCases = [
+  {
+    actual: instance.parts.persistentVolume,
+    expected: {
+      apiVersion: "v1",
+      kind: "PersistentVolume",
+      metadata: {
+        name: "aws-efs-pv",
+        namespace: "kf-001",
+      },
+      spec: {
+        accessModes: [
+          "ReadWriteMany",
+        ],
+        capacity: {
+          storage: "1T",
+        },
+        nfs: {
+          path: "/kubeflow",
+          server: "10.10.10.10",
+        },
+      },
+    },
+  },
+  {
+    actual: instance.parts.persistentVolumeClaim,
+    expected: {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name: "aws-efs-pv",
+        namespace: "kf-001",
+      },
+      spec: {
+        accessModes: [
+          "ReadWriteMany",
+        ],
+        resources: {
+          requests: {
+            storage: "1T",
+          },
+        },
+        storageClassName: "nfs-storage",
+        volumeName: "aws-efs-pv",
+      },
+    },
+  },
+  {
+    actual: instance.parts.efsPersmissions,
+    expected: {
+      apiVersion: "batch/v1",
+      kind: "Job",
+      metadata: {
+        name: "set-efs-permissions",
+        namespace: "kf-001",
+      },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                command: [
+                  "chmod",
+                  "777",
+                  "/kubeflow-efs",
+                ],
+                image: "gcr.io/kubeflow-images-public/ubuntu:18.04",
+                name: "set-efs-permissions",
+                volumeMounts: [
+                  {
+                    mountPath: "/kubeflow-efs",
+                    name: "aws-efs-pv",
+                  },
+                ],
+              },
+            ],
+            restartPolicy: "OnFailure",
+            volumes: [
+              {
+                name: "aws-efs-pv",
+                persistentVolumeClaim: {
+                  claimName: "aws-efs-pv",
+                  readOnly: false,
+                },
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+];
+
+testSuite.run(testCases)

--- a/kubeflow/aws/tests/aws-fsx-csi-driver_test.jsonnet
+++ b/kubeflow/aws/tests/aws-fsx-csi-driver_test.jsonnet
@@ -1,0 +1,256 @@
+local testSuite = import "kubeflow/common/testsuite.libsonnet";
+local awsFsxCsiDriver = import "kubeflow/aws/aws-fsx-csi-driver.libsonnet";
+
+local params = {
+  name: "aws-fsx-csi-driver",
+  csiControllerImage: "amazon/aws-fsx-csi-driver:latest",
+  csiProvisionerImage: "quay.io/k8scsi/csi-provisioner:v0.4.2",
+  csiAttacherImage: "quay.io/k8scsi/csi-attacher:v0.4.2",
+};
+
+local env = {
+  namespace: "kf-001",
+};
+
+local instance = awsFsxCsiDriver.new(env, params);
+
+local testCases = [
+  {
+    actual: instance.parts.csiControllerServiceAccount,
+    expected: {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: "fsx-csi-controller-sa",
+        namespace: "kf-001",
+      },
+    },
+  },
+  {
+    actual: instance.parts.csiProvisionerClusterRole,
+    expected: {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-external-provisioner-clusterrole",
+      },
+      rules: [
+        {
+          apiGroups: [""],
+          resources: ["persistentvolumes"],
+          verbs: ["get", "list", "watch", "create", "delete"],
+        },
+        {
+          apiGroups: [""],
+          resources: ["persistentvolumeclaims"],
+          verbs: ["get", "list", "watch", "update"],
+        },
+        {
+          apiGroups: ["storage.k8s.io"],
+          resources: ["storageclasses"],
+          verbs: ["get", "list", "watch"],
+        },
+        {
+          apiGroups: [""],
+          resources: ["events"],
+          verbs: ["get", "list", "watch", "create", "update", "patch"],
+        },
+      ],
+    },
+  },
+  {
+    actual: instance.parts.csiProvisionerClusterRoleBinding,
+    expected: {
+      kind: "ClusterRoleBinding",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-provisioner-binding",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "fsx-csi-controller-sa",
+          namespace: "kf-001",
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "csi-fsx-external-provisioner-clusterrole",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+    },
+  },
+  {
+    actual: instance.parts.csiAttacherClusterRole,
+    expected: {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-external-attacher-clusterrole",
+      },
+      rules: [
+        {
+          apiGroups: [""],
+          resources: ["persistentvolumes"],
+          verbs: ["get", "list", "watch", "update"],
+        },
+        {
+          apiGroups: [""],
+          resources: ["nodes"],
+          verbs: ["get", "list", "watch"],
+        },
+        {
+          apiGroups: ["storage.k8s.io"],
+          resources: ["volumeattachments"],
+          verbs: ["get", "list", "watch", "update"],
+        },
+      ],
+    },
+  },
+  {
+    actual: instance.parts.csiAttacherClusterRoleBinding,
+    expected: {
+      kind: "ClusterRoleBinding",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "csi-fsx-attacher-binding",
+      },
+      subjects: [
+        {
+          kind: "ServiceAccount",
+          name: "fsx-csi-controller-sa",
+          namespace: "kf-001",
+        },
+      ],
+      roleRef: {
+        kind: "ClusterRole",
+        name: "csi-fsx-external-attacher-clusterrole",
+        apiGroup: "rbac.authorization.k8s.io",
+      },
+    },
+  },
+  {
+    actual: instance.parts.csiControllerDeploy,
+    expected: {
+      apiVersion: "apps/v1beta1",
+      kind: "StatefulSet",
+      metadata: {
+        name: "fsx-csi-controller",
+        namespace: "kf-001",
+      },
+      spec: {
+        serviceAccount: "fsx-csi-controller",
+        replicas: 1,
+        template: {
+          metadata: {
+            labels: {
+              app: "fsx-csi-controller",
+            },
+          },
+          spec: {
+            serviceAccount: "csi-controller-sa",
+            priorityClassName: "system-cluster-critical",
+
+            tolerations: [
+              {
+                key: "CriticalAddonsOnly",
+                operator: "Exists"
+              },
+            ],
+            containers: [
+              {
+                name: "fsx-plugin",
+                image: "amazon/aws-fsx-csi-driver:latest",
+                args: [
+                  "--endpoint=$(CSI_ENDPOINT)",
+                  "--logtostderr",
+                  "--v=5"
+                ],
+                env: [
+                  {
+                    name: "CSI_ENDPOINT",
+                    value: "unix:///var/lib/csi/sockets/pluginproxy/csi.sock",
+                  },
+                  {
+                    name: "AWS_ACCESS_KEY_ID",
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: "aws-secret",
+                        key: "AWS_ACCESS_KEY_ID",
+                      },
+                    },
+                  },
+                  {
+                    name: "AWS_SECRET_ACCESS_KEY",
+                    valueFrom: {
+                      secretKeyRef: {
+                        name: "aws-secret",
+                        key: "AWS_SECRET_ACCESS_KEY",
+                      },
+                    },
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "socket-dir",
+                    mountPath: "/var/lib/csi/sockets/pluginproxy/",
+                  },
+                ],
+              },
+              {
+                name: "fsx-csi-provisioner",
+                image: "quay.io/k8scsi/csi-provisioner:v0.4.2",
+                args: [
+                  "--provisioner=fsx.csi.aws.com",
+                  "--csi-address=$(ADDRESS)",
+                  "--connection-timeout=5m",
+                  "--v=5"
+                ],
+                env: [
+                  {
+                    name: "ADDRESS",
+                    value: "/var/lib/csi/sockets/pluginproxy/csi.sock",
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "socket-dir",
+                    mountPath: "/var/lib/csi/sockets/pluginproxy/",
+                  },
+                ],
+              },
+              {
+                name: "fsx-csi-attacher",
+                image: "quay.io/k8scsi/csi-attacher:v0.4.2",
+                args: [
+                  "--csi-address=$(ADDRESS)",
+                  "--v=5"
+                ],
+                env: [
+                  {
+                    name: "ADDRESS",
+                    value: "/var/lib/csi/sockets/pluginproxy/csi.sock",
+                  },
+                ],
+                volumeMounts: [
+                  {
+                    name: "socket-dir",
+                    mountPath: "/var/lib/csi/sockets/pluginproxy/",
+                  },
+                ],
+              },
+            ],
+            volumes: [
+              {
+                name: "socket-dir",
+                emptyDir: {},
+              },
+            ],
+          },
+        },
+      },
+    },
+  },
+];
+
+testSuite.run(testCases)

--- a/kubeflow/aws/tests/istio-ingress_test.jsonnet
+++ b/kubeflow/aws/tests/istio-ingress_test.jsonnet
@@ -1,0 +1,215 @@
+local testSuite = import "kubeflow/common/testsuite.libsonnet";
+local istioIngress = import "kubeflow/aws/istio-ingress.libsonnet";
+
+local params = {
+  name: "isto-ingress",
+  istioNamespace: "istio-system",
+  enableJwtChecking: "false",
+  istioTls: "false",
+  hostname: "null",
+};
+
+local tlsEnabledParams = {
+  name: "isto-ingress",
+  istioNamespace: "istio-system",
+  enableJwtChecking: "false",
+  istioTls: "true",
+  hostname: "example.com",
+  certArn: "arn:aws:acm:us-west-2:3482112113:certificate/eeeeeee-a759-40de-80e1-ef619eadae79"
+};
+
+local authEnabledParams = {
+  name: "isto-ingress",
+  istioNamespace: "istio-system",
+  enableJwtChecking: "true",
+  istioTls: "true",
+  hostname: "example.com",
+  CognitoAppClientId: "cognito_app_client_id",
+  CoginitoRegion: "us-west-2",
+  CognitoUserPoolId: "kubeflow-user-pool",
+  certArn: "arn:aws:acm:us-west-2:3482112113:certificate/eeeeeee-a759-40de-80e1-ef619eadae79"
+};
+
+local env = {
+  namespace: "kf-001",
+};
+
+local instance = istioIngress.new(env, params);
+
+local testCases = [
+  {
+    actual: instance.parts.gateway,
+    expected: {
+      apiVersion: "networking.istio.io/v1alpha3",
+      kind: "Gateway",
+      metadata: {
+        name: "kubeflow-gateway",
+        namespace: "kf-001",
+      },
+      spec: {
+        selector: {
+          istio: "ingressgateway"
+        },
+        servers: [
+          {
+            port: {
+              number: 80,
+              name: "http",
+              protocol: "HTTP"
+            },
+            hosts: [
+              "*"
+            ],
+          },
+        ],
+      },
+    },
+  },
+  {
+    actual: instance.parts.virtualService,
+    expected: {
+      apiVersion: "networking.istio.io/v1alpha3",
+      kind: "VirtualService",
+      metadata: {
+        name: "kubeflow-routes",
+        namespace: "kf-001",
+      },
+      spec: {
+        hosts: [
+          "*",
+        ],
+        gateways: [
+          "kubeflow-gateway",
+        ],
+        http: [
+          {
+            "match": [
+              {
+                "uri": {
+                  "prefix": "/"
+                }
+              }
+            ],
+            "route": [
+              {
+                "destination": {
+                  "host": "ambassador",
+                  "port": {
+                    "number": 80
+                  }
+                }
+              }
+            ]
+          }
+        ],
+      },
+    },
+  },
+  {
+    actual: instance.parts.ingress,
+    expected: {
+      apiVersion: "extensions/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "istio-ingress",
+        namespace: "istio-system",
+        annotations: {
+          "kubernetes.io/ingress.class": "alb",
+          "alb.ingress.kubernetes.io/scheme": "internet-facing",
+        },
+      },
+      spec: {
+        rules: [
+          {
+            http: {
+              paths: [
+                {
+                  backend: {
+                    serviceName: "istio-ingressgateway",
+                    servicePort: 80,
+                  },
+                  path: "/*",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    actual: istioIngress.new(env, tlsEnabledParams).parts.ingress,
+    expected: {
+      apiVersion: "extensions/v1beta1",
+      kind: "Ingress",
+      metadata: {
+        name: "istio-ingress",
+        namespace: "istio-system",
+        annotations: {
+          "kubernetes.io/ingress.class": "alb",
+          "alb.ingress.kubernetes.io/scheme": "internet-facing",
+          "alb.ingress.kubernetes.io/certificate-arn": "arn:aws:acm:us-west-2:3482112113:certificate/eeeeeee-a759-40de-80e1-ef619eadae79",
+          "alb.ingress.kubernetes.io/listen-ports":  '[{"HTTP": 80}, {"HTTPS":443}]',
+        },
+      },
+      spec: {
+        rules: [
+          {
+            host: "example.com",
+            http: {
+              paths: [
+                {
+                  backend: {
+                    serviceName: "istio-ingressgateway",
+                    servicePort: 80,
+                  },
+                  path: "/*",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    actual: istioIngress.new(env, authEnabledParams).parts.policy,
+    expected: {
+      apiVersion: "authentication.istio.io/v1alpha1",
+      kind: "Policy",
+      metadata: {
+        name: "istio-jwt",
+        namespace: "istio-system",
+      },
+      spec: {
+        "targets": [
+          {
+            "name": "istio-ingressgateway",
+            "ports": [
+              {
+                "number": 80
+              }
+            ]
+          }
+        ],
+        "origins": [
+          {
+            "jwt": {
+              "audiences": [
+                "cognito_app_client_id",
+              ],
+              "issuer": "https://cognito-idp.us-west-2.amazonaws.com/kubeflow-user-pool",
+              "jwksUri": "https://cognito-idp.us-west-2.amazonaws.com/kubeflow-user-pool/.well-known/jwks.json",
+              "jwtHeaders": [
+                "x-amzn-cognito-jwt-assertion"
+              ],
+            }
+          }
+        ],
+        "principalBinding": "USE_ORIGIN"
+      },
+    },
+  },
+];
+
+testSuite.run(testCases)

--- a/scripts/aws/delete_deployment.sh
+++ b/scripts/aws/delete_deployment.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Teardown the AWS deployment for Kubeflow.
+#
+# Don't fail on error because some commands will fail if the resources were already deleted.
+
+set -x
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+parseArgs() {
+  # Parse all command line options
+  while [[ $# -gt 0 ]]; do
+    # Parameters should be of the form
+    # --{name}=${value}
+    echo parsing "$1"
+    if [[ $1 =~ ^--(.*)=(.*)$ ]]; then
+      name=${BASH_REMATCH[1]}
+      value=${BASH_REMATCH[2]}
+
+      eval ${name}="${value}"
+    elif [[ $1 =~ ^--(.*)$ ]]; then
+    name=${BASH_REMATCH[1]}
+    value=true
+    eval ${name}="${value}"
+    else
+      echo "Argument $1 did not match the pattern --{name}={value} or --{name}"
+    fi
+    shift
+  done
+}
+
+usage() {
+  echo "Usage: delete_cluster --cluster_name=CLUSTER_NAME --delete_cluster=true"
+}
+
+delete_iam_role_inline_policy() {
+  declare -r POLICY_NAME="$1"
+
+  if [[ -z "$NODEGROUP_ROLE_NAMES" ]]; then
+    # only new cluster rely on scripts to figure out roles
+    export NODEGROUP_ROLE_NAMES=$(aws iam list-roles \
+      | jq -r ".Roles[] \
+      | select(.RoleName \
+      | startswith(\"eksctl-${cluster_name}-nodegroup-0-NodeInstanceRole\")) \
+      .RoleName")
+  fi
+
+  for IAM_ROLE in ${NODEGROUP_ROLE_NAMES//,/ }
+  do
+    echo "Deleting inline policy $POLICY_NAME for iam role $IAM_ROLE"
+    if ! aws iam delete-role-policy --role-name=$IAM_ROLE --policy-name=$POLICY_NAME; then
+        echo "Unable to delete iam inline policy $POLICY_NAME" >&2
+        return 1
+    fi
+  done
+
+  return 0
+}
+
+main() {
+
+ cd "${DIR}"
+
+  # List of required parameters
+  names=(cluster_name)
+
+  missingParam=false
+  for i in ${names[@]}; do
+    if [ -z ${!i} ]; then
+      echo "--${i} not set"
+      missingParam=true
+    fi
+  done
+
+  if ${missingParam}; then
+    usage
+    exit 1
+  fi
+
+delete_cluster=${delete_cluster:-"false"}
+
+# Uninstall system manifests
+kubectl delete -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-crds.yaml
+kubectl delete -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-noauth.yaml
+kubectl delete -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/fluentd-cloudwatch.yaml
+
+# Detach inline policy from iam roles
+delete_iam_role_inline_policy iam_alb_ingress_policy
+delete_iam_role_inline_policy iam_cloudwatch_policy
+
+# Ensure resources are deleted.
+if [ $delete_cluster == "true" ] ; then
+  if ! eksctl delete cluster --name=${cluster_name} >/dev/null ; then
+    echo "Please go to aws console to check CloudFormation."
+  fi
+fi
+
+# Exit with status zero.
+exit 0
+}
+
+parseArgs $*
+main
+
+

--- a/scripts/aws/delete_deployment.sh
+++ b/scripts/aws/delete_deployment.sh
@@ -41,7 +41,7 @@ delete_iam_role_inline_policy() {
     export NODEGROUP_ROLE_NAMES=$(aws iam list-roles \
       | jq -r ".Roles[] \
       | select(.RoleName \
-      | startswith(\"eksctl-${cluster_name}-nodegroup-0-NodeInstanceRole\")) \
+      | startswith(\"eksctl-${cluster_name}-nodegroup-n-NodeInstanceRole\")) \
       .RoleName")
   fi
 

--- a/scripts/aws/delete_deployment.sh
+++ b/scripts/aws/delete_deployment.sh
@@ -50,7 +50,6 @@ delete_iam_role_inline_policy() {
     echo "Deleting inline policy $POLICY_NAME for iam role $IAM_ROLE"
     if ! aws iam delete-role-policy --role-name=$IAM_ROLE --policy-name=$POLICY_NAME; then
         echo "Unable to delete iam inline policy $POLICY_NAME" >&2
-        return 1
     fi
   done
 
@@ -62,7 +61,7 @@ main() {
  cd "${DIR}"
 
   # List of required parameters
-  names=(cluster_name)
+  names=(cluster_name resource_dir)
 
   missingParam=false
   for i in ${names[@]}; do
@@ -80,9 +79,9 @@ main() {
 delete_cluster=${delete_cluster:-"false"}
 
 # Uninstall system manifests
-kubectl delete -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-crds.yaml
-kubectl delete -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-noauth.yaml
-kubectl delete -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/fluentd-cloudwatch.yaml
+kubectl delete -f ${resource_dir}/istio-crds.yaml
+kubectl delete -f ${resource_dir}/istio-noauth.yaml
+kubectl delete -f ${resource_dir}/fluentd-cloudwatch.yaml
 
 # Detach inline policy from iam roles
 delete_iam_role_inline_policy iam_alb_ingress_policy
@@ -90,7 +89,7 @@ delete_iam_role_inline_policy iam_cloudwatch_policy
 
 # Ensure resources are deleted.
 if [ $delete_cluster == "true" ] ; then
-  if ! eksctl delete cluster --name=${cluster_name} >/dev/null ; then
+  if ! eksctl delete cluster --name=${cluster_name} ; then
     echo "Please go to aws console to check CloudFormation."
   fi
 fi

--- a/scripts/aws/util.sh
+++ b/scripts/aws/util.sh
@@ -174,19 +174,6 @@ aws_ks_apply() {
 }
 
 validate_aws_arg() {
-  if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
-    echo "AWS aws_access_key_id must be provided using --aws_access_key_id <AWS_ACCESS_KEY_ID>"
-    exit 1
-  fi
-  if [[ -z "$AWS_SECRET_ACCESS_KEY" ]]; then
-    echo "AWS aws_secret_access_key must be provided using --aws_secret_access_key <AWS_SECRET_ACCESS_KEY>"
-    exit 1
-  fi
-  if [[ -z "$AWS_REGION" ]]; then
-    echo "AWS region must be provided using --aws_region <AWS_REGION>"
-    exit 1
-  fi
-
   if [[ -z "$CLUSTER_NAME" ]]; then
     echo "eks cluster_name must be provided using --clusterName <CLUSTER_NAME>"
     exit 1
@@ -229,6 +216,8 @@ check_nodegroup_roles() {
 
 # don't enabled cluster create by default. Use flags to control it.
 create_eks_cluster() {
+  AWS_REGION=${AWS_REGION:-"us-west-2"}
+
   # Options for nodegroup provision used by ekstctl
   if [[ -z "$AWS_SSH_PUBLIC_KEY" ]]; then
       aws_ssh_public_key_option=""
@@ -236,10 +225,10 @@ create_eks_cluster() {
       aws_ssh_public_key_option="--ssh-access --ssh-public-key=${AWS_SSH_PUBLIC_KEY}"
   fi
 
-  if [[ -z "$AWS_NODE_ZONES" ]]; then
-      aws_node_zones_option=""
+  if [[ -z "$AWS_AVAILABILITY_ZONES" ]]; then
+      aws_az_option=""
   else
-      aws_node_zones_option="--node-zones=${AWS_NODE_ZONES}"
+      aws_az_option="--node-zones=${AWS_AVAILABILITY_ZONES}"
   fi
 
   if [[ -z "$AWS_NUM_NODES" ]]; then
@@ -248,13 +237,13 @@ create_eks_cluster() {
       aws_num_nodes_option="--nodes=${AWS_NUM_NODES}"
   fi
 
-  if [[ -z "$AWS_NODE_TYPE" ]]; then
-      aws_node_type_option=""
+  if [[ -z "$AWS_INSTANCE_TYPE" ]]; then
+      aws_instance_type_option=""
   else
-      aws_node_type_option="--node-type=${AWS_NODE_TYPE}"
+      aws_instance_type_option="--node-type=${AWS_INSTANCE_TYPE}"
   fi
 
-  OPTIONS="${aws_ssh_public_key_option} ${aws_node_zones_option} ${aws_num_nodes_option} ${aws_node_type_option}"
+  OPTIONS="${aws_ssh_public_key_option} ${aws_az_option} ${aws_num_nodes_option} ${aws_instance_type_option}"
 
   if ! eksctl create cluster --name "${CLUSTER_NAME}" --region "${AWS_REGION}" ${OPTIONS} ; then
       echo "aws eks create failed."

--- a/scripts/aws/util.sh
+++ b/scripts/aws/util.sh
@@ -1,0 +1,252 @@
+#!/usr/bin/env bash
+#
+# Define functions to customize the Kubeflow app for AWS.
+#
+set -xe
+
+aws_init_project() {
+  # FSx
+
+  # log permission
+  # https://eksworkshop.com/logging/prereqs/
+  echo "TODO. Permission setup"
+}
+
+################################ Infrastructure Changes ################################
+
+## Prepare Infrastrcture Configurations
+generate_infra_configs() {
+  # Create the infrastructure configs if they don't exist.
+  if [ ! -d "${KUBEFLOW_INFRA_DIR}" ]; then
+    echo "Creating AWS infrastructure configs in directory ${KUBEFLOW_INFRA_DIR}"
+    mkdir -p "${KUBEFLOW_INFRA_DIR}"
+    cp -r ${KUBEFLOW_REPO}/deployment/aws/infra_configs/* ${KUBEFLOW_INFRA_DIR}
+
+    # Create EFS
+
+    # Create RDS
+
+  else
+    echo AWS infrastructure configs already exist in directory "${KUBEFLOW_INFRA_DIR}"
+  fi
+}
+
+
+update_infra() {
+  set +e
+  O=$(kubectl get namespace ${K8S_NAMESPACE} 2>&1)
+  RESULT=$?
+  set -e
+
+  if [ "${RESULT}" -eq 0 ]; then
+    echo namespace ${K8S_NAMESPACE} already exists
+  else
+    kubectl create namespace ${K8S_NAMESPACE}
+  fi
+}
+
+################################ Kubernetes Changes ################################
+
+install_k8s_manifests() {
+  # Download k8s manifests for resources to deploy on the cluster and install them.
+  mkdir -p ${KUBEFLOW_K8S_MANIFESTS_DIR}
+
+  # Create secret to store aws credentials
+  #create_secrets
+
+  install_gpu_driver
+  install_fluentd_cloudwatch
+  install_alb_ingress_controller
+  install_csi_driver
+}
+
+create_secrets() {
+  # Need to install secrets in different namespaces
+  create_aws_secret ${K8S_NAMESPACE} aws_secret
+  create_aws_secret kubeflow aws_secret
+}
+
+# TensorFlow Serving, TensorBoard and CSI FSx for Lustre both use AWS secret.
+create_aws_secret() {
+  # Store aws credentials in a k8s secret.
+  local NAMESPACE=$1
+  local SECRET=$2
+
+  check_variable "${AWS_ACCESS_KEY_ID}" "AWS_ACCESS_KEY_ID"
+  check_variable "${AWS_SECRET_ACCESS_KEY}" "AWS_SECRET_ACCESS_KEY"
+
+  set +e
+  O=$(kubectl get secret --namespace=${NAMESPACE} ${SECRET} 2>&1)
+  local RESULT=$?
+  set -e
+
+  if [ "${RESULT}" -eq 0 ]; then
+    echo "secret ${SECRET} already exists"
+    return
+  fi
+
+  kubectl create secret generic --namespace=${NAMESPACE} ${SECRET} --from-literal=key_id=$AWS_ACCESS_KEY_ID --from-literal=access_key=$AWS_SECRET_ACCESS_KEY
+}
+
+install_gpu_driver() {
+  local INSTANCE_TYPE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.beta\.kubernetes\.io/instance-type}')
+
+  # Install the nvidia device plugin for accelarator nodes
+  if [[ ($INSTANCE_TYPE == *"p2"*) || ($INSTANCE_TYPE == *"p3"*) ]]; then
+    if [ ! `kubectl get ds --all-namespaces | grep nvidia-device-plugin` ] ; then
+        kubectl apply -f https://raw.githubusercontent.com/nvidia/k8s-device-plugin/v1.11/nvidia-device-plugin.yml
+        echo "installed nvidia-device-plugin"
+    fi
+  fi
+}
+
+install_fluentd_cloudwatch() {
+  # Install Fluentd-Cloudwatch Kubernetes agents.
+  curl -o ${KUBEFLOW_K8S_MANIFESTS_DIR}/fluentd-cloudwatch.yaml \
+    https://eksworkshop.com/logging/deploy.files/fluentd.yml
+
+  replace_text_in_file "us-west-2" ${AWS_REGION} ${KUBEFLOW_K8S_MANIFESTS_DIR}/fluentd-cloudwatch.yaml
+  replace_text_in_file "eksworkshop-eksctl" ${DEPLOYMENT_NAME} ${KUBEFLOW_K8S_MANIFESTS_DIR}/fluentd-cloudwatch.yaml
+
+  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/fluentd-cloudwatch.yaml
+}
+
+install_alb_ingress_controller() {
+  # Install AWS ALB Ingress controller.
+  curl -o ${KUBEFLOW_K8S_MANIFESTS_DIR}/aws-alb-ingress-controller-rbac.yaml \
+    https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.0/docs/examples/rbac-role.yaml
+
+  curl -o ${KUBEFLOW_K8S_MANIFESTS_DIR}/aws-alb-ingress-controller.yaml \
+    https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.0/docs/examples/alb-ingress-controller.yaml
+
+  replace_text_in_file "devCluster" ${DEPLOYMENT_NAME} ${KUBEFLOW_K8S_MANIFESTS_DIR}/aws-alb-ingress-controller.yaml
+
+  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/aws-alb-ingress-controller-rbac.yaml
+  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/aws-alb-ingress-controller.yaml
+}
+
+install_csi_driver() {
+  # Install CSI driver for aws FSx for Lustre. FSx controller needs aws-secret
+  curl -o ${KUBEFLOW_K8S_MANIFESTS_DIR}/csi-driver-aws-fsx-controller.yaml \
+    https://raw.githubusercontent.com/aws/csi-driver-amazon-fsx/master/deploy/kubernetes/controller.yaml
+
+  curl -o ${KUBEFLOW_K8S_MANIFESTS_DIR}/csi-driver-aws-fsx-node.yaml \
+    https://raw.githubusercontent.com/aws/csi-driver-amazon-fsx/master/deploy/kubernetes/node.yaml
+
+  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/csi-driver-aws-fsx-controller.yaml
+  kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/csi-driver-aws-fsx-node.yaml
+}
+
+################################ Ksonnet changes ################################
+
+
+aws_generate_ks_app() {
+  pushd .
+  cd "${KUBEFLOW_KS_DIR}"
+
+  # Install the aws package
+  #ks pkg install kubeflow/aws
+
+  # TODO: create ingress, fsx libsconnet
+
+  popd
+}
+
+# TODO: Waiting for alb-ingress-controller iam cert integration
+aws_ks_apply() {
+  # Apply the components generated
+  pushd .
+
+  popd
+}
+
+validate_aws_arg() {
+  if [[ -z "$AWS_ACCESS_KEY_ID" ]]; then
+    echo "AWS aws_access_key_id must be provided using --aws_access_key_id <AWS_ACCESS_KEY_ID>"
+    exit 1
+  fi
+  if [[ -z "$AWS_SECRET_ACCESS_KEY" ]]; then
+    echo "AWS aws_secret_access_key must be provided using --aws_secret_access_key <AWS_SECRET_ACCESS_KEY>"
+    exit 1
+  fi
+  if [[ -z "$AWS_REGION" ]]; then
+    echo "AWS region must be provided using --aws_region <AWS_REGION>"
+    exit 1
+  fi
+
+  # Rest of them are all optional, we can provide default value there
+  if [[ -z "$AWS_SSH_PUBLIC_KEY" ]]; then
+      aws_ssh_public_key_option="--ssh-access --ssh-public-key=${AWS_SSH_PUBLIC_KEY}"
+  else
+      aws_ssh_public_key_option=""
+  fi
+
+  # set default value
+  if [[ -z "$AWS_NODE_ZONES" ]]; then
+      aws_node_zones_option="--node-zones=${AWS_NODE_ZONES}"
+  else
+      aws_node_zones_option=""
+  fi
+
+  if [[ -z "$AWS_NUM_NODES" ]]; then
+      aws_num_nodes_option="--nodes=${AWS_NUM_NODES}"
+  else
+      aws_num_nodes_option=""
+  fi
+
+  if [[ -z "$AWS_NODE_TYPE" ]]; then
+      aws_node_type_option="--node-type=${AWS_NODE_TYPE}"
+  else
+      aws_node_type_option=""
+  fi
+}
+
+check_aws_cli() {
+  if ! which "aws" &>/dev/null && ! type -a "aws" &>/dev/null ; then
+    echo "You don't have awscli installed. Please install aws cli. https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html"
+    exit 1
+  fi
+}
+
+check_eksctl_cli() {
+  # eskctl is recommended to create EKS clusters now. This will be replaced by awscli eventually.
+  if ! which "eksctl" &>/dev/null && ! type -a "eksctl" &>/dev/null ; then
+    echo "You don't have eksctl installed. Please install eksctl cli. https://eksctl.io/"
+    exit 1
+  fi
+}
+
+check_aws_credential() {
+    if ! aws sts get-caller-identity >/dev/null ; then
+      echo "aws get caller identity failed. Please check the aws credentials provided and try again."
+      exit 1
+    fi
+}
+
+create_eks_cluster() {
+  OPTIONS="${aws_ssh_public_key_option} ${aws_node_zones_option} ${aws_num_nodes_option} ${aws_node_type_option}"
+
+  if [ `eksctl get cluster --name "${DEPLOYMENT_NAME}"  "${OPTIONS}"` == "false" ] ; then
+      if ! eksctl create --name "${DEPLOYMENT_NAME}" --region "${AWS_LOCATION} " &>/dev/null ; then
+          echo "aws eks create failed."
+          exit 1
+      fi
+  else
+      echo "Kubernetes cluster already exists, skip aws eks cluster create."
+  fi
+
+  local context_name = "eks-dev@${DEPLOYMENT_NAME}.${AWS_REGION}.eksctl.io"
+
+  if [ `kubectl config use-context ${context_name}` &> /dev/null ] ; then
+      eksctl utils  write-kubeconfig --name=${DEPLOYMENT_NAME}
+  fi
+}
+
+replace_text_in_file() {
+  local FIND_TEXT=$1
+  local REPLACE_TEXT=$2
+  local SRC_FILE=$3
+
+  sed -i.bak "s/${FIND_TEXT}/${REPLACE_TEXT}/" ${SRC_FILE}
+  rm $SRC_FILE.bak
+}

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -110,12 +110,16 @@ createEnv() {
       ;;
     aws)
       export KUBEFLOW_PLATFORM=aws
-      INPUT+=('KUBEFLOW_INFRA_DIR=$KUBEFLOW_INFRA_DIR\n'
+      INPUT+=('CLUSTER_NAME=$CLUSTER_NAME\n'
+              'NODEGROUP_ROLE_NAMES=$NODEGROUP_ROLE_NAMES\n'
+              'KUBEFLOW_INFRA_DIR=$KUBEFLOW_INFRA_DIR\n'
               'KUBEFLOW_K8S_MANIFESTS_DIR=$KUBEFLOW_K8S_MANIFESTS_DIR\n')
-      FORMAT+=('$KUBEFLOW_INFRA_DIR'
+      FORMAT+=('$CLUSTER_NAME'
+               '$NODEGROUP_ROLE_NAMES'
+               '$KUBEFLOW_INFRA_DIR'
                '$KUBEFLOW_K8S_MANIFESTS_DIR')
-      ## Reuse ~/.aws/configure and ~/.aws/credential. Do not show credential for security reason
-      # Kubeflow directories
+      export CLUSTER_NAME=${CLUSTER_NAME:-""}
+      export NODEGROUP_ROLE_NAMES=${NODEGROUP_ROLE_NAMES:-""}
       export KUBEFLOW_INFRA_DIR=${KUBEFLOW_INFRA_DIR:-"$(pwd)/aws_config"}
       export KUBEFLOW_K8S_MANIFESTS_DIR="$(pwd)/k8s_specs"
       ;;
@@ -309,6 +313,14 @@ parseArgs() {
         shift
         AZ_NODE_SIZE=$1
         ;;
+      --clusterName)
+        shift
+        CLUSTER_NAME=$1
+        ;;
+      --nodegroupRoleNames)
+        shift
+        NODEGROUP_ROLE_NAMES=$1
+        ;;
     esac
     shift
   done
@@ -462,6 +474,7 @@ main() {
     check_aws_cli
     check_eksctl_cli
     check_aws_credential
+    #check_nodegroup_roles
   fi
 
   if [[ "${COMMAND}" == "generate" ]]; then

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -113,11 +113,21 @@ createEnv() {
       INPUT+=('CLUSTER_NAME=$CLUSTER_NAME\n'
               'NODEGROUP_ROLE_NAMES=$NODEGROUP_ROLE_NAMES\n'
               'KUBEFLOW_INFRA_DIR=$KUBEFLOW_INFRA_DIR\n'
-              'KUBEFLOW_K8S_MANIFESTS_DIR=$KUBEFLOW_K8S_MANIFESTS_DIR\n')
+              'KUBEFLOW_K8S_MANIFESTS_DIR=$KUBEFLOW_K8S_MANIFESTS_DIR\n'
+              'AWS_SSH_PUBLIC_KEY=$AWS_SSH_PUBLIC_KEY\n'
+              'AWS_REGION=$AWS_REGION\n'
+              'AWS_AVAILABILITY_ZONES=$AWS_AVAILABILITY_ZONES\n'
+              'AWS_NUM_NODES=$AWS_NUM_NODES\n'
+              'AWS_INSTANCE_TYPE=$AWS_INSTANCE_TYPE\n')
       FORMAT+=('$CLUSTER_NAME'
                '$NODEGROUP_ROLE_NAMES'
                '$KUBEFLOW_INFRA_DIR'
-               '$KUBEFLOW_K8S_MANIFESTS_DIR')
+               '$KUBEFLOW_K8S_MANIFESTS_DIR'
+               '$AWS_SSH_PUBLIC_KEY'
+               '$AWS_AVAILABILITY_ZONES'
+               '$AWS_REGION'
+               '$AWS_NUM_NODES'
+               '$AWS_INSTANCE_TYPE')
       export CLUSTER_NAME=${CLUSTER_NAME:-""}
       export NODEGROUP_ROLE_NAMES=${NODEGROUP_ROLE_NAMES:-""}
       export KUBEFLOW_INFRA_DIR=${KUBEFLOW_INFRA_DIR:-"$(pwd)/aws_config"}
@@ -320,6 +330,26 @@ parseArgs() {
       --nodegroupRoleNames)
         shift
         NODEGROUP_ROLE_NAMES=$1
+        ;;
+      --awsSSHPublicKey)
+        shift
+        AWS_SSH_PUBLIC_KEY=$1
+        ;;
+      --awsRegion)
+        shift
+        AWS_REGION=$1
+        ;;
+      --awsAZs)
+        shift
+        AWS_AVAILABILITY_ZONES=$1
+        ;;
+      --awsNumNodes)
+        shift
+        AWS_NUM_NODES=$1
+        ;;
+      --awsInstanceType)
+        shift
+        AWS_INSTANCE_TYPE=$1
         ;;
     esac
     shift

--- a/scripts/kfctl.sh
+++ b/scripts/kfctl.sh
@@ -630,7 +630,7 @@ main() {
       if [[ "${PLATFORM}" == "aws" ]]; then
         if [[ -d "${KUBEFLOW_INFRA_DIR}" ]]; then
           pushd ${KUBEFLOW_INFRA_DIR}
-          ${DIR}/aws/delete_deployment.sh --cluster=${DEPLOYMENT_NAME} --zone=${ZONE}
+          ${DIR}/aws/delete_deployment.sh --cluster_name=${CLUSTER_NAME} --delete_cluster=false
           popd
         fi
       fi


### PR DESCRIPTION
1. Documentation will come to kubeflow/website soon.
2. This PR only includes shell scripts change to provision cluster. Go cmd is in progress. 
3. AWS use ALB ingress controller to manage external traffic. Traffic will route to istio first and then come into Ambassador. 
4. Integrate few aws services like Lustre for DL training and Cloudwatch as log backend.
4. Looks like Kubeflow will move to Istio for routing later and we install [istio](https://www.kubeflow.org/docs/components/istio/) in the progress of kubeflow provision.
5. Authentication and TLS will not be enabled by default. They needs some manual efforts from users now. This will be documented in kubeflow/website.
6. Using eksctl to provision EKS cluster.  This is added in `apply platform` phase

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2823)
<!-- Reviewable:end -->
