### PR TITLE
fixed based images of tf gpu notebooks

### DIFF
--- a/components/tensorflow-notebook-image/versions/1.13.1gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/1.13.1gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:10.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://files.pythonhosted.org/packages/7b/b1/0ad4ae02e17ddd62109cd54c291e311c4b5fd09b4d0678d3d6ce4159b0f0/tensorflow_gpu-1.13.1-cp36-cp36m-manylinux1_x86_64.whl",
    "TF_PACKAGE_PY_27": "https://files.pythonhosted.org/packages/24/8c/459eb5fdaa8666010b6a32244ddb92f4015cfc54156d612959625096601d/tensorflow_gpu-1.13.1-cp27-cp27mu-manylinux1_x86_64.whl",
   "TFMA_VERSION": "0.13.0",

--- a/components/tensorflow-notebook-image/versions/2.0.0a0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/2.0.0a0gpu/version-config.json
@@ -1,5 +1,5 @@
 {
-  "BASE_IMAGE": "nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04",
+  "BASE_IMAGE": "nvidia/cuda:10.0-cudnn7-runtime-ubuntu16.04",
   "TF_PACKAGE": "https://files.pythonhosted.org/packages/1a/66/32cffad095253219d53f6b6c2a436637bbe45ac4e7be0244557210dc3918/tensorflow_gpu-2.0.0a0-cp36-cp36m-manylinux1_x86_64.whl",
   "TF_PACKAGE_PY_27": "https://files.pythonhosted.org/packages/55/18/48ea6802a165fc4c24216768ad497af287f18db5bf91597b85f8903e70dc/tensorflow_gpu-2.0.0a0-cp27-cp27mu-manylinux1_x86_64.whl",
 "INSTALL_TFMA": "yes"


### PR DESCRIPTION
updated base image of jupyter notebooks of tf 1.13.1gpu and tf 2.0.0a0gpu from the following:
- [tf build configuration ](https://www.tensorflow.org/install/source#tested_build_configurations)
- [nvidia docker image tags](https://hub.docker.com/r/nvidia/cuda/tags?page=5),
- [nvidia dockerfile for nvidia/cuda:10.0-cudnn7-runtime-ubuntu16.04 ](https://gitlab.com/nvidia/cuda/blob/ubuntu16.04/10.0/runtime/cudnn7/Dockerfile)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3117)
<!-- Reviewable:end -->
