### PR TITLE
Collapse sidebar threshold updated from 900px to 1270px

### DIFF
--- a/components/centraldashboard/public/components/main-page.css
+++ b/components/centraldashboard/public/components/main-page.css
@@ -41,7 +41,7 @@ app-drawer-layout[narrow] #MainDrawer {
     }
 }
 
-app-drawer-layout[thin] #MainDrawer {
+app-drawer-layout[bleed] #MainDrawer {
     background: var(--primary-background-color);
     --app-drawer-content-container: {
         background: transparent !important;

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -2,7 +2,7 @@ iron-ajax(auto, url='/api/env-info', handle-as='json',
     on-response='_onEnvInfoResponse')
 app-drawer-layout.flex(narrow='{{narrowMode}}',
         force-narrow='[[or(inIframe, thinView, notFoundInIframe)]]',
-        thin$='[[thinView]]')
+        bleed$='[[sidebarBleed]]')
     app-location(route='{{route}}', query-params='{{queryParams}}')
     app-route(route='{{route}}', pattern='/:page', data='{{routeData}}',
         tail='{{subRouteData}}')
@@ -61,4 +61,5 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     iframe#PageFrame.flex(src='[[iframeUrl]]')
                 neon-animatable(page='not_found')
                     not-found-view(path="[[route.path]]")
+    iron-media-query(query='(max-width: 900px)', query-matches='{{sidebarBleed}}')
     iron-media-query(query='(max-width: 1270px)', query-matches='{{thinView}}')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -61,4 +61,4 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     iframe#PageFrame.flex(src='[[iframeUrl]]')
                 neon-animatable(page='not_found')
                     not-found-view(path="[[route.path]]")
-    iron-media-query(query='(max-width: 900px)', query-matches='{{thinView}}')
+    iron-media-query(query='(max-width: 1270px)', query-matches='{{thinView}}')


### PR DESCRIPTION
#### Fixes #3370

## About:
The old responsive threshold for collapsing sidebar was 900px (when dashboard was 2 columnar) now it's 1270px

---
/area front-end
/area centraldashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3372)
<!-- Reviewable:end -->