### PR TITLE
Let jupyter service account list/get/create secret

### DIFF
--- a/kubeflow/jupyter/jupyter.libsonnet
+++ b/kubeflow/jupyter/jupyter.libsonnet
@@ -281,6 +281,7 @@
           resources: [
             "pods",
             "pods/log",
+            "secrets",
             "services",
           ],
           verbs: [

--- a/kubeflow/jupyter/tests/jupyter_test.jsonnet
+++ b/kubeflow/jupyter/tests/jupyter_test.jsonnet
@@ -214,6 +214,7 @@ local testCases = [
           resources: [
             "pods",
             "pods/log",
+            "secrets",
             "services",
           ],
           verbs: [


### PR DESCRIPTION
The jupyter service account can already create a deployment with a
secret mounted and read it that way, so its just more of a hassle to not
let it explicitly list secrets.

Fixes https://github.com/kubeflow/kubeflow/issues/2876

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2887)
<!-- Reviewable:end -->
