### PR TITLE
Delete the NFS directory.

### DIFF
--- a/testing/workflows/components/kfctl_go_test.jsonnet
+++ b/testing/workflows/components/kfctl_go_test.jsonnet
@@ -304,7 +304,6 @@ local testDirDeleteStep = {
       dependencies: ["copy-artifacts"],
     };
 
-// TODO(jlewi): Add testDirDeleteStep
 local exitTemplates =
   deleteStep +
   [
@@ -322,7 +321,8 @@ local exitTemplates =
       dependencies: if deleteKubeflow then
          ["kfctl-delete"]
       else null,
-    },    
+    },
+    testDirDeleteStep,
   ];
 
 // Dag defines the tasks in the graph


### PR DESCRIPTION
Delete the NFS directory after running the workflow. This should help
prevent the NFS directory from filling up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3209)
<!-- Reviewable:end -->
