### PR TITLE
Fix overlay for app.yaml

### DIFF
--- a/bootstrap/config/base/kfctl_default.yaml
+++ b/bootstrap/config/base/kfctl_default.yaml
@@ -29,3 +29,11 @@ spec:
   - spartakus
   - tensorboard
   - tf-job-operator
+  componentParams:
+    spartakus:
+      - name: usageId
+        value: <randomly-generated-id>
+        initRequired: true
+      - name: reportUsage
+        value: "true"
+        initRequired: true

--- a/bootstrap/config/base/kfctl_default.yaml
+++ b/bootstrap/config/base/kfctl_default.yaml
@@ -27,6 +27,7 @@ spec:
   - katib
   - notebook-controller
   - pytorch-operator
+  - spartakus
   - tensorboard
   - tf-job-operator
   componentParams:

--- a/bootstrap/config/base/kfctl_default.yaml
+++ b/bootstrap/config/base/kfctl_default.yaml
@@ -20,7 +20,6 @@ spec:
   - tf-training
   components:
   - metacontroller
-  - ambassador
   - argo
   - centraldashboard
   - jupyter-web-app
@@ -30,7 +29,3 @@ spec:
   - spartakus
   - tensorboard
   - tf-job-operator
-  componentParams:
-    ambassador:
-    - name: ambassadorServiceType
-      value: NodePort

--- a/bootstrap/config/overlays/basic_auth/kfctl_default-patch.yaml
+++ b/bootstrap/config/overlays/basic_auth/kfctl_default-patch.yaml
@@ -1,6 +1,10 @@
 - op: add
   path: /spec/components/-
   value: 
+    ambassador
+- op: add
+  path: /spec/components/-
+  value: 
     cert-manager
 - op: add
   path: /spec/components/-
@@ -18,10 +22,6 @@
   path: /spec/components/-
   value: 
     basic-auth-ingress
-- op: add
-  path: /spec/components/-
-  value: 
-    spartakus
 - op: add
   path: /spec/packages/-
   value: 

--- a/bootstrap/config/overlays/basic_auth/kfctl_default.yaml
+++ b/bootstrap/config/overlays/basic_auth/kfctl_default.yaml
@@ -55,11 +55,4 @@ spec:
     - initRequired: true
       name: injectIstio
       value: "false"
-    spartakus:
-      - name: usageId
-        value: <randomly-generated-id>
-        initRequired: true
-      - name: reportUsage
-        value: "true"
-        initRequired: true
   platform: gcp

--- a/bootstrap/config/overlays/basic_auth/kfctl_default.yaml
+++ b/bootstrap/config/overlays/basic_auth/kfctl_default.yaml
@@ -4,6 +4,9 @@ metadata:
   name: config
 spec:
   componentParams:
+    ambassador:
+    - name: ambassadorServiceType
+      value: NodePort
     argo:
     - initRequired: true
       name: injectIstio

--- a/bootstrap/config/overlays/gcp/kfctl_default-patch.yaml
+++ b/bootstrap/config/overlays/gcp/kfctl_default-patch.yaml
@@ -15,10 +15,6 @@
   value: 
     iap-ingress
 - op: add
-  path: /spec/components/-
-  value: 
-    spartakus
-- op: add
   path: /spec/packages/-
   value: 
     gcp

--- a/bootstrap/config/overlays/gcp/kfctl_default.yaml
+++ b/bootstrap/config/overlays/gcp/kfctl_default.yaml
@@ -51,7 +51,4 @@ spec:
     - initRequired: true
       name: injectIstio
       value: "false"
-    foo:
-    - name: bar
-      value: "baz"
   platform: gcp

--- a/bootstrap/config/overlays/gcp/kfctl_default.yaml
+++ b/bootstrap/config/overlays/gcp/kfctl_default.yaml
@@ -43,6 +43,13 @@ spec:
     - initRequired: true
       name: injectIstio
       value: "false"
