### PR TITLE
Improve the scripts for mirroing images to support VPC service controls

### DIFF
--- a/kubeflow/gcp/cloud-endpoints.libsonnet
+++ b/kubeflow/gcp/cloud-endpoints.libsonnet
@@ -1,9 +1,9 @@
 {
   local k = import "k.libsonnet",
   new(_env, _params):: {
-    local params = _params + _env {
+    local params = {
       cloudEndpointsImage: "gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1",
-    },
+    } + _params + _env,
 
     local endpointsCRD = {
       apiVersion: "apiextensions.k8s.io/v1beta1",

--- a/kubeflow/gcp/iap.libsonnet
+++ b/kubeflow/gcp/iap.libsonnet
@@ -803,7 +803,7 @@
                     value: "8081",
                   },
                 ],
-                image: "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
+                image: params.espSampleAppImage,
                 name: "app",
                 ports: [
                   {

--- a/kubeflow/gcp/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/gcp/prototypes/iap-ingress.jsonnet
@@ -14,7 +14,7 @@
 // @optionalParam privateGKECluster string false Is the k8s cluster a private GKE cluster
 // @optionalParam useIstio string false The namespace where Istio is installed
 // @optionalParam istioNamespace string istio-system The namespace where Istio is installed
-// @optionalParam  espSampleAppImage string gcr.io/cloud-solutions-group/esp-sample-app:1.0.0 The sample app used with IAP
+// @optionalParam espSampleAppImage string gcr.io/cloud-solutions-group/esp-sample-app:1.0.0 The sample app used with IAP
 
 local iap = import "kubeflow/gcp/iap.libsonnet";
 local instance = iap.new(env, params);

--- a/kubeflow/gcp/prototypes/iap-ingress.jsonnet
+++ b/kubeflow/gcp/prototypes/iap-ingress.jsonnet
@@ -14,6 +14,7 @@
 // @optionalParam privateGKECluster string false Is the k8s cluster a private GKE cluster
 // @optionalParam useIstio string false The namespace where Istio is installed
 // @optionalParam istioNamespace string istio-system The namespace where Istio is installed
+// @optionalParam  espSampleAppImage string gcr.io/cloud-solutions-group/esp-sample-app:1.0.0 The sample app used with IAP
 
 local iap = import "kubeflow/gcp/iap.libsonnet";
 local instance = iap.new(env, params);

--- a/kubeflow/gcp/tests/iap_test.jsonnet
+++ b/kubeflow/gcp/tests/iap_test.jsonnet
@@ -8,6 +8,7 @@ local testCases = [
       {
         envoyPort: 8080,
         useIstio: "false",
+        espSampleAppImage: "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
       }
     ).service,
     expected: {
@@ -48,6 +49,7 @@ local testCases = [
         hostname: "hostname",
         issuer: "issuer",
         useIstio: "false",
+        espSampleAppImage: "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
       }
     ).ingress,
     expected: {
@@ -94,6 +96,7 @@ local testCases = [
         hostname: "null",
         issuer: "issuer",
         useIstio: "false",
+        espSampleAppImage: "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
       }
     ).ingress,
     expected: {
@@ -139,6 +142,7 @@ local testCases = [
         issuer: "issuer",
         privateGKECluster: "false",
         useIstio: "false",
+        espSampleAppImage: "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
       }
     ).certificate,
     expected: {
@@ -180,6 +184,7 @@ local testCases = [
       },
       {
         useIstio: "false",
+        espSampleAppImage: "cloud-solutions-group/esp-sample-app:5.0.0",
       }
     ).whoamiApp,
     expected: {
@@ -206,7 +211,7 @@ local testCases = [
                     value: "8081",
                   },
                 ],
-                image: "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
+                image: "cloud-solutions-group/esp-sample-app:5.0.0",
                 name: "app",
                 ports: [
                   {
@@ -238,6 +243,7 @@ local testCases = [
       },
       {
         useIstio: "false",
+        espSampleAppImage: "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
       }
     ).whoamiService,
     expected: {

--- a/scripts/gke/gcb_copy_images.jsonnet
+++ b/scripts/gke/gcb_copy_images.jsonnet
@@ -10,13 +10,17 @@
   // A template for defining the steps  to retag each image.
   local subGraphTemplate(image) = {
     local imagePieces = std.split(image, "/"),
-    local nameAndTag = std.split(imagePieces[std.length(imagePieces) -1], ":"),
+    local imageName = if std.length(imagePieces) > 1 then
+      imagePieces[1:]
+      else
+      [image],
+    local nameAndTag = std.split(imageName[std.length(imageName) -1], ":"),
 
     local name = nameAndTag[0],
 
     local template = self,
 
-    local newImage = std.join("/", [newRegistry] +  imagePieces[1:]),
+    local newImage = std.join("/", [newRegistry] +  imageName),
 
     images+: [newImage],
 
@@ -41,6 +45,13 @@
     "argoproj/argoui:v2.2.0",
     "argoproj/argoexec:v2.2.0",
     "argoproj/workflow-controller:v2.2.0",
+    "gcr.io/cloud-solutions-group/cloud-endpoints-controller:0.2.1",
+    "gcr.io/cloud-solutions-group/esp-sample-app:1.0.0",
+    "gcr.io/ml-pipeline/api-server:0.1.17",
+    "gcr.io/ml-pipeline/persistenceagent:0.1.17",
+    "gcr.io/ml-pipeline/scheduledworkflow:0.1.17",
+    "gcr.io/ml-pipeline/frontend:0.1.17",
+    "gcr.io/ml-pipeline/viewer-crd-controller:0.1.17",
     "metacontroller/metacontroller:v0.3.0",
     "minio/minio:RELEASE.2018-02-09T22-40-05Z",
     "mysql:8.0.3",

--- a/scripts/gke/use_gcr_for_all_images.sh
+++ b/scripts/gke/use_gcr_for_all_images.sh
@@ -59,17 +59,30 @@ main() {
     ks param set ambassador ambassadorImage ${registry}/datawire/ambassador:0.37.0
   fi
 
+  if ks component list | awk '{print $1}' | grep -q "^cloud-endpoints$"; then
+    ks param set cloud-endpoints cloudEndpointsImage ${registry}/cloud-solutions-group/cloud-endpoints-controller:0.2.1
+  fi
+
   if ks component list | awk '{print $1}' | grep -q "^katib$"; then
     ks param set katib vizierDbImage ${registry}/mysql:8.0.3
+  fi
+
+  if ks component list | awk '{print $1}' | grep -q "^iap$"; then
+    ks param set iap-ingress  ${registry}/cloud-solutions-group/esp-sample-app:1.0.0
   fi
 
   if ks component list | awk '{print $1}' | grep -q "^metacontroller$"; then
     ks param set metacontroller image ${registry}/metacontroller:v0.3.0
   fi
 
-    if ks component list | awk '{print $1}' | grep -q "^pipeline$"; then
-    ks param set pipeline mysqlImage ${registry}/minio:RELEASE.2018-02-09T22-40-05Z
-    ks param set minioImage mysqlImage ${registry}/mysql:8.0.3
+  if ks component list | awk '{print $1}' | grep -q "^pipeline$"; then
+    ks param set pipeline minioImage ${registry}/minio:RELEASE.2018-02-09T22-40-05Z
+    ks param set pipeline mysqlImage ${registry}/mysql:8.0.3
+
+    ks param set pipeline apiImage ${registry}/ml-pipeline/api-server:0.1.17
+    ks param set pipeline scheduledWorkflowImage ${registry}/ml-pipeline/scheduledworkflow:0.1.17
+    ks param set pipeline persistenceAgentImage ${registry}/ml-pipeline/persistenceagent:0.1.17
+    ks param set pipeline viewerCrdControllerImage ${registry}/ml-pipeline/viewer-crd-controller:0.1.17
   fi
 
 }


### PR DESCRIPTION
* Add more images to be mirror'd when using VPC service controls

  * When using VPC service controls not all GCR repos are accessible so
    some images hosted in GCR need to be mirror'd

* Fix a bug in cloud-endpoints controller that prevents the image from being
  overwritten by parameters

   Related to #3106

Fixes to support VPC service controlls.

* ESP sample web app should get the image from ksonnet parameters so
  it can be overwritten with a version from a mirror.

* To support pipelines we need to mirror a bunch of images from
  gcr.io/ml-pipeline so they are accessible inside the service perimeter.

Related to kubeflow/pipelines#1203
Related to kubeflow/pipelines#1204

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3111)
<!-- Reviewable:end -->
