### PR TITLE
Create a minimal release process for kfctl.

### DIFF
--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -84,6 +84,28 @@ build-bootstrap: /tmp/v2 deepcopy generate fmt vet
 build-kfctl: /tmp/v2 deepcopy generate fmt vet
 	$(GO) build -i -gcflags 'all=-N -l' -o bin/kfctl cmd/kfctl/main.go
 
+# Release tarballs suitable for upload to GitHub release pages
+build-kfctl-tgz: build-kfctl
+	chmod a+rx ./bin/kfctl
+	rm -f bin/*.tgz
+	cd bin && tar -cvzf kfctl_$(TAG)_linux.tar.gz ./kfctl
+	cp -f ./bin/kfctl_$(TAG)_linux.tar.gz ./bin/kfctl_$(TAG)_darwin.tar.gz
+
+# push the releases to a GitHub page
+push-to-github-release: build-kfctl-tgz
+	github-release upload \
+	    --user kubeflow \
+	    --repo kubeflow \
+	    --tag $(TAG) \
+	    --name "kfctl_$(TAG)_linux.tar.gz" \
+	    --file bin/kfctl_$(TAG)_linux.tar.gz
+	github-release upload \
+	    --user kubeflow \
+	    --repo kubeflow \
+	    --tag $(TAG) \
+	    --name "kfctl_$(TAG)_darwin.tar.gz" \
+	    --file bin/kfctl_$(TAG)_darwin.tar.gz
+	 
 build-kfctl-container:
 	docker build \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \

--- a/bootstrap/developer_guide.md
+++ b/bootstrap/developer_guide.md
@@ -188,3 +188,6 @@ cd ../components/gcp-click-to-deploy
 npm start
 ```
 
+## Releasing kfctl
+
+See [release guide](https://github.com/kubeflow/kubeflow/blob/master/docs_dev/releasing.md)

--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -401,6 +401,46 @@ Releasing a new version on the website requires the following steps:
     ```
    * Make this change in the master branch, and then cherry-pick the commit back to the newly released branch. This allows the user to browse between all the released versions on the website.
 
+## Release kfctl
+
+You can use the [CLI github-release](https://github.com/aktau/github-release) to automate uploading artifacts.
+Alternatively you can use the UI.
+
+1. Get aktau/github-release
+
+   ```
+   go get github.com/aktau/github-release
+   ```
+
+1. You'll need a GitHub token to authenticate to GitHub see [docs](https://github.com/aktau/github-release)
+
+1. Checkout the release commit
+
+   ```
+   git checkout ${COMMIT}
+   ```
+
+   * TODO(jlewi): Ideally we automate the builds and publish them e.g. to a GCS bucket on postsubmit.
+
+1. Build kfctl for linux
+
+   ```
+   cd bootstrap
+   make build-kfctl
+   ```
+
+1. Upload the artifact
+
+   ```
+   TAG=${e.g v0.5.0-rc.1}
+   github-release upload \
+    --user kubeflow \
+    --repo kubeflow \
+    --tag ${TAG} \
+    --name "kfctl_${TAG}_linux" \
+    --file bin/kfctl
+   ```
+
 ## Update the changelog
 
 1. After the release branch is created run the following script to update the changelog

--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -422,24 +422,13 @@ Alternatively you can use the UI.
 
    * TODO(jlewi): Ideally we automate the builds and publish them e.g. to a GCS bucket on postsubmit.
 
-1. Build kfctl for linux
+1. Build kfctl for linux and mac
 
    ```
    cd bootstrap
-   make build-kfctl
+   TAG=v0.5.0-rc.1 make push-to-github-release
    ```
-
-1. Upload the artifact
-
-   ```
-   TAG=${e.g v0.5.0-rc.1}
-   github-release upload \
-    --user kubeflow \
-    --repo kubeflow \
-    --tag ${TAG} \
-    --name "kfctl_${TAG}_linux" \
-    --file bin/kfctl
-   ```
+   * Set the tag to be the correct version for the tag.
 
 ## Update the changelog
 


### PR DESCRIPTION
* Instructions for building binaries and uploading to GitHub release page.
* We need to figure out if/how we cross-compile for linux.
  * Cross compiling seems to be unnecessary
  * The go binaries built on linux appear to work on macosx.

Fix: #2383

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2894)
<!-- Reviewable:end -->
