### PR TITLE
Add volumn support and unit tests for mpi-job

### DIFF
--- a/kubeflow/mpi-job/mpi-job.libsonnet
+++ b/kubeflow/mpi-job/mpi-job.libsonnet
@@ -1,0 +1,87 @@
+
+{
+  local k = import "k.libsonnet",
+
+  parts(env, params):: {
+    local containerCommand = if params.command != "null" then
+      {
+        command: std.split(params.command, ","),
+      }
+      else {},
+
+    local containerArgs = if params.args != "null" then
+      {
+        args: std.split(params.args, ","),
+      }
+      else {},
+
+    local storageEnabled =
+      if std.objectHas(params, "pvcName") && std.objectHas(params, "volumeMountPath")
+        && params.pvcName != 'null' && params.volumeMountPath != 'null' then true else false,
+
+    mpiJobSimple:: {
+      apiVersion: "kubeflow.org/v1alpha1",
+      kind: "MPIJob",
+      metadata: {
+        name: params.name,
+        namespace: env.namespace,
+      },
+      spec: {
+        gpus: params.gpus,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: params.name,
+                image: params.image,
+              } + containerCommand + containerArgs,
+            ],
+          },
+        },
+      },
+    },
+
+    mpiJobCustom:: {
+      apiVersion: "kubeflow.org/v1alpha1",
+      kind: "MPIJob",
+      metadata: {
+        name: params.name,
+        namespace: env.namespace,
+      },
+      spec: {
+        replicas: params.replicas,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: params.name,
+                image: params.image,
+                resources: {
+                  limits: {
+                    "nvidia.com/gpu": params.gpusPerReplica,
+                  },
+                },
+              } + containerCommand + containerArgs + if storageEnabled then {
+                  volumeMounts: [
+                    {
+                      name: "persistent-storage",
+                      mountPath: params.volumeMountPath,
+                    }
+                  ]
+              } else {} ,
+            ],
+          } + if storageEnabled then {
+            volumes:[
+              {
+                name: "persistent-storage",
+                persistentVolumeClaim: {
+                  claimName: params.pvcName
+                },
+              }
+            ]
+          } else {},
+        }
+      }
+    }
+  }
+}

