### PR TITLE
Notebook ui default namespace

### DIFF
--- a/components/jupyter-web-app/kubeflow_jupyter/default/app.py
+++ b/components/jupyter-web-app/kubeflow_jupyter/default/app.py
@@ -162,5 +162,7 @@ def home():
     nmsps = [base_ns]
     logger.warning("Can't  list namespaces: %s" % api.parse_error(e))
 
+  # todo(apverma): To Be removed after multi-user isolation support is implemented
+  nmsps = [base_ns] # Issue #2937
   return render_template(
       'notebooks.html', prefix=prefix(), title='Notebooks', namespaces=nmsps)

--- a/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
+++ b/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
@@ -13,7 +13,7 @@
     <select class="mdl-textfield__input" id="ns-select" name="ns">
       <!-- Fill with the namespaces the user can see -->
       {% for ns in namespaces %}
-        <option value="{{ ns }}" {{ ns == 'kubeflow'|yesno:"selected" }}>{{ ns }}</option>
+        <option value="{{ ns }}">{{ ns }}</option>
       {% endfor %}
     </select>
     <label class="mdl-textfield__label" for="ns">Select Namespace</label>

--- a/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
+++ b/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
@@ -13,7 +13,7 @@
     <select class="mdl-textfield__input" id="ns-select" name="ns">
       <!-- Fill with the namespaces the user can see -->
       {% for ns in namespaces %}
-        <option value="{{ ns }}">{{ ns }}</option>
+        <option value="{{ ns }}" {{ ns == 'kubeflow'|yesno:"selected" }}>{{ ns }}</option>
       {% endfor %}
     </select>
     <label class="mdl-textfield__label" for="ns">Select Namespace</label>


### PR DESCRIPTION
Hotfix for: #2937 

Now only one namespace is available: `kubeflow`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2951)
<!-- Reviewable:end -->
