### PR TITLE
Make kubebench reporter optional

### DIFF
--- a/kubeflow/kubebench/kubebench-job.libsonnet
+++ b/kubeflow/kubebench/kubebench-job.libsonnet
@@ -12,6 +12,10 @@ local k = import "k.libsonnet";
              experimentPvc,
              githubTokenSecret,
              githubTokenSecretKey,
+             awsCredentialsSecret,
+             awsCredentialsSecretAccessKeyId,
+             awsCredentialsSecretAccessKey,
+             awsRegion,
              gcpCredentialsSecret,
              gcpCredentialsSecretKey,
              mainJobKsPrototype,
@@ -57,6 +61,31 @@ local k = import "k.libsonnet";
         "--output-file=" + csvReporterOutput,
       ] else [];
 
+      local awsSecretEnv = if awsCredentialsSecret != "null" then [
+        {
+          name: "AWS_ACCESS_KEY_ID",
+          valueFrom: {
+            secretKeyRef: {
+              name: awsCredentialsSecret,
+              key: awsCredentialsSecretAccessKeyId,
+            },
+          },
+        },
+        {
+          name: "AWS_SECRET_ACCESS_KEY",
+          valueFrom: {
+            secretKeyRef: {
+              name: awsCredentialsSecret,
+              key: awsCredentialsSecretAccessKey,
+            },
+          },
+        },
+        {
+          name: "AWS_REGION",
+          value: awsRegion
+        },
+      ] else [];
+
       local secretEnvVars = [
         if gcpCredentialsSecret != "null" then {
           name: "GOOGLE_APPLICATION_CREDENTIALS",
@@ -71,7 +100,7 @@ local k = import "k.libsonnet";
             },
           },
         },
-      ];  // secretEnvVars
+      ] + awsSecretEnv;  // secretEnvVars
       local baseEnvVars = [
         {
           name: "KUBEBENCH_CONFIG_ROOT",

--- a/kubeflow/kubebench/kubebench-job.libsonnet
+++ b/kubeflow/kubebench/kubebench-job.libsonnet
@@ -262,6 +262,7 @@ local k = import "k.libsonnet";
                     ],
                   ),
                 ],
+                if postJobImage != "null" && postJobArgs != "null" then
                 [
                   buildStep(
                     "run-post-job",
@@ -277,7 +278,8 @@ local k = import "k.libsonnet";
                       },
                     ],
                   ),
-                ],
+                ] else [],
+                if reporterType != "null" then
                 [
                   buildStep(
                     "run-reporter",
@@ -293,7 +295,7 @@ local k = import "k.libsonnet";
                       },
                     ],
                   ),
-                ],
+                ] else [],
               ],
             },
             buildTemplate(
@@ -342,6 +344,7 @@ local k = import "k.libsonnet";
               successCondition="status.completionTime",
               inParams=[{ name: "kf-job-manifest" }],
             ),
+            if postJobImage != "null" && postJobArgs != "null" then
             buildTemplate(
               "post-job",
               postJobImage,
@@ -349,7 +352,8 @@ local k = import "k.libsonnet";
               envVars=baseEnvVars + expEnvVars(),
               volMnts=baseVolMnts,
               inParams=[{ name: "experiment-id" }],
-            ),
+            ) else {},
+            if reporterType != "null" then
             buildTemplate(
               "reporter",
               controllerImage,
@@ -357,7 +361,7 @@ local k = import "k.libsonnet";
               envVars=secretEnvVars + baseEnvVars + expEnvVars(),
               volMnts=secretVolMnts + baseVolMnts,
               inParams=[{ name: "experiment-id" }],
-            ),
+            ) else {},
           ],  // templates
         },
       },  // workflow

--- a/kubeflow/kubebench/prototypes/kubebench-job.jsonnet
+++ b/kubeflow/kubebench/prototypes/kubebench-job.jsonnet
@@ -7,6 +7,10 @@
 // @optionalParam controllerImage string gcr.io/kubeflow-images-public/kubebench/kubebench-controller:v0.4.0-13-g262c593 Configurator image
 // @optionalParam githubTokenSecret string null Github token secret
 // @optionalParam githubTokenSecretKey string null Key of Github token secret
+// @optionalParam awsCredentialsSecret string null AWS credentials secret
+// @optionalParam awsCredentialsSecretAccessKeyId string null AWS credentials secret access key id
+// @optionalParam awsCredentialsSecretAccessKey string null AWS credentials secret access key
+// @optionalParam awsRegion string null Key of AWS Region
 // @optionalParam gcpCredentialsSecret string null GCP credentials secret
 // @optionalParam gcpCredentialsSecretKey string null Key of GCP credentials secret
 // @optionalParam mainJobKsPrototype string kubebench-example-tfcnn The Ksonnet prototype of the job being benchmarked
@@ -33,6 +37,10 @@ local controllerImage = params.controllerImage;
 local configPvc = params.experimentConfigPvc;
 local dataPvc = params.experimentDataPvc;
 local experimentPvc = params.experimentRecordPvc;
+local awsCredentialsSecret = params.awsCredentialsSecret;
+local awsCredentialsSecretAccessKeyId = params.awsCredentialsSecretAccessKeyId;
+local awsCredentialsSecretAccessKey = params.awsCredentialsSecretAccessKey;
+local awsRegion = params.awsRegion;
 local gcpCredentialsSecret = params.gcpCredentialsSecret;
 local gcpCredentialsSecretKey = params.gcpCredentialsSecretKey;
 local githubTokenSecret = params.githubTokenSecret;
@@ -70,6 +78,10 @@ local jobParts = [
                               experimentPvc,
                               githubTokenSecret,
                               githubTokenSecretKey,
+                              awsCredentialsSecret,
+                              awsCredentialsSecretAccessKeyId,
+                              awsCredentialsSecretAccessKey,
+                              awsRegion,
                               gcpCredentialsSecret,
                               gcpCredentialsSecretKey,
                               mainJobKsPrototype,


### PR DESCRIPTION
I feel heavy to writer processor/reporter for different kind of models. Logs are enough for some of cases and I want to make reporter step optional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3062)
<!-- Reviewable:end -->
