### PR TITLE
use whitelist for iam policy clean

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -510,7 +510,7 @@ func (gcp *Gcp) updateDM(resources kftypes.ResourceEnum) error {
 	if iamPolicyErr != nil {
 		return fmt.Errorf("Read IAM policy YAML error: %v", iamPolicyErr)
 	}
-	utils.ClearIamPolicy(policy, iamPolicy)
+	utils.ClearIamPolicy(policy, gcp.Name, gcp.Spec.Project)
 	if err := utils.SetIamPolicy(gcp.Spec.Project, policy, gcpClient); err != nil {
 		return fmt.Errorf("Set Cleared IamPolicy error: %v", err)
 	}

--- a/bootstrap/pkg/utils/iamutils.go
+++ b/bootstrap/pkg/utils/iamutils.go
@@ -17,13 +17,13 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"github.com/deckarep/golang-set"
 	"github.com/ghodss/yaml"
 	"golang.org/x/net/context"
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"io/ioutil"
 	"net/http"
-	"strings"
 )
 
 func transformSliceToInterface(slice []string) []interface{} {
@@ -54,14 +54,11 @@ func GetIamPolicy(project string, gcpClient *http.Client) (*cloudresourcemanager
 }
 
 // Modify currentPolicy: Remove existing bindings associated with service accounts of current deployment
-func ClearIamPolicy(currentPolicy *cloudresourcemanager.Policy, pendingPolicy *cloudresourcemanager.Policy) {
-	serviceAccounts := make(map[string]bool)
-	for _, binding := range pendingPolicy.Bindings {
-		for _, member := range binding.Members {
-			if strings.HasPrefix(member, "serviceAccount:kfctl-") {
-				serviceAccounts[member] = true
-			}
-		}
+func ClearIamPolicy(currentPolicy *cloudresourcemanager.Policy, deployName string, project string) {
+	serviceAccounts := map[string]bool{
+		fmt.Sprintf("serviceAccount:%v-admin@%v.iam.gserviceaccount.com", deployName, project): true,
+		fmt.Sprintf("serviceAccount:%v-user@%v.iam.gserviceaccount.com", deployName, project):  true,
+		fmt.Sprintf("serviceAccount:%v-vm@%v.iam.gserviceaccount.com", deployName, project):    true,
 	}
 	var newBindings []*cloudresourcemanager.Binding
 	for _, binding := range currentPolicy.Bindings {

--- a/bootstrap/pkg/utils/iamutils_test.go
+++ b/bootstrap/pkg/utils/iamutils_test.go
@@ -53,23 +53,6 @@ func Test(t *testing.T) {
 				},
 				Etag: "ShouldKeep",
 			},
-			saPolicy: &cloudresourcemanager.Policy{
-				Bindings: []*cloudresourcemanager.Binding{
-					&cloudresourcemanager.Binding{
-						Role: "roles/source.admin",
-						Members: []string{
-							"serviceAccount:kfctl-admin@project.iam.gserviceaccount.com",
-							"serviceAccount:kfctl-vm@project.iam.gserviceaccount.com",
-						},
-					},
-					&cloudresourcemanager.Binding{
-						Role: "roles/iap.httpsResourceAccessor",
-						Members: []string{
-							"user:user1@google.com",
-						},
-					},
-				},
-			},
 			expectedPolicy: &cloudresourcemanager.Policy{
 				Bindings: []*cloudresourcemanager.Binding{
 					// 'kfctl' service accounts binding should be deleted
@@ -93,7 +76,7 @@ func Test(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		ClearIamPolicy(test.currentPolicy, test.saPolicy)
+		ClearIamPolicy(test.currentPolicy, "kfctl", "project")
 		if !reflect.DeepEqual(test.currentPolicy, test.expectedPolicy) {
 			t.Errorf("Expect:\n%v; Output:\n%v", PolicyToString(test.expectedPolicy),
 				PolicyToString(test.currentPolicy))


### PR DESCRIPTION
Choose the safe way to clean and only clean the auto-generated service accounts bindings of current deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2856)
<!-- Reviewable:end -->
