### PR TITLE
Resource charts for CPU Utilization

### DIFF
--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -3358,6 +3358,44 @@
             "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
             "dev": true
         },
+        "chart.js": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.8.0.tgz",
+            "integrity": "sha512-Di3wUL4BFvqI5FB5K26aQ+hvWh8wnP9A3DWGvXHVkO13D3DSnaSsdZx29cXlEsYKVkn1E2az+ZYFS4t0zi8x0w==",
+            "requires": {
+                "chartjs-color": "^2.1.0",
+                "moment": "^2.10.2"
+            }
+        },
+        "chartjs-color": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.3.0.tgz",
+            "integrity": "sha512-hEvVheqczsoHD+fZ+tfPUE+1+RbV6b+eksp2LwAhwRTVXEjCSEavvk+Hg3H6SZfGlPh/UfmWKGIvZbtobOEm3g==",
+            "requires": {
+                "chartjs-color-string": "^0.6.0",
+                "color-convert": "^0.5.3"
+            },
+            "dependencies": {
+                "color-convert": {
+                    "version": "0.5.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
+                    "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
+                }
+            }
+        },
+        "chartjs-color-string": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/chartjs-color-string/-/chartjs-color-string-0.6.0.tgz",
+            "integrity": "sha512-TIB5OKn1hPJvO7JcteW4WY/63v6KwEdt6udfnDE9iCAZgy+V4SrbSxoIbTw/xkUIapjEI4ExGtD0+6D3KyFd7A==",
+            "requires": {
+                "color-name": "^1.0.0"
+            }
+        },
+        "chartjs-plugin-crosshair": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/chartjs-plugin-crosshair/-/chartjs-plugin-crosshair-1.1.2.tgz",
+            "integrity": "sha512-WM8PK0FQfpo08FZB/HLthABxChfIu7TRJ4k4JHRc5WxD8WJSvqkYYBwjhX7tixUUcvTUUuija34og6oAuTMBTw=="
+        },
         "chokidar": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
@@ -3517,8 +3555,7 @@
         "color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "colors": {
             "version": "0.5.1",
@@ -9338,6 +9375,11 @@
                     "dev": true
                 }
             }
+        },
+        "moment": {
+            "version": "2.24.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
         },
         "move-concurrently": {
             "version": "1.0.1",

--- a/components/centraldashboard/package.json
+++ b/components/centraldashboard/package.json
@@ -60,6 +60,8 @@
         "@polymer/polymer": "^3.2.0",
         "@types/dotenv": "^6.1.1",
         "@webcomponents/webcomponentsjs": "^2.2.10",
+        "chart.js": "^2.8.0",
+        "chartjs-plugin-crosshair": "^1.1.2",
         "express": "^4.16.4",
         "web-animations-js": "^2.3.1"
     },

--- a/components/centraldashboard/public/components/dashboard-view.css
+++ b/components/centraldashboard/public/components/dashboard-view.css
@@ -1,10 +1,8 @@
 :host {
     @apply --layout-vertical;
-    /* 20px */
-    padding: 1.3em;
+    padding: 1.3em; /* 20px */
     overflow: auto;
-    /* 12px */
-    grid-gap: .75em;
+    grid-gap: .75em; /* 12px */
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     min-height: 0;
@@ -46,37 +44,37 @@ paper-card {
         font-weight: 500;
         padding: 0 1em;
         flex: 1;
-    }
-    ;
+    };
     --paper-card-content: {
         font-size: 14px;
     }
 }
+<<<<<<< HEAD
 paper-card {
+=======
+paper-card#Quick-Links {
+>>>>>>> Completes resource-charts with full test coverage.
     --paper-item-body-two-line-min-height: 2em;
 }
-
 paper-card#Platform-Links {
     --paper-card-header-color: #2c6acb;
     --paper-card-header: {
+        font-family: "Google Sans";
         background: #e9f0fd;
         height: 62px;
         border-color: white;
         @apply --layout-horizontal;
         @apply --layout-center;
-    }
-    ;
+    };
     --paper-card-header-image-text: {
         flex: 1;
         padding: 16px 0;
         position: initial;
-    }
-    ;
+    };
     --paper-card-header-image: {
         width: 2em;
         padding: .5em .75em .5em 1.25em;
-    }
-    ;
+    };
 }
 
 #Documentation [secondary] {
@@ -102,13 +100,11 @@ paper-icon-item {
     --paper-item-icon-width: 40px;
     --paper-icon-item: {
         font-weight: 500;
-    }
-    ;
+    };
     --paper-item-icon: {
         color: var(--icon-color);
         border-radius: 50%;
-    }
-    ;
+    };
     --paper-item-focused-before: {
         /* Approximates the hover style since it uses opacity */
         background: var(--google-grey-700);
@@ -119,8 +115,7 @@ paper-icon-item {
 paper-icon-item.external {
     --paper-item-icon: {
         color: var(--external-icon-color);
-    }
-    ;
+    };
 }
 
 #Quick-Links paper-icon-item {

--- a/components/centraldashboard/public/components/dashboard-view.css
+++ b/components/centraldashboard/public/components/dashboard-view.css
@@ -1,8 +1,10 @@
 :host {
     @apply --layout-vertical;
-    padding: 1.3em; /* 20px */
+    /* 20px */
+    padding: 1.3em;
     overflow: auto;
-    grid-gap: .75em; /* 12px */
+    /* 12px */
+    grid-gap: .75em;
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     min-height: 0;
@@ -44,7 +46,8 @@ paper-card {
         font-weight: 500;
         padding: 0 1em;
         flex: 1;
-    };
+    }
+    ;
     --paper-card-content: {
         font-size: 14px;
     }
@@ -52,17 +55,28 @@ paper-card {
 paper-card {
     --paper-item-body-two-line-min-height: 2em;
 }
+
 paper-card#Platform-Links {
     --paper-card-header-color: #2c6acb;
+    --paper-card-header: {
+        background: #e9f0fd;
+        height: 62px;
+        border-color: white;
+        @apply --layout-horizontal;
+        @apply --layout-center;
+    }
+    ;
     --paper-card-header-image-text: {
         flex: 1;
         padding: 16px 0;
         position: initial;
-    };
+    }
+    ;
     --paper-card-header-image: {
         width: 2em;
         padding: .5em .75em .5em 1.25em;
-    };
+    }
+    ;
 }
 
 #Documentation [secondary] {
