### PR TITLE
define kubeflow Access Management API

### DIFF
--- a/components/access-management/README.md
+++ b/components/access-management/README.md
@@ -30,8 +30,11 @@ The goal is to support multi-tenancy kubeflow cluster / services.
 #####`/v1/bindings`
 * `create`: create new binding; 
   * called when admin or owner share namespace access with other users.
-* `get`: get binding; 
+* `get`: get bindings; 
   * called when query for binding status.
+  * filter by user=... | namespace=... | role=owner/editor to query permissions related to a user / namespace.
+  * For example filter by "user=abc@def.com" when need to list namespaces for user "abc@def.com".
+  * For example filter by "namespace=abc" when need to list users of a namespace "abc"
 * `delete`: delete binding; 
   * called when admin or owner revoke namespace access.
 

--- a/components/access-management/README.md
+++ b/components/access-management/README.md
@@ -1,0 +1,44 @@
+# Kubeflow Access Management API
+
+Kubeflow Access Management API provides fine-grain user-namespace level access control.
+The goal is to support multi-tenancy kubeflow cluster / services.
+
+## Resources
+
+### Profile
+- Profile contains owner which refers to a k8s user.
+- Profile will spawn a namespace with same name and make profile owner the namespace owner.
+- Profile will fulfill necessary k8s resources to enable owner access to kubeflow servuces under multi-tenancy mode.
+- Delete profile will delete namespace and other k8s resources owned by this profile.
+
+### Binding
+- Binding contains a user-namespace pair.
+- Binding will give user edit access to referred namespace.
+- Delete binding will revoke user's access in binding.
+
+
+## APIs
+
+#####`/v1/profiles`
+* `create`: create new profile; 
+  * called when new user self-register.
+
+#####`/v1/profiles/{profile}`
+* `delete`: delete profile; 
+  * called when admin or owner delete profile / namespace.
+
+#####`/v1/bindings`
+* `create`: create new binding; 
+  * called when admin or owner share namespace access with other users.
+* `get`: get binding; 
+  * called when query for binding status.
+* `delete`: delete binding; 
+  * called when admin or owner revoke namespace access.
+
+#####`/v1/users/{user}/namespaces`
+* `get`: return namespaces that queried user can access as owner or editor.
+  * called when need to list namespaces for an user: list namespaces on notebook spawner for current user
+
+#####`/v1/profiles/{profile}/users`
+* `get`: return users with owner or editor permission to queried profile / namespace.
+  * called when need to list users of a namespace

--- a/components/access-management/README.md
+++ b/components/access-management/README.md
@@ -7,14 +7,23 @@ The goal is to support multi-tenancy kubeflow cluster / services.
 
 ### Profile
 - Profile contains owner which refers to a k8s user.
-- Profile will spawn a namespace with same name and make profile owner the namespace owner.
-- Profile will fulfill necessary k8s resources to enable owner access to kubeflow servuces under multi-tenancy mode.
+- Profile will create a namespace with same name and make profile owner the namespace owner.
+- Profile will create necessary k8s resources to enable owner access to kubeflow servuces under multi-tenancy mode.
+- After the namespace is created, the owner can grant access to additional users or groups using the API or by creating RBAC roles & bindings directly.
 - Delete profile will delete namespace and other k8s resources owned by this profile.
 
 ### Binding
 - Binding contains a user-namespace pair.
 - Binding will give user edit access to referred namespace.
 - Delete binding will revoke user's access in binding.
+
+
+## Use Cases
+#### Case 1: Self serve Kubeflow
+
+A Kubeflow admin would like to grant a set of users the ability to create/delete a namespace in which they can consume Kubeflow. 
+The resulting namespace should only be accessible to the user who created it; or people they grant access to.
+RBAC doesn't directly support this. So we provide a service on top of RBAC which will enforce this based on the user's identity
 
 
 ## APIs

