### PR TITLE
Automated cherry pick of #2968: set injectGcpCredentials to true by default Cherry pick of #2968 on v0.5-branch. #2968: set injectGcpCredentials to true by default

### DIFF
--- a/kubeflow/jupyter/prototypes/notebook_controller.jsonnet
+++ b/kubeflow/jupyter/prototypes/notebook_controller.jsonnet
@@ -4,7 +4,7 @@
 // @shortDescription notebooks
 // @param name string Name
 // @optionalParam controllerImage string gcr.io/kubeflow-images-public/notebook-controller:v20190401-v0.4.0-rc.1-308-g33618cc9-e3b0c4 The image to use for the notebook controller
-// @optionalParam injectGcpCredentials string false Whether to inject gcp credentials
+// @optionalParam injectGcpCredentials string true Whether to inject gcp credentials
 
 local notebooks = import "kubeflow/jupyter/notebook_controller.libsonnet";
 local instance = notebooks.new(env, params);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2970)
<!-- Reviewable:end -->
