### PR TITLE
Central Dashboard - Add statefulness to generated links

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -97,7 +97,6 @@ export class MainPage extends PolymerElement {
         };
     }
 
-
     /**
      * Array of strings describing multi-property observer methods and their
      * dependant properties
@@ -134,8 +133,9 @@ export class MainPage extends PolymerElement {
      * @param {MouseEvent} e
      */
     openInIframe(e) {
-        const url = new URL(e.currentTarget.href);
-        window.history.pushState({}, null, `_${url.pathname}`);
+        // e.currentTarget is an anchor element
+        const url = e.currentTarget.href.substr(e.currentTarget.origin.length);
+        window.history.pushState({}, null, `_${url}`);
         window.dispatchEvent(new CustomEvent('location-changed'));
         e.preventDefault();
     }
@@ -204,6 +204,20 @@ export class MainPage extends PolymerElement {
      */
     _isInsideOfIframe() {
         return window.location !== window.parent.location;
+    }
+
+    /**
+     * Builds and returns an href value preserving the existing query string and
+     * hash.
+     * @param {string} href
+     * @return {string}
+     */
+    _buildHref(href) {
+        const current = new URL(window.location.href);
+        const url = new URL(href, window.location.origin);
+        url.search = current.search;
+        url.hash = current.hash;
+        return url.href;
     }
 }
 

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -210,13 +210,16 @@ export class MainPage extends PolymerElement {
      * Builds and returns an href value preserving the existing query string and
      * hash.
      * @param {string} href
+     * @param {Object} queryParams
      * @return {string}
      */
-    _buildHref(href) {
-        const current = new URL(window.location.href);
+    _buildHref(href, queryParams) {
         const url = new URL(href, window.location.origin);
-        url.search = current.search;
-        url.hash = current.hash;
+        for (const k in queryParams) {
+            if (Object.prototype.hasOwnProperty.call(queryParams, k)) {
+                url.searchParams.set(k, queryParams[k]);
+            }
+        }
         return url.href;
     }
 }

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -95,6 +95,7 @@ export class MainPage extends PolymerElement {
             dashVersion: {type: String, value: VERSION},
             inIframe: {type: Boolean, value: false, readOnly: true},
             hideTabs: {type: Boolean, value: false, readOnly: true},
+            hideNamespaces: {type: Boolean, value: false, readOnly: true},
             notFoundInIframe: {type: Boolean, value: false, readOnly: true},
         };
     }
