### PR TITLE
kfctl - Makefile and Dockerfile enhancements

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -40,9 +40,14 @@ WORKDIR ${GOPATH}/src/github.com/kubeflow/kubeflow/bootstrap
 
 # TODO(jlewi) This is copying in the source. Do we really want to bake the source into the image.
 # Might be better to mount it via a volume.
-COPY . .
+# Download dependencies first to optimize Docker caching.
+COPY go.mod .
+COPY go.sum .
+COPY hack/v2.zip hack/v2.zip
 RUN unzip -q -d /tmp hack/v2.zip
 RUN go mod download
+# Then copy source and build.
+COPY . .
 RUN go build -gcflags 'all=-N -l' -o bin/bootstrapper cmd/bootstrap/main.go
 
 #

--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -119,6 +119,12 @@ build-kfctl-container:
 		--target=$(KFCTL_TARGET) \
 		--tag $(KFCTL_IMG)/builder:$(TAG) .
 	@echo Built $(KFCTL_IMG)/builder:$(TAG)
+	docker create \
+		--name=temp_kfctl_container \
+		$(KFCTL_IMG)/builder:$(TAG)
+	docker cp temp_kfctl_container:/usr/local/bin/kfctl ./bin/kfctl
+	docker rm temp_kfctl_container
+	@echo Exported kfctl binary to bin/kfctl
 
 # build containers using GCLOUD_PROJECT
 build-gcb:


### PR DESCRIPTION
This PR adds the following functionality:

* **bootstrap/Makefile**: Target `build-kfctl-container` exports the generated kfctl binary. This gives developers a reploducible build environment to generate the kfctl binary. In addition, it only requires the user to have Docker installed.
* **bootstrap/Dockerfile**: The go.mod and go.sum files are copied in and `go mod download` is run before copying in the code. This is done because dependencies don't change often, so this lets us optimize Docker caching. After adding this, the build time for `kfctl-build-container` was cut in half (5min after vs 10min before).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3189)
<!-- Reviewable:end -->