@@ -71,10 +85,6 @@ paper-card#Platform-Links {
     white-space: normal;
     font-size: .9em;
     line-height: 1.5em;
-}
-
-#Quick-Links {
-    grid-column: 3
 }
 
 #Platform-Links header {
@@ -92,11 +102,13 @@ paper-icon-item {
     --paper-item-icon-width: 40px;
     --paper-icon-item: {
         font-weight: 500;
-    };
+    }
+    ;
     --paper-item-icon: {
         color: var(--icon-color);
         border-radius: 50%;
-    };
+    }
+    ;
     --paper-item-focused-before: {
         /* Approximates the hover style since it uses opacity */
         background: var(--google-grey-700);
@@ -107,7 +119,8 @@ paper-icon-item {
 paper-icon-item.external {
     --paper-item-icon: {
         color: var(--external-icon-color);
-    };
+    }
+    ;
 }
 
 #Quick-Links paper-icon-item {

--- a/components/centraldashboard/public/components/dashboard-view.css
+++ b/components/centraldashboard/public/components/dashboard-view.css
@@ -13,6 +13,28 @@
     flex: 1;
     --accent-color: #007dfc;
     --primary-background-color: white;
+
+    --dashboard-card: {
+        background-color: var(--paper-card-background-color,
+            var(--primary-background-color));
+        border-radius: 5px;
+        display: inline-block;
+        font-size: 14px;
+        max-width: 400px;
+        min-width: 320px;
+        position: relative;
+        width: 100%;
+        @apply --paper-material-elevation-1;
+    }
+
+    --dashboard-card-header: {
+        font-family: "Google Sans";
+        height: 62px;
+        border-bottom: 1px solid var(--divider-color);
+        margin-bottom: .5em;
+        @apply --layout-horizontal;
+        @apply --layout-center;
+    }
 }
 
 .column {grid-row: 1}
