### PR TITLE
Prune root OWNERs file to better assign reviews.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -6,5 +6,4 @@ approvers:
   - kunmingg
   - lluunn
   - pdmack
-  - r2d4
   - richardsliu

--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,5 @@
-# TODO(jlewi): We should probably have OWNERs files in subdirectories that
-# list approvers for individual components (e.g. Seldon folks for Seldon component)
+# We want to rely on fine grained OWNERs files.
+# Approvers listed here is just a backup in case someone is out.
 approvers:
   - abhi-g
   - jlewi
@@ -8,6 +8,3 @@ approvers:
   - pdmack
   - r2d4
   - richardsliu
-  - texasmichelle
-reviewers:
-  - ellis-bigelow


### PR DESCRIPTION
* @ellis-biegelow and @texasmichelle  are being assigned a lot of reviews because we are hitting
  the root OWNERs file; these reviews shouldn't be assigned to them. 

* Removing them from root OWNERs file is a partial fix; the other part is to create finer grained OWNERs files with better a set of users.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3231)
<!-- Reviewable:end -->
