### PR TITLE
Use empty list when OIDC not being used

### DIFF
--- a/kubeflow/aws/istio-ingress.libsonnet
+++ b/kubeflow/aws/istio-ingress.libsonnet
@@ -199,7 +199,7 @@
     ] else [
     ] + if params.authType == "oidc" then [
       self.oidcSecret
-    ],
+    ] else [],
 
     list(obj=self.all):: k.core.v1.list.new(obj,),
   },


### PR DESCRIPTION
See comment by @Jeffwan on https://github.com/kubeflow/kubeflow/pull/3272

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3302)
<!-- Reviewable:end -->
