### PR TITLE
Python 2/3 agnostic dict iteration in update_ks_app.py

### DIFF
--- a/scripts/upgrade_ks_app.py
+++ b/scripts/upgrade_ks_app.py
@@ -57,7 +57,7 @@ def main():
   registries = app['registries']
   libraries = app['libraries']
 
-  for name in registries.iterkeys():
+  for name in registries.keys():
     if name != registry_name:
       logging.info("Skipping registry %s", name)
       continue
@@ -75,7 +75,7 @@ def main():
     shutil.rmtree(target)
 
   libs_to_remove = []
-  for name in libraries.iterkeys():
+  for name in libraries.keys():
     lib_registry = libraries[name]["registry"]
     if lib_registry != registry_name:
       continue

--- a/scripts/upgrade_ks_app.py
+++ b/scripts/upgrade_ks_app.py
@@ -57,12 +57,12 @@ def main():
   registries = app['registries']
   libraries = app['libraries']
 
-  for name in registries.keys():
+  for name, reg in registries.items():
     if name != registry_name:
       logging.info("Skipping registry %s", name)
       continue
 
-    if registries[name]["uri"].startswith("file"):
+    if reg["uri"].startswith("file"):
       # File registries are not stored in .ksonnet
       # TODO(jlewi): This messes with bootstrapper because we might want  to
       # switch from using the file URI to using the git location.
@@ -75,8 +75,8 @@ def main():
     shutil.rmtree(target)
 
   libs_to_remove = []
-  for name in libraries.keys():
-    lib_registry = libraries[name]["registry"]
+  for name, lib in libraries.items():
+    lib_registry = lib["registry"]
     if lib_registry != registry_name:
       continue
     libs_to_remove.append(name)


### PR DESCRIPTION
Fixes #3098, it turned out to be a tiny change. There is more info on iterating over dicts in a 2/3 agnostic way at [PEP469](https://www.python.org/dev/peps/pep-0469/). 

I wasn't sure whether to open this PR against the 0.5 branch or master so just let me know if I did the wrong thing!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3107)
<!-- Reviewable:end -->
