### PR TITLE
Allow defining VPC id and region for AWS alb-ingress-controller

### DIFF
--- a/kubeflow/aws/aws-alb-ingress-controller.libsonnet
+++ b/kubeflow/aws/aws-alb-ingress-controller.libsonnet
@@ -100,7 +100,13 @@
                 args: [
                   "--ingress-class=alb",
                   "--cluster-name=" + params.clusterName,
-                ],
+                ] + (if params.awsVpcId != "null" then [
+                  "--aws-vpc-id=" + params.awsVpcId
+                ] else [
+                ]) + (if params.awsRegion != "null" then [
+                  "--aws-region=" + params.awsRegion
+                ] else [
+                ]),
                 name: "alb-ingress-controller",
                 image: params.albIngressControllerImage,
                 imagePullPolicy: "Always",

--- a/kubeflow/aws/prototypes/aws-alb-ingress-controller.jsonnet
+++ b/kubeflow/aws/prototypes/aws-alb-ingress-controller.jsonnet
@@ -5,6 +5,8 @@
 // @param name string Name for the component
 // @param clusterName string Kubernetes Cluster Name
 // @optionalParam albIngressControllerImage string docker.io/amazon/aws-alb-ingress-controller:v1.1.0 ALB Ingress Controller Image.
+// @optionalParam awsVpcId string null VPC ID of the cluster in case ec2metadata is not available from the controller pod
+// @optionalParam awsRegion string null AWS region of the cluster in case ec2metadata is not available from the controller pod
 
 local albIngressController = import "kubeflow/aws/aws-alb-ingress-controller.libsonnet";
 local instance = albIngressController.new(env, params);

--- a/kubeflow/aws/tests/aws-alb-ingress-controller_test.jsonnet
+++ b/kubeflow/aws/tests/aws-alb-ingress-controller_test.jsonnet
@@ -1,10 +1,20 @@
 local testSuite = import "kubeflow/common/testsuite.libsonnet";
 local albIngressController = import "kubeflow/aws/aws-alb-ingress-controller.libsonnet";
 
-local params = {
+local defaultParams = {
+  albIngressControllerImage: "docker.io/amazon/aws-alb-ingress-controller:v1.1.0",
+  awsVpcId: "null",
+  awsRegion: "null",
+};
+
+local params = defaultParams + {
   name: "aws-alb-ingress-controller",
   clusterName: "eks-test-cluster",
-  albIngressControllerImage: "docker.io/amazon/aws-alb-ingress-controller:v1.1.0",
+};
+
+local noEc2MetadataParams = params + {
+  awsVpcId: "AWS-VPC-ID",
+  awsRegion: "AWS-REGION",
 };
 
 local env = {
@@ -13,6 +23,7 @@ local env = {
 
 
 local instance = albIngressController.new(env, params);
+local noEc2MetadataInstance = albIngressController.new(env, noEc2MetadataParams);
 
 local testCases = [
   {
@@ -120,6 +131,67 @@ local testCases = [
                 args: [
                   "--ingress-class=alb",
                   "--cluster-name=eks-test-cluster",
+                ],
+                name: "alb-ingress-controller",
+                image: "docker.io/amazon/aws-alb-ingress-controller:v1.1.0",
+                imagePullPolicy: "Always",
+                resources: {},
+                terminationMessagePath: "/dev/termination-log"
+              },
+            ],
+            dnsPolicy: "ClusterFirst",
+            restartPolicy: "Always",
+            securityContext: {},
+            terminationGracePeriodSeconds: 30,
+            serviceAccountName: "alb-ingress-controller",
+            serviceAccount: "alb-ingress-controller",
+          },
+        },
+      },
+    },
+  },
+
+  // NO EC2METADATA AVAILABLE
+  {
+    actual: noEc2MetadataInstance.parts.albIngressDeploy,
+    expected: {
+      apiVersion: "apps/v1",
+      kind: "Deployment",
+      metadata: {
+        name: "alb-ingress-controller",
+        namespace: "kubeflow",
+        labels: {
+          app: "alb-ingress-controller"
+        },
+      },
+      spec: {
+        replicas: 1,
+        selector: {
+          matchLabels: {
+            app: "alb-ingress-controller"
+          },
+        },
+        strategy: {
+          rollingUpdate: {
+            maxSurge: 1,
+            maxUnavailable: 1
+          },
+          type: "RollingUpdate"
+        },
+        template: {
+          metadata: {
+            labels: {
+              app: "alb-ingress-controller",
+            },
+          },
+          spec: {
+            containers: [
+              {
+                args: [
+                  "--ingress-class=alb",
+                  "--cluster-name=eks-test-cluster",
+                  "--aws-vpc-id=AWS-VPC-ID",
+                  "--aws-region=AWS-REGION",
                 ],
                 name: "alb-ingress-controller",
                 image: "docker.io/amazon/aws-alb-ingress-controller:v1.1.0",


### PR DESCRIPTION
In case ec2metadata is not available for the alb-ingress-controller pod it is required to configure the VPC id and region.

We had this need and thus I enhanced the `aws-alb-ingress-controller` component to support defining these values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3292)
<!-- Reviewable:end -->
