### PR TITLE
remove openmpi from registry file

### DIFF
--- a/kubeflow/registry.yaml
+++ b/kubeflow/registry.yaml
@@ -49,9 +49,6 @@ libraries:
   new-package-stub:
     version: master
     path: new-package-stub
-  openmpi:
-    version: master
-    path: openmpi
   katib:
     version: master
     path: katib


### PR DESCRIPTION
Need cherry pick to v0.5

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2840)
<!-- Reviewable:end -->