--- a/components/access-management/README.md
+++ b/components/access-management/README.md
@@ -3,7 +3,7 @@
 Kubeflow Access Management API provides fine-grain user-namespace level access control.
 The goal is to support multi-tenancy kubeflow cluster / services.
 
-## Resources
+## Resources under management
 
 ### Profile
 - Profile contains owner which refers to a k8s user.
@@ -25,6 +25,10 @@ A Kubeflow admin would like to grant a set of users the ability to create/delete
 The resulting namespace should only be accessible to the user who created it; or people they grant access to.
 RBAC doesn't directly support this. So we provide a service on top of RBAC which will enforce this based on the user's identity
 
+#### Case 2: Allow user to update / share resources they own.
+
+We will not grant user permission to edit cluster-scoped CRD resources. Then to enable user editting their own resources,
+we provide update / share / delete APIs and perform permission check on every coming request.  
 
 ## APIs
 
@@ -42,15 +46,7 @@ RBAC doesn't directly support this. So we provide a service on top of RBAC which
 * `get`: get bindings; 
   * called when query for binding status.
   * filter by user=... | namespace=... | role=owner/editor to query permissions related to a user / namespace.
-  * For example filter by "user=abc@def.com" when need to list namespaces for user "abc@def.com".
-  * For example filter by "namespace=abc" when need to list users of a namespace "abc"
+  * For example filter by "user=abc@def.com" when need to list namespaces for user "abc@def.com"; called when need to list namespaces for an user (list namespaces on notebook spawner for current user)
+  * For example filter by "namespace=abc" when need to list users of a namespace "abc"; called when need to list users of namespace "abc".
 * `delete`: delete binding; 
   * called when admin or owner revoke namespace access.
-
-#####`/v1/users/{user}/namespaces`
-* `get`: return namespaces that queried user can access as owner or editor.
-  * called when need to list namespaces for an user: list namespaces on notebook spawner for current user
-
-#####`/v1/profiles/{profile}/users`
-* `get`: return users with owner or editor permission to queried profile / namespace.
-  * called when need to list users of a namespace

--- a/components/access-management/api/swagger.yaml
+++ b/components/access-management/api/swagger.yaml
@@ -85,8 +85,8 @@ paths:
         500:
           description: "Internal Server Error"
     get:
-      summary: "Get binding specified in request body"
-      description: "If succeeded, returned binding will contain it's current status"
+      summary: "Get bindings filtered by query param"
+      description: "bindings will contain it's current status"
       operationId: "read binding"
       consumes:
         - "application/json"
@@ -99,6 +99,18 @@ paths:
           required: true
           schema:
             $ref: "#/definitions/Binding"
+        - in: "query"
+          name: "user"
+          description: "User name, when not empty, only return bindings of this user"
+          type: "string"
+        - in: "query"
+          name: "namespace"
+          description: "Namespace name, when not empty, only return bindings of this namespace"
+          type: "string"
+        - in: "query"
+          name: "role"
+          description: "owner or editor, when not empty, only return bindings of this role"
+          type: "string"
       responses:
         200:
           description: "OK"
@@ -132,61 +144,14 @@ paths:
           description: "Entry not found"
         500:
           description: "Internal Server Error"
-  /v1/profiles/{profile}/users:
-    get:
-      summary: "Get users with owner or editor permission to queried profile / namespace"
-      description: "return list of users"
-      operationId: "read users"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
-      parameters:
-        - in: "path"
-          name: "profile"
-          description: "Profile name"
-          required: true
-          type: "string"
-      responses:
-        200:
-          description: "OK"
-          schema:
-            $ref: "#/definitions/UserEntries"
-        404:
-          description: "Entry not found"
-        500:
-          description: "Internal Server Error"
-  /v1/users/{user}/namespaces:
-    get:
-      summary: "Get namespaces that queried user can access as owner or editor"
-      operationId: "read namespaces"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
-      parameters:
-        - in: "path"
-          name: "user"
-          description: "k8s user name"
-          required: true
-          type: "string"
-      responses:
-        200:
-          description: "OK"
-          schema:
-            $ref: "#/definitions/NamespaceEntries"
-        404:
-          description: "Entry not found"
-        500:
-          description: "Internal Server Error"
 definitions:
