### PR TITLE
Add command field for defaultMetricsColloctor deployment

### DIFF
--- a/kubeflow/katib/studyjobcontroller.libsonnet
+++ b/kubeflow/katib/studyjobcontroller.libsonnet
@@ -129,8 +129,8 @@
                       containers:
                       - name: {{.WorkerID}}
                         image: %(mcimage)s
+                        command: ["./metricscollector"]
                         args:
-                        - "./metricscollector"
                         - "-s"
                         - "{{.StudyID}}"
                         - "-t"


### PR DESCRIPTION
Just keep consistent with https://github.com/kubeflow/katib/pull/550

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3314)
<!-- Reviewable:end -->