+    pipeline:
+    - name: mysqlPd
+      value: <deployName>-storage-metadata-store
+    - name: minioPd
+      value: <deployName>-storage-artifact-store
+    - name: injectIstio
+      value: "false"
     tensorboard:
     - initRequired: true
       name: injectIstio

--- a/bootstrap/config/overlays/gcp/kfctl_default.yaml
+++ b/bootstrap/config/overlays/gcp/kfctl_default.yaml
@@ -43,13 +43,6 @@ spec:
     - initRequired: true
       name: injectIstio
       value: "false"
-    pipeline:
-    - name: mysqlPd
-      value: <deployName>-storage-metadata-store
-    - name: minioPd
-      value: <deployName>-storage-artifact-store
-    - name: injectIstio
-      value: "false"
     tensorboard:
     - initRequired: true
       name: injectIstio
@@ -58,4 +51,7 @@ spec:
     - initRequired: true
       name: injectIstio
       value: "false"
+    foo:
+    - name: bar
+      value: "baz"
   platform: gcp

--- a/bootstrap/config/overlays/gcp/kfctl_default.yaml
+++ b/bootstrap/config/overlays/gcp/kfctl_default.yaml
@@ -29,6 +29,9 @@ spec:
       # TODO change value on the fly: replace with user-provide parameters. This need to be fully qualified domain name to use with ingress.
       value: <deployName>.endpoints.<project>.cloud.goog
       initRequired: true
+    - name: injectIstio
+      value: "false"
+      initRequired: true
     notebook-controller:
     - name: injectGcpCredentials
       value: "true"

--- a/bootstrap/config/overlays/gcp/kfctl_default.yaml
+++ b/bootstrap/config/overlays/gcp/kfctl_default.yaml
@@ -58,11 +58,4 @@ spec:
     - initRequired: true
       name: injectIstio
       value: "false"
-    spartakus:
-      - name: usageId
-        value: <randomly-generated-id>
-        initRequired: true
-      - name: reportUsage
-        value: "true"
-        initRequired: true
   platform: gcp

--- a/bootstrap/config/overlays/ksonnet/kfctl_default.yaml
+++ b/bootstrap/config/overlays/ksonnet/kfctl_default.yaml
@@ -11,3 +11,10 @@ spec:
       value: <deployName>-storage-artifact-store
     - name: injectIstio
       value: "false"
+    spartakus:
+      - name: usageId
+        value: <randomly-generated-id>
+        initRequired: true
+      - name: reportUsage
+        value: "true"
+        initRequired: true

--- a/bootstrap/config/overlays/ksonnet/kfctl_default.yaml
+++ b/bootstrap/config/overlays/ksonnet/kfctl_default.yaml
@@ -11,10 +11,3 @@ spec:
       value: <deployName>-storage-artifact-store
     - name: injectIstio
       value: "false"
-    spartakus:
-      - name: usageId
-        value: <randomly-generated-id>
-        initRequired: true
-      - name: reportUsage
-        value: "true"
-        initRequired: true

--- a/bootstrap/config/overlays/ksonnet/kustomization.yaml
+++ b/bootstrap/config/overlays/ksonnet/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
+patchesStrategicMerge:
+- kfctl_default.yaml
 patchesJson6902:
 - target:
     group: kfdef.apps.kubeflow.org


### PR DESCRIPTION
- [x] ambassador overlays.
- [x] `injectIstio` in iap-ingress.
- [x] all params for pipeline.
- [x] spartakus is not GCP specific.

Fixes #3273 
Relates to #3282 

Root cause of failure is because #3283 changed parameter from `useIstio` to `injectIstio` so that istio related flags can be unified and flipped by this line:
https://github.com/kubeflow/kubeflow/blob/a70c866ee7811ec907c63368a43703447348d99f/bootstrap/pkg/kfapp/coordinator/coordinator.go#L292

However, #3108 changed kubeflow app config to use kustomize but overlay didn't include this parameter.  And thus for all ISTIO deployments `iap-ingress` will always be deployed as if it's not for ISTIO.  This PR adds back this flag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3283)
<!-- Reviewable:end -->