-  UserEntries:
+  BindingEntries:
     type: "object"
     properties:
       users:
         type: "array"
         items:
-          $ref: "#/definitions/User"
+          $ref: "#/definitions/Binding"
   User:
     type: "object"
     properties:
@@ -194,13 +159,6 @@ definitions:
         type: "string"
       name:
         type: "string"
-  NamespaceEntries:
-    type: "object"
-    properties:
-      namespaces:
-        type: "array"
-        items:
-          type: "string"
   Binding:
     type: "object"
     description: "Binding will give user edit access to referredNamespace"
@@ -208,6 +166,9 @@ definitions:
       user:
         $ref: "#/definitions/User"
       referredNamespace:
+        type: "string"
+      role:
+        description: "owner or editor"
         type: "string"
       status:
         description: "Status of the profile, one of Succeeded, Failed, Unknown."

--- a/components/access-management/api/swagger.yaml
+++ b/components/access-management/api/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  description: "Profile Spawner API."
+  description: "Access Management API."
   version: "1.0.0"
   title: "Kubeflow Auth"
   termsOfService: "https://www.kubeflow.org/"
@@ -9,24 +9,19 @@ info:
   license:
     name: "Apache 2.0"
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-basePath: "/kfauth"
+basePath: "/kfam"
 schemes:
   - "http"
 paths:
-  /profiles/{profile}/register:
+  /v1/profiles:
     post:
-      summary: "Create a owning-profile instance, which own a namespace of same name"
-      operationId: "register"
+      summary: "Create a instance, which own a namespace of same name"
+      operationId: "create profile"
       consumes:
         - "application/json"
       produces:
         - "application/json"
       parameters:
-        - in: "path"
-          name: "profile"
-          description: "Profile name"
-          required: true
-          type: "string"
         - in: "body"
           name: "body"
           description: "Profile spec"
@@ -42,27 +37,42 @@ paths:
             $ref: "#/definitions/ErrorMessage"
         500:
           description: "Internal Server Error"
-  /profiles/{profile}/share:
-    post:
-      summary: "Create a sharing-profile instance, which grant profile-owner edit-access to referred namespace"
-      description: "Only admin owner of referred namespace can share referred namespace"
-      operationId: "share"
-      consumes:
-        - "application/json"
-      produces:
-        - "application/json"
+  /v1/profiles/{profile}:
+    delete:
+      summary: "Delete profile"
+      description: "Only admin or profile owner can delete profile"
+      operationId: "delete profile"
       parameters:
         - in: "path"
           name: "profile"
           description: "Profile name"
           required: true
           type: "string"
+      responses:
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Entry not found"
+        500:
+          description: "Internal Server Error"
+  /v1/bindings:
+    post:
+      summary: "Create a binding specifying a user and an namespace, the binding will grant user edit-access to referred namespace"
+      description: "Only admin or referred namespace owner can create binding"
+      operationId: "create binding"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
         - in: "body"
           name: "body"
-          description: "Profile spec"
+          description: "Binding spec"
           required: true
           schema:
-            $ref: "#/definitions/Profile"
+            $ref: "#/definitions/Binding"
       responses:
         200:
           description: "OK"
@@ -74,51 +84,59 @@ paths:
             $ref: "#/definitions/ErrorMessage"
         500:
           description: "Internal Server Error"
-  /profiles/{profile}:
     get:
-      summary: "Get profile"
-      operationId: "getProfile"
+      summary: "Get binding specified in request body"
+      description: "If succeeded, returned binding will contain it's current status"
+      operationId: "read binding"
       consumes:
         - "application/json"
       produces:
         - "application/json"
       parameters:
