### PR TITLE
fix patch string for admission webhook

### DIFF
--- a/components/gcp-admission-webhook/main.go
+++ b/components/gcp-admission-webhook/main.go
@@ -46,13 +46,6 @@ type admitFunc func(v1beta1.AdmissionReview) *v1beta1.AdmissionResponse
 var scheme = runtime.NewScheme()
 var codecs = serializer.NewCodecFactory(scheme)
 
-// patchString patches: Add volume, volumeMount, and environment variable
-const patchString = `[
-{"op":"add","path":"/spec/volumes","value":{"name":"gcp-credentials","secret":{"secretName": "%s"}}},
-{"op":"add","path":"ENV_PATH","value":"ENV_VALUE"}},
-{"op":"add","path":"VOLUMEMOUNT_PATH","value":{"name":"gcp-credentials","readOnly": true,"mountPath":"/secrets/gcp-service-account-credentials"}}
-]`
-
 type patchOperation struct {
 	Op    string      `json:"op"`
 	Path  string      `json:"path"`

--- a/kubeflow/gcp/prototypes/webhook.jsonnet
+++ b/kubeflow/gcp/prototypes/webhook.jsonnet
@@ -3,7 +3,7 @@
 // @description This prototype creates a admission controller which injects credentials into pods
 // @shortDescription This prototype creates a admission controller which injects credentials into pods
 // @param name string Name to give to each of the components
-// @optionalParam image string gcr.io/kubeflow-images-public/gcp-admission-webhook:v20190316-v0.4.0-rc.1-227-gac45af55-dirty-3f9236 The image for the webhook.
+// @optionalParam image string gcr.io/kubeflow-images-public/gcp-admission-webhook:v20190401-v0.4.0-rc.1-309-g4014fa2e-dirty-be6212 The image for the webhook.
 // @optionalParam webhookSetupImage string gcr.io/kubeflow-images-public/ingress-setup:latest The image for setting up ingress.
 
 local webhook = import "kubeflow/gcp/webhook.libsonnet";


### PR DESCRIPTION
Fix #2896

Reference: https://github.com/istio/istio/blob/master/pilot/pkg/kube/inject/webhook.go#L377

Tested the notebook is accessible, and the volume/env are there by webhook

/cc @jlewi @abhi-g

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2903)
<!-- Reviewable:end -->
