### PR TITLE
remove profile from v0.5

### DIFF
--- a/bootstrap/config/kfctl_basic_auth.yaml
+++ b/bootstrap/config/kfctl_basic_auth.yaml
@@ -14,7 +14,6 @@ packages:
   - modeldb
   - mpi-job
   - pipeline
-  - profiles
   - pytorch-job
   - seldon
   - tensorboard
@@ -35,7 +34,6 @@ components:
   - metacontroller
   - notebook-controller
   - pipeline
-  - profiles
   - pytorch-operator
   - spartakus
   - tensorboard

--- a/bootstrap/config/kfctl_default.yaml
+++ b/bootstrap/config/kfctl_default.yaml
@@ -14,7 +14,6 @@ packages:
   - modeldb
   - mpi-job
   - pipeline
-  - profiles
   - pytorch-job
   - seldon
   - tensorboard
@@ -29,7 +28,6 @@ components:
   - metacontroller
   - notebook-controller
   - pipeline
-  - profiles
   - pytorch-operator
   - tensorboard
   - tf-job-operator

--- a/bootstrap/config/kfctl_iap.yaml
+++ b/bootstrap/config/kfctl_iap.yaml
@@ -14,7 +14,6 @@ packages:
   - modeldb
   - mpi-job
   - pipeline
-  - profiles
   - pytorch-job
   - seldon
   - tensorboard
@@ -34,7 +33,6 @@ components:
   - metacontroller
   - notebook-controller
   - pipeline
-  - profiles
   - pytorch-operator
   - spartakus
   - tensorboard


### PR DESCRIPTION
We should exclude profile from default set till permission leak:
https://github.com/kubeflow/kubeflow/issues/2601 is fixed.