### PR TITLE
Grant user-created notebook namespaced default edit permission

### DIFF
--- a/components/jupyter-web-app/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/kubeflow_jupyter/common/utils.py
@@ -93,7 +93,7 @@ def create_notebook_template():
       "spec": {
           "template": {
               "spec": {
-                  "serviceAccountName": "jupyter-notebook",
+                  "serviceAccountName": "default-editor",
                   "containers": [{
                       "name": "",
                       "volumeMounts": [],

--- a/kubeflow/jupyter/jupyter-web-app.libsonnet
+++ b/kubeflow/jupyter/jupyter-web-app.libsonnet
@@ -88,6 +88,7 @@
       },
     },
 
+    // TODO: "default-editor" will be shared by multiple components; update here once other components switched to new auth-model
     defaultEditorServiceAccount:: {
       apiVersion: "v1",
       kind: "ServiceAccount",

--- a/kubeflow/jupyter/jupyter-web-app.libsonnet
+++ b/kubeflow/jupyter/jupyter-web-app.libsonnet
@@ -87,93 +87,32 @@
         apiGroup: "rbac.authorization.k8s.io",
       },
     },
-    
-    notebookRole:: {
-      apiVersion: "rbac.authorization.k8s.io/v1beta1",
-      kind: "Role",
-      metadata: {
-        name: "jupyter-notebook-role",
-        namespace: params.namespace,
-      },
-      rules: [
-        {
-          apiGroups: [
-            "",
-          ],
-          resources: [
-            "pods",
-            "pods/log",
-            "secrets",
-            "services",
-          ],
-          verbs: [
-            "*",
-          ],
-        },
-        {
-          apiGroups: [
-            "",
-            "apps",
-            "extensions",
-          ],
-          resources: [
-            "deployments",
-            "replicasets",
-          ],
-          verbs: [
-            "*",
-          ],
-        },
-        {
-          apiGroups: [
-            "kubeflow.org",
-          ],
-          resources: [
-            "*",
-          ],
-          verbs: [
-            "*",
-          ],
-        },
-        {
-          apiGroups: [
-            "batch",
-          ],
-          resources: [
-            "jobs",
-          ],
-          verbs: [
-            "*",
-          ],
-        },
-      ],
-    },
-    
-    notebookServiceAccount:: {
+
+    defaultEditorServiceAccount:: {
       apiVersion: "v1",
       kind: "ServiceAccount",
       metadata: {
-        name: "jupyter-notebook",
+        name: "default-editor",
         namespace: params.namespace,
       },
     },
     
-    notebookRoleBinding:: {
+    defaultEditorRoleBinding:: {
       apiVersion: "rbac.authorization.k8s.io/v1beta1",
       kind: "RoleBinding",
       metadata: {
-        name: "jupyter-notebook-role-binding",
+        name: "default-editor-role-binding",
         namespace: params.namespace,
       },
       roleRef: {
         apiGroup: "rbac.authorization.k8s.io",
-        kind: "Role",
-        name: "jupyter-notebook-role",
+        kind: "ClusterRole",
+        name: "edit",
       },
       subjects: [
         {
           kind: "ServiceAccount",
-          name: "jupyter-notebook",
+          name: "default-editor",
           namespace: params.namespace,
         },
       ],
@@ -338,9 +277,8 @@
       self.serviceAccount,
       self.clusterRoleBinding,
       self.clusterRole,
-      self.notebookServiceAccount,
-      self.notebookRole,
-      self.notebookRoleBinding,
+      self.defaultEditorServiceAccount,
+      self.defaultEditorRoleBinding,
     ] + if util.toBool(params.injectIstio) then [
       self.istioVirtualService,
     ] else [],


### PR DESCRIPTION
We can migrate all user created pods to service accounts.
```default-editor```
```default-viewer```
Those accounts will be managed by profile: https://github.com/kubeflow/kubeflow/pull/3123
We can start with notebook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3161)
<!-- Reviewable:end -->
