### PR TITLE
Fix pipeline viewer ISTIO rule

### DIFF
--- a/kubeflow/pipeline/istio-service.libsonnet
+++ b/kubeflow/pipeline/istio-service.libsonnet
@@ -86,6 +86,7 @@
                   host: std.join(".", [
                     "ml-pipeline-ui",
                     namespace,
+                    "svc",
                     clusterDomain,
                   ]),
                   port: {


### PR DESCRIPTION
Forgot to add `svc` to the service path.

/assign @lluunn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3192)
<!-- Reviewable:end -->
