### PR TITLE
update kfctl version for 0.5 branch

### DIFF
--- a/bootstrap/cmd/kfctl/cmd/version.go
+++ b/bootstrap/cmd/kfctl/cmd/version.go
@@ -43,5 +43,5 @@ func init() {
 }
 
 func versionfunc(cmd *cobra.Command, args []string) {
-	fmt.Println("v20181207-4e7f4ed-198-gaeea303e-dirty-03e65e")
+	fmt.Println("v0.5.0")
 }

--- a/bootstrap/pkg/apis/apps/group.go
+++ b/bootstrap/pkg/apis/apps/group.go
@@ -17,10 +17,16 @@ package apps
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"plugin"
+	"regexp"
+	"strings"
+
 	kfapis "github.com/kubeflow/kubeflow/bootstrap/pkg/apis"
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps/kfdef/v1alpha1"
 	log "github.com/sirupsen/logrus"
-	"io"
 	ext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	crdclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -29,17 +35,12 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"os"
-	"path/filepath"
-	"plugin"
-	"regexp"
-	"strings"
 )
 
 const (
 	DefaultNamespace = "kubeflow"
 	// TODO: find the latest tag dynamically
-	DefaultVersion     = "master"
+	DefaultVersion     = "v0.5.0"
 	DefaultGitRepo     = "https://github.com/kubeflow/kubeflow/tarball"
 	KfConfigFile       = "app.yaml"
 	DefaultCacheDir    = ".cache"


### PR DESCRIPTION
for #2716

- kfctl should use v0.5.0 by default
- `kfctl version` will print v0.5.0

Will rebuild the binary after this.

/cc @kunmingg @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/2985)
<!-- Reviewable:end -->
