### PR TITLE
retry for long running API enabling services

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -863,7 +863,6 @@ func (gcp *Gcp) deleteEndpoints(ctx context.Context) error {
 		}
 		log.Warnf("Endpoint deletion is running: %v (op = %v)", gcp.Spec.Hostname, newOp.Name)
 		opName = newOp.Name
-		// This error is used to invoke another retry, no need to use KfError.
 		return &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
 			Message: fmt.Sprintf("Endpoint deletion is running..."),
@@ -1506,17 +1505,51 @@ func (gcp *Gcp) gcpInitProject() error {
 		"iam.googleapis.com",
 		"sqladmin.googleapis.com",
 	}
-	for _, api := range enabledApis {
-		service := fmt.Sprintf("projects/%v/services/%v", gcp.Spec.Project, api)
-		_, opErr := serviceusageService.Services.Enable(service, &serviceusage.EnableServiceRequest{}).Context(ctx).Do()
-		if opErr != nil {
-			return &kfapis.KfError{
-				Code:    int(kfapis.INVALID_ARGUMENT),
-				Message: fmt.Sprintf("could not enable API service %v: %v", api, opErr),
-			}
+	op, opErr := serviceusageService.Services.BatchEnable("projects/"+gcp.Spec.Project,
+		&serviceusage.BatchEnableServicesRequest{
+			ServiceIds: enabledApis,
+		}).Context(ctx).Do()
+	if opErr != nil {
+		return &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: fmt.Sprintf("issuing batch API enabling services error: %v", opErr),
 		}
 	}
-	return nil
+	opService := serviceusage.NewOperationsService(serviceusageService)
+	opName := "" + op.Name
+	return backoff.Retry(func() error {
+		newOp, retryErr := opService.Get(opName).Context(ctx).Do()
+		if retryErr != nil {
+			log.Errorf("long running batch API enabling services error: %v", retryErr)
+			return &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: fmt.Sprintf("long running batch API enabling services error: %v", retryErr),
+			}
+		}
+		if newOp.Error != nil {
+			return &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: fmt.Sprintf("long running batch API enabling services error: %v", newOp.Error.Message),
+			}
+		}
+		if newOp.Done {
+			if newOp.HTTPStatusCode != 200 {
+				return backoff.Permanent(&kfapis.KfError{
+					Code:    int(kfapis.INTERNAL_ERROR),
+					Message: fmt.Sprintf("Abnormal response code: %v", newOp.HTTPStatusCode),
+				})
+			}
+			log.Infof("batch API enabling is completed: %v", enabledApis)
+			return nil
+
+		}
+		log.Warnf("batch API enabling is running: %v (op = %v)", enabledApis, newOp.Name)
+		opName = "" + newOp.Name
+		return &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: fmt.Sprintf("batch API enabling is running..."),
+		}
+	}, backoff.NewExponentialBackOff())
 }
 
 // Init initializes a gcp kfapp

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1522,13 +1522,13 @@ func (gcp *Gcp) gcpInitProject() error {
 		if retryErr != nil {
 			log.Errorf("long running batch API enabling services error: %v", retryErr)
 			return &kfapis.KfError{
-				Code:    int(kfapis.INTERNAL_ERROR),
+				Code:    int(kfapis.INVALID_ARGUMENT),
 				Message: fmt.Sprintf("long running batch API enabling services error: %v", retryErr),
 			}
 		}
 		if newOp.Error != nil {
 			return &kfapis.KfError{
-				Code:    int(kfapis.INTERNAL_ERROR),
+				Code:    int(kfapis.INVALID_ARGUMENT),
 				Message: fmt.Sprintf("long running batch API enabling services error: %v", newOp.Error.Message),
 			}
 		}


### PR DESCRIPTION
Fixes #2824 

Currently when invoking long running API calls to GCP/k8s, we'll keep retry until exponential backoff is expired.  This PR is to fix one call that is left - `serviceusage.Enable`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2914)
<!-- Reviewable:end -->