-        - in: "path"
-          name: "profile"
-          description: "Profile name"
+        - in: "body"
+          name: "body"
+          description: "Binding spec"
           required: true
-          type: "string"
+          schema:
+            $ref: "#/definitions/Binding"
       responses:
         200:
           description: "OK"
           schema:
-            $ref: "#/definitions/Profile"
-        401:
-          description: "Unauthorized"
+            $ref: "#/definitions/Binding"
+        404:
+          description: "Entry not found"
         500:
           description: "Internal Server Error"
     delete:
-      summary: "Delete profile"
-      description: "Only admin owner of referred namespace can delete profile"
-      operationId: "deleteProfile"
+      summary: "Delete binding specified in request body"
+      description: "Only admin or referred namespace owner can delete binding"
+      operationId: "delete binding"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
       parameters:
-        - in: "path"
-          name: "profile"
-          description: "Profile name"
+        - in: "body"
+          name: "body"
+          description: "Binding spec"
           required: true
-          type: "string"
+          schema:
+            $ref: "#/definitions/Binding"
       responses:
         200:
           description: "OK"
         401:
           description: "Unauthorized"
+        404:
+          description: "Entry not found"
         500:
           description: "Internal Server Error"
-  /profiles/{profile}/users:
+  /v1/profiles/{profile}/users:
     get:
-      summary: "Get owner and editor users of target owning-profile"
+      summary: "Get users with owner or editor permission to queried profile / namespace"
       description: "return list of users"
-      operationId: "getProfileUsers"
+      operationId: "read users"
       consumes:
         - "application/json"
       produces:
@@ -134,38 +152,29 @@ paths:
           description: "OK"
           schema:
             $ref: "#/definitions/UserEntries"
-        401:
-          description: "Unauthorized"
-        403:
-          description: "Forbidden"
-          schema:
-            $ref: "#/definitions/ErrorMessage"
         404:
           description: "Entry not found"
         500:
           description: "Internal Server Error"
-  /users/permission:
+  /v1/users/{user}/namespaces:
     get:
-      summary: "Return namespace list that user can access as owner or editor"
-      operationId: "getUsersPermission"
+      summary: "Get namespaces that queried user can access as owner or editor"
+      operationId: "read namespaces"
       consumes:
         - "application/json"
       produces:
         - "application/json"
       parameters:
-        - in: "body"
-          name: "body"
-          description: "User spec"
+        - in: "path"
+          name: "user"
+          description: "k8s user name"
           required: true
-          schema:
-            $ref: "#/definitions/User"
+          type: "string"
       responses:
         200:
           description: "OK"
           schema:
-            $ref: "#/definitions/ProfileEntries"
-        401:
-          description: "Unauthorized"
+            $ref: "#/definitions/NamespaceEntries"
         404:
           description: "Entry not found"
         500:
@@ -174,7 +183,7 @@ definitions:
   UserEntries:
     type: "object"
     properties:
-      configs:
+      users:
         type: "array"
         items:
           $ref: "#/definitions/User"
@@ -185,13 +194,24 @@ definitions:
         type: "string"
       name:
         type: "string"
-  ProfileEntries:
+  NamespaceEntries:
     type: "object"
     properties:
-      configs:
+      namespaces:
         type: "array"
         items:
-          $ref: "#/definitions/Profile"
+          type: "string"
+  Binding:
+    type: "object"
+    description: "Binding will give user edit access to referredNamespace"
+    properties:
+      user:
+        $ref: "#/definitions/User"
+      referredNamespace:
+        type: "string"
+      status:
+        description: "Status of the profile, one of Succeeded, Failed, Unknown."
+        type: "string"
   Metadata:
     type: "object"
     properties:
@@ -209,9 +229,6 @@ definitions:
         properties:
           owner:
             $ref: "#/definitions/User"