--- a/kubeflow/mpi-job/mpi-operator.libsonnet
+++ b/kubeflow/mpi-job/mpi-operator.libsonnet
@@ -1,8 +1,11 @@
-local k = import "k.libsonnet";
-
 {
-  parts:: {
-    crd:: {
+  local k = import "k.libsonnet",
+  local util = import "kubeflow/common/util.libsonnet",
+
+  new(_env, _params):: {
+    local params = _params + _env,
+
+    local mpiJobCrd = {
       apiVersion: "apiextensions.k8s.io/v1beta1",
       kind: "CustomResourceDefinition",
       metadata: {
@@ -74,12 +77,23 @@ local k = import "k.libsonnet";
         },
       },
     },
+    mpiJobCrd:: mpiJobCrd,
 
-    clusterRole(name):: {
+    local serviceAccount = {
+      apiVersion: "v1",
+      kind: "ServiceAccount",
+      metadata: {
+        name: params.name,
+        namespace: params.namespace,
+      },
+    },
+    serviceAccount:: serviceAccount,
+
+    local clusterRole = {
       kind: "ClusterRole",
       apiVersion: "rbac.authorization.k8s.io/v1",
       metadata: {
-        name: name,
+        name: params.name,
       },
       rules: [
         {
@@ -213,72 +227,65 @@ local k = import "k.libsonnet";
         },
       ],
     },
+    clusterRole:: clusterRole,
 
-    serviceAccount(namespace, name):: {
-      apiVersion: "v1",
-      kind: "ServiceAccount",
-      metadata: {
-        name: name,
-        namespace: namespace,
-      },
-    },
-
-    clusterRoleBinding(namespace, name):: {
+    local clusterRoleBinding = {
       kind: "ClusterRoleBinding",
       apiVersion: "rbac.authorization.k8s.io/v1",
       metadata: {
-        name: name,
-        namespace: namespace,
+        name: params.name,
+        namespace: params.namespace,
       },
       roleRef: {
         apiGroup: "rbac.authorization.k8s.io",
         kind: "ClusterRole",
-        name: name,
+        name: params.name,
       },
       subjects: [
         {
           kind: "ServiceAccount",
-          name: name,
-          namespace: namespace,
+          name: params.name,
+          namespace: params.namespace,
         },
       ],
     },
+    clusterRoleBinding:: clusterRoleBinding,
 
-    deploy(namespace, name, image, kubectlDeliveryImage, gpusPerNode):: {
+    local deployment = {
       apiVersion: "apps/v1",
       kind: "Deployment",
       metadata: {
-        name: name,
-        namespace: namespace,
+        name: params.name,
+        namespace: params.namespace,
         labels: {
-          app: name,
+          app: params.name,
         },
       },
       spec: {
         replicas: 1,
         selector: {
           matchLabels: {
-            app: name,
+            app: params.name,
           },
         },
         template: {
           metadata: {
             labels: {
-              app: name,
+              app: params.name,
             },
           },
           spec: {
-            serviceAccountName: name,
+            serviceAccountName: params.name,
             containers: [
               {
                 name: "mpi-operator",
-                image: image,
+                image: params.image,
                 args: [
                   "-alsologtostderr",
                   "--gpus-per-node",
-                  std.toString(gpusPerNode),
+                  std.toString(params.gpusPerNode),
                   "--kubectl-delivery-image",
-                  kubectlDeliveryImage,
+                  params.kubectlDeliveryImage,
                 ],
                 imagePullPolicy: "Always",
               },
@@ -287,5 +294,17 @@ local k = import "k.libsonnet";
         },
       },
     },
+    deployment:: deployment,
+
+    parts:: self,
+    all:: [
+      self.mpiJobCrd,
+      self.serviceAccount,
+      self.clusterRole,
+      self.clusterRoleBinding,
+      self.deployment
+    ],
+
+    list(obj=self.all):: util.list(obj),
   },
 }

--- a/kubeflow/mpi-job/prototypes/mpi-job-custom.jsonnet
+++ b/kubeflow/mpi-job/prototypes/mpi-job-custom.jsonnet
@@ -8,56 +8,12 @@
 // @optionalParam image string mpioperator/tensorflow-benchmarks:latest The image to use for the job
 // @optionalParam command string null Command to pass to the job
 // @optionalParam args string null Comma separated list of arguments to pass to the job
+// @optionalParam pvcName string null claim PersistentVolumeClaim name for training data
+// @optionalParam volumeMountPath string null /data PersistentVolume mount path for training data
 
 local k = import "k.libsonnet";
-
-local namespace = env.namespace;  // namespace is inherited from the environment
-local name = params.name;
-local replicas = params.replicas;
-local gpusPerReplica = params.gpusPerReplica;
-local image = params.image;
-local command = params.command;
-local args = params.args;
-
-local containerCommand =
-  if command != "null" then
-    {
-      command: std.split(command, ","),
-    }
-  else {};
-local containerArgs =
-  if args != "null" then
-    {
-      args: std.split(args, ","),
-    }
-  else {};
-
-local mpiJobCustom = {
-  apiVersion: "kubeflow.org/v1alpha1",
-  kind: "MPIJob",
-  metadata: {
-    name: name,
-    namespace: namespace,
-  },
-  spec: {
-    replicas: replicas,
-    template: {
-      spec: {
-        containers: [
-          {
-            name: name,
-            image: image,
-            resources: {
-              limits: {
-                "nvidia.com/gpu": gpusPerReplica,
-              },
-            },
-          } + containerCommand + containerArgs,
-        ],
-      },
-    },
-  },
-};
+local mpiJob = import "kubeflow/mpi-job/mpi-job.libsonnet";
+local mpiJobCustom = mpiJob.parts(env, params).mpiJobCustom;
 
 std.prune(k.core.v1.list.new([
   mpiJobCustom,

--- a/kubeflow/mpi-job/prototypes/mpi-job-simple.jsonnet
+++ b/kubeflow/mpi-job/prototypes/mpi-job-simple.jsonnet
@@ -9,48 +9,8 @@
 // @optionalParam args string null Comma separated list of arguments to pass to the job
 
 local k = import "k.libsonnet";
-
-local namespace = env.namespace;  // namespace is inherited from the environment
-local name = params.name;
-local gpus = params.gpus;
-local image = params.image;
-local command = params.command;
-local args = params.args;
-
-local containerCommand =
-  if command != "null" then
-    {
-      command: std.split(command, ","),
-    }
-  else {};
-local containerArgs =
-  if args != "null" then
-    {
-      args: std.split(args, ","),
-    }
-  else {};
-
-local mpiJobSimple = {
-  apiVersion: "kubeflow.org/v1alpha1",
-  kind: "MPIJob",
-  metadata: {
-    name: name,
-    namespace: namespace,
-  },
-  spec: {
-    gpus: gpus,
-    template: {
-      spec: {
-        containers: [
-          {
-            name: name,
-            image: image,
-          } + containerCommand + containerArgs,
-        ],
-      },
-    },
-  },
-};
+local mpiJob = import "kubeflow/mpi-job/mpi-job.libsonnet";
+local mpiJobSimple = mpiJob.parts(env, params).mpiJobSimple;
 
 std.prune(k.core.v1.list.new([
   mpiJobSimple,

--- a/kubeflow/mpi-job/prototypes/mpi-operator.jsonnet
+++ b/kubeflow/mpi-job/prototypes/mpi-operator.jsonnet
@@ -7,19 +7,6 @@
 // @optionalParam kubectlDeliveryImage string mpioperator/kubectl-delivery:latest The image for delivering kubectl.
 // @optionalParam gpusPerNode number 8 The maximum number of GPUs per node.
 
-local k = import "k.libsonnet";
-local operator = import "kubeflow/mpi-job/mpi-operator.libsonnet";
-
-local namespace = env.namespace;  // namespace is inherited from the environment
-local name = params.name;
-local image = params.image;
-local kubectlDeliveryImage = params.kubectlDeliveryImage;
-local gpusPerNode = params.gpusPerNode;
-
-std.prune(k.core.v1.list.new([
-  operator.parts.crd,
-  operator.parts.clusterRole(name),
-  operator.parts.serviceAccount(namespace, name),
-  operator.parts.clusterRoleBinding(namespace, name),
-  operator.parts.deploy(namespace, name, image, kubectlDeliveryImage, gpusPerNode),
-]))
+local mpiOperator = import "kubeflow/mpi-job/mpi-operator.libsonnet";
+local instance = mpiOperator.new(env, params);
+instance.list(instance.all)

--- a/kubeflow/mpi-job/tests/mpi-job_test.jsonnet
+++ b/kubeflow/mpi-job/tests/mpi-job_test.jsonnet
@@ -1,0 +1,227 @@
+local mpiJob = import "kubeflow/mpi-job/mpi-job.libsonnet";
+
+local paramsSimple = {
+  name: "mpi-job-simple",
+  gpus: 8,
+  image: "mpioperator/tensorflow-benchmarks:v1.13",
+  args: "--synthetic,--num_epochs=10",
+  command: "mpirun,-mca,btl_tcp_if_exclude,lo,python,/model/train_imagenet_resnet_hvd.py",
+};
+
+local paramsCustom = {
+  name: "mpi-job-custom",
+  replicas: 2,
+  gpusPerReplica: 8,
+  image: "mpioperator/tensorflow-benchmarks:v1.13",
+  args: "--synthetic,--num_epochs=10",
+  command: "mpirun,-mca,btl_tcp_if_exclude,lo,python,/model/train_imagenet_resnet_hvd.py",
+};
+
+local paramsCustomWithVolume = {
+  name: "mpi-job-custom-volume",
+  replicas: 2,
+  gpusPerReplica: 8,
+  image: "mpioperator/tensorflow-benchmarks:v1.13",
+  args: "--data=/data,--num_epochs=10",
+  command: "mpirun,-mca,btl_tcp_if_exclude,lo,python,/model/train_imagenet_resnet_hvd.py",
+  pvcName: "storage-claim",
+  volumeMountPath: "/data"
+};
+
+local paramsCustomWithVolumeNull = {
+  name: "mpi-job-custom-volume",
+  replicas: 2,
+  gpusPerReplica: 8,
+  image: "mpioperator/tensorflow-benchmarks:v1.13",
+  args: "--data=/data,--num_epochs=10",
+  command: "mpirun,-mca,btl_tcp_if_exclude,lo,python,/model/train_imagenet_resnet_hvd.py",
+  pvcName: "null",
+  volumeMountPath: "null"
+};
+
+
+local env = {
+  namespace: "kubeflow",
+};
+
+local mpiJobSimple = mpiJob.parts(env, paramsSimple).mpiJobSimple;
+local mpiJobCustom = mpiJob.parts(env, paramsCustom).mpiJobCustom;
+local mpiJobCustomWithVolume = mpiJob.parts(env, paramsCustomWithVolume).mpiJobCustom;
+local mpiJobCustomWithVolumeNull = mpiJob.parts(env, paramsCustomWithVolumeNull).mpiJobCustom;
+
+std.assertEqual(
+  mpiJobSimple,
+  {
+    apiVersion: "kubeflow.org/v1alpha1",
+      kind: "MPIJob",
+      metadata: {
+        name: "mpi-job-simple",
+        namespace: "kubeflow",
+      },
+      spec: {
+        gpus: 8,
+        template: {
+          spec: {
+            containers: [
+              {
+                name: "mpi-job-simple",
+                image: "mpioperator/tensorflow-benchmarks:v1.13",
+                command: [
+                  "mpirun",
+                    "-mca",
+                    "btl_tcp_if_exclude",
+                    "lo",
+                    "python",
+                    "/model/train_imagenet_resnet_hvd.py"
+                ],
+                args: [
+                  "--synthetic",
+                  "--num_epochs=10",
+                ],
+              },
+            ],
+          },
+        },
+      },
+  },
+) &&
+
+std.assertEqual(
+  mpiJobCustom,
+  {
+    apiVersion: "kubeflow.org/v1alpha1",
+    kind: "MPIJob",
+    metadata: {
+      name: "mpi-job-custom",
+      namespace: "kubeflow",
+    },
+    spec: {
+      replicas: 2,
+      template: {
+        spec: {
+          containers: [
+            {
+              name: "mpi-job-custom",
+              image: "mpioperator/tensorflow-benchmarks:v1.13",
+              command: [
+                "mpirun",
+                "-mca",
+                "btl_tcp_if_exclude",
+                "lo",
+                "python",
+                "/model/train_imagenet_resnet_hvd.py"
+              ],
+              args: [
+                "--synthetic",
+                "--num_epochs=10",
+              ],
+              resources: {
+                limits: {
+                  "nvidia.com/gpu": 8,
+                },
+              },
+            },
+          ]
+        },
+      },
+    },
+  },
+) &&
+
+std.assertEqual(
+  mpiJobCustomWithVolume,
+  {
+    apiVersion: "kubeflow.org/v1alpha1",
+    kind: "MPIJob",
+    metadata: {
+      name: "mpi-job-custom-volume",
+      namespace: "kubeflow",
+    },
+    spec: {
+      replicas: 2,
+      template: {
+        spec: {
+          containers: [
+            {
+              name: "mpi-job-custom-volume",
+              image: "mpioperator/tensorflow-benchmarks:v1.13",
+              command: [
+                "mpirun",
+                "-mca",
+                "btl_tcp_if_exclude",
+                "lo",
+                "python",
+                "/model/train_imagenet_resnet_hvd.py"
+              ],
+              args: [
+                "--data=/data",
+                "--num_epochs=10",
+              ],
+              resources: {
+                limits: {
+                  "nvidia.com/gpu": 8,
+                },
+              },
+              volumeMounts: [
+                {
+                  name: "persistent-storage",
+                  mountPath: "/data",
+                }
+              ],
+            },
+          ],
+          volumes:[
+            {
+              name: "persistent-storage",
+              persistentVolumeClaim: {
+                claimName: "storage-claim"
+              },
+            }
+          ]
+        },
+      },
+    },
+  },
+) &&
+
+std.assertEqual(
+  mpiJobCustomWithVolumeNull,
+  {
+    apiVersion: "kubeflow.org/v1alpha1",
+    kind: "MPIJob",
+    metadata: {
+      name: "mpi-job-custom-volume",
+      namespace: "kubeflow",
+    },
+    spec: {
+      replicas: 2,
+      template: {
+        spec: {
+          containers: [
+            {
+              name: "mpi-job-custom-volume",
+              image: "mpioperator/tensorflow-benchmarks:v1.13",
+              command: [
+                "mpirun",
+                "-mca",
+                "btl_tcp_if_exclude",
+                "lo",
+                "python",
+                "/model/train_imagenet_resnet_hvd.py"
+              ],
+              args: [
+                "--data=/data",
+                "--num_epochs=10",
+              ],
+              resources: {
+                limits: {
+                  "nvidia.com/gpu": 8,
+                },
+              },
+            },
+          ]
+        },
+      },
+    },
+  },
+)

--- a/kubeflow/mpi-job/tests/mpi-operator_test.jsonnet
+++ b/kubeflow/mpi-job/tests/mpi-operator_test.jsonnet
@@ -1,0 +1,322 @@
+// Run following command to test mpi-operator libsonnet
+// jsonnet eval ./kubeflow/mpi-job/tests/mpi-operator_test.jsonnet --jpath ./ --jpath ./testing/workflows/lib/v1.7.0
+
+local mpiOperator = import "kubeflow/mpi-job/mpi-operator.libsonnet";
+
+local v1beta1params = {
+  name: "mpi-operator-v1beta1",
+  image: "mpioperator/mpi-operator:v1beta1",
+  kubectlDeliveryImage: "mpioperator/kubectl-delivery:v1beta1",
+  gpusPerNode: 4
+};
+
+local env = {
+  namespace: "kubeflow",
+};
+
+local mpiOperatorInstance = mpiOperator.new(env, v1beta1params);
+
+// does it have all and items?
+std.assertEqual(
+  std.length(mpiOperatorInstance.all),
+  5,
+) &&
+
+std.assertEqual(
+  mpiOperatorInstance.mpiJobCrd,
+  {
+    apiVersion: "apiextensions.k8s.io/v1beta1",
+    kind: "CustomResourceDefinition",
+    metadata: {
+      name: "mpijobs.kubeflow.org",
+    },
+    spec: {
+      group: "kubeflow.org",
+      version: "v1alpha1",
+      scope: "Namespaced",
+      names: {
+        plural: "mpijobs",
+        singular: "mpijob",
+        kind: "MPIJob",
+        shortNames: [
+          "mj",
+          "mpij",
+        ],
+      },
+      validation: {
+        openAPIV3Schema: {
+          properties: {
+            spec: {
+              title: "The MPIJob spec",
+              description: "Either `gpus` or `replicas` should be specified, but not both",
+              oneOf: [
+                {
+                  properties: {
+                    gpus: {
+                      title: "Total number of GPUs",
+                      description: "Valid values are 1, 2, 4, or any multiple of 8",
+                      oneOf: [
+                        {
+                          type: "integer",
+                          enum: [
+                            1,
+                            2,
+                            4,
+                          ],
+                        },
+                        {
+                          type: "integer",
+                          multipleOf: 8,
+                          minimum: 8,
+                        },
+                      ],
+                    },
+                  },
+                  required: [
+                    "gpus",
+                  ],
+                },
+                {
+                  properties: {
+                    replicas: {
+                      title: "Total number of replicas",
+                      description: "The GPU resource limit should be specified for each replica",
+                      type: "integer",
+                      minimum: 1,
+                    },
+                  },
+                  required: [
+                    "replicas",
+                  ],
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+  },
+) &&
+
+std.assertEqual(
+  mpiOperatorInstance.serviceAccount,
+  {
+    apiVersion: "v1",
+    kind: "ServiceAccount",
+    metadata: {
+      name: "mpi-operator-v1beta1",
+      namespace: "kubeflow",
+    },
+  },
+) &&
+
+std.assertEqual(
+  mpiOperatorInstance.clusterRole,
+  {
+      kind: "ClusterRole",
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      metadata: {
+        name: "mpi-operator-v1beta1",
+      },
+      rules: [
+        {
+          apiGroups: [
+            "",
+          ],
+          resources: [
+            "configmaps",
+            "serviceaccounts",
+          ],
+          verbs: [
+            "create",
+            "list",
+            "watch",
+          ],
+        },
+        {
+          apiGroups: [
+            "",
+          ],
+          resources: [
+            "pods",
+          ],
+          verbs: [
+            "get",
+          ],
+        },
+        {
+          apiGroups: [
+            "",
+          ],
+          resources: [
+            "pods/exec",
+          ],
+          verbs: [
+            "create",
+          ],
+        },
+        {
+          apiGroups: [
+            "",
+          ],
+          resources: [
+            "events",
+          ],
+          verbs: [
+            "create",
+            "patch",
+          ],
+        },
+        {
+          apiGroups: [
+            "rbac.authorization.k8s.io",
+          ],
+          resources: [
+            "roles",
+            "rolebindings",
+          ],
+          verbs: [
+            "create",
+            "list",
+            "watch",
+          ],
+        },
+        {
+          apiGroups: [
+            "apps",
+          ],
+          resources: [
+            "statefulsets",
+          ],
+          verbs: [
+            "create",
+            "list",
+            "update",
+            "watch",
+          ],
+        },
+        {
+          apiGroups: [
+            "batch",
+          ],
+          resources: [
+            "jobs",
+          ],
+          verbs: [
+            "create",
+            "list",
+            "update",
+            "watch",
+          ],
+        },
+        {
+          apiGroups: [
+            "policy",
+          ],
+          resources: [
+            "poddisruptionbudgets",
+          ],
+          verbs: [
+            "create",
+            "list",
+            "update",
+            "watch",
+          ],
+        },
+        {
+          apiGroups: [
+            "apiextensions.k8s.io",
+          ],
+          resources: [
+            "customresourcedefinitions",
+          ],
+          verbs: [
+            "create",
+            "get",
+          ],
+        },
+        {
+          apiGroups: [
+            "kubeflow.org",
+          ],
+          resources: [
+            "mpijobs",
+          ],
+          verbs: [
+            "*",
+          ],
+        },
+      ],
+    },
+) &&
+
+std.assertEqual(
+  mpiOperatorInstance.clusterRoleBinding,
+  {
+    kind: "ClusterRoleBinding",
+    apiVersion: "rbac.authorization.k8s.io/v1",
+    metadata: {
+      name: "mpi-operator-v1beta1",
+      namespace: "kubeflow",
+    },
+    roleRef: {
+      apiGroup: "rbac.authorization.k8s.io",
+      kind: "ClusterRole",
+      name: "mpi-operator-v1beta1",
+    },
+    subjects: [
+      {
+        kind: "ServiceAccount",
+        name: "mpi-operator-v1beta1",
+        namespace: "kubeflow",
+      },
+    ],
+  },
+) &&
+
+std.assertEqual(
+  mpiOperatorInstance.deployment,
+  {
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: {
+        name: "mpi-operator-v1beta1",
+        namespace: "kubeflow",
+        labels: {
+          app: "mpi-operator-v1beta1",
+        },
+      },
+      spec: {
+        replicas: 1,
+        selector: {
+          matchLabels: {
+            app: "mpi-operator-v1beta1",
+          },
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "mpi-operator-v1beta1",
+            },
+          },
+          spec: {
+            serviceAccountName: "mpi-operator-v1beta1",
+            containers: [
+              {
+                name: "mpi-operator",
+                image: "mpioperator/mpi-operator:v1beta1",
+                args: [
+                  "-alsologtostderr",
+                  "--gpus-per-node",
+                  "4",
+                  "--kubectl-delivery-image",
+                  "mpioperator/kubectl-delivery:v1beta1",
+                ],
+                imagePullPolicy: "Always",
+              },
+            ],
+          },
+        },
+      },
+    },
+)

--- a/kubeflow/mpi-job/tests/mpi-operator_test.jsonnet
+++ b/kubeflow/mpi-job/tests/mpi-operator_test.jsonnet
@@ -3,10 +3,10 @@
 
 local mpiOperator = import "kubeflow/mpi-job/mpi-operator.libsonnet";
 
-local v1beta1params = {
-  name: "mpi-operator-v1beta1",
-  image: "mpioperator/mpi-operator:v1beta1",
-  kubectlDeliveryImage: "mpioperator/kubectl-delivery:v1beta1",
+local v1alpha2params = {
+  name: "mpi-operator-v1alpha2",
+  image: "mpioperator/mpi-operator:v1alpha2",
+  kubectlDeliveryImage: "mpioperator/kubectl-delivery:v1alpha2",
   gpusPerNode: 4
 };
 
@@ -14,7 +14,7 @@ local env = {
   namespace: "kubeflow",
 };
 
-local mpiOperatorInstance = mpiOperator.new(env, v1beta1params);
+local mpiOperatorInstance = mpiOperator.new(env, v1alpha2params);
 
 // does it have all and items?
 std.assertEqual(
@@ -25,7 +25,7 @@ std.assertEqual(
 std.assertEqual(
   mpiOperatorInstance.mpiJobCrd,
   {
-    apiVersion: "apiextensions.k8s.io/v1beta1",
+    apiVersion: "apiextensions.k8s.io/v1alpha2",
     kind: "CustomResourceDefinition",
     metadata: {
       name: "mpijobs.kubeflow.org",
@@ -104,7 +104,7 @@ std.assertEqual(
     apiVersion: "v1",
     kind: "ServiceAccount",
     metadata: {
-      name: "mpi-operator-v1beta1",
+      name: "mpi-operator-v1alpha2",
       namespace: "kubeflow",
     },
   },
@@ -116,7 +116,7 @@ std.assertEqual(
       kind: "ClusterRole",
       apiVersion: "rbac.authorization.k8s.io/v1",
       metadata: {
-        name: "mpi-operator-v1beta1",
+        name: "mpi-operator-v1alpha2",
       },
       rules: [
         {
@@ -256,18 +256,18 @@ std.assertEqual(
     kind: "ClusterRoleBinding",
     apiVersion: "rbac.authorization.k8s.io/v1",
     metadata: {
-      name: "mpi-operator-v1beta1",
+      name: "mpi-operator-v1alpha2",
       namespace: "kubeflow",
     },
     roleRef: {
       apiGroup: "rbac.authorization.k8s.io",
       kind: "ClusterRole",
-      name: "mpi-operator-v1beta1",
+      name: "mpi-operator-v1alpha2",
     },
     subjects: [
       {
         kind: "ServiceAccount",
-        name: "mpi-operator-v1beta1",
+        name: "mpi-operator-v1alpha2",
         namespace: "kubeflow",
       },
     ],
@@ -280,37 +280,37 @@ std.assertEqual(
       apiVersion: "apps/v1",
       kind: "Deployment",
       metadata: {
-        name: "mpi-operator-v1beta1",
+        name: "mpi-operator-v1alpha2",
         namespace: "kubeflow",
         labels: {
-          app: "mpi-operator-v1beta1",
+          app: "mpi-operator-v1alpha2",
         },
       },
       spec: {
         replicas: 1,
         selector: {
           matchLabels: {
-            app: "mpi-operator-v1beta1",
+            app: "mpi-operator-v1alpha2",
           },
         },
         template: {
           metadata: {
             labels: {
-              app: "mpi-operator-v1beta1",
+              app: "mpi-operator-v1alpha2",
             },
           },
           spec: {
-            serviceAccountName: "mpi-operator-v1beta1",
+            serviceAccountName: "mpi-operator-v1alpha2",
             containers: [
               {
                 name: "mpi-operator",
-                image: "mpioperator/mpi-operator:v1beta1",
+                image: "mpioperator/mpi-operator:v1alpha2",
                 args: [
                   "-alsologtostderr",
                   "--gpus-per-node",
                   "4",
                   "--kubectl-delivery-image",
-                  "mpioperator/kubectl-delivery:v1beta1",
+                  "mpioperator/kubectl-delivery:v1alpha2",
                 ],
                 imagePullPolicy: "Always",
               },


### PR DESCRIPTION
Resolve #2858 

1. Did some refactor and make mpi-job testable. Add unit tests for both mpi-job and mpi-operator
2. Add volume support for mpi-job.

I didn't change/add/remove any prototype names.  should be very safe.

This is still for v1alpha1. Notice mpi-job has v1alpha2 released and corresponding prototype should be separate tasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2869)
<!-- Reviewable:end -->