@@ -150,6 +151,7 @@ export class MainPage extends PolymerElement {
         let isIframe = false;
         let notFoundInIframe = false;
         let hideTabs = true;
+        let hideNamespaces = false;
         switch (newPage) {
         case 'activity':
             this.sidebarItemIndex = 0;
@@ -159,6 +161,7 @@ export class MainPage extends PolymerElement {
         case '_': // iframe case
             this._setIframeFromRoute(this.subRouteData.path);
             isIframe = true;
+            hideNamespaces = this.subRouteData.path.startsWith('/pipeline');
             break;
         case '':
             this.sidebarItemIndex = 0;
@@ -175,6 +178,7 @@ export class MainPage extends PolymerElement {
         }
         this._setNotFoundInIframe(notFoundInIframe);
         this._setHideTabs(hideTabs);
+        this._setHideNamespaces(hideNamespaces);
         this._setInIframe(isIframe);
         // If iframe <-> [non-frame OR other iframe]
         if (isIframe !== this.inIframe || isIframe) {

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -35,6 +35,8 @@ import './dashboard-view.js';
 import './activity-view.js';
 import './not-found-view.js';
 
+const VALID_QUERY_PARAMS = ['ns'];
+
 /**
  * Entry point for application UI.
  */
@@ -54,7 +56,7 @@ export class MainPage extends PolymerElement {
             subRouteData: Object,
             queryParams: {
                 type: Object,
-                value: null,
+                value: () => {},
             },
             iframeRoute: Object,
             menuLinks: {
@@ -133,8 +135,8 @@ export class MainPage extends PolymerElement {
      * @param {MouseEvent} e
      */
     openInIframe(e) {
-        // e.currentTarget is an anchor element
-        const url = e.currentTarget.href.substr(e.currentTarget.origin.length);
+        // e.currentTarget is an HTMLAnchorElement
+        const url = e.currentTarget.href.slice(e.currentTarget.origin.length);
         window.history.pushState({}, null, `_${url}`);
         window.dispatchEvent(new CustomEvent('location-changed'));
         e.preventDefault();
@@ -207,20 +209,19 @@ export class MainPage extends PolymerElement {
     }
 
     /**
-     * Builds and returns an href value preserving the existing query string and
-     * hash.
+     * Builds and returns an href value preserving the current query string.
      * @param {string} href
      * @param {Object} queryParams
      * @return {string}
      */
     _buildHref(href, queryParams) {
         const url = new URL(href, window.location.origin);
-        for (const k in queryParams) {
-            if (Object.prototype.hasOwnProperty.call(queryParams, k)) {
-                url.searchParams.set(k, queryParams[k]);
+        VALID_QUERY_PARAMS.forEach((qp) => {
+            if (queryParams[qp]) {
+                url.searchParams.set(qp, queryParams[qp]);
             }
-        }
-        return url.href;
+        });
+        return url.href.slice(url.origin.length);
     }
 }
 

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -9,11 +9,12 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
             |!{logo}
             figcaption Kubeflow
         iron-selector(selected='{{sidebarItemIndex}}')
-            a(href='/', tabindex='-1')
+            a(href$='[[_buildHref("/")]]', tabindex='-1')
                 paper-item.menu-item Home
                 aside.divider
             template(is='dom-repeat', items='[[menuLinks]]')
-                a(href$='[[item.href]]', on-click='openInIframe', tabindex='-1')
+                a(href$='[[_buildHref(item.href)]]',
+                    on-click='openInIframe', tabindex='-1')
                     paper-item.menu-item [[item.text]]
         aside.flex
         footer.footer
@@ -32,10 +33,10 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 paper-tabs.bottom(selected='[[page]]', attr-for-selected='page',
                         hides, hidden$='[[hideTabs]]')
                     paper-tab(page='dashboard', link)
-                        a.link(tabindex='-1', href='/') Dashboard
+                        a.link(tabindex='-1', href$='[[_buildHref("/")]]') Dashboard
                     paper-tab(page='activity', link)
-                        a.link(tabindex='-1', href='/activity') Activity
-                aside#NamespaceSelector(hidden$='[[!equals(page, "activity")]]')
+                        a.link(tabindex='-1', href$='[[_buildHref("/activity")]]') Activity
+                aside#NamespaceSelector
                     namespace-selector(query-params='{{queryParams}}')
         neon-animated-pages(selected='[[page]]', attr-for-selected='page',
                             entry-animation='fade-in-animation',

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -9,11 +9,11 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
             |!{logo}
             figcaption Kubeflow
         iron-selector(selected='{{sidebarItemIndex}}')
-            a(href$='[[_buildHref("/")]]', tabindex='-1')
+            a(href$='[[_buildHref("/", queryParams)]]', tabindex='-1')
                 paper-item.menu-item Home
                 aside.divider
             template(is='dom-repeat', items='[[menuLinks]]')
-                a(href$='[[_buildHref(item.href)]]',
+                a(href$='[[_buildHref(item.href, queryParams)]]',
                     on-click='openInIframe', tabindex='-1')
                     paper-item.menu-item [[item.text]]
         aside.flex
@@ -33,9 +33,9 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 paper-tabs.bottom(selected='[[page]]', attr-for-selected='page',
                         hides, hidden$='[[hideTabs]]')
                     paper-tab(page='dashboard', link)
-                        a.link(tabindex='-1', href$='[[_buildHref("/")]]') Dashboard
+                        a.link(tabindex='-1', href$='[[_buildHref("/", queryParams)]]') Dashboard
                     paper-tab(page='activity', link)
-                        a.link(tabindex='-1', href$='[[_buildHref("/activity")]]') Activity
+                        a.link(tabindex='-1', href$='[[_buildHref("/activity", queryParams)]]') Activity
                 aside#NamespaceSelector
                     namespace-selector(query-params='{{queryParams}}')
         neon-animated-pages(selected='[[page]]', attr-for-selected='page',

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -36,7 +36,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         a.link(tabindex='-1', href$='[[_buildHref("/", queryParams)]]') Dashboard
                     paper-tab(page='activity', link)
                         a.link(tabindex='-1', href$='[[_buildHref("/activity", queryParams)]]') Activity
-                aside#NamespaceSelector
+                aside#NamespaceSelector(hides, hidden$='[[hideNamespaces]]')
                     namespace-selector(query-params='{{queryParams}}')
         neon-animated-pages(selected='[[page]]', attr-for-selected='page',
                             entry-animation='fade-in-animation',

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -158,4 +158,16 @@ describe('Main Page', () => {
             .forEach((l) => hrefs.push(l.href));
         hrefs.forEach((h) => expect(h).toContain('?ns=another-namespace'));
     });
+
+    it('Hides namespace selector when showing Pipelines dashboard', () => {
+        flush();
+        expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
+            .hasAttribute('hidden')).toBe(false);
+
+        mainPage.subRouteData.path = '/pipeline-dashboard';
+        mainPage._routePageChanged('_');
+        flush();
+        expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
+            .hasAttribute('hidden')).toBe(true);
+    });
 });

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -68,8 +68,6 @@ describe('Main Page', () => {
         expect(mainPage.page).toBe('dashboard');
         expect(mainPage.sidebarItemIndex).toBe(0);
         expect(mainPage.inIframe).toBe(false);
-        expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
-            .hasAttribute('hidden')).toBe(true);
 
         await selectedTabPromise;
         expect(mainPage.shadowRoot.querySelector('paper-tab[page="dashboard"]')
@@ -89,8 +87,6 @@ describe('Main Page', () => {
         expect(mainPage.page).toBe('activity');
         expect(mainPage.sidebarItemIndex).toBe(0);
         expect(mainPage.inIframe).toBe(false);
-        expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
-            .hasAttribute('hidden')).toBe(false);
 
         await selectedTabPromise;
         expect(mainPage.shadowRoot.querySelector('paper-tab[page="activity"]')
@@ -106,8 +102,6 @@ describe('Main Page', () => {
         expect(mainPage.sidebarItemIndex).toBe(-1);
         expect(mainPage.notFoundInIframe).toBe(false);
         expect(mainPage.inIframe).toBe(false);
-        expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
-            .hasAttribute('hidden')).toBe(true);
         expect(mainPage.shadowRoot.querySelector('paper-tabs')
             .hasAttribute('hidden')).toBe(true);
     });
@@ -122,8 +116,6 @@ describe('Main Page', () => {
             expect(mainPage.sidebarItemIndex).toBe(-1);
             expect(mainPage.notFoundInIframe).toBe(true);
             expect(mainPage.shadowRoot.querySelector('paper-tabs')
-                .hasAttribute('hidden')).toBe(true);
-            expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
                 .hasAttribute('hidden')).toBe(true);
             expect(mainPage.shadowRoot.querySelector('paper-tabs')
                 .hasAttribute('hidden')).toBe(true);
@@ -144,5 +136,26 @@ describe('Main Page', () => {
         expect(mainPage.shadowRoot.querySelector('app-toolbar')
             .hasAttribute('blue')).toBe(true);
         expect(mainPage.$.MainDrawer.close).toHaveBeenCalled();
+    });
+
+    it('Appends query string when building links', () => {
+        // Base case
+        flush();
+        const hrefs = [];
+        mainPage.shadowRoot.querySelectorAll('#MainDrawer iron-selector a')
+            .forEach((l) => hrefs.push(l.href));
+        mainPage.shadowRoot.querySelectorAll('app-header paper-tabs a')
+            .forEach((l) => hrefs.push(l.href));
+        hrefs.forEach((h) => expect(h).not.toContain('?'));
+
+        // Set namespace case
+        mainPage.set('queryParams.ns', 'another-namespace');
+        flush();
+        hrefs.splice(0);
+        mainPage.shadowRoot.querySelectorAll('#MainDrawer iron-selector a')
+            .forEach((l) => hrefs.push(l.href));
+        mainPage.shadowRoot.querySelectorAll('app-header paper-tabs a')
+            .forEach((l) => hrefs.push(l.href));
+        hrefs.forEach((h) => expect(h).toContain('?ns=another-namespace'));
     });
 });


### PR DESCRIPTION
Ensures that all links on the Central Dashboard are namespace-aware in order to preserve state and allow it to be passed down to child components.

/area front-end
/area centraldashboard
/assign @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2913)
<!-- Reviewable:end -->
