### PR TITLE
Add permssion for ml-pipeline-ui account to access pod resources

### DIFF
--- a/kubeflow/pipeline/pipeline-ui.libsonnet
+++ b/kubeflow/pipeline/pipeline-ui.libsonnet
@@ -144,6 +144,23 @@
             "list",
           ],
         },
+        {
+          apiGroups: [
+            "kubeflow.org",
+          ],
+          resources: [
+            "viewers",
+          ],
+          verbs: [
+            "create",
+            "get",
+            "list",
+            "watch",
+            "update",
+            "patch",
+            "delete",
+          ],
+        },
       ],
     },  // role
 
@@ -185,34 +202,5 @@
         },
       },
     },  // deployUi
-
-    crd: {
-      apiVersion: "apiextensions.k8s.io/v1beta1",
-      kind: "CustomResourceDefinition",
-      metadata: {
-        name: "viewers.kubeflow.org",
-      },
-      spec: {
-        group: "kubeflow.org",
-        versions: [
-          {
-            name: "v1beta1",
-            storage: true,
-            served: true,
-          },
-        ],
-        scope: "Namespaced",
-        names: {
-          kind: "Viewer",
-          listKind: "ViewerList",
-          singular: "viewer",
-          plural: "viewers",
-          shortNames: [
-            "vi",
-          ],
-        },
-      },
-    },  // crd    
-    
   },  // parts
 }

--- a/kubeflow/pipeline/pipeline-ui.libsonnet
+++ b/kubeflow/pipeline/pipeline-ui.libsonnet
@@ -185,5 +185,34 @@
         },
       },
     },  // deployUi
+
+    crd: {
+      apiVersion: "apiextensions.k8s.io/v1beta1",
+      kind: "CustomResourceDefinition",
+      metadata: {
+        name: "viewers.kubeflow.org",
+      },
+      spec: {
+        group: "kubeflow.org",
+        versions: [
+          {
+            name: "v1beta1",
+            storage: true,
+            served: true,
+          },
+        ],
+        scope: "Namespaced",
+        names: {
+          kind: "Viewer",
+          listKind: "ViewerList",
+          singular: "viewer",
+          plural: "viewers",
+          shortNames: [
+            "vi",
+          ],
+        },
+      },
+    },  // crd    
+    
   },  // parts
 }


### PR DESCRIPTION
I copied the "crd" section to pipeline-ui.libsonnet from pipeline-viewercrd.libsonnet, in order for ml-pipeline-ui service in our pipeline deployment to list/create tensorboard crd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3255)
<!-- Reviewable:end -->
