### PR TITLE
ISTIO support for notebook controller

### DIFF
--- a/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
+++ b/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
@@ -393,7 +393,6 @@ func virtualServiceName(kfName string, namespace string) string {
 func generateVirtualService(instance *v1alpha1.Notebook) (*unstructured.Unstructured, error) {
 	name := instance.Name
 	namespace := instance.Namespace
-	appName := fmt.Sprintf("notebook-%s-%s", namespace, name)
 	prefix := fmt.Sprintf("/notebook/%s/%s", namespace, name)
 	rewrite := fmt.Sprintf("/notebook/%s/%s", namespace, name)
 	// TODO(gabrielwen): Make clusterDomain an option.

--- a/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
+++ b/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
@@ -94,6 +94,18 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes to Notebook virtualservices.
+	virtualService := &unstructured.Unstructured{}
+	virtualService.SetAPIVersion("networking.istio.io/v1alpha3")
+	virtualService.SetKind("VirtualService")
+	err = c.Watch(&source.Kind{Type: virtualService}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &v1alpha1.Notebook{},
+	})
+	if err != nil {
+		return err
+	}
+
 	// Watch underlying pod.
 	// mapFn defines the mapping from object in event to reconcile request
 	mapFn := handler.ToRequestsFunc(

--- a/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
+++ b/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
@@ -196,7 +196,10 @@ func (r *ReconcileNotebook) Reconcile(request reconcile.Request) (reconcile.Resu
 	if err := controllerutil.SetControllerReference(instance, service, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
-	virtualService := generateVirtualService(instance)
+	virtualService, err := generateVirtualService(instance)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
 	if err := controllerutil.SetControllerReference(instance, virtualService, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}

--- a/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
+++ b/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
 	v1alpha1 "github.com/kubeflow/kubeflow/components/notebook-controller/pkg/apis/notebook/v1alpha1"
@@ -407,30 +406,32 @@ func generateVirtualService(instance *v1alpha1.Notebook) (*unstructured.Unstruct
 		return nil, fmt.Errorf("Set .spec.gateways error: %v", err)
 	}
 
-	http := map[string]interface{}{
-		"match": []interface{}{
-			map[string]interface{}{
-				"uri": map[string]interface{}{
-					"prefix": prefix,
+	http := []interface{}{
+		map[string]interface{}{
+			"match": []interface{}{
+				map[string]interface{}{
+					"uri": map[string]interface{}{
+						"prefix": prefix,
+					},
 				},
 			},
-		},
-		"rewrite": map[string]interface{}{
-			"uri": rewrite,
-		},
-		"route": []interface{}{
-			map[string]interface{}{
-				"destination": map[string]interface{}{
-					"host": service,
-				},
-				"port": map[string]interface{}{
-					"number": strconv.Itoa(port),
+			"rewrite": map[string]interface{}{
+				"uri": rewrite,
+			},
+			"route": []interface{}{
+				map[string]interface{}{
+					"destination": map[string]interface{}{
+						"host": service,
+						"port": map[string]interface{}{
+							"number": int64(port),
+						},
+					},
 				},
 			},
+			"timeout": "300s",
 		},
-		"timeout": "300s",
 	}
-	if err := unstructured.SetNestedMap(vsvc.Object, http, "spec", "http"); err != nil {
+	if err := unstructured.SetNestedSlice(vsvc.Object, http, "spec", "http"); err != nil {
 		return nil, fmt.Errorf("Set .spec.http error: %v", err)
 	}
 

--- a/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
+++ b/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
@@ -383,6 +383,8 @@ func generateService(instance *v1alpha1.Notebook) *corev1.Service {
 }
 
 func generateVirtualService(instance *v1alpha1.Notebook) (*unstructured.Unstructured, error) {
+	name := instance.Name
+	namespace := instance.Namespace
 	prefix := fmt.Sprintf("/notebook/%s/%s", namespace, name)
 	rewrite := fmt.Sprintf("/notebook/%s/%s", namespace, name)
 	// TODO(gabrielwen): Make clusterDomain an option.

--- a/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
+++ b/components/notebook-controller/pkg/controller/notebook/notebook_controller.go
@@ -224,7 +224,7 @@ func (r *ReconcileNotebook) Reconcile(request reconcile.Request) (reconcile.Resu
 	if err := controllerutil.SetControllerReference(instance, virtualService, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
-	// Check if the virtual service already exists. Noop if it already exists.
+	// Check if the virtual service already exists.
 	foundVirtual := &unstructured.Unstructured{}
 	justCreated = false
 	foundVirtual.SetAPIVersion("networking.istio.io/v1alpha3")

--- a/components/notebook-controller/pkg/util/util.go
+++ b/components/notebook-controller/pkg/util/util.go
@@ -18,6 +18,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Reference: https://github.com/pwittrock/kubebuilder-workshop/blob/master/pkg/util/util.go
@@ -78,4 +79,28 @@ func CopyServiceFields(from, to *corev1.Service) bool {
 	to.Spec.Ports = from.Spec.Ports
 
 	return requireUpdate
+}
+
+func CopyVirtualService(from, to *unstructured.Unstructured) bool {
+	fromSpec, found, err := unstructured.NestedMap(from.Object, "spec")
+	if !found {
+		return true
+	}
+	if err != nil {
+		return true
+	}
+
+	toSpec, found, err := unstructured.NestedMap(to.Object, "spec")
+	if !found {
+		return true
+	}
+	if err != nil {
+		return true
+	}
+
+	requiresUpdate := !reflect.DeepEqual(fromSpec, toSpec)
+	if requiresUpdate {
+		unstructured.SetNestedMap(to.Object, fromSpec, "spec")
+	}
+	return requiresUpdate
 }

--- a/components/notebook-controller/pkg/util/util.go
+++ b/components/notebook-controller/pkg/util/util.go
@@ -81,20 +81,20 @@ func CopyServiceFields(from, to *corev1.Service) bool {
 	return requireUpdate
 }
 
+// Copy configuration related fields to another instance and returns true if there
+// is a diff and thus needs to update.
 func CopyVirtualService(from, to *unstructured.Unstructured) bool {
 	fromSpec, found, err := unstructured.NestedMap(from.Object, "spec")
 	if !found {
-		return true
+		return false
 	}
 	if err != nil {
-		return true
+		return false
 	}
 
 	toSpec, found, err := unstructured.NestedMap(to.Object, "spec")
-	if !found {
-		return true
-	}
-	if err != nil {
+	if !found || err != nil {
+		unstructured.SetNestedMap(to.Object, fromSpec, "spec")
 		return true
 	}
 

--- a/components/notebook-controller/pkg/util/util.go
+++ b/components/notebook-controller/pkg/util/util.go
@@ -18,6 +18,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Reference: https://github.com/pwittrock/kubebuilder-workshop/blob/master/pkg/util/util.go
@@ -78,4 +79,9 @@ func CopyServiceFields(from, to *corev1.Service) bool {
 	to.Spec.Ports = from.Spec.Ports
 
 	return requireUpdate
+}
+
+// Deep compare between two unstructured instances.
+func DiffUnstructured(from, to *unstructured.Unstructured) bool {
+	return !reflect.DeepEqual(from, to)
 }

--- a/components/notebook-controller/pkg/util/util.go
+++ b/components/notebook-controller/pkg/util/util.go
@@ -18,7 +18,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 // Reference: https://github.com/pwittrock/kubebuilder-workshop/blob/master/pkg/util/util.go
@@ -79,9 +78,4 @@ func CopyServiceFields(from, to *corev1.Service) bool {
 	to.Spec.Ports = from.Spec.Ports
 
 	return requireUpdate
-}
-
-// Deep compare between two unstructured instances.
-func DiffUnstructured(from, to *unstructured.Unstructured) bool {
-	return !reflect.DeepEqual(from, to)
 }

--- a/kubeflow/jupyter/notebook_controller.libsonnet
+++ b/kubeflow/jupyter/notebook_controller.libsonnet
@@ -1,32 +1,32 @@
 {
-  local util = import "kubeflow/common/util.libsonnet",
+  local util = import 'kubeflow/common/util.libsonnet',
 
   new(_env, _params):: {
     local params = _env + _params,
 
     local notebooksCRD = {
-      apiVersion: "apiextensions.k8s.io/v1beta1",
-      kind: "CustomResourceDefinition",
+      apiVersion: 'apiextensions.k8s.io/v1beta1',
+      kind: 'CustomResourceDefinition',
       metadata: {
-        name: "notebooks.kubeflow.org",
+        name: 'notebooks.kubeflow.org',
       },
       spec: {
-        group: "kubeflow.org",
-        version: "v1alpha1",
-        scope: "Namespaced",
+        group: 'kubeflow.org',
+        version: 'v1alpha1',
+        scope: 'Namespaced',
         subresources: {
           status: {},
         },
         names: {
-          plural: "notebooks",
-          singular: "notebook",
-          kind: "Notebook",
+          plural: 'notebooks',
+          singular: 'notebook',
+          kind: 'Notebook',
         },
       },
       status: {
         acceptedNames: {
-          kind: "",
-          plural: "",
+          kind: '',
+          plural: '',
         },
         conditions: [],
         storedVersions: [],
@@ -35,15 +35,15 @@
     notebooksCRD:: notebooksCRD,
 
     local controllerService = {
-      apiVersion: "v1",
-      kind: "Service",
+      apiVersion: 'v1',
+      kind: 'Service',
       metadata: {
-        name: "notebooks-controller",
+        name: 'notebooks-controller',
         namespace: params.namespace,
       },
       spec: {
         selector: {
-          app: "notebooks-controller",
+          app: 'notebooks-controller',
         },
         ports: [
           {
@@ -55,38 +55,38 @@
     controllerService:: controllerService,
 
     local controllerDeployment = {
-      apiVersion: "apps/v1beta1",
-      kind: "Deployment",
+      apiVersion: 'apps/v1beta1',
+      kind: 'Deployment',
       metadata: {
-        name: "notebooks-controller",
+        name: 'notebooks-controller',
         namespace: params.namespace,
       },
       spec: {
         selector: {
           matchLabels: {
-            app: "notebooks-controller",
+            app: 'notebooks-controller',
           },
         },
         template: {
           metadata: {
             labels: {
-              app: "notebooks-controller",
+              app: 'notebooks-controller',
             },
           },
           spec: {
-            serviceAccountName: "notebook-controller",
+            serviceAccountName: 'notebook-controller',
             containers: [
               {
-                name: "manager",
+                name: 'manager',
                 image: params.controllerImage,
-                imagePullPolicy: "Always",
+                imagePullPolicy: 'Always',
                 command: [
-                  "/manager",
+                  '/manager',
                 ],
                 env: if util.toBool(params.injectGcpCredentials) then [
                   {
-                    name: "POD_LABELS",
-                    value: "gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json",
+                    name: 'POD_LABELS',
+                    value: 'gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json',
                   },
                 ] else [],
               },
@@ -98,59 +98,70 @@
     controllerDeployment:: controllerDeployment,
 
     local serviceAccount = {
-      apiVersion: "v1",
-      kind: "ServiceAccount",
+      apiVersion: 'v1',
+      kind: 'ServiceAccount',
       metadata: {
         labels: {
-          app: "notebook-controller",
+          app: 'notebook-controller',
         },
-        name: "notebook-controller",
+        name: 'notebook-controller',
         namespace: params.namespace,
       },
     },
     serviceAccount:: serviceAccount,
 
     local role = {
-      apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "ClusterRole",
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRole',
       metadata: {
-        name: "notebooks-controller",
+        name: 'notebooks-controller',
       },
       rules: [
         {
           apiGroups: [
-            "apps",
+            'apps',
           ],
           resources: [
-            "statefulsets",
-            "deployments",
+            'statefulsets',
+            'deployments',
           ],
           verbs: [
-            "*",
+            '*',
           ],
         },
         {
           apiGroups: [
-            "",
+            '',
           ],
           resources: [
-            "services",
-            "pods",
+            'services',
+            'pods',
           ],
           verbs: [
-            "*",
+            '*',
           ],
         },
         {
           apiGroups: [
-            "kubeflow.org",
+            'kubeflow.org',
           ],
           resources: [
-            "notebooks",
-            "notebooks/status",
+            'notebooks',
+            'notebooks/status',
           ],
           verbs: [
-            "*",
+            '*',
+          ],
+        },
+        {
+          apiGroups: [
+            'networking.istio.io',
+          ],
+          resources: [
+            'virtualservices',
+          ],
+          verbs: [
+            '*',
           ],
         },
       ],
@@ -158,20 +169,20 @@
     role:: role,
 
     local roleBinding = {
-      apiVersion: "rbac.authorization.k8s.io/v1",
-      kind: "ClusterRoleBinding",
+      apiVersion: 'rbac.authorization.k8s.io/v1',
+      kind: 'ClusterRoleBinding',
       metadata: {
-        name: "notebooks-controller",
+        name: 'notebooks-controller',
       },
       roleRef: {
-        apiGroup: "rbac.authorization.k8s.io",
-        kind: "ClusterRole",
-        name: "notebooks-controller",
+        apiGroup: 'rbac.authorization.k8s.io',
+        kind: 'ClusterRole',
+        name: 'notebooks-controller',
       },
       subjects: [
         {
-          kind: "ServiceAccount",
-          name: "notebook-controller",
+          kind: 'ServiceAccount',
+          name: 'notebook-controller',
           namespace: params.namespace,
         },
       ],

--- a/kubeflow/jupyter/notebook_controller.libsonnet
+++ b/kubeflow/jupyter/notebook_controller.libsonnet
@@ -1,32 +1,32 @@
 {
-  local util = import 'kubeflow/common/util.libsonnet',
+  local util = import "kubeflow/common/util.libsonnet",
 
   new(_env, _params):: {
     local params = _env + _params,
 
     local notebooksCRD = {
-      apiVersion: 'apiextensions.k8s.io/v1beta1',
-      kind: 'CustomResourceDefinition',
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
       metadata: {
-        name: 'notebooks.kubeflow.org',
+        name: "notebooks.kubeflow.org",
       },
       spec: {
-        group: 'kubeflow.org',
-        version: 'v1alpha1',
-        scope: 'Namespaced',
+        group: "kubeflow.org",
+        version: "v1alpha1",
+        scope: "Namespaced",
         subresources: {
           status: {},
         },
         names: {
-          plural: 'notebooks',
-          singular: 'notebook',
-          kind: 'Notebook',
+          plural: "notebooks",
+          singular: "notebook",
+          kind: "Notebook",
         },
       },
       status: {
         acceptedNames: {
-          kind: '',
-          plural: '',
+          kind: "",
+          plural: "",
         },
         conditions: [],
         storedVersions: [],
@@ -35,15 +35,15 @@
     notebooksCRD:: notebooksCRD,
 
     local controllerService = {
-      apiVersion: 'v1',
-      kind: 'Service',
+      apiVersion: "v1",
+      kind: "Service",
       metadata: {
-        name: 'notebooks-controller',
+        name: "notebooks-controller",
         namespace: params.namespace,
       },
       spec: {
         selector: {
-          app: 'notebooks-controller',
+          app: "notebooks-controller",
         },
         ports: [
           {
@@ -55,38 +55,38 @@
     controllerService:: controllerService,
 
     local controllerDeployment = {
-      apiVersion: 'apps/v1beta1',
-      kind: 'Deployment',
+      apiVersion: "apps/v1beta1",
+      kind: "Deployment",
       metadata: {
-        name: 'notebooks-controller',
+        name: "notebooks-controller",
         namespace: params.namespace,
       },
       spec: {
         selector: {
           matchLabels: {
-            app: 'notebooks-controller',
+            app: "notebooks-controller",
           },
         },
         template: {
           metadata: {
             labels: {
-              app: 'notebooks-controller',
+              app: "notebooks-controller",
             },
           },
           spec: {
-            serviceAccountName: 'notebook-controller',
+            serviceAccountName: "notebook-controller",
             containers: [
               {
-                name: 'manager',
+                name: "manager",
                 image: params.controllerImage,
-                imagePullPolicy: 'Always',
+                imagePullPolicy: "Always",
                 command: [
-                  '/manager',
+                  "/manager",
                 ],
                 env: if util.toBool(params.injectGcpCredentials) then [
                   {
-                    name: 'POD_LABELS',
-                    value: 'gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json',
+                    name: "POD_LABELS",
+                    value: "gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json",
                   },
                 ] else [],
               },
@@ -98,70 +98,70 @@
     controllerDeployment:: controllerDeployment,
 
     local serviceAccount = {
-      apiVersion: 'v1',
-      kind: 'ServiceAccount',
+      apiVersion: "v1",
+      kind: "ServiceAccount",
       metadata: {
         labels: {
-          app: 'notebook-controller',
+          app: "notebook-controller",
         },
-        name: 'notebook-controller',
+        name: "notebook-controller",
         namespace: params.namespace,
       },
     },
     serviceAccount:: serviceAccount,
 
     local role = {
-      apiVersion: 'rbac.authorization.k8s.io/v1',
-      kind: 'ClusterRole',
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      kind: "ClusterRole",
       metadata: {
-        name: 'notebooks-controller',
+        name: "notebooks-controller",
       },
       rules: [
         {
           apiGroups: [
-            'apps',
+            "apps",
           ],
           resources: [
-            'statefulsets',
-            'deployments',
+            "statefulsets",
+            "deployments",
           ],
           verbs: [
-            '*',
+            "*",
           ],
         },
         {
           apiGroups: [
-            '',
+            "",
           ],
           resources: [
-            'services',
-            'pods',
+            "services",
+            "pods",
           ],
           verbs: [
-            '*',
+            "*",
           ],
         },
         {
           apiGroups: [
-            'kubeflow.org',
+            "kubeflow.org",
           ],
           resources: [
-            'notebooks',
-            'notebooks/status',
+            "notebooks",
+            "notebooks/status",
           ],
           verbs: [
-            '*',
+            "*",
           ],
         },
         {
           apiGroups: [
-            'networking.istio.io',
+            "networking.istio.io",
           ],
           resources: [
-            'virtualservices',
+            "virtualservices",
           ],
           verbs: [
-            '*',
+            "*",
           ],
         },
       ],
@@ -169,20 +169,20 @@
     role:: role,
 
     local roleBinding = {
-      apiVersion: 'rbac.authorization.k8s.io/v1',
-      kind: 'ClusterRoleBinding',
+      apiVersion: "rbac.authorization.k8s.io/v1",
+      kind: "ClusterRoleBinding",
       metadata: {
-        name: 'notebooks-controller',
+        name: "notebooks-controller",
       },
       roleRef: {
-        apiGroup: 'rbac.authorization.k8s.io',
-        kind: 'ClusterRole',
-        name: 'notebooks-controller',
+        apiGroup: "rbac.authorization.k8s.io",
+        kind: "ClusterRole",
+        name: "notebooks-controller",
       },
       subjects: [
         {
-          kind: 'ServiceAccount',
-          name: 'notebook-controller',
+          kind: "ServiceAccount",
+          name: "notebook-controller",
           namespace: params.namespace,
         },
       ],


### PR DESCRIPTION
Relates to #2978

Tested through manual deployment:
1. Remove ambassador from component list.
1. Bring up KF cluster.
1. Navigate to `Notebooks` and use the UI to create a new notebook server.
1. Verify that `CONNECT` could correctly find Jupyter notebook UI page.
1. Verify that when deleting a notebook server, virtual service is gone with it.

/assign @lluunn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3104)
<!-- Reviewable:end -->
