### PR TITLE
Enable iframed pages to communicate with Central Dashboard.

### DIFF
--- a/components/centraldashboard/README.md
+++ b/components/centraldashboard/README.md
@@ -82,10 +82,14 @@ code with business logic.
 ---
 
 ## Style-Guide
-Kubeflow central dashboard is a visualization and networking platform that links fellow sub-apps within the Kubeflow Ecosystem together. As a result we have various web-apps that are iframed within the app. To keep this experience uniform, we have a style guide for all Kubeflow Integrators to follow / use.
+Kubeflow central dashboard is a visualization and networking platform that links
+fellow sub-apps within the Kubeflow Ecosystem together. As a result we have
+various web-apps that are iframed within the app. To keep this experience
+ uniform, we have a style guide for all Kubeflow Integrators to follow / use.
 
 ### Approach
-We store our CSS palette in [_public/kubeflow-palette.css_](public/kubeflow-palette.css). This contains variables such as
+The CSS palette is found at [_public/kubeflow-palette.css_](public/kubeflow-palette.css).
+When deployed to a cluster, it can be imported from `cluster-host/kubeflow-palette.css`
 
 Name | Value | Usage
 --- | --- | ---
@@ -124,12 +128,12 @@ Since the Central Dashboard wraps other Kubeflow components in an iframe, a
 standalone Javascript library is exposed to make it possible to communicate
 between the child pages and the dashboard.
 
-The library is available for import from `/lib.bundle.js` within the cluster.
-When imported in this manner, a `centraldashboard` module is created in the
-global scope. To establish a channel for communication between the iframed page
-and the Dashboard, use the following example which would disable a `<select>`
-element and assign the value from the Dashboard's Namespace selector when it
-changes:
+The library is available for import from `/dashboard_lib.bundle.js` within the
+cluster. When imported in this manner, a `centraldashboard` module is created in
+the global scope. To establish a channel for communication between the iframed
+page and the Dashboard, use the following example which would disable a
+`<select>` element and assign the value from the Dashboard's Namespace selector
+when it changes:
 
 ```
 window.addEventListener('DOMContentLoaded', function (event) {

--- a/components/centraldashboard/README.md
+++ b/components/centraldashboard/README.md
@@ -118,3 +118,34 @@ body > .Main-Toolbar {background-color: var(--primary-background-color)}
 .List > .item:not(:first-of-type) {border-top: 1px solid var(--border-color)}
 /* etc */
 ```
