### PR TITLE
Use platform info to display provider-specific links.

### DIFF
--- a/components/centraldashboard/Makefile
+++ b/components/centraldashboard/Makefile
@@ -21,7 +21,7 @@ clean:
 	rm -rf coverage/ dist/ node_modules/ .nyc_output/
 
 # Builds the package locally
-build-local: clean
+build-local:
 	npm install
 
 # Runs unit tests with coverage

--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -8,6 +8,11 @@ export function api(kubeConfig: KubeConfig): express.Router {
   const k8sService = new KubernetesService(kubeConfig);
   return express.Router()
       .get(
+          '/platform-info',
+          async (_: express.Request, res: express.Response) => {
+            res.json(await k8sService.getPlatformInfo());
+          })
+      .get(
           '/namespaces',
           async (_: express.Request, res: express.Response) => {
             res.json(await k8sService.getNamespaces());

--- a/components/centraldashboard/app/k8s_service.ts
+++ b/components/centraldashboard/app/k8s_service.ts
@@ -3,22 +3,65 @@ import * as k8s from '@kubernetes/client-node';
 /** Information about the Kubernetes hosting platform. */
 interface PlatformInfo {
   provider: string;
+  providerName: string;
+  kubeflowVersion: string;
 }
+
+/**
+ * Relevant fields from the description property of the Application CRD
+ * https://github.com/kubernetes-sigs/application/blob/master/config/crds/app_v1beta1_application.yaml
+ */
+interface V1BetaApplicationDescriptor {
+  version: string;
+}
+
+/**
+ * Relevant fields from the spec property of the Application CRD
+ * https://github.com/kubernetes-sigs/application/blob/master/config/crds/app_v1beta1_application.yaml
+ */
+interface V1BetaApplicationSpec {
+  descriptor: V1BetaApplicationDescriptor;
+}
+
+/** Generic definition of the Kubeflow Application CRD */
+interface V1BetaApplication {
+  apiVersion: string;
+  kind: string;
+  metadata?: k8s.V1ObjectMeta;
+  spec: V1BetaApplicationSpec;
+}
+
+interface V1BetaApplicationList {
+  items: V1BetaApplication[];
+}
+
+const APP_API_GROUP = 'app.k8s.io';
+const APP_API_VERSION = 'v1beta1';
+const APP_API_NAME = 'applications';
 
 /** Wrap Kubernetes API calls in a simpler interface for use in routes. */
 export class KubernetesService {
-  private k8sApi: k8s.Core_v1Api;
+  private namespace = 'kubeflow';
+  private coreAPI: k8s.Core_v1Api;
+  private customObjectsAPI: k8s.Custom_objectsApi;
 
   constructor(private kubeConfig: k8s.KubeConfig) {
     console.info('Initializing Kubernetes configuration');
     this.kubeConfig.loadFromDefault();
-    this.k8sApi = this.kubeConfig.makeApiClient(k8s.Core_v1Api);
+    const context =
+        this.kubeConfig.getContextObject(this.kubeConfig.getCurrentContext());
+    if (context && context.namespace) {
+      this.namespace = context.namespace;
+    }
+    this.coreAPI = this.kubeConfig.makeApiClient(k8s.Core_v1Api);
+    this.customObjectsAPI =
+        this.kubeConfig.makeApiClient(k8s.Custom_objectsApi);
   }
 
   /** Retrieves the list of namespaces from the Cluster. */
   async getNamespaces(): Promise<k8s.V1Namespace[]> {
     try {
-      const {body} = await this.k8sApi.listNamespace();
+      const {body} = await this.coreAPI.listNamespace();
       return body.items;
     } catch (err) {
       console.error('Unable to fetch Namespaces:', err.body || err);
@@ -29,7 +72,7 @@ export class KubernetesService {
   /** Retrieves the list of events for the given Namespace from the Cluster. */
   async getEventsForNamespace(namespace: string): Promise<k8s.V1Event[]> {
     try {
-      const {body} = await this.k8sApi.listNamespacedEvent(namespace);
+      const {body} = await this.coreAPI.listNamespacedEvent(namespace);
       return body.items;
     } catch (err) {
       console.error(
@@ -38,19 +81,62 @@ export class KubernetesService {
     }
   }
 
-  /** Retrieves the list of namespaces from the Cluster. */
+  /**
+   * Obtains cloud platform information from cluster Nodes,
+   * as well as the Kubeflow version from the Application custom resource.
+   */
   async getPlatformInfo(): Promise<PlatformInfo> {
-    const info: PlatformInfo = {provider: 'other'};
     try {
-      const {body} = await this.k8sApi.listNode();
-      const prefix = body.items.map((n) => n.spec.providerID)
-                         .filter(Boolean)
-                         .map((p) => p.split(':')[0])
-                         .find(Boolean);
-      info.provider = prefix || 'other';
+      const [provider, version] =
+          await Promise.all([this.getProvider(), this.getKubeflowVersion()]);
+      return {
+        kubeflowVersion: version,
+        provider,
+        providerName: provider.split(':')[0]
+      };
+    } catch (err) {
+      console.error('Unexpected error', err);
+      throw err;
+    }
+  }
+
+  /**
+   * Returns the provider identifier or 'other://' from the K8s cluster.
+   */
+  private async getProvider(): Promise<string> {
+    let provider = 'other://';
+    try {
+      const {body} = await this.coreAPI.listNode();
+      const foundProvider =
+          body.items.map((n) => n.spec.providerID).find(Boolean);
+      if (foundProvider) {
+        provider = foundProvider;
+      }
     } catch (err) {
       console.error('Unable to fetch Node information:', err.body || err);
     }
-    return info;
+    return provider;
+  }
+
+  /**
+   * Returns the Kubeflow version from the Application custom resource or
+   * 'unknown'.
+   */
+  private async getKubeflowVersion(): Promise<string> {
+    let version = 'unknown';
+    try {
+      const response = await this.customObjectsAPI.listNamespacedCustomObject(
+          APP_API_GROUP, APP_API_VERSION, this.namespace, APP_API_NAME);
+      const body = response.body as V1BetaApplicationList;
+      if (body.items && body.items.length && body.items[0].spec &&
+          body.items[0].spec.descriptor &&
+          body.items[0].spec.descriptor.version) {
+        version = body.items[0].spec.descriptor.version;
+      }
+    } catch (err) {
+      console.error(
+          'Unable to fetch Application information:', err.body || err);
+    }
+    return version;
   }
 }

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -4776,8 +4776,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4798,14 +4797,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4820,20 +4817,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4950,8 +4944,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4963,7 +4956,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4978,7 +4970,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4986,14 +4977,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5012,7 +5001,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5093,8 +5081,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5106,7 +5093,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5192,8 +5178,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5229,7 +5214,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5249,7 +5233,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5293,14 +5276,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/components/centraldashboard/public/ajax_test_helper.js
+++ b/components/centraldashboard/public/ajax_test_helper.js
@@ -10,15 +10,19 @@ import 'jasmine-ajax';
  * @param {HTMLElement} component
  * @param {object} response
  * @param {boolean=} respondWithError
+ * @param {string=} matchUrl
  * @return {Promise} Resolves when iron-ajax-response is handled
  */
-export function mockRequest(component, response, respondWithError = false) {
+export function mockRequest(component, response, respondWithError = false,
+    matchUrl = null) {
     const responseEvent = respondWithError ?
         'iron-ajax-error' : 'iron-ajax-response';
     return new Promise((resolve) => {
-        component.addEventListener('iron-ajax-request', () =>
-            jasmine.Ajax.requests.mostRecent().respondWith(response)
-        );
+        component.addEventListener('iron-ajax-request', (event) => {
+            if (!matchUrl || matchUrl === event.detail.options.url) {
+                jasmine.Ajax.requests.mostRecent().respondWith(response);
+            }
+        });
         component.addEventListener(responseEvent, () => resolve());
     });
 }

--- a/components/centraldashboard/public/components/dashboard-view.css
+++ b/components/centraldashboard/public/components/dashboard-view.css
@@ -15,6 +15,29 @@
 
 .link {
     background: #f1f3f4;
+    margin: .5em 1em;
+    border: 1px solid #eeeeef;
+    padding: .5em 1em;
+    border-radius: 5px;
+    @apply --layout-horizontal;
+}
+
+.link paper-icon-item {
+    @apply --layout-flex;
+    @apply --layout-justified;
+    @apply --layout-horizontal-reverse;
+    --paper-item-icon-width: 40px;
+    --paper-item-icon: {
+        color: var(--accent-color);
+        background: rgba(0, 125, 252, 0.25);
+        border-radius: 50%;
+    }
+}
+
+.link.more-coming {
+    opacity: .4;
+    font-style: italic;
+    pointer-events: none
 }
 
 paper-card {
@@ -52,25 +75,11 @@ paper-card.thin {
     grid-column: 3
 }
 
-#Quick-Links .link {
-    width: 80%;
-    margin: .5em auto;
-    border: 1px solid #eeeeef;
-    padding: .5em 1em;
-    border-radius: 5px;
-    @apply --layout-horizontal;
-}
-
-#Quick-Links .link.more-coming {
-    opacity: .4;
-    font-style: italic;
-    pointer-events: none
-}
-
-#Quick-Links .link .button {
-    color: var(--accent-color);
-    background: rgba(0, 125, 252, 0.25);
-    border-radius: 50%
+#Platform-Links header {
+    font-size: 18px;
+    font-weight: 400;
+    font-family: var(--paper-card-header_-_font-family);
+    padding: 8px 16px;
 }
 
 a {

--- a/components/centraldashboard/public/components/dashboard-view.css
+++ b/components/centraldashboard/public/components/dashboard-view.css
@@ -76,10 +76,9 @@ paper-card.thin {
 }
 
 #Platform-Links header {
-    font-size: 18px;
+    font-size: 1.25em;
     font-weight: 400;
-    font-family: var(--paper-card-header_-_font-family);
-    padding: 8px 16px;
+    padding: .5em 1em;
 }
 
 a {

--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -1,6 +1,10 @@
+import '@polymer/iron-ajax/iron-ajax.js';
+
 import {html, PolymerElement} from '@polymer/polymer';
 import css from './dashboard-view.css';
 import template from './dashboard-view.pug';
+
+const DOCS = 'https://www.kubeflow.org/docs/started';
 
 export class DashboardView extends PolymerElement {
     static get template() {
@@ -11,9 +15,8 @@ export class DashboardView extends PolymerElement {
      * Object describing property-related metadata used by Polymer features
      */
     static get properties() {
-        const kubeflowDocs = 'https://www.kubeflow.org/docs/started';
-
         return {
+            platformType: String,
             gettingStartedItems: {
                 type: Array,
                 value: [
@@ -21,18 +24,18 @@ export class DashboardView extends PolymerElement {
                         text: 'Getting started with Kubeflow',
                         desc: 'Quickly get running with your ML workflow on ' +
                             'an existing Kubernetes installation',
-                        link: `${kubeflowDocs}/getting-started/`,
+                        link: `${DOCS}/getting-started/`,
                     },
                     {
                         text: 'Microk8s for Kubeflow',
                         desc: 'Quickly get Kubeflow running locally on ' +
                             'native hypervisors',
-                        link: `${kubeflowDocs}/getting-started-multipass/`,
+                        link: `${DOCS}/getting-started-multipass/`,
                     },
                     {
                         text: 'Minikube for Kubeflow',
                         desc: 'Quickly get Kubeflow running locally',
-                        link: `${kubeflowDocs}/getting-started-minikube/`,
+                        link: `${DOCS}/getting-started-minikube/`,
                     },
                     {
                         text: 'Kubernetes Engine for Kubeflow',
@@ -40,13 +43,13 @@ export class DashboardView extends PolymerElement {
                                 'Platform. This guide is a quickstart' +
                                 ' to deploying Kubeflow on Google' +
                                 ' Kubernetes Engine',
-                        link: `${kubeflowDocs}/getting-started-gke/`,
+                        link: `${DOCS}/getting-started-gke/`,
                     },
                     {
                         text: 'Requirements for Kubeflow',
                         desc: 'Get more detailed information about using ' +
                 'Kubeflow and its components',
-                        link: `${kubeflowDocs}/requirements/`,
+                        link: `${DOCS}/requirements/`,
                     },
                 ],
             },
@@ -55,7 +58,7 @@ export class DashboardView extends PolymerElement {
                 value: [
                     {
                         text: 'Open docs',
-                        link: `${kubeflowDocs}/getting-started/`,
+                        link: `${DOCS}/getting-started/`,
                     },
                     {
                         text: 'Open Github',
@@ -64,6 +67,18 @@ export class DashboardView extends PolymerElement {
                 ],
             },
         };
+    }
+
+    // TODO: Move to mixin class
+    equals(...e) {
+        const crit = e.shift();
+        if (!e.length) return true;
+        return e.every((e) => e === crit);
+    }
+
+    _onPlatformInfoResponse(responseEvent) {
+        const {response} = responseEvent.detail;
+        this.platformType = response.provider;
     }
 }
 

--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -11,6 +11,10 @@ import template from './dashboard-view.pug';
 const DOCS = 'https://www.kubeflow.org/docs/started';
 const GCP_LINKS = [
     {
+        text: 'Stackdriver Logging',
+        link: 'https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=',
+    },
+    {
         text: 'Project Overview',
         link: 'https://console.cloud.google.com/home/dashboard?project=',
     },
@@ -21,10 +25,6 @@ const GCP_LINKS = [
     {
         text: 'Kubernetes Engine',
         link: 'https://console.cloud.google.com/kubernetes/list?project=',
-    },
-    {
-        text: 'Stackdriver Logging',
-        link: 'https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=',
     },
 ];
 

--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -1,10 +1,32 @@
-import '@polymer/iron-ajax/iron-ajax.js';
+import '@polymer/iron-icon/iron-icon.js';
+import '@polymer/iron-icons/iron-icons.js';
+import '@polymer/paper-card/paper-card.js';
+import '@polymer/paper-item/paper-icon-item.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
 
 import {html, PolymerElement} from '@polymer/polymer';
 import css from './dashboard-view.css';
 import template from './dashboard-view.pug';
 
 const DOCS = 'https://www.kubeflow.org/docs/started';
+const GCP_LINKS = [
+    {
+        text: 'Project Overview',
+        link: 'https://console.cloud.google.com/home/dashboard?project=',
+    },
+    {
+        text: 'Deployment Manager',
+        link: 'https://console.cloud.google.com/dm/deployments?project=',
+    },
+    {
+        text: 'Kubernetes Engine',
+        link: 'https://console.cloud.google.com/kubernetes/list?project=',
+    },
+    {
+        text: 'Stackdriver Logging',
+        link: 'https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=',
+    },
+];
 
 export class DashboardView extends PolymerElement {
     static get template() {
@@ -16,7 +38,6 @@ export class DashboardView extends PolymerElement {
      */
     static get properties() {
         return {
-            platformType: String,
             gettingStartedItems: {
                 type: Array,
                 value: [
@@ -66,19 +87,33 @@ export class DashboardView extends PolymerElement {
                     },
                 ],
             },
+            platformName: String,
+            platformLinks: Array,
+            platformInfo: {
+                type: Object,
+                observer: '_platformInfoChanged',
+            },
         };
     }
 
-    // TODO: Move to mixin class
-    equals(...e) {
-        const crit = e.shift();
-        if (!e.length) return true;
-        return e.every((e) => e === crit);
-    }
-
-    _onPlatformInfoResponse(responseEvent) {
-        const {response} = responseEvent.detail;
-        this.platformType = response.provider;
+    /**
+     * Observer for platformInfo property
+     */
+    _platformInfoChanged() {
+        if (this.platformInfo && this.platformInfo.providerName === 'gce') {
+            this.platformName = 'GCP';
+            const pieces = this.platformInfo.provider.split('/');
+            let gcpProject = '';
+            if (pieces.length >= 3) {
+                gcpProject = pieces[2];
+            }
+            this.platformLinks = GCP_LINKS.map((l) => {
+                return {
+                    text: l.text,
+                    link: l.link + gcpProject,
+                };
+            });
+        }
     }
 }
 

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -1,5 +1,3 @@
-iron-ajax(auto, url='/api/platform-info', handle-as='json',
-    on-response='_onPlatformInfoResponse')
 paper-card#Getting-Started(heading='Getting Started')
     template(is='dom-repeat', items='[[gettingStartedItems]]')
         a.heading(href$='[[item.link]]', tabindex='-1',
@@ -11,21 +9,17 @@ paper-card#Getting-Started(heading='Getting Started')
                     aside(secondary) [[item.desc]]
 paper-card.thin#Quick-Links(heading='Quick Links')
     template(is='dom-repeat', items='[[quickLinks]]')
-        article.link
-            paper-item-body [[item.text]]
-            a(href$='[[item.link]]', tabindex='-1', target='_blank')
-                paper-icon-button.button(icon='arrow-forward', alt='[[item.text]]')
-    article.link.more-coming
-        paper-item-body More coming soon
-        paper-icon-button.button(icon='arrow-forward', disabled)
-paper-card#Platform-Links(heading='Platform Links')
-    template(is='dom-if', if='[[equals(platformType, "aws")]]')
-        article.link
-            paper-item-body AWS Link 1
-    template(is='dom-if', if='[[equals(platformType, "azure")]]')
-        article.link
-            paper-item-body Azure Link 1
-    template(is='dom-if', if='[[equals(platformType, "gce")]]')
-        article.link
-            paper-item-body GCP Link 1
-            paper-item-body GCP Link 2
+        a.link(href$='[[item.link]]', tabindex='-1', target='_blank')
+            paper-icon-item [[item.text]]
+                paper-icon-button.button(icon='arrow-forward',
+                    slot='item-icon', alt='[[item.text]]')
+    template(is='dom-if', if='[[platformLinks]]')
+        section#Platform-Links
+            header [[ platformName ]] Information
+            template(is='dom-repeat', items='[[platformLinks]]')
+                a.link(href$='[[item.link]]', tabindex='-1', target='_blank')
+                    paper-icon-item
+                        aside [[item.text]]
+                        paper-icon-button.button(icon='arrow-forward',
+                            slot='item-icon', alt='[[item.text]]')
+

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -1,3 +1,5 @@
+iron-ajax(auto, url='/api/platform-info', handle-as='json',
+    on-response='_onPlatformInfoResponse')
 paper-card#Getting-Started(heading='Getting Started')
     template(is='dom-repeat', items='[[gettingStartedItems]]')
         a.heading(href$='[[item.link]]', tabindex='-1',
@@ -16,3 +18,14 @@ paper-card.thin#Quick-Links(heading='Quick Links')
     article.link.more-coming
         paper-item-body More coming soon
         paper-icon-button.button(icon='arrow-forward', disabled)
+paper-card#Platform-Links(heading='Platform Links')
+    template(is='dom-if', if='[[equals(platformType, "aws")]]')
+        article.link
+            paper-item-body AWS Link 1
+    template(is='dom-if', if='[[equals(platformType, "azure")]]')
+        article.link
+            paper-item-body Azure Link 1
+    template(is='dom-if', if='[[equals(platformType, "gce")]]')
+        article.link
+            paper-item-body GCP Link 1
+            paper-item-body GCP Link 2

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -15,7 +15,7 @@ paper-card.thin#Quick-Links(heading='Quick Links')
                     slot='item-icon', alt='[[item.text]]')
     template(is='dom-if', if='[[platformLinks]]')
         section#Platform-Links
-            header [[ platformName ]] Information
+            header [[platformName]] Information
             template(is='dom-repeat', items='[[platformLinks]]')
                 a.link(href$='[[item.link]]', tabindex='-1', target='_blank')
                     paper-icon-item

--- a/components/centraldashboard/public/components/dashboard-view_test.js
+++ b/components/centraldashboard/public/components/dashboard-view_test.js
@@ -62,10 +62,10 @@ describe('Dashboard View', () => {
                 hrefs.push(l.href);
             });
         expect(hrefs).toEqual([
+            'https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=test-project',
             'https://console.cloud.google.com/home/dashboard?project=test-project',
             'https://console.cloud.google.com/dm/deployments?project=test-project',
             'https://console.cloud.google.com/kubernetes/list?project=test-project',
-            'https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=test-project',
         ]);
     });
 });

--- a/components/centraldashboard/public/components/dashboard-view_test.js
+++ b/components/centraldashboard/public/components/dashboard-view_test.js
@@ -1,0 +1,71 @@
+import '@polymer/test-fixture/test-fixture';
+import {flush} from '@polymer/polymer/lib/utils/flush.js';
+
+import './dashboard-view';
+
+const FIXTURE_ID = 'dashboard-view-fixture';
+const DASHBOARD_VIEW_SELECTOR_ID = 'test-dashboard-view';
+const TEMPLATE = `
+<test-fixture id="${FIXTURE_ID}">
+  <template>
+    <dashboard-view id="${DASHBOARD_VIEW_SELECTOR_ID}"></dashboard-view>
+  </template>
+</test-fixture>
+`;
+
+describe('Dashboard View', () => {
+    let dashboardView;
+
+    beforeAll(() => {
+        const div = document.createElement('div');
+        div.innerHTML = TEMPLATE;
+        document.body.appendChild(div);
+    });
+
+    beforeEach(() => {
+        document.getElementById(FIXTURE_ID).create();
+        dashboardView = document.getElementById(DASHBOARD_VIEW_SELECTOR_ID);
+    });
+
+    afterEach(() => {
+        document.getElementById(FIXTURE_ID).restore();
+    });
+
+    it('Does not show links without platform info', () => {
+        expect(dashboardView.shadowRoot.getElementById('Platform-Links'))
+            .toBeNull();
+    });
+
+    it('Does not show links for an unrecognized provider', async () => {
+        dashboardView.platformInfo = {
+            providerName: 'some-cloud-provider',
+            provider: 'some-cloud-provider-project-id-unknown-format',
+        };
+        flush();
+        expect(dashboardView.shadowRoot.getElementById('Platform-Links'))
+            .toBeNull();
+    });
+
+    it('Shows GCP links when provider is gce', () => {
+        dashboardView.platformInfo = {
+            provider: 'gce://test-project/us-east1-c/gke-kubeflow-node-123',
+            providerName: 'gce',
+            kubeflowVersion: '1.0.0',
+        };
+        flush();
+        expect(dashboardView.shadowRoot.querySelector('#Platform-Links header')
+            .innerText).toBe('GCP Information');
+
+        const hrefs = [];
+        dashboardView.shadowRoot.querySelectorAll('#Platform-Links a.link')
+            .forEach((l) => {
+                hrefs.push(l.href);
+            });
+        expect(hrefs).toEqual([
+            'https://console.cloud.google.com/home/dashboard?project=test-project',
+            'https://console.cloud.google.com/dm/deployments?project=test-project',
+            'https://console.cloud.google.com/kubernetes/list?project=test-project',
+            'https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=test-project',
+        ]);
+    });
+});

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -6,11 +6,10 @@ import '@polymer/app-layout/app-scroll-effects/app-scroll-effects.js';
 import '@polymer/app-layout/app-toolbar/app-toolbar.js';
 import '@polymer/app-route/app-location.js';
 import '@polymer/app-route/app-route.js';
+import '@polymer/iron-ajax/iron-ajax.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '@polymer/iron-collapse/iron-collapse.js';
 import '@polymer/iron-selector/iron-selector.js';
-import '@polymer/iron-flex-layout/iron-flex-layout-classes.js';
-import '@polymer/iron-flex-layout/iron-flex-layout.js';
 import '@polymer/iron-media-query/iron-media-query.js';
 import '@polymer/paper-card/paper-card.js';
 import '@polymer/paper-tabs/paper-tabs.js';
@@ -43,10 +42,8 @@ const VALID_QUERY_PARAMS = ['ns'];
 export class MainPage extends PolymerElement {
     static get template() {
         const pugVariables = {logo: logo};
-        return html([`
-        <style is="custom-style"
-            include="iron-flex iron-flex-alignment iron-positioning">
-        <style>${css.toString()}</style>${template(pugVariables)}`]);
+        return html([
+            `<style>${css.toString()}</style>${template(pugVariables)}`]);
     }
 
     static get properties() {
@@ -93,6 +90,7 @@ export class MainPage extends PolymerElement {
             iframeUrl: {type: String, value: ''},
             buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
+            platformInfo: Object,
             inIframe: {type: Boolean, value: false, readOnly: true},
             hideTabs: {type: Boolean, value: false, readOnly: true},
             hideNamespaces: {type: Boolean, value: false, readOnly: true},
@@ -226,6 +224,17 @@ export class MainPage extends PolymerElement {
             }
         });
         return url.href.slice(url.origin.length);
+    }
+
+    /* Handles the AJAX response from the platform-info API.
+     * @param {Event} responseEvent AJAX-response
+     */
+    _onPlatformInfoResponse(responseEvent) {
+        const {response} = responseEvent.detail;
+        this.platformInfo = response;
+        if (this.platformInfo.kubeflowVersion) {
+            this.buildVersion = this.platformInfo.kubeflowVersion;
+        }
     }
 }
 

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -1,3 +1,5 @@
+iron-ajax(auto, url='/api/platform-info', handle-as='json',
+    on-response='_onPlatformInfoResponse')
 app-drawer-layout.flex(narrow='{{narrowMode}}',
         force-narrow='[[or(inIframe, thinView, notFoundInIframe)]]',
         thin$='[[thinView]]')
@@ -44,7 +46,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                             entry-animation='fade-in-animation',
                             exit-animation='fade-out-animation')
             neon-animatable(page='dashboard')
-                dashboard-view
+                dashboard-view(platform-info='[[platformInfo]]')
             neon-animatable(page='activity')
                 activity-view(namespace='[[queryParams.ns]]')
             neon-animatable#iframe-page(page='iframe')

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -3,6 +3,7 @@ import 'jasmine-ajax';
 import {flush} from '@polymer/polymer/lib/utils/flush.js';
 
 import './main-page';
+import {mockRequest} from '../ajax_test_helper';
 
 const FIXTURE_ID = 'main-page-fixture';
 const MAIN_PAGE_SELECTOR_ID = 'test-main-page';
@@ -169,5 +170,24 @@ describe('Main Page', () => {
         flush();
         expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
             .hasAttribute('hidden')).toBe(true);
+    });
+
+    it('Sets build version when platform info is received', async () => {
+        const responsePromise = mockRequest(mainPage, {
+            status: 200,
+            responseText: JSON.stringify({
+                provider: 'gce://test-project/us-east1-c/gke-kubeflow-node-123',
+                providerName: 'gce',
+                kubeflowVersion: '1.0.0',
+            }),
+        }, false, '/api/platform-info');
+        await responsePromise;
+        flush();
+
+        const buildVersion = mainPage.shadowRoot.querySelector(
+            'section.build span');
+        // textContent is used because innerText would be empty if sidebar is
+        // hidden
+        expect(buildVersion.textContent).toEqual('1.0.0');
     });
 });


### PR DESCRIPTION
addresses #2885 

Adds new /api/platform-info endpoint to expose provider information to allow front-end to set platform specific links.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2935)
<!-- Reviewable:end -->
