### PR TITLE
Remove kfctl-go-iap workflow test

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -26,25 +26,6 @@ workflows:
     params:
       installIstio: true
       workflowName: deployapp-istio
-  # kfctl test runs tests on gke using the new kfctl go binary and IAP
-  - app_dir: kubeflow/kubeflow/testing/workflows
-    component: kfctl_go_test
-    name: kfctl-go-iap
-    job_types:
-      - presubmit
-      - postsubmit
-      - periodic
-    include_dirs:
-      - bootstrap/*
-      - deployment/*
-      - kubeflow/*
-      - testing/*
-    params:
-      platform: gke
-      gkeApiVersion: v1
-      workflowName: kfctl-go
-      useBasicAuth: false
-      useIstio: false
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: kfctl_go_test
     name: kfctl-go-iap-istio


### PR DESCRIPTION
Since kfctl-go-iap does not install istio it fails to deploy the componnets whcih have dependency on istio (e.g., notebook-controller). We can remove it. kfctl-go-iap-istio already covers what kfctl-go-iap  does. #3306

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3307)
<!-- Reviewable:end -->
