### PR TITLE
Conditionally make kubeflow the default namespace if found

### DIFF
--- a/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
+++ b/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
@@ -13,7 +13,7 @@
     <select class="mdl-textfield__input" id="ns-select" name="ns">
       <!-- Fill with the namespaces the user can see -->
       {% for ns in namespaces %}
-        <option value="{{ ns }}">{{ ns }}</option>
+        <option value="{{ ns }}" {{ ns == 'kubeflow'|yesno:"selected" }}>{{ ns }}</option>
       {% endfor %}
     </select>
     <label class="mdl-textfield__label" for="ns">Select Namespace</label>


### PR DESCRIPTION
#### fixes #2937

## About
As namespaces are populated in UI, conditionally default the namespace to `kubeflow` if found in list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2941)
<!-- Reviewable:end -->
