### PR TITLE
basic-auth: make kflogin work with NodePort

### DIFF
--- a/components/kflogin/src/login.js
+++ b/components/kflogin/src/login.js
@@ -63,8 +63,8 @@ class Login extends Component {
 
   handleClick(){
     try {
-      const hostname = window.location.hostname;
-      axios.post("https://" + hostname + "/apikflogin", {"req-num": "1"}, {
+      const origin = window.location.origin;
+      axios.post(origin + "/apikflogin", {"req-num": "1"}, {
         auth: {
           username: this.state.username,
           password: this.state.password


### PR DESCRIPTION
Fix the way the post request is formed so that it uses the correct
port.
Helpful for using basic-auth with a NodePort Service.

Fixes #3277

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3278)
<!-- Reviewable:end -->
