### PR TITLE
#3259 AWS: Disable istio-injection by default in kubeflow ns

### DIFF
--- a/scripts/aws/util.sh
+++ b/scripts/aws/util.sh
@@ -146,15 +146,15 @@ install_istio() {
   curl -o ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-crds.yaml \
     https://raw.githubusercontent.com/kubeflow/kubeflow/master/dependencies/istio/install/crds.yaml
 
-  # 1. sidecar injection configmap policy is changed from enabled to disabled
-  # 2. istio-ingressgateway is of type NodePort instead of LoadBalancer
+  # istio-ingressgateway is of type NodePort instead of LoadBalancer
   curl -o ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-noauth.yaml \
     https://raw.githubusercontent.com/kubeflow/kubeflow/master/dependencies/istio/install/istio-noauth.yaml
 
   kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-crds.yaml
   kubectl apply -f ${KUBEFLOW_K8S_MANIFESTS_DIR}/istio-noauth.yaml
 
-  kubectl label namespace ${K8S_NAMESPACE} istio-injection=enabled --overwrite
+  # ensure istio injection is disabled by default
+  kubectl label namespace ${K8S_NAMESPACE} istio-injection=disabled --overwrite
 }
 
 ################################ Ksonnet changes ################################


### PR DESCRIPTION
As discussed in #3259 I changed the namespace label in the AWS setup for the kubeflow namespace, so that istio injection is by-default disabled.

Fixes #3259

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3289)
<!-- Reviewable:end -->
