### PR TITLE
 Restyles dashboard namespace selector to match UX specifications

### DIFF
--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -1577,6 +1577,17 @@
         "@polymer/polymer": "^3.0.0"
       }
     },
+    "@polymer/paper-button": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@polymer/paper-button/-/paper-button-3.0.1.tgz",
+      "integrity": "sha512-JRNBc+Oj9EWnmyLr7FcCr8T1KAnEHPh6mosln9BUdkM+qYaYsudSICh3cjTIbnj6AuF5OJidoLkM1dlyj0j6Zg==",
+      "requires": {
+        "@polymer/iron-flex-layout": "^3.0.0-pre.26",
+        "@polymer/paper-behaviors": "^3.0.0-pre.27",
+        "@polymer/paper-styles": "^3.0.0-pre.26",
+        "@polymer/polymer": "^3.0.0"
+      }
+    },
     "@polymer/paper-card": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@polymer/paper-card/-/paper-card-3.0.1.tgz",
@@ -5334,12 +5345,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5354,17 +5367,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5481,7 +5497,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5493,6 +5510,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5507,6 +5525,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5514,12 +5533,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5538,6 +5559,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5618,7 +5640,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5630,6 +5653,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5751,6 +5775,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/components/centraldashboard/public/components/main-page.css
+++ b/components/centraldashboard/public/components/main-page.css
@@ -121,6 +121,10 @@ app-toolbar>header {
     fill: currentColor;
 }
 
+#NamespaceSelector {
+    flex-basis: 33%;
+}
+
 #NamespaceSelector>paper-dropdown-menu {
     color: var(--accent-color);
     --paper-input-container-focus-color: var(--accent-color);

--- a/components/centraldashboard/public/components/main-page.css
+++ b/components/centraldashboard/public/components/main-page.css
@@ -87,13 +87,6 @@ app-drawer .footer>.build {
     color: rgba(255, 255, 255, 0.64)
 }
 
-#NamespaceSelector {
-    position: absolute;
-    right: 1em;
-    top: 50%;
-    transform: translateY(-50%)
-}
-
 app-toolbar {
     @apply --layout-horizontal;
     @apply --layout-center;
@@ -108,6 +101,10 @@ app-toolbar>header {
 #Narrow-Slider {
     @apply --layout-horizontal;
     @apply --layout-center;
+}
+
+#Narrow-Slider[hidden] {
+    display: none;
 }
 
 #Narrow-Slider>.Logo {

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -40,9 +40,9 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     paper-icon-button#Menu(icon='menu', drawer-toggle)
                     figure.Logo
                         |!{logo}
-                aside#NamespaceSelector(hides, hidden$='[[hideNamespaces]]')
-                    namespace-selector(query-params='{{queryParams}}',
-                        selected="{{namespace}}")
+                namespace-selector#NamespaceSelector(
+                    query-params='{{queryParams}}', selected="{{namespace}}",
+                    hides, hidden$='[[hideNamespaces]]')
                 paper-tabs.bottom(selected='[[page]]', attr-for-selected='page',
                         hides, hidden$='[[hideTabs]]')
                     paper-tab(page='dashboard', link)

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -40,15 +40,15 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     paper-icon-button#Menu(icon='menu', drawer-toggle)
                     figure.Logo
                         |!{logo}
+                aside#NamespaceSelector(hides, hidden$='[[hideNamespaces]]')
+                    namespace-selector(query-params='{{queryParams}}',
+                        selected="{{namespace}}")
                 paper-tabs.bottom(selected='[[page]]', attr-for-selected='page',
                         hides, hidden$='[[hideTabs]]')
                     paper-tab(page='dashboard', link)
                         a.link(tabindex='-1', href$='[[buildHref("/", queryParams)]]') Dashboard
                     paper-tab(page='activity', link)
                         a.link(tabindex='-1', href$='[[buildHref("/activity", queryParams)]]') Activity
