### PR TITLE
Add AWS ALB OIDC support

### DIFF
--- a/kubeflow/aws/prototypes/istio-ingress.jsonnet
+++ b/kubeflow/aws/prototypes/istio-ingress.jsonnet
@@ -7,13 +7,20 @@
 // @optionalParam istioNamespace string istio-system The namespace where Istio is installed
 // @optionalParam hostname string null The hostname associated with this ingress. Eg: mykubeflow.example.com
 // @optionalParam issuer string letsencrypt-prod The cert-manager issuer name.
-// @optionalParam enableCognito string false Enabel enableCognito authentication.
-// @optionalParam enableJwtChecking string false Enable JWT checking.
-// @optionalParam certArn string acm-cert AWS Certificate Manager certicate arn.
+// @optionalParam enableCognito string false Enable Cognito authentication.
 // @optionalParam CognitoAppClientId string null Cognito App client Id
 // @optionalParam CognitoUserPoolId string null Cognito User Pool Id
 // @optionalParam CognitoUserPoolArn string null Cognito User Pool Arn
 // @optionalParam CognitoUserPoolDomain string null Cognito User Pool Domain
+// @optionalParam enableJwtChecking string false Enable JWT checking.
+// @optionalParam certArn string null AWS Certificate Manager certicate arn, if not given TLS will not be used.
+// @optionalParam enableOidc string false Enable OIDC authentication.
+// @optionalParam OidcIssuer string null OIDC Issuer
+// @optionalParam OidcAuthorizationEndpoint string null OIDC Authorization Endpoint
+// @optionalParam OidcTokenEndpoint string null OIDC Token endpoint
+// @optionalParam OidcUserInfoEndpoint string null OIDC User Info endpoint
+// @optionalParam OidcClientId string null OIDC Client id
+// @optionalParam OidcClientSecret string null OIDC Client secret
 
 local istioIngress = import "kubeflow/aws/istio-ingress.libsonnet";
 local instance = istioIngress.new(env, params);


### PR DESCRIPTION
I noticed that only Cognito is supported by kubeflow AWS setup, but we want to use OIDC and thus I added a few new optional parameters to the `istio-ingress` component that allows to enable OIDC and define the required parameters. I think this could also be helpful for other kubeflow users.

Additionally I enhanced the test to ensure that the default params that are defined in the prototype will be used for all available test-case parameter sets.

I wasn't sure if you need an issue in advance, so please let me know if I should create one.

Let me know if I should change something. I was able to test my changes with our kubeflow setup on AWS EKS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3272)
<!-- Reviewable:end -->
