### PR TITLE
Fix manifest rewritten in error during apply

### DIFF
--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -289,8 +289,8 @@ func (kustomize *kustomize) deployResources(config *rest.Config, filename string
 	splitter := regexp.MustCompile(bootstrap.YamlSeparator)
 	objects := splitter.Split(string(data), -1)
 
-	var o map[string]interface{}
 	for _, object := range objects {
+		var o map[string]interface{}
 		if err = yaml.Unmarshal([]byte(object), &o); err != nil {
 			return err
 		}


### PR DESCRIPTION
`yaml.Unmarshal` is not replacing content of output, it's merging it with `src`.  Plus placing `o` in the scope outside of the loop isn't doing anything.  Making it in the same scope as the applying loop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3321)
<!-- Reviewable:end -->
