### PR TITLE
ksonnet does not include pipeline componentParams when package manager == KSONNET and platform == GCP

### DIFF
--- a/bootstrap/config/overlays/ksonnet/kustomization.yaml
+++ b/bootstrap/config/overlays/ksonnet/kustomization.yaml
@@ -2,6 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 - ../../base
+patchesStrategicMerge:
+- kfctl_default.yaml
 patchesJson6902:
 - target:
     group: kfdef.apps.kubeflow.org


### PR DESCRIPTION
fixes #3284

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3285)
<!-- Reviewable:end -->
