### PR TITLE
Add emacs package to the Jupyter Image

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update && apt-get install -yq --no-install-recommends \
   vim \
   wget \
   zip \
+  emacs \
   && apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION

Fixes  https://github.com/kubeflow/kubeflow/issues/3016

#added emacs to list of packages installed by apt-get 
Related to the issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3089)
<!-- Reviewable:end -->