@@ -32,12 +54,7 @@ paper-card {
     font-size: 14px;
     --paper-card-header-color: #202124;
     --paper-card-header: {
-        font-family: "Google Sans";
-        height: 62px;
-        border-bottom: 1px solid var(--divider-color);
-        margin-bottom: .5em;
-        @apply --layout-horizontal;
-        @apply --layout-center;
+        @apply --dashboard-card-header;
     }
     --paper-card-header-text: {
         font-size: 16px;
@@ -49,23 +66,11 @@ paper-card {
         font-size: 14px;
     }
 }
-<<<<<<< HEAD
 paper-card {
-=======
-paper-card#Quick-Links {
->>>>>>> Completes resource-charts with full test coverage.
     --paper-item-body-two-line-min-height: 2em;
 }
 paper-card#Platform-Links {
     --paper-card-header-color: #2c6acb;
-    --paper-card-header: {
-        font-family: "Google Sans";
-        background: #e9f0fd;
-        height: 62px;
-        border-color: white;
-        @apply --layout-horizontal;
-        @apply --layout-center;
-    };
     --paper-card-header-image-text: {
         flex: 1;
         padding: 16px 0;

--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -5,6 +5,7 @@ import '@polymer/paper-card/paper-card.js';
 import '@polymer/paper-ripple/paper-ripple.js';
 import '@polymer/paper-item/paper-icon-item.js';
 import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-styles/element-styles/paper-material-styles.js';
 
 import {html, PolymerElement} from '@polymer/polymer';
 import css from './dashboard-view.css';
@@ -18,7 +19,10 @@ const DOCS = 'https://www.kubeflow.org/docs/started';
 
 export class DashboardView extends PolymerElement {
     static get template() {
-        return html([`<style>${css.toString()}</style> ${template()}`]);
+        return html([`
+            <style include="paper-material-styles">${css.toString()}</style>
+            ${template()}
+        `]);
     }
 
     /**

--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -11,6 +11,7 @@ import css from './dashboard-view.css';
 import template from './dashboard-view.pug';
 
 import './iframe-link.js';
+import './resource-chart.js';
 import {getGCPData} from './resources/cloud-platform-data.js';
 
 const DOCS = 'https://www.kubeflow.org/docs/started';

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -10,12 +10,14 @@
                     paper-ripple
 template(is='dom-if', if='[[platformDetails.resourceChartsLink]]')
     .column
-        resource-chart(heading='Cluster CPU Utilization', metric='cpu',
+        resource-chart(header-text='Cluster CPU Utilization', metric='cpu',
             interval='Last60m',
-            external-link='[[platformDetails.resourceChartsLink]]')
-        resource-chart(heading='Pod CPU Utilization', metric='podcpu',
+            external-link='[[platformDetails.resourceChartsLink]]',
+            external-link-text='[[platformDetails.resourceChartsLinkText]]')
+        resource-chart(header-text='Pod CPU Utilization', metric='podcpu',
             interval='Last60m',
-            external-link='[[platformDetails.resourceChartsLink]]')
+            external-link='[[platformDetails.resourceChartsLink]]'
+            external-link-text='[[platformDetails.resourceChartsLinkText]]')
 .column
     template(is='dom-if', if='[[platformDetails.links]]')
         paper-card#Platform-Links(class$='[[platformDetails.name]]',

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -8,7 +8,25 @@
                         .header [[item.text]]
                         aside(secondary) [[item.desc]]
                     paper-ripple
+template(is='dom-if', if='[[platformDetails.resourceChartsLink]]')
+    .column
+        resource-chart(heading='Cluster CPU Utilization', metric='cpu',
+            interval='Last60m',
+            external-link='[[platformDetails.resourceChartsLink]]')
+        resource-chart(heading='Pod CPU Utilization', metric='podcpu',
+            interval='Last60m',
+            external-link='[[platformDetails.resourceChartsLink]]')
 .column
+    template(is='dom-if', if='[[platformDetails.links]]')
+        paper-card#Platform-Links(class$='[[platformDetails.name]]',
+            heading='[[platformDetails.title]]', image='[[platformDetails.logo]]')
+            template(is='dom-repeat', items='[[platformDetails.links]]')
+                a.link(href$='[[item.link]]', tabindex='-1', target='_blank')
+                    paper-icon-item.external
+                        paper-ripple
+                        aside [[item.text]]
+                        paper-icon-button.button(icon='open-in-new',
+                            slot='item-icon', alt='[[item.text]]', tabindex=-1)
     paper-card#Documentation(heading='Documentation')
         template(is='dom-repeat', items='[[documentationItems]]')
             a.link(href$='[[item.link]]', tabindex='-1',
@@ -20,16 +38,3 @@
                         aside(secondary) [[item.desc]]
                     paper-icon-button.button(icon='open-in-new',
                         slot='item-icon', alt='[[item.text]]', tabindex=-1)
-.column
-    template(is='dom-if', if='[[platformDetails.links]]')
-        paper-card#Platform-Links(class$='[[platformDetails.name]]',
-            heading='[[platformDetails.title]]', image='[[platformDetails.logo]]')
-            template(is='dom-repeat', items='[[platformDetails.links]]')
-                a.link(href$='[[item.link]]', tabindex='-1', target='_blank')
-                    paper-icon-item.external
-                        paper-ripple
-                        paper-item-body(two-line)
-                            .header [[item.headerText]]
-                            aside(secondary) [[item.secondaryText]]
-                        paper-icon-button.button(icon='open-in-new',
-                            slot='item-icon', alt='[[item.text]]', tabindex=-1)

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -26,7 +26,9 @@ template(is='dom-if', if='[[platformDetails.resourceChartsLink]]')
                 a.link(href$='[[item.link]]', tabindex='-1', target='_blank')
                     paper-icon-item.external
                         paper-ripple
-                        aside [[item.text]]
+                        paper-item-body(two-line)
+                            .header [[item.headerText]]
+                            aside(secondary) [[item.secondaryText]]
                         paper-icon-button.button(icon='open-in-new',
                             slot='item-icon', alt='[[item.text]]', tabindex=-1)
     paper-card#Documentation(heading='Documentation')

--- a/components/centraldashboard/public/components/dashboard-view_test.js
+++ b/components/centraldashboard/public/components/dashboard-view_test.js
@@ -1,4 +1,5 @@
 import '@polymer/test-fixture/test-fixture';
+import 'jasmine-ajax';
 import {flush} from '@polymer/polymer/lib/utils/flush.js';
 
 import './dashboard-view';
@@ -17,6 +18,7 @@ describe('Dashboard View', () => {
     let dashboardView;
 
     beforeAll(() => {
+        jasmine.Ajax.install();
         const div = document.createElement('div');
         div.innerHTML = TEMPLATE;
         document.body.appendChild(div);
@@ -31,9 +33,15 @@ describe('Dashboard View', () => {
         document.getElementById(FIXTURE_ID).restore();
     });
 
+    afterAll(() => {
+        jasmine.Ajax.uninstall();
+    });
+
     it('Does not show links without platform info', () => {
         expect(dashboardView.shadowRoot.getElementById('Platform-Links'))
             .toBeNull();
+        expect(dashboardView.shadowRoot.querySelectorAll('resource-chart')
+            .length).toBe(0);
     });
 
     it('Does not show links for an unrecognized provider', async () => {
@@ -44,9 +52,11 @@ describe('Dashboard View', () => {
         flush();
         expect(dashboardView.shadowRoot.getElementById('Platform-Links'))
             .toBeNull();
+        expect(dashboardView.shadowRoot.querySelectorAll('resource-chart')
+            .length).toBe(0);
     });
 
-    it('Shows GCP links when provider is gce', () => {
+    it('Shows GCP links and Stackdriver charts when provider is gce', () => {
         dashboardView.platformInfo = {
             provider: 'gce://test-project/us-east1-c/gke-kubeflow-node-123',
             providerName: 'gce',
@@ -68,5 +78,7 @@ describe('Dashboard View', () => {
             'https://console.cloud.google.com/dm/deployments?project=test-project',
             'https://console.cloud.google.com/kubernetes/list?project=test-project',
         ]);
+        expect(dashboardView.shadowRoot.querySelectorAll('resource-chart')
+            .length).toBe(2);
     });
 });

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -3,7 +3,6 @@ import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '@polymer/paper-button/paper-button.js';
 import '@polymer/paper-menu-button/paper-menu-button.js';
-import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light';
 import '@polymer/paper-listbox/paper-listbox.js';
 import '@polymer/paper-item/paper-item.js';
 

--- a/components/centraldashboard/public/components/resource-chart.js
+++ b/components/centraldashboard/public/components/resource-chart.js
@@ -6,7 +6,6 @@ import '@polymer/paper-icon-button/paper-icon-button.js';
 import '@polymer/paper-menu-button/paper-menu-button.js';
 import '@polymer/paper-listbox/paper-listbox.js';
 import '@polymer/paper-item/paper-item.js';
-import '@polymer/paper-styles/element-styles/paper-material-styles.js';
 import 'chartjs-plugin-crosshair';
 
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
@@ -36,24 +35,12 @@ const MAX_TOOLTIP_LENGTH = 10;
 class ResourceChart extends PolymerElement {
     static get template() {
         return html`
-        <style include="iron-flex iron-flex-alignment paper-material-styles">
+        <style include="iron-flex iron-flex-alignment">
             :host {
-                @apply --paper-material-elevation-1;
-                background-color: var(--paper-card-background-color,
-                    var(--primary-background-color));
-                border-radius: 5px;
-                display: inline-block;
-                font-size: 14px;
-                max-width: 400px;
-                min-width: 320px;
-                position: relative;
-                width: 100%;
+                @apply --dashboard-card;
             }
             header {
-                height: 62px;
-                border-bottom: 1px solid var(--divider-color);
-                @apply --layout-horizontal;
-                @apply --layout-center;
+                @apply --dashboard-card-header;
             }
             paper-menu-button {
                 padding: 0;
@@ -116,7 +103,8 @@ class ResourceChart extends PolymerElement {
                     on-click="_refresh"></paper-button>
             </header>
             <section id="chart-container">
-                <canvas id="chart" height="400" width="400"></canvas></section>
+                <canvas id="chart" height="400" width="400"></canvas>
+            </section>
             <footer>
                 <a id="external-link" href="[[externalLink]]".
                     target="_blank" tabindex="-1">
@@ -227,10 +215,9 @@ class ResourceChart extends PolymerElement {
      * @param {Event} responseEvent
      */
     _onResponse(responseEvent) {
-        let i = 0;
-        this._chartOptions.data.datasets = [];
-        for (const ds of this._buildDatasets(responseEvent.detail.response)) {
-            this._chartOptions.data.datasets.push({
+        const dataSets = this._buildDatasets(responseEvent.detail.response);
+        this._chartOptions.data.datasets = dataSets.map((ds, i) => (
+            {
                 type: 'line',
                 label: ds[0],
                 backgroundColor: LINE_COLORS[i % LINE_COLORS.length],
@@ -240,9 +227,8 @@ class ResourceChart extends PolymerElement {
                 borderWidth: 2,
                 lineTension: 0,
                 pointRadius: 0,
-            });
-            i++;
-        }
+            }
+        ));
         // Adds % formatting for CPU utilization
         if (this.metric !== 'podmem') {
             this._chartOptions.options.scales.yAxes[0].ticks = {
@@ -284,9 +270,8 @@ class ResourceChart extends PolymerElement {
             p.mean = ((p.mean * (p.data.length - 1) + point.value) /
                 p.data.length);
         });
-        let series = dataPointsByLabel.entries();
-        if (dataPointsByLabel.size > MAX_SERIES) {
-            series = Array.from(dataPointsByLabel.entries());
+        const series = Array.from(dataPointsByLabel.entries());
+        if (series.length > MAX_SERIES) {
             series.sort((a, b) => b[1].mean - a[1].mean);
             series.splice(MAX_SERIES);
             this._chartOptions.options.legend.display = false;

--- a/components/centraldashboard/public/components/resource-chart.js
+++ b/components/centraldashboard/public/components/resource-chart.js
@@ -71,6 +71,9 @@ class ResourceChart extends PolymerElement {
             #external-link {
                 flex: 0 1 auto;
                 text-decoration: none;
+                --iron-icon: {
+                    padding-left: 8px;
+                };
                 --iron-icon-width: 20px;
                 --iron-icon-height: 20px;
                 --paper-button: {

--- a/components/centraldashboard/public/components/resource-chart.js
+++ b/components/centraldashboard/public/components/resource-chart.js
@@ -1,0 +1,316 @@
+import '@polymer/iron-ajax/iron-ajax.js';
+import '@polymer/iron-icon/iron-icon.js';
+import '@polymer/iron-icons/iron-icons.js';
+import '@polymer/paper-button/paper-button.js';
+import '@polymer/paper-dropdown-menu/paper-dropdown-menu-light';
+import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@polymer/paper-styles/element-styles/paper-material-styles.js';
+import 'chartjs-plugin-crosshair';
+
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {Chart} from 'chart.js';
+
+Chart.defaults.global.defaultFontFamily = '"Google Sans", sans-serif';
+
+// Preferred colors for Material Charts
+const LINE_COLORS = [
+    '#1e88e5', // google-blue-600,
+    '#00acc1', // paper-cyan-600
+    '#e91e63', // paper-pink-500
+    '#ff9800', // paper-orange-500
+    '#9ccc65', // paper-light-green-400
+];
+const METRICS = new Set(['node', 'podcpu', 'podmem']);
+const INTERVALS = new Set([
+    'Last5m',
+    'Last15m',
+    'Last30m',
+    'Last60m',
+    'Last180m',
+]);
+const MAX_SERIES = 5;
+const MAX_TOOLTIP_LENGTH = 10;
+
+class ResourceChart extends PolymerElement {
+    static get template() {
+        return html`
+        <style include="paper-material-styles">
+            :host {
+                @apply --paper-material-elevation-1;
+                background-color: var(--paper-card-background-color,
+                    var(--primary-background-color));
+                border-radius: 5px;
+                display: inline-block;
+                font-size: 14px;
+                max-width: 400px;
+                min-width: 320px;
+                position: relative;
+                overflow: hidden;
+                width: 100%;
+            }
+            header {
+                height: 62px;
+                border-bottom: 1px solid var(--divider-color);
+                @apply --layout-horizontal;
+                @apply --layout-center;
+            }
+            footer {
+                height: 62px;
+                padding: 0 16px;
+                @apply --layout-horizontal;
+                @apply --layout-center;
+                @apply --layout-justified;
+            }
+            #header-text {
+                font-family: "Google Sans";
+                font-size: 16px;
+                font-weight: 500;
+                flex: 1;
+                height: 20px;
+                padding: 0 16px;
+            }
+            #chart-container {
+                position: relative;
+                padding: 16px;
+                height: 250px;
+            }
+            #interval {
+                flex-basis: 33%;
+            }
+            #external-link {
+                flex: 0 1 auto;
+                text-decoration: none;
+                --iron-icon-width: 20px;
+                --iron-icon-height: 20px;
+                --paper-button: {
+                    color: var(--paper-blue-700);
+                    text-transform: none;
+                };
+            }
+        </style>
+        <iron-ajax auto url="[[metricUrl]]" handle-as="json"
+            on-response="_onResponse"></iron-ajax>
+        <article id="card">
+            <header>
+                <h1 id="header-text">[[heading]]</h1>
+                <paper-icon-button icon="refresh" title="Refresh Chart"
+                    alt="Refresh chart"></paper-button>
+            </header>
+            <section id="chart-container">
+                <canvas id="chart" height="400" width="400"></canvas></section>
+            <footer>
+                <paper-dropdown-menu-light id="interval" label="Interval">
+                    <paper-listbox slot="dropdown-content"
+                        attr-for-selected="value" selected="{{interval}}">
+                        <paper-item value="Last5m">5m</paper-item>
+                        <paper-item value="Last15m">15m</paper-item>
+                        <paper-item value="Last30m">30m</paper-item>
+                        <paper-item value="Last60m">1h</paper-item>
+                        <paper-item value="Last180m">3h</paper-item>
+                    </paper-listbox>
+                </paper-dropdown-menu-light>
+                <a id="external-link" href="[[externalLink]]".
+                    target="_blank" tabindex="-1">
+                    <paper-button>
+                        View more
+                        <iron-icon icon="launch"></iron-icon>
+                    </paper-button>
+                </a>
+            </footer>
+        </article>
+        `;
+    }
+
+    static get properties() {
+        return {
+            heading: String,
+            metric: String,
+            interval: String,
+            externalLink: String,
+            metricUrl: {
+                type: String,
+                computed: '_getUrl(metric, interval)',
+            },
+        };
+    }
+
+    constructor() {
+        super();
+        const tooltipFontColor = '#666'; // Matches default Chart.js color
+        this._chartOptions = {
+            type: 'line',
+            data: {
+                datasets: [],
+            },
+            options: {
+                maintainAspectRatio: false,
+                tooltips: {
+                    backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                    borderWidth: 1,
+                    borderColor: '#eeeeef',
+                    titleFontColor: tooltipFontColor,
+                    bodyFontColor: tooltipFontColor,
+                    footerFontColor: tooltipFontColor,
+                    mode: 'index',
+                    intersect: false,
+                    callbacks: {
+                        label: this._buildTooltipsLabel.bind(this),
+                    },
+                },
+                scales: {
+                    xAxes: [{
+                        type: 'time',
+                        gridLines: {
+                            display: false,
+                        },
+                        distribution: 'series',
+                        ticks: {
+                            source: 'auto',
+                        },
+                    }],
+                    yAxes: [{
+                        type: 'linear',
+                    }],
+                },
+                legend: {
+                    display: true,
+                    position: 'bottom',
+                    labels: {
+                        boxWidth: 6,
+                        usePointStyle: true,
+                    },
+                },
+                plugins: {
+                    crosshair: {
+                        line: {
+                            color: '#dadce0',
+                            width: 1,
+                        },
+                        zoom: {
+                            enabled: false,
+                        },
+                    },
+                },
+            },
+        };
+    }
+
+    /**
+     * Instantiates the Chart object using the canvas context.
+     */
+    ready() {
+        super.ready();
+        this._chart = new Chart(this.$.chart, this._chartOptions);
+    }
+
+    /**
+     * Handles the Metrics response to build datasets and create the Chart.
+     * @param {Event} responseEvent
+     */
+    _onResponse(responseEvent) {
+        let i = 0;
+        this._chartOptions.data.datasets = [];
+        for (const ds of this._buildDatasets(responseEvent.detail.response)) {
+            this._chartOptions.data.datasets.push({
+                type: 'line',
+                label: ds[0],
+                backgroundColor: LINE_COLORS[i % LINE_COLORS.length],
+                borderColor: LINE_COLORS[i % LINE_COLORS.length],
+                data: ds[1].data,
+                fill: false,
+                borderWidth: 2,
+                lineTension: 0,
+                pointRadius: 0,
+            });
+            i++;
+        }
+        // Adds % formatting for CPU utilization
+        if (this.metric !== 'podmem') {
+            this._chartOptions.options.scales.yAxes[0].ticks = {
+                stepSize: 0.2,
+                callback: (value) => `${(value * 100).toFixed(0)}%`,
+            };
+        }
+        this._chart.resize();
+        this._chart.update();
+    }
+
+    /**
+     * Builds a list of Chart.js compatible datasets from the timeSeriesPoints
+     * returned from the server.
+     * @param {Array} timeSeriesPoints
+     * @return {Array}
+     */
+    _buildDatasets(timeSeriesPoints) {
+        // Create a Map from timeseries label to objects with the following
+        // shape:
+        // {
+        //   mean: cumulative moving average
+        //   data: [{t: timestamp in s, y: value}]
+        // }
+        const dataPointsByLabel = new Map();
+        timeSeriesPoints.forEach((point) => {
+            if (!dataPointsByLabel.has(point.label)) {
+                dataPointsByLabel.set(point.label, {
+                    mean: 0,
+                    data: [],
+                });
+            }
+            const p = dataPointsByLabel.get(point.label);
+            p.data.push({
+                t: new Date(point.timestamp * 1000),
+                y: point.value,
+            });
+            p.mean = ((p.mean * (p.data.length - 1) + point.value) /
+                p.data.length);
+        });
+        let series = dataPointsByLabel.entries();
+        if (dataPointsByLabel.size > MAX_SERIES) {
+            series = Array.from(dataPointsByLabel.entries());
+            series.sort((a, b) => b[1].mean - a[1].mean);
+            series.splice(MAX_SERIES);
+            this._chartOptions.options.legend.display = false;
+        }
+        return series;
+    }
+
+    /**
+     * Computer property function to returns the URL to use for obtaining
+     * metrics.
+     * @param {string} metric
+     * @param {string} interval
+     * @return {string}
+     */
+    _getUrl(metric, interval) {
+        let _metric = 'node';
+        let _interval = 'Last15m';
+        if (METRICS.has(metric)) {
+            _metric = metric;
+        }
+        if (INTERVALS.has(interval)) {
+            _interval = interval;
+        }
+        return `/api/metrics/${_metric}?interval=${_interval}`;
+    }
+
+    /**
+     * Trims and formats the tooltip label values according to callback spec:
+     * https://www.chartjs.org/docs/latest/configuration/tooltip.html#label-callback
+     * @param {Object} item
+     * @param {Object} data
+     * @return {string}
+     */
+    _buildTooltipsLabel(item, data) {
+        let seriesLabel = data.datasets[item.datasetIndex].label;
+        if (seriesLabel.length > MAX_TOOLTIP_LENGTH) {
+            seriesLabel = seriesLabel.slice(0, MAX_TOOLTIP_LENGTH) + '...';
+        }
+        let value = item.value;
+        if (this.metric !== 'podmem') {
+            value = `${(Number(item.value) * 100).toFixed(2)}%`;
+        }
+        return `${seriesLabel} - ${value}`;
+    }
+}
+
+customElements.define('resource-chart', ResourceChart);

--- a/components/centraldashboard/public/components/resource-chart_test.js
+++ b/components/centraldashboard/public/components/resource-chart_test.js
@@ -1,0 +1,143 @@
+import '@polymer/test-fixture/test-fixture';
+import 'jasmine-ajax';
+import {flush} from '@polymer/polymer/lib/utils/flush.js';
+
+import './resource-chart';
+import {mockRequest} from '../ajax_test_helper';
+
+const FIXTURE_ID = 'resource-chart-fixture';
+const RESOURCE_CHART_SELECTOR_ID = 'test-resource-chart';
+const TEMPLATE = `
+<test-fixture id="${FIXTURE_ID}">
+  <template>
+    <resource-chart id="${RESOURCE_CHART_SELECTOR_ID}"></resource-chart>
+  </template>
+</test-fixture>
+`;
+
+describe('Resource Chart', () => {
+    let resourceChart;
+
+    beforeAll(() => {
+        jasmine.Ajax.install();
+        const div = document.createElement('div');
+        div.innerHTML = TEMPLATE;
+        document.body.appendChild(div);
+    });
+
+    beforeEach(() => {
+        document.getElementById(FIXTURE_ID).create();
+        resourceChart = document.getElementById(RESOURCE_CHART_SELECTOR_ID);
+        resourceChart.heading = 'Test Resource Chart';
+        resourceChart.externalLink = 'http://test.link';
+    });
+
+    afterEach(() => {
+        document.getElementById(FIXTURE_ID).restore();
+    });
+
+    afterAll(() => {
+        jasmine.Ajax.uninstall();
+    });
+
+    it('Draws chart from node time-series metrics', async () => {
+        resourceChart.metric = 'node';
+        resourceChart.interval = 'Last60m';
+        const metrics = [
+            {timestamp: 1558621807, label: 'node-1', value: 0.5},
+            {timestamp: 1558621807, label: 'node-2', value: 0.4},
+            {timestamp: 1558621867, label: 'node-1', value: 0.5},
+            {timestamp: 1558621867, label: 'node-2', value: 0.4},
+            {timestamp: 1558621927, label: 'node-1', value: 0.5},
+            {timestamp: 1558621927, label: 'node-2', value: 0.4},
+            {timestamp: 1558621987, label: 'node-1', value: 0.5},
+            {timestamp: 1558621987, label: 'node-2', value: 0.4},
+            {timestamp: 1558622047, label: 'node-1', value: 0.5},
+            {timestamp: 1558622047, label: 'node-2', value: 0.4},
+        ];
+        const responsePromise = mockRequest(resourceChart, {
+            status: 200,
+            responseText: JSON.stringify(metrics),
+        }, false, '/api/metrics/node?interval=Last60m');
+        await responsePromise;
+        flush();
+
+        expect(resourceChart.shadowRoot.getElementById('interval')
+            .selectedItem.innerText).toBe('1h');
+        // Validate chart properties and callback behavior directly
+        expect(resourceChart._chart.data.datasets.length).toBe(2);
+        expect(resourceChart._chart.options.legend.display).toBe(true);
+        expect(resourceChart._chart.options.scales.yAxes[0].ticks
+            .stepSize).toBe(0.2);
+        expect(resourceChart._chart.options.scales.yAxes[0].ticks
+            .callback(0.5)).toBe('50%');
+
+        const [ds1, ds2] = resourceChart._chart.data.datasets;
+        expect(ds1.label).toBe('node-1');
+        expect(ds1.backgroundColor).toBe('#1e88e5');
+        expect(ds1.borderColor).toBe('#1e88e5');
+        expect(ds2.label).toBe('node-2');
+        expect(ds2.backgroundColor).toBe('#00acc1');
+        expect(ds2.borderColor).toBe('#00acc1');
+    });
+
+    it('Shows top 5 time-series', async () => {
+        resourceChart.metric = 'podcpu';
+        resourceChart.interval = 'Last30m';
+        const metrics = [
+            {timestamp: 1558621807, label: 'node-1', value: 0.5},
+            {timestamp: 1558621807, label: 'node-2', value: 0.4},
+            {timestamp: 1558621867, label: 'node-1', value: 0.5},
+            {timestamp: 1558621867, label: 'node-2', value: 0.4},
+            {timestamp: 1558621927, label: 'node-1', value: 0.5},
+            {timestamp: 1558621927, label: 'node-2', value: 0.4},
+            {timestamp: 1558621987, label: 'node-1', value: 0.5},
+            {timestamp: 1558621987, label: 'node-2', value: 0.4},
+            {timestamp: 1558622047, label: 'node-1', value: 0.5},
+            {timestamp: 1558622047, label: 'node-2', value: 0.4},
+        ];
+        const responsePromise = mockRequest(resourceChart, {
+            status: 200,
+            responseText: JSON.stringify(metrics),
+        }, false, '/api/metrics/podcpu?interval=Last30m');
+        await responsePromise;
+        flush();
+
+        expect(resourceChart.shadowRoot.getElementById('interval')
+            .selectedItem.innerText).toBe('30m');
+        // Validate chart properties directly
+        expect(resourceChart._chart.data.datasets.length).toBe(2);
+        expect(resourceChart._chart.options.scales.yAxes[0].ticks
+            .stepSize).toBe(0.2);
+
+        // Validate callbacks behavior
+        expect(resourceChart._chart.options.scales.yAxes[0].ticks
+            .callback(0.5)).toBe('50%');
+
+        const [ds1, ds2] = resourceChart._chart.data.datasets;
+        expect(ds1.label).toBe('node-1');
+        expect(ds1.backgroundColor).toBe('#1e88e5');
+        expect(ds1.borderColor).toBe('#1e88e5');
+        expect(ds2.label).toBe('node-2');
+        expect(ds2.backgroundColor).toBe('#00acc1');
+        expect(ds2.borderColor).toBe('#00acc1');
+    });
+
+    it('Formats tooltip labels based on metric type and label length', () => {
+        const item = {datasetIndex: 0, value: 0.45755};
+        const data = {datasets: [{label: 'short'}]};
+        resourceChart.metric = 'podcpu';
+        expect(resourceChart._buildTooltipsLabel(item, data))
+            .toBe('short - 45.76%');
+
+        data.datasets[0].label = 'truncatedlabel';
+        expect(resourceChart._buildTooltipsLabel(item, data))
+            .toBe('truncatedl... - 45.76%');
+
+
+        item.value = 600;
+        resourceChart.metric = 'podmem';
+        expect(resourceChart._buildTooltipsLabel(item, data))
+            .toBe('truncatedl... - 600');
+    });
+});

--- a/components/centraldashboard/public/components/resource-chart_test.js
+++ b/components/centraldashboard/public/components/resource-chart_test.js
@@ -28,8 +28,9 @@ describe('Resource Chart', () => {
     beforeEach(() => {
         document.getElementById(FIXTURE_ID).create();
         resourceChart = document.getElementById(RESOURCE_CHART_SELECTOR_ID);
-        resourceChart.heading = 'Test Resource Chart';
+        resourceChart.headerText = 'Test Resource Chart';
         resourceChart.externalLink = 'http://test.link';
+        resourceChart.externalLinkText = 'View in External Metrics Site';
     });
 
     afterEach(() => {
@@ -76,51 +77,122 @@ describe('Resource Chart', () => {
         expect(ds1.label).toBe('node-1');
         expect(ds1.backgroundColor).toBe('#1e88e5');
         expect(ds1.borderColor).toBe('#1e88e5');
+        expect(ds1.data).toEqual([
+            {t: new Date('2019-05-23T14:30:07.000Z'), y: 0.5},
+            {t: new Date('2019-05-23T14:31:07.000Z'), y: 0.5},
+            {t: new Date('2019-05-23T14:32:07.000Z'), y: 0.5},
+            {t: new Date('2019-05-23T14:33:07.000Z'), y: 0.5},
+            {t: new Date('2019-05-23T14:34:07.000Z'), y: 0.5},
+        ]);
+        expect(ds2.data).toEqual([
+            {t: new Date('2019-05-23T14:30:07.000Z'), y: 0.4},
+            {t: new Date('2019-05-23T14:31:07.000Z'), y: 0.4},
+            {t: new Date('2019-05-23T14:32:07.000Z'), y: 0.4},
+            {t: new Date('2019-05-23T14:33:07.000Z'), y: 0.4},
+            {t: new Date('2019-05-23T14:34:07.000Z'), y: 0.4},
+        ]);
         expect(ds2.label).toBe('node-2');
         expect(ds2.backgroundColor).toBe('#00acc1');
         expect(ds2.borderColor).toBe('#00acc1');
+        expect(resourceChart.shadowRoot.getElementById('header-text').innerText)
+            .toBe('Test Resource Chart');
     });
 
-    it('Shows top 5 time-series', async () => {
-        resourceChart.metric = 'podcpu';
+    it('Draws chart with top 5 time-series for podmem', async () => {
+        resourceChart.metric = 'podmem';
         resourceChart.interval = 'Last30m';
         const metrics = [
-            {timestamp: 1558621807, label: 'node-1', value: 0.5},
-            {timestamp: 1558621807, label: 'node-2', value: 0.4},
-            {timestamp: 1558621867, label: 'node-1', value: 0.5},
-            {timestamp: 1558621867, label: 'node-2', value: 0.4},
-            {timestamp: 1558621927, label: 'node-1', value: 0.5},
-            {timestamp: 1558621927, label: 'node-2', value: 0.4},
-            {timestamp: 1558621987, label: 'node-1', value: 0.5},
-            {timestamp: 1558621987, label: 'node-2', value: 0.4},
-            {timestamp: 1558622047, label: 'node-1', value: 0.5},
-            {timestamp: 1558622047, label: 'node-2', value: 0.4},
+            {timestamp: 1558621807, label: 'node-1', value: 1},
+            {timestamp: 1558621867, label: 'node-1', value: 1},
+            {timestamp: 1558621927, label: 'node-1', value: 1},
+            {timestamp: 1558621807, label: 'node-2', value: 2},
+            {timestamp: 1558621867, label: 'node-2', value: 2},
+            {timestamp: 1558621927, label: 'node-2', value: 2},
+            {timestamp: 1558621807, label: 'node-3', value: 3},
+            {timestamp: 1558621867, label: 'node-3', value: 3},
+            {timestamp: 1558621927, label: 'node-3', value: 3},
+            {timestamp: 1558621807, label: 'node-4', value: 4},
+            {timestamp: 1558621867, label: 'node-4', value: 4},
+            {timestamp: 1558621927, label: 'node-4', value: 4},
+            {timestamp: 1558621807, label: 'node-5', value: 5},
+            {timestamp: 1558621867, label: 'node-5', value: 5},
+            {timestamp: 1558621927, label: 'node-5', value: 5},
+            {timestamp: 1558621807, label: 'node-6', value: 6},
+            {timestamp: 1558621867, label: 'node-6', value: 6},
+            {timestamp: 1558621927, label: 'node-6', value: 6},
+            {timestamp: 1558621807, label: 'node-7', value: 7},
+            {timestamp: 1558621867, label: 'node-7', value: 7},
+            {timestamp: 1558621927, label: 'node-7', value: 7},
+            {timestamp: 1558621807, label: 'node-8', value: 8},
+            {timestamp: 1558621867, label: 'node-8', value: 8},
+            {timestamp: 1558621927, label: 'node-8', value: 8},
+            {timestamp: 1558621807, label: 'node-9', value: 9},
+            {timestamp: 1558621867, label: 'node-9', value: 9},
+            {timestamp: 1558621927, label: 'node-9', value: 9},
+            {timestamp: 1558621807, label: 'node-10', value: 10},
+            {timestamp: 1558621867, label: 'node-10', value: 10},
+            {timestamp: 1558621927, label: 'node-10', value: 10},
         ];
         const responsePromise = mockRequest(resourceChart, {
             status: 200,
             responseText: JSON.stringify(metrics),
-        }, false, '/api/metrics/podcpu?interval=Last30m');
+        }, false, '/api/metrics/podmem?interval=Last30m');
         await responsePromise;
         flush();
 
         expect(resourceChart.shadowRoot.getElementById('interval')
             .selectedItem.innerText).toBe('30m');
         // Validate chart properties directly
-        expect(resourceChart._chart.data.datasets.length).toBe(2);
+        expect(resourceChart._chart.data.datasets.length).toBe(5);
         expect(resourceChart._chart.options.scales.yAxes[0].ticks
-            .stepSize).toBe(0.2);
+            .stepSize).toBeUndefined();
+        expect(resourceChart._chart.options.legend.display).toBe(false);
 
-        // Validate callbacks behavior
-        expect(resourceChart._chart.options.scales.yAxes[0].ticks
-            .callback(0.5)).toBe('50%');
-
-        const [ds1, ds2] = resourceChart._chart.data.datasets;
-        expect(ds1.label).toBe('node-1');
+        const [ds1, ds2, ds3, ds4, ds5] = resourceChart._chart.data.datasets;
+        expect(ds1.label).toBe('node-10');
         expect(ds1.backgroundColor).toBe('#1e88e5');
         expect(ds1.borderColor).toBe('#1e88e5');
-        expect(ds2.label).toBe('node-2');
+        expect(ds2.label).toBe('node-9');
         expect(ds2.backgroundColor).toBe('#00acc1');
         expect(ds2.borderColor).toBe('#00acc1');
+        expect(ds3.label).toBe('node-8');
+        expect(ds3.backgroundColor).toBe('#e91e63');
+        expect(ds3.borderColor).toBe('#e91e63');
+        expect(ds4.label).toBe('node-7');
+        expect(ds4.backgroundColor).toBe('#ff9800');
+        expect(ds4.borderColor).toBe('#ff9800');
+        expect(ds5.label).toBe('node-6');
+        expect(ds5.backgroundColor).toBe('#9ccc65');
+        expect(ds5.borderColor).toBe('#9ccc65');
+        expect(resourceChart.shadowRoot.getElementById('header-text').innerText)
+            .toBe('Test Resource Chart (Top 5)');
+    });
+
+    it('Refreshes when interval is changed', (done) => {
+        resourceChart.metric = 'podcpu';
+        resourceChart.interval = 'Last180m';
+        resourceChart.addEventListener('iron-ajax-request', (event) => {
+            expect(event.detail.options.url).toBe(
+                '/api/metrics/podcpu?interval=Last60m');
+            done();
+        });
+        resourceChart.shadowRoot.getElementById('interval')
+            .selected = 'Last60m';
+        flush();
+    });
+
+    it('Refreshes when clicked is changed', (done) => {
+        let requests = 0;
+        resourceChart.addEventListener('iron-ajax-request', (event) => {
+            expect(event.detail.options.url).toBe(
+                '/api/metrics/node?interval=Last30m');
+            if (++requests === 2) done();
+        });
+        resourceChart.metric = 'node';
+        resourceChart.interval = 'Last30m';
+
+        resourceChart.shadowRoot.getElementById('refresh').click();
+        flush();
     });
 
     it('Formats tooltip labels based on metric type and label length', () => {

--- a/components/centraldashboard/public/components/resources/cloud-platform-data.js
+++ b/components/centraldashboard/public/components/resources/cloud-platform-data.js
@@ -39,4 +39,5 @@ export const getGCPData = (project) => ({
     logo: '/assets/gcp-logo.png',
     name: 'GCP',
     resourceChartsLink: `https://app.google.stackdriver.com/gke?project=${project}`,
+    resourceChartsLinkText: 'View in Stackdriver',
 });

--- a/components/centraldashboard/public/components/resources/cloud-platform-data.js
+++ b/components/centraldashboard/public/components/resources/cloud-platform-data.js
@@ -38,4 +38,5 @@ export const getGCPData = (project) => ({
     title: 'Google Cloud Platform',
     logo: '/assets/gcp-logo.png',
     name: 'GCP',
+    resourceChartsLink: `https://app.google.stackdriver.com/gke?project=${project}`,
 });


### PR DESCRIPTION
Adds charts to display the past hour of CPU resource utilization at the Node level and the top 5 Pods.

Backend implementation is in #3251 
Closes #3225

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3326)
<!-- Reviewable:end -->
