### PR TITLE
Extend the grace period for ksonnet.go to delete namespace

### DIFF
--- a/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
+++ b/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
@@ -18,6 +18,13 @@ package ksonnet
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"time"
+
 	"github.com/cenkalti/backoff"
 	"github.com/ghodss/yaml"
 	"github.com/ksonnet/ksonnet/pkg/actions"
@@ -30,17 +37,11 @@ import (
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps/kfdef/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"io/ioutil"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-	"os"
-	"path"
-	"path/filepath"
-	"regexp"
-	"time"
 )
 
 // Ksonnet implements the KfApp Interface
@@ -267,7 +268,7 @@ func (ksApp *ksApp) Delete(resources kftypes.ResourceEnum) error {
 		},
 		actions.OptionEnvName:        ksApp.KsEnvName,
 		actions.OptionComponentNames: components,
-		actions.OptionGracePeriod:    int64(100),
+		actions.OptionGracePeriod:    int64(300),
 	})
 	if err != nil {
 		log.Infof("there was a problem deleting %v: %v", components, err)
@@ -283,7 +284,7 @@ func (ksApp *ksApp) Delete(resources kftypes.ResourceEnum) error {
 	log.Infof("deleting namespace: %v", namespace)
 	ns, nsMissingErr := clientset.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
 	if nsMissingErr == nil {
-		nsErr := clientset.CoreV1().Namespaces().Delete(ns.Name, metav1.NewDeleteOptions(int64(100)))
+		nsErr := clientset.CoreV1().Namespaces().Delete(ns.Name, metav1.NewDeleteOptions(int64(300)))
 		if nsErr != nil {
 			return &kfapis.KfError{
 				Code:    int(kfapis.INVALID_ARGUMENT),


### PR DESCRIPTION
https://github.com/kubeflow/testing/issues/361

We have testing infra resources leaked due to undeleted ingress resources. A possible cause is the ingress controller doesn't have enough time to delete the resource completely. https://github.com/kubernetes/ingress-gce/issues/136#issuecomment-417480155

[It usually takes at least 90s to delete a compute instance.](https://cloud.google.com/compute/docs/instances/deleting-instance) So this PR extends the grace period from 100s to 300s.

/cc @gabrielwen @kkasravi @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3185)
<!-- Reviewable:end -->
