### PR TITLE
Fix notebook example

### DIFF
--- a/kubeflow/jupyter/prototypes/README.md
+++ b/kubeflow/jupyter/prototypes/README.md
@@ -38,9 +38,8 @@ spec:
             cpu: 500m
             memory: 1Gi
         workingDir: "/home/jovyan"
-      ttlSecondsAfterFinished: 300
       securityContext:
-      - fsGroup: 100
+        fsGroup: 100
         runAsUser: 1000
 ```
 

--- a/kubeflow/jupyter/prototypes/README.md
+++ b/kubeflow/jupyter/prototypes/README.md
@@ -37,7 +37,7 @@ spec:
           requests:
             cpu: 500m
             memory: 1Gi
-        workingDir: "/home/jovyan"
+        workingDir: /home/jovyan
       securityContext:
         fsGroup: 100
         runAsUser: 1000


### PR DESCRIPTION
I think, here: https://github.com/kubeflow/kubeflow/tree/master/kubeflow/jupyter/prototypes#design yaml structure is incorrect.
According to this: https://github.com/kubernetes/api/blob/master/core/v1/types.go#L3004:

1. `securityContext` is not a list.
2. `PodSpec` doesn't have `ttlSecondsAfterFinished` field.

/assign @kkasravi @lluunn 
/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3308)
<!-- Reviewable:end -->