+
+## Client-Side Library
+Since the Central Dashboard wraps other Kubeflow components in an iframe, a
+standalone Javascript library is exposed to make it possible to communicate
+between the child pages and the dashboard.
+
+The library is available for import from `/lib.bundle.js` within the cluster.
+When imported in this manner, a `centraldashboard` module is created in the
+global scope. To establish a channel for communication between the iframed page
+and the Dashboard, use the following example which would disable a `<select>`
+element and assign the value from the Dashboard's Namespace selector when it
+changes:
+
+```
+window.addEventListener('DOMContentLoaded', function (event) {
+    if (window.centraldashboard.CentralDashboardEventHandler) {
+        // Init method will invoke the callback with the event handler instance
+        // and a boolean indicating whether the page is iframed or not
+        window.centraldashboard.CentralDashboardEventHandler
+            .init(function (cdeh, isIframed) {
+                var namespaceSelector = document.getElementById('ns-select');
+                namespaceSelector.disabled = isIframed;
+                // Binds a callback that gets invoked anytime the Dashboard's
+                // namespace is changed
+                cdeh.onNamespaceSelected = function (namespace) {
+                    namespaceSelector.value = namespace;
+                };
+            });
+    }
+});
+```

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -4797,12 +4797,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4817,17 +4819,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4944,7 +4949,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4956,6 +4962,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4970,6 +4977,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4977,12 +4985,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5001,6 +5011,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5081,7 +5092,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5093,6 +5105,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5214,6 +5227,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -274,7 +274,7 @@ export class MainPage extends PolymerElement {
      * @param {Event} responseEvent AJAX-response
      */
     _onPlatformInfoResponse(responseEvent) {
-        const { response } = responseEvent.detail;
+        const {response} = responseEvent.detail;
         this.platformInfo = response;
         if (this.platformInfo.kubeflowVersion) {
             this.buildVersion = this.platformInfo.kubeflowVersion;
@@ -286,12 +286,11 @@ export class MainPage extends PolymerElement {
      * load event as well as when the namespace changes.
      */
     _sendNamespaceMessage() {
-        if (this._iframeConnected) {
-            this.$.PageFrame.contentWindow.postMessage({
-                type: NAMESPACE_SELECTED_EVENT,
-                value: this.namespace,
-            }, this._iframeOrigin);
-        }
+        if (!this._iframeConnected) return;
+        this.$.PageFrame.contentWindow.postMessage({
+            type: NAMESPACE_SELECTED_EVENT,
+            value: this.namespace,
+        }, this._iframeOrigin);
     }
 
     /**

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -210,7 +210,7 @@ export class MainPage extends PolymerElement {
      * @param {int} curr
      * @param {int} old
      */
-    _revertSidebarIndexIfExternal(curr, old = 0) {
+    _revertSidebarIndexIfExternal(curr, old=0) {
         if (curr != 1) return;
         this.sidebarItemIndex = old;
     }

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -45,7 +45,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     paper-tab(page='activity', link)
                         a.link(tabindex='-1', href$='[[_buildHref("/activity", queryParams)]]') Activity
                 aside#NamespaceSelector(hides, hidden$='[[hideNamespaces]]')
-                    namespace-selector(query-params='{{queryParams}}')
+                    namespace-selector(query-params='{{queryParams}}',
+                        selected="{{namespace}}")
         neon-animated-pages(selected='[[page]]', attr-for-selected='page',
                             entry-animation='fade-in-animation',
                             exit-animation='fade-out-animation')

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -41,10 +41,7 @@ export class NamespaceSelector extends PolymerElement {
      */
     static get properties() {
         return {
-            queryParams: {
-                type: Object,
-                notify: true,
-            },
+            queryParams: Object,
             namespaces: {
                 type: Array,
                 value: [],
@@ -52,6 +49,7 @@ export class NamespaceSelector extends PolymerElement {
             selected: {
                 type: String,
                 observer: '_onSelected',
+                notify: true,
             },
         };
     }
@@ -81,9 +79,7 @@ export class NamespaceSelector extends PolymerElement {
      * @param {Event} responseEvent
      */
     _onResponse(responseEvent) {
-        const {status, response} = responseEvent.detail;
-        // TODO: Surface the error in some manner
-        if (status !== 200) return;
+        const {response} = responseEvent.detail;
         this.namespaces = response.map((n) => {
             return {name: n.metadata.name, id: n.metadata.uid};
         });

--- a/components/centraldashboard/public/index_test.js
+++ b/components/centraldashboard/public/index_test.js
@@ -4,5 +4,7 @@
  */
 /* eslint-disable no-undef*/
 const testsContext = require.context('./components', true, /_test.js$/);
-
 testsContext.keys().forEach(testsContext);
+
+// Manually include the library_test file
+import './library_test.js';

--- a/components/centraldashboard/public/library.js
+++ b/components/centraldashboard/public/library.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Library for use with pages that need to communicate with the
+ * Central Dashboard.
+ */
+export const PARENT_CONNECTED_EVENT = 'parent-connected';
+export const IFRAME_CONNECTED_EVENT = 'iframe-connected';
+export const NAMESPACE_SELECTED_EVENT = 'namespace-selected';
+export const MESSAGE = 'message';
+
+/**
+ * Encapsulates the sending, receiving, and handling of events between iframed
+ * pages and the CentralDashboard component.
+ */
+export class CentralDashboardEventHandler {
+    /**
+     * Initializes the handler with a reference to its parent and flag
+     * indicating whether it's iframed.
+     */
+    constructor() {
+        this.window = window;
+        this.parent = window.parent;
+        this._onParentConnected = null;
+        this._onNamespaceSelected = null;
+
+        if (this.window.location !== this.parent.location) {
+            this.window.addEventListener(MESSAGE,
+                this._onMessageReceived.bind(this));
+            this.parent.postMessage({type: IFRAME_CONNECTED_EVENT},
+                this.parent.origin);
+        }
+    }
+
+    /**
+     * Attaches a callback function to respond to the PARENT_CONNECTED_EVENT
+     * event.
+     * @param {Function} callback - Callback accepting an object that contains
+     *  the event data.
+     */
+    set onParentConnected(callback) {
+        if (typeof callback === 'function') {
+            this._onParentConnected = callback;
+        }
+    }
+
+    /**
+     * Attaches a callback function to respond to the NAMESPACE_SELECTED_EVENT
+     * event.
+     * @param {Function} callback - Callback accepting an object that contains
+     *  the event data.
+     */
+    set onNamespaceSelected(callback) {
+        if (typeof callback === 'function') {
+            this._onNamespaceSelected = callback;
+        }
+    }
+
+    /**
+     * Handle the receipt of a message and dispatch to any added callbacks.
+     * @param {MessageEvent} event
+     */
+    _onMessageReceived(event) {
+        const {data} = event;
+        switch (data.type) {
+        case PARENT_CONNECTED_EVENT:
+            if (this._onParentConnected) {
+                this._onParentConnected(data);
+            }
+            break;
+        case NAMESPACE_SELECTED_EVENT:
+            if (this._onNamespaceSelected) {
+                this._onNamespaceSelected(data);
+            }
+            break;
+        }
+    }
+}

--- a/components/centraldashboard/public/library_test.js
+++ b/components/centraldashboard/public/library_test.js
@@ -1,0 +1,69 @@
+import {
+    IFRAME_CONNECTED_EVENT, PARENT_CONNECTED_EVENT,
+    NAMESPACE_SELECTED_EVENT, CentralDashboardEventHandler,
+} from './library';
+
+describe('CentralDashboardEventHandler', () => {
+    // eslint-disable-next-line no-unused-vars
+    let cdEventHandler;
+    let parentSpy;
+    let oldParent;
+
+    beforeEach(() => {
+        parentSpy = jasmine.createSpyObj('parent', ['postMessage']);
+        oldParent = window.parent;
+        window.parent = parentSpy;
+
+        spyOn(window, 'addEventListener');
+    });
+
+    afterEach(() => {
+        window.parent = oldParent;
+    });
+
+    it('Should not post message when outside of iframe', () => {
+        parentSpy.location = window.location;
+
+        cdEventHandler = new CentralDashboardEventHandler();
+
+        expect(window.addEventListener).not.toHaveBeenCalled();
+        expect(window.parent.postMessage).not.toHaveBeenCalled();
+    });
+
+    it('Should bind listener and send message to parent when in iframe', () => {
+        parentSpy.origin = 'http://testpage.com';
+
+        cdEventHandler = new CentralDashboardEventHandler();
+
+        expect(window.addEventListener).toHaveBeenCalled();
+        expect(window.parent.postMessage).toHaveBeenCalledWith(
+            {
+                type: IFRAME_CONNECTED_EVENT,
+            }, 'http://testpage.com'
+        );
+    });
+
+    it('Should invoke callbacks when messages are received', () => {
+        cdEventHandler = new CentralDashboardEventHandler();
+        const callbacksSpy = jasmine.createSpyObj('callbacksSpy', [
+            'onParentConnected', 'onNamespaceSelected']);
+
+        cdEventHandler.onParentConnected = callbacksSpy.onParentConnected;
+        cdEventHandler.onNamespaceSelected = callbacksSpy.onNamespaceSelected;
+
+        const message1 = {data: {type: PARENT_CONNECTED_EVENT, value: 'foo'}};
+        const message2 = {
+            data: {
+                type: NAMESPACE_SELECTED_EVENT, value: 'default-namespace',
+            },
+        };
+
+        cdEventHandler._onMessageReceived(message1);
+        expect(callbacksSpy.onParentConnected)
+            .toHaveBeenCalledWith(message1.data);
+
+        cdEventHandler._onMessageReceived(message2);
+        expect(callbacksSpy.onNamespaceSelected)
+            .toHaveBeenCalledWith(message2.data);
+    });
+});

--- a/components/centraldashboard/webpack.config.js
+++ b/components/centraldashboard/webpack.config.js
@@ -9,15 +9,16 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
-let commit = process.env.BUILD_COMMIT || ''
+let commit = process.env.BUILD_COMMIT || '';
 
 try {
-    commit = commit || `${execSync(`git rev-parse HEAD`)}`.replace(/\s/g,'');
-} catch(e) {}
+    commit = commit || `${execSync(`git rev-parse HEAD`)}`.replace(/\s/g, '');
+} catch (e) {}
 
 const ENV = process.env.NODE_ENV || 'development';
 const NODE_MODULES = /\/node_modules\//;
-const PKG_VERSION = `${require('./package.json').version}-${commit.slice(0,6)}`;
+const PKG_VERSION =
+    `${require('./package.json').version}-${commit.slice(0, 6)}`;
 const BUILD_VERSION = process.env.BUILD_VERSION || `dev_local`;
 const SRC = resolve(__dirname, 'public');
 const COMPONENTS = resolve(SRC, 'components');

--- a/components/centraldashboard/webpack.config.js
+++ b/components/centraldashboard/webpack.config.js
@@ -54,10 +54,15 @@ const COMPONENT_RULES = [
 
 module.exports = {
     mode: ENV,
-    entry: resolve(SRC, 'index.js'),
+    entry: {
+        app: resolve(SRC, 'index.js'),
+        lib: resolve(SRC, 'library.js'),
+    },
     output: {
         filename: '[name].bundle.js',
         path: DESTINATION,
+        library: 'centraldashboard',
+        libraryTarget: 'umd',
     },
     devtool: 'cheap-source-map',
     module: {
@@ -143,12 +148,6 @@ module.exports = {
         })],
         splitChunks: {
             cacheGroups: {
-                commons: {
-                    chunks: 'all',
-                    minChunks: 2,
-                    maxInitialRequests: 5,
-                    minSize: 0,
-                },
                 vendor: {
                     test: NODE_MODULES,
                     chunks: 'all',
@@ -169,6 +168,7 @@ module.exports = {
         new HtmlWebpackPlugin({
             filename: resolve(DESTINATION, 'index.html'),
             template: resolve(SRC, 'index.html'),
+            excludeChunks: ['lib'],
             inject: true,
             minify: ENV == 'development' ? false : {
                 collapseWhitespace: true,

--- a/components/centraldashboard/webpack.config.js
+++ b/components/centraldashboard/webpack.config.js
@@ -56,7 +56,7 @@ module.exports = {
     mode: ENV,
     entry: {
         app: resolve(SRC, 'index.js'),
-        lib: resolve(SRC, 'library.js'),
+        dashboard_lib: resolve(SRC, 'library.js'),
     },
     output: {
         filename: '[name].bundle.js',
@@ -160,7 +160,9 @@ module.exports = {
     },
     plugins: [
         new CleanWebpackPlugin([DESTINATION]),
-        new CopyWebpackPlugin(POLYFILLS),
+        new CopyWebpackPlugin(POLYFILLS.concat([
+            {from: resolve(SRC, 'kubeflow-palette.css'), to: DESTINATION},
+        ])),
         new DefinePlugin({
             BUILD_VERSION: JSON.stringify(BUILD_VERSION),
             VERSION: JSON.stringify(PKG_VERSION),


### PR DESCRIPTION
addresses #2845 
child of #2913 

This WIP PR demonstrates a working solution for passing the active namespace to child pages. We bind to the **load** event of the iframe element and pass the active namespace (if selected) down through the message bus. We then pass the namespace to the active iframe anytime it is changed by observing a property change.

See https://screencast.googleplex.com/cast/NjUwNzg4MTA3NTU3MjczNnw5NDI1OGNjNi1jZg for a demo or pull and run it locally. Run `python -m SimpleHTTPServer` from the centraldashboard directory to run serve the test.html page included in this commit which receives the message from the parent page. 

/area front-end
/area centraldashboard
/assign @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2926)
<!-- Reviewable:end -->
