### PR TITLE
Shows involvedObject rather than Cluster Host in Activities view

### DIFF
--- a/components/centraldashboard/public/components/activities-list.js
+++ b/components/centraldashboard/public/components/activities-list.js
@@ -131,7 +131,7 @@ export class ActivitiesList extends PolymerElement {
                 time: time,
                 event: a.message,
                 icon: a.type === 'Normal' ? 'build' : 'error',
-                source: a.source.host,
+                source: a.involvedObject.name,
             };
             if (!(day in eventsByDate)) {
                 eventsByDate[day] = [];

--- a/components/centraldashboard/public/components/activities-list_test.js
+++ b/components/centraldashboard/public/components/activities-list_test.js
@@ -39,15 +39,15 @@ describe('Activities List', () => {
             lastTimestamp: today.toLocaleString(),
             message: 'Something happened',
             type: 'Normal',
-            source: {
-                host: 'some-container',
+            involvedObject: {
+                name: 'some-pod',
             },
         }, {
             lastTimestamp: yesterday.toLocaleString(),
             message: 'Something bad happened',
             type: 'Error',
-            source: {
-                host: 'a-failing-container',
+            involvedObject: {
+                name: 'a-failing-pod',
             },
         }];
         flush();
@@ -71,8 +71,8 @@ describe('Activities List', () => {
                     .toLocaleString(),
                 message: `Something happened ${i}`,
                 type: 'Normal',
-                source: {
-                    host: 'some-container',
+                involvedObject: {
+                    name: 'some-pod',
                 },
             });
         }


### PR DESCRIPTION
This adds slightly more context about the events being displayed. See the screenshots which reflect the events emitted from running the *ML - TFX - Taxi Tip Prediction Model Trainer* sample pipeline

**Current**:
![Screenshot from 2019-04-11 13-56-36](https://user-images.githubusercontent.com/6835846/55980100-bc2a9080-5c61-11e9-8554-6d683702ec4c.png)

**New Change**:
![Screenshot from 2019-04-11 13-57-00](https://user-images.githubusercontent.com/6835846/55980118-c64c8f00-5c61-11e9-891d-a9c7502f9e9c.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3001)
<!-- Reviewable:end -->
