### PR TITLE
iap-ingress is missing parameters used in ksonnet

### DIFF
--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -621,6 +621,8 @@ func MergeKustomization(compDir string, targetDir string, kfDef *cltypes.KfDef, 
 					params[i] = paramName + "=" + val
 				} else {
 					switch paramName {
+					case "appName":
+						params[i] = paramName + "=" + kfDef.Name
 					case "namespace":
 						params[i] = paramName + "=" + kfDef.Namespace
 					case "project":


### PR DESCRIPTION
paired with [manifests/#77](https://github.com/kubeflow/manifests/pull/77)
fixes #3303
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3304)
<!-- Reviewable:end -->
