### PR TITLE
Use jupyter service account for notebook CRD

### DIFF
--- a/components/jupyter-web-app/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/kubeflow_jupyter/common/utils.py
@@ -93,6 +93,7 @@ def create_notebook_template():
       "spec": {
           "template": {
               "spec": {
+                  "serviceAccountName": "jupyter-notebook",
                   "containers": [{
                       "name": "",
                       "volumeMounts": [],


### PR DESCRIPTION
We could also implement this in the notebook controller, since doing it in the notebook CRD itself would allow any service account to be mounted. However, we will most likely want that behavior in the future

cc @abhi-g

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2917)
<!-- Reviewable:end -->
