### PR TITLE
Use exact name when updating backend healthz path

### DIFF
--- a/kubeflow/gcp/iap.libsonnet
+++ b/kubeflow/gcp/iap.libsonnet
@@ -311,6 +311,10 @@
                     name: "GOOGLE_APPLICATION_CREDENTIALS",
                     value: "/var/run/secrets/sa/admin-gcp-sa.json",
                   },
+                  {
+                    name: "INGRESS_NAME",
+                    value: params.ingressName,
+                  },
                 ] + if params.useIstio then [
                   {
                     name: "USE_ISTIO",

--- a/kubeflow/gcp/update_backend.sh
+++ b/kubeflow/gcp/update_backend.sh
@@ -55,8 +55,6 @@ fi
 
 if [[ ${USE_ISTIO} ]]; then
   # Create the route so healthcheck can pass
-  echo istio healthcheck_route is
-  cat /var/envoy-config/healthcheck_route.yaml
   kubectl apply -f /var/envoy-config/healthcheck_route.yaml
 fi
 


### PR DESCRIPTION
Fixes #3014 

Root cause is because of port conflict.  It seems when installing ISTIO, node port is always assigned as [31380](https://github.com/kubeflow/kubeflow/blob/cbc792bd082f1c3575a02f62faaa643cbbe198d8/dependencies/istio/install/istio-noauth.yaml#L13745).  Therefore when more than one deployments exists, update_backend.sh will not succeed when updating healthz path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3025)
<!-- Reviewable:end -->