-          referredNamespace:
-            type: "string"
-            description: "when referredNamespace not empty, this profile is sharing-profile; otherwise it's an owning-profile"
       status:
         type: "object"
         properties:

--- a/components/access-management/api/swagger.yaml
+++ b/components/access-management/api/swagger.yaml
@@ -85,7 +85,7 @@ paths:
         500:
           description: "Internal Server Error"
     get:
-      summary: "Get bindings filtered by query param"
+      summary: "Get bindings created via kubeflow; filtered by query param"
       description: "bindings will contain it's current status"
       operationId: "read binding"
       consumes:
@@ -152,9 +152,22 @@ definitions:
         type: "array"
         items:
           $ref: "#/definitions/Binding"
-  User:
+  Subject:
     type: "object"
+    description: "in consistent with io.k8s.api.rbac.v1.Subject"
     properties:
+      kind:
+        type: "string"
+      name:
+        type: "string"
+      namespace:
+        type: "string"
+  RoleRef:
+    type: "object"
+    description: "in consistent with io.k8s.api.rbac.v1.RoleRef"
+    properties:
+      apiGroup:
+        type: "string"
       kind:
         type: "string"
       name:
@@ -164,12 +177,11 @@ definitions:
     description: "Binding will give user edit access to referredNamespace"
     properties:
       user:
-        $ref: "#/definitions/User"
+        $ref: "#/definitions/Subject"
       referredNamespace:
         type: "string"
-      role:
-        description: "owner or editor or viewer"
-        type: "string"
+      RoleRef:
+        $ref: "#/definitions/RoleRef"
       status:
         description: "Status of the profile, one of Succeeded, Failed, Unknown."
         type: "string"
@@ -189,7 +201,8 @@ definitions:
         type: "object"
         properties:
           owner:
-            $ref: "#/definitions/User"
+            description: "Only accept kind: user"
+            $ref: "#/definitions/Subject"
       status:
         type: "object"
         properties:

--- a/components/access-management/api/swagger.yaml
+++ b/components/access-management/api/swagger.yaml
@@ -109,7 +109,7 @@ paths:
           type: "string"
         - in: "query"
           name: "role"
-          description: "owner or editor, when not empty, only return bindings of this role"
+          description: "owner or editor or viewer, when not empty, only return bindings of this role"
           type: "string"
       responses:
         200:
@@ -168,7 +168,7 @@ definitions:
       referredNamespace:
         type: "string"
       role:
-        description: "owner or editor"
+        description: "owner or editor or viewer"
         type: "string"
       status:
         description: "Status of the profile, one of Succeeded, Failed, Unknown."

