### PR TITLE
Upgrade eksctl api version to v1alpha5

### DIFF
--- a/deployment/aws/infra_configs/cluster_config.yaml
+++ b/deployment/aws/infra_configs/cluster_config.yaml
@@ -1,7 +1,7 @@
 # For details, Please check eksctl documentation or API specs.
 # https://github.com/weaveworks/eksctl/blob/master/pkg/apis/eksctl.io/v1alpha4/types.go
 
-apiVersion: eksctl.io/v1alpha4
+apiVersion: eksctl.io/v1alpha5
 kind: ClusterConfig
 metadata:
   # AWS_CLUSTER_NAME and AWS_REGION will override `name` and `region` here.


### PR DESCRIPTION
Address https://github.com/kubeflow/kubeflow/issues/3223 https://github.com/kubeflow/website/issues/714


1. Talk with maintainer in eksctl community, it will has older version backward compatibility in the future releases.  https://github.com/weaveworks/eksctl/issues/797
2. May get ride of fixed version later. Since we use basic and stable apis of eksctl, we may generate config in runtime based on user's eksctl version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3280)
<!-- Reviewable:end -->
