### PR TITLE
Added a height change for Firefox support

### DIFF
--- a/components/centraldashboard/public/styles.css
+++ b/components/centraldashboard/public/styles.css
@@ -8,6 +8,7 @@ html, body {
     left: 0;
     right: 0;
     bottom: 0;
+    height: 100vh; /* needed for firefox */
     display: flex;
     flex-direction: column;
     box-sizing: border-box;


### PR DESCRIPTION
Resolves #2847. Essentially full-bleed doesn't work on firefox since `bottom: 0` on frame absolute positioning isn't defaulted to `100vh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2859)
<!-- Reviewable:end -->
