### PR TITLE
Allow defining kubeflow repo in download script

### DIFF
--- a/scripts/download.sh
+++ b/scripts/download.sh
@@ -10,10 +10,11 @@ if [ ! -z "${KUBEFLOW_VERSION}" ]; then
 fi
 
 KUBEFLOW_TAG=${KUBEFLOW_TAG:-master}
+KUBEFLOW_GH_REPO=${KUBEFLOW_GH_REPO:-kubeflow/kubeflow}
 
 # Create a local copy of the Kubeflow source repo
 TMPDIR=$(mktemp -d /tmp/tmp.kubeflow-repo-XXXXXX)
-curl -L -o ${TMPDIR}/kubeflow.tar.gz https://github.com/kubeflow/kubeflow/archive/${KUBEFLOW_TAG}.tar.gz
+curl -L -o ${TMPDIR}/kubeflow.tar.gz https://github.com/${KUBEFLOW_GH_REPO}/archive/${KUBEFLOW_TAG}.tar.gz
 tar -xzvf ${TMPDIR}/kubeflow.tar.gz -C ${TMPDIR}
 # GitHub seems to strip out the v in the file name.
 KUBEFLOW_SOURCE=$(find ${TMPDIR} -maxdepth 1 -type d -name "kubeflow*")


### PR DESCRIPTION
We had the need to use the download script for my fork as long as this one is different than the official kubeflow repository.
Therefore I did a small change in the `download.sh` script that allows defining the repository in a `KUBEFLOW_GH_REPO` env-variable.

I think this could also be helpful for other forks in the future and doesn't have any drawbacks for the official repository as this one will by default still be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3291)
<!-- Reviewable:end -->
