### PR TITLE
Default central dashboard URI matching to /

### DIFF
--- a/kubeflow/common/centraldashboard.libsonnet
+++ b/kubeflow/common/centraldashboard.libsonnet
@@ -102,7 +102,7 @@
             match: [
               {
                 uri: {
-                  prefix: "/_/",
+                  prefix: "/",
                 },
               },
             ],


### PR DESCRIPTION
Somehow the app itself fixed the problem:
https://github.com/kubeflow/kubeflow/pull/3037#discussion_r277376524

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3076)
<!-- Reviewable:end -->