-                aside#NamespaceSelector(hides, hidden$='[[hideNamespaces]]')
-                    namespace-selector(query-params='{{queryParams}}',
-                        selected="{{namespace}}")
         neon-animated-pages(selected='[[page]]', attr-for-selected='page',
                             entry-animation='fade-in-animation',
                             exit-animation='fade-out-animation')

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -160,8 +160,6 @@ describe('Main Page', () => {
         expect(mainPage.inIframe).toBe(true);
         expect(mainPage.shadowRoot.querySelector('paper-tabs')
             .hasAttribute('hidden')).toBe(true);
-        expect(mainPage.shadowRoot.querySelector('app-toolbar')
-            .hasAttribute('blue')).toBe(true);
     });
 
     it('Sets build version when platform info is received', async () => {

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -1,4 +1,8 @@
 import '@polymer/iron-ajax/iron-ajax.js';
+import '@polymer/iron-icon/iron-icon.js';
+import '@polymer/iron-icons/iron-icons.js';
+import '@polymer/paper-button/paper-button.js';
+import '@polymer/paper-menu-button/paper-menu-button.js';
 import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light';
 import '@polymer/paper-listbox/paper-listbox.js';
 import '@polymer/paper-item/paper-item.js';
@@ -13,6 +17,36 @@ export class NamespaceSelector extends PolymerElement {
     static get template() {
         return html`
             <style>
+                paper-menu-button {
+                    --paper-menu-button: {
+                        font-size: 14px;
+                        color: #3c4043
+                    }
+                }
+
+                paper-button {
+                    @apply --layout-horizontal;
+                    @apply --layout-center;
+                    text-transform: none;
+                }
+
+                paper-button iron-icon:first-child {
+                    padding-right: 0.5em;
+                    --iron-icon-fill-color: var(--primary-background-color);
+                    --iron-icon-height: 20px;
+                    --iron-icon-width: 20px;
+                }
+
+                paper-button span {
+                    width: 170px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                }
+                paper-button span:empty::before {
+                    content: 'Select namespace';
+                }
+
                 paper-item {
                     cursor: pointer;
                 }
@@ -25,14 +59,21 @@ export class NamespaceSelector extends PolymerElement {
                 on-response="_onResponse">
             </iron-ajax>
             <app-route query-params="{{queryParams}}"></app-route>
-            <paper-dropdown-menu-light label="Namespace" vertical-offset="60"
-                value="{{selected}}">
-                <paper-listbox slot="dropdown-content">
+            <paper-menu-button>
+                <paper-button slot="dropdown-trigger">
+                    <iron-icon icon="group-work"></iron-icon>
+                    <span>[[selected]]</span>
+                    <iron-icon icon="arrow-drop-down"></iron-icon>
+                </paper-button>
+                <paper-listbox slot="dropdown-content"
+                    attr-for-selected="name" selected="{{selected}}">
                     <template is="dom-repeat" items="{{namespaces}}">
-                        <paper-item>[[item.name]]</paper-item>
+                        <paper-item name="[[item.name]]">
+                            [[item.name]]
+                        </paper-item>
                     </template>
                 </paper-listbox>
-            </paper-dropdown-menu>
+            </paper-menu-button>
         `;
     }
 
@@ -49,6 +90,7 @@ export class NamespaceSelector extends PolymerElement {
             selected: {
                 type: String,
                 observer: '_onSelected',
+                value: '',
                 notify: true,
             },
         };

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -38,7 +38,7 @@ export class NamespaceSelector extends PolymerElement {
                 }
 
                 #dropdown-trigger span {
-                    min-width: 120px;
+                    max-width: 170px;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -24,26 +24,26 @@ export class NamespaceSelector extends PolymerElement {
                     }
                 }
 
-                paper-button {
+                #dropdown-trigger {
                     @apply --layout-horizontal;
                     @apply --layout-center;
                     text-transform: none;
                 }
 
-                paper-button iron-icon:first-child {
+                #dropdown-trigger iron-icon:first-child {
                     padding-right: 0.5em;
                     --iron-icon-fill-color: var(--primary-background-color);
                     --iron-icon-height: 20px;
                     --iron-icon-width: 20px;
                 }
 
-                paper-button span {
-                    width: 170px;
+                #dropdown-trigger span {
+                    min-width: 120px;
                     overflow: hidden;
                     text-overflow: ellipsis;
                     white-space: nowrap;
                 }
-                paper-button span:empty::before {
+                #dropdown-trigger span:empty::before {
                     content: 'Select namespace';
                 }
 
@@ -59,8 +59,8 @@ export class NamespaceSelector extends PolymerElement {
                 on-response="_onResponse">
             </iron-ajax>
             <app-route query-params="{{queryParams}}"></app-route>
-            <paper-menu-button>
-                <paper-button slot="dropdown-trigger">
+            <paper-menu-button no-overlap horizontal-align="right">
+                <paper-button id="dropdown-trigger" slot="dropdown-trigger">
                     <iron-icon icon="group-work"></iron-icon>
                     <span>[[selected]]</span>
                     <iron-icon icon="arrow-drop-down"></iron-icon>

--- a/components/centraldashboard/public/components/namespace-selector_test.js
+++ b/components/centraldashboard/public/components/namespace-selector_test.js
@@ -59,7 +59,7 @@ describe('Namespace Selector', () => {
         const namespaces = [];
         namespaceSelector.shadowRoot.querySelectorAll('paper-item')
             .forEach((n) => {
-                namespaces.push(n.innerText);
+                namespaces.push(n.innerText.trim());
             });
         expect(namespaces).toEqual(['default', 'other-namespace']);
     });
@@ -95,7 +95,8 @@ describe('Namespace Selector', () => {
                 (event) =>resolve(event.detail));
         });
 
-        namespaceSelector.shadowRoot.querySelector('paper-listbox').select(0);
+        namespaceSelector.shadowRoot.querySelector('paper-listbox')
+            .select('default');
         const eventDetail = await queryParamsChangedPromise;
         expect(eventDetail.path).toBe('queryParams.ns');
         expect(eventDetail.value).toBe('default');
@@ -117,8 +118,8 @@ describe('Namespace Selector', () => {
         ];
         flush();
 
-        const dropDownMenu = namespaceSelector.shadowRoot
-            .querySelector('paper-dropdown-menu-light');
-        expect(dropDownMenu.value).toBe('other-namespace');
+        expect(namespaceSelector.selected).toBe('other-namespace');
+        expect(namespaceSelector.shadowRoot.querySelector('paper-button span')
+            .innerText).toBe('other-namespace');
     });
 });


### PR DESCRIPTION
Addresses item 2 from #3154
Child of #3157 

Empty State:
![Screenshot from 2019-05-03 16-19-20](https://user-images.githubusercontent.com/6835846/57163441-382a7b00-6dbf-11e9-9b81-91e686b29a4f.png)

Selected:
![Screenshot from 2019-05-03 16-19-42](https://user-images.githubusercontent.com/6835846/57163462-46789700-6dbf-11e9-9ab3-f9fa422bac8b.png)

When viewing iframed-application:
![Screenshot from 2019-05-03 16-20-04](https://user-images.githubusercontent.com/6835846/57163492-5abc9400-6dbf-11e9-991d-6841e48fbf2f.png)

/area front-end
/area centraldashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3191)
<!-- Reviewable:end -->
