### PR TITLE
fix permission leak; give default admin permission for namespace owner

### DIFF
--- a/components/profile-controller/pkg/apis/apis.go
+++ b/components/profile-controller/pkg/apis/apis.go
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 // Generate deepcopy for apis
-//go:generate go run ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../hack/boilerplate.go.txt
 
 // Package apis contains Kubernetes API groups.
 package apis

--- a/components/profile-controller/pkg/apis/kubeflow/v1alpha1/profile_types.go
+++ b/components/profile-controller/pkg/apis/kubeflow/v1alpha1/profile_types.go
@@ -39,8 +39,8 @@ const (
 type ProfileStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
-	Status  ProfileState `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
-	Message string       `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
+	Status  ProfileState `json:"status,omitempty"`
+	Message string       `json:"message,omitempty"`
 }
 
 // +genclient

--- a/components/profile-controller/pkg/apis/kubeflow/v1alpha1/profile_types.go
+++ b/components/profile-controller/pkg/apis/kubeflow/v1alpha1/profile_types.go
@@ -27,10 +27,20 @@ type ProfileSpec struct {
 	Owner rbacv1.Subject `json:"owner,omitempty"`
 }
 
+type ProfileState string
+
+const (
+	ProfileSucceed ProfileState = "Succeed"
+	ProfileFailed  ProfileState = "Failed"
+	ProfileUnknown ProfileState = "Unknown"
+)
+
 // ProfileStatus defines the observed state of Profile
 type ProfileStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	Status  ProfileState `json:"status" protobuf:"bytes,2,opt,name=status,casttype=k8s.io/api/core/v1.ConditionStatus"`
+	Message string       `json:"message,omitempty" protobuf:"bytes,5,opt,name=message"`
 }
 
 // +genclient


### PR DESCRIPTION
* fix https://github.com/kubeflow/kubeflow/issues/2601
* Create owner's default k8s rbac rolebinding for https://github.com/kubeflow/kubeflow/issues/2982
* generate service accounts for user pods
  * Can be used by https://github.com/kubeflow/kubeflow/issues/2980
* fix duplicate update for newly created binding
* use k8s default role when possible
* fix go generate

Manually tested, works as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3123)
<!-- Reviewable:end -->