--- a/components/profile-spawner/api/swagger.yaml
+++ b/components/profile-spawner/api/swagger.yaml
@@ -1,0 +1,228 @@
+swagger: "2.0"
+info:
+  description: "Profile Spawner API."
+  version: "1.0.0"
+  title: "Kubeflow Auth"
+  termsOfService: "https://www.kubeflow.org/"
+  contact:
+    email: "kubeflow-engineering@google.com"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+basePath: "/kfauth"
+schemes:
+  - "http"
+paths:
+  /profiles/{profile}/register:
+    post:
+      summary: "Create a owning-profile instance, which own a namespace of same name"
+      operationId: "register"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "profile"
+          description: "Profile name"
+          required: true
+          type: "string"
+        - in: "body"
+          name: "body"
+          description: "Profile spec"
+          required: true
+          schema:
+            $ref: "#/definitions/Profile"
+      responses:
+        200:
+          description: "OK"
+        403:
+          description: "Forbidden"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+        500:
+          description: "Internal Server Error"
+  /profiles/{profile}/share:
+    post:
+      summary: "Create a sharing-profile instance, which grant profile-owner edit-access to referred namespace"
+      description: "Only admin owner of referred namespace can share referred namespace"
+      operationId: "share"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "profile"
+          description: "Profile name"
+          required: true
+          type: "string"
+        - in: "body"
+          name: "body"
+          description: "Profile spec"
+          required: true
+          schema:
+            $ref: "#/definitions/Profile"
+      responses:
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        403:
+          description: "Forbidden"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+        500:
+          description: "Internal Server Error"
+  /profiles/{profile}:
+    get:
+      summary: "Get profile"
+      operationId: "getProfile"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "profile"
+          description: "Profile name"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/Profile"
+        401:
+          description: "Unauthorized"
+        500:
+          description: "Internal Server Error"
+    delete:
+      summary: "Delete profile"
+      description: "Only admin owner of referred namespace can delete profile"
+      operationId: "deleteProfile"
+      parameters:
+        - in: "path"
+          name: "profile"
+          description: "Profile name"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "OK"
+        401:
+          description: "Unauthorized"
+        500:
+          description: "Internal Server Error"
+  /profiles/{profile}/users:
+    get:
+      summary: "Get owner and editor users of target owning-profile"
+      description: "return list of users"
+      operationId: "getProfileUsers"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "path"
+          name: "profile"
+          description: "Profile name"
+          required: true
+          type: "string"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/UserEntries"
+        401:
+          description: "Unauthorized"
+        403:
+          description: "Forbidden"
+          schema:
+            $ref: "#/definitions/ErrorMessage"
+        404:
+          description: "Entry not found"
+        500:
+          description: "Internal Server Error"
+  /users/permission:
+    get:
+      summary: "Return namespace list that user can access as owner or editor"
+      operationId: "getUsersPermission"
+      consumes:
+        - "application/json"
+      produces:
+        - "application/json"
+      parameters:
+        - in: "body"
+          name: "body"
+          description: "User spec"
+          required: true
+          schema:
+            $ref: "#/definitions/User"
+      responses:
+        200:
+          description: "OK"
+          schema:
+            $ref: "#/definitions/ProfileEntries"
+        401:
+          description: "Unauthorized"
+        404:
+          description: "Entry not found"
+        500:
+          description: "Internal Server Error"
+definitions:
+  UserEntries:
+    type: "object"
+    properties:
+      configs:
+        type: "array"
+        items:
+          $ref: "#/definitions/User"
+  User:
+    type: "object"
+    properties:
+      kind:
+        type: "string"
+      name:
+        type: "string"
+  ProfileEntries:
+    type: "object"
+    properties:
+      configs:
+        type: "array"
+        items:
+          $ref: "#/definitions/Profile"
+  Metadata:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      namespace:
+        type: "string"
+  Profile:
+    type: "object"
+    properties:
+      metadata:
+        $ref: "#/definitions/Metadata"
+      spec:
+        type: "object"
+        properties:
+          owner:
+            $ref: "#/definitions/User"
+          referredNamespace:
+            type: "string"
+            description: "when referredNamespace not empty, this profile is sharing-profile; otherwise it's an owning-profile"
+      status:
+        type: "object"
+        properties:
+          status:
+            description: "Status of the profile, one of Succeeded, Failed, Unknown."
+            type: "string"
+          message:
+            description: "Non empty when at Failed status, containing detailed error messages"
+            type: "string"
+  ErrorMessage:
+    type: "object"
+    properties:
+      errorMessage:
+        type: "string"


### PR DESCRIPTION
Define kubeflow access management API which serves following need:
* fulfill user-facing CUJs
  * self-register
  * access sharing
  * user / namespace listing
* provide endpoint for central dashboard and other components to fulfill ```list``` verb
  * query users that can access an namespace
  * query namespaces that accessible from a user

API doc:
https://rebilly.github.io/ReDoc/?url=https://raw.githubusercontent.com/kubeflow/kubeflow/89be54122464e5b033e7b1d192dc8f0e057f1a42/components/access-management/api/swagger.yaml

Note:
* this API will only accept request from Istio and require user identity in coming request
 
Once we locked down the APIs we can implement frontend & backend components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3171)
<!-- Reviewable:end -->
