### PR TITLE
on-prem: verify gateway/virtualservices for various 

### DIFF
--- a/bootstrap/Makefile
+++ b/bootstrap/Makefile
@@ -122,6 +122,7 @@ build-kfctl-container:
 	docker create \
 		--name=temp_kfctl_container \
 		$(KFCTL_IMG)/builder:$(TAG)
+	mkdir -p bin
 	docker cp temp_kfctl_container:/usr/local/bin/kfctl ./bin/kfctl
 	docker rm temp_kfctl_container
 	@echo Exported kfctl binary to bin/kfctl

--- a/bootstrap/config/overlays/ksonnet/kfctl_default.yaml
+++ b/bootstrap/config/overlays/ksonnet/kfctl_default.yaml
@@ -4,10 +4,37 @@ metadata:
   name: config
 spec:
   componentParams:
+    argo:
+    - initRequired: true
+      name: injectIstio
+      value: "false"
+    centraldashboard:
+    - initRequired: true
+      name: injectIstio
+      value: "false"
+    jupyter-web-app:
+    - initRequired: true
+      name: injectIstio
+      value: "false"
+    katib:
+    - initRequired: true
+      name: injectIstio
+      value: "false"
     pipeline:
-    - name: mysqlPd
-      value: <deployName>-storage-metadata-store
-    - name: minioPd
-      value: <deployName>-storage-artifact-store
     - name: injectIstio
+      value: "false"
+    spartakus:
+    - initRequired: true
+      name: usageId
+      value: myrandomstring
+    - initRequired: true
+      name: reportUsage
+      value: "false"
+    tensorboard:
+    - initRequired: true
+      name: injectIstio
+      value: "false"
+    tf-job-operator:
+    - initRequired: true
+      name: injectIstio
       value: "false"

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -19,7 +19,9 @@ package coordinator
 import (
 	"fmt"
 	"github.com/ghodss/yaml"
+	bootstrap "github.com/kubeflow/kubeflow/bootstrap/cmd/bootstrap/app"
 	"github.com/kubeflow/kubeflow/bootstrap/config"
+	configtypes "github.com/kubeflow/kubeflow/bootstrap/config"
 	kfapis "github.com/kubeflow/kubeflow/bootstrap/pkg/apis"
 	kftypes "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps"
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps/kfdef/v1alpha1"
@@ -30,6 +32,8 @@ import (
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	valid "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"os"
@@ -97,7 +101,7 @@ func getConfigFromCache(pathDir string, kfDef *kfdefs.KfDef) ([]byte, error) {
 	if dataErr != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("can not encode as yaml Error %v", configPath, resMapErr),
+			Message: fmt.Sprintf("can not encode as yaml Error %v", dataErr),
 		}
 	}
 	return data, nil
@@ -258,17 +262,17 @@ func NewKfApp(options map[string]interface{}) (kftypes.KfApp, error) {
 			APIVersion: "kfdef.apps.kubeflow.org/v1alpha1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name: appName,
+			Name:      appName,
 			Namespace: namespace,
 		},
 		Spec: kfdefs.KfDefSpec{
 			ComponentConfig: config.ComponentConfig{
-				Platform:platform,
+				Platform: platform,
 			},
-			Project: project,
+			Project:        project,
 			PackageManager: packageManager,
-			UseBasicAuth: useBasicAuth,
-			UseIstio: useIstio,
+			UseBasicAuth:   useBasicAuth,
+			UseIstio:       useIstio,
 		},
 	}
 	configFileBuffer, configFileErr := getConfigFromCache(cacheDir, kfDef)
@@ -405,6 +409,7 @@ type coordinator struct {
 }
 
 func (kfapp *coordinator) Apply(resources kftypes.ResourceEnum) error {
+
 	platform := func() error {
 		if kfapp.KfDef.Spec.Platform != "" {
 			platform := kfapp.Platforms[kfapp.KfDef.Spec.Platform]
@@ -429,6 +434,15 @@ func (kfapp *coordinator) Apply(resources kftypes.ResourceEnum) error {
 	}
 
 	k8s := func() error {
+
+		// Apply common functionality first
+		if err := kfapp.applyCommon(); err != nil {
+			return &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: fmt.Sprintf("failed to apply common resources: %v", err),
+			}
+		}
+
 		kfapp.PackageManagers = *getPackageManagers(kfapp.KfDef)
 		for packageManagerName, packageManager := range kfapp.PackageManagers {
 			packageManagerErr := packageManager.Apply(kftypes.K8S)
@@ -454,6 +468,65 @@ func (kfapp *coordinator) Apply(resources kftypes.ResourceEnum) error {
 	case kftypes.K8S:
 		return k8s()
 	}
+	return nil
+}
+
+func (kfapp *coordinator) applyCommon() error {
+
+	// Get a K8s client
+	config := kftypes.GetConfig()
+	kubeclient := kftypes.GetClientset(config)
+
+	// Create KFApp's namespace
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kfapp.KfDef.Namespace,
+		},
+	}
+	log.Infof("Creating namespace: %v", ns.Name)
+
+	_, err := kubeclient.CoreV1().Namespaces().Create(ns)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		log.Errorf("Error creating namespace %v", ns.Name)
+		return &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: err.Error(),
+		}
+	}
+
+	// Apply Istio if use_istio option is set
+	if kfapp.KfDef.Spec.UseIstio {
+		log.Infof("Installing istio...")
+		nv := configtypes.NameValue{Name: "namespace", Value: kfapp.KfDef.Namespace}
+		parentDir := path.Dir(kfapp.KfDef.Spec.Repo)
+		err := bootstrap.CreateResourceFromFile(kftypes.GetConfig(), path.Join(parentDir, "dependencies/istio/install/crds.yaml"))
+
+		if err != nil {
+			log.Errorf("Failed to create istio CRD: %v", err)
+			return &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: err.Error(),
+			}
+		}
+		err = bootstrap.CreateResourceFromFile(config, path.Join(parentDir, "dependencies/istio/install/istio-noauth.yaml"))
+		if err != nil {
+			log.Errorf("Failed to create istio manifest: %v", err)
+			return &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: err.Error(),
+			}
+		}
+		err = bootstrap.CreateResourceFromFile(config, path.Join(parentDir, "dependencies/istio/kf-istio-resources.yaml"), nv)
+		if err != nil {
+			log.Errorf("Failed to create kubeflow istio resource: %v", err)
+			return &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: err.Error(),
+			}
+		}
+		log.Infof("Done installing istio.")
+	}
+
 	return nil
 }
 

--- a/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
+++ b/bootstrap/pkg/kfapp/ksonnet/ksonnet.go
@@ -37,7 +37,6 @@ import (
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps/kfdef/v1alpha1"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/afero"
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -96,7 +95,6 @@ func (ksApp *ksApp) Apply(resources kftypes.ResourceEnum) error {
 			Message: "Error: nil restConfig or apiConfig, exit",
 		}
 	}
-	clientset := kftypes.GetClientset(ksApp.restConfig)
 	// TODO(gabrielwen): Make env name an option.
 	envSetErr := ksApp.envSet(KsEnvName, ksApp.restConfig.Host)
 	if envSetErr != nil {
@@ -106,21 +104,7 @@ func (ksApp *ksApp) Apply(resources kftypes.ResourceEnum) error {
 				KsEnvName, envSetErr.(*kfapis.KfError).Message),
 		}
 	}
-	namespace := ksApp.ObjectMeta.Namespace
-	log.Infof(string(kftypes.NAMESPACE)+": %v", namespace)
-	_, nsMissingErr := clientset.CoreV1().Namespaces().Get(namespace, metav1.GetOptions{})
-	if nsMissingErr != nil {
-		log.Infof("Creating namespace: %v", namespace)
-		nsSpec := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-		_, nsErr := clientset.CoreV1().Namespaces().Create(nsSpec)
-		if nsErr != nil {
-			return &kfapis.KfError{
-				Code: int(kfapis.INVALID_ARGUMENT),
-				Message: fmt.Sprintf("couldn't create %v %v Error: %v",
-					string(kftypes.NAMESPACE), namespace, nsErr),
-			}
-		}
-	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return &kfapis.KfError{

--- a/dependencies/istio/install/istio-noauth.yaml
+++ b/dependencies/istio/install/istio-noauth.yaml
@@ -16366,6 +16366,8 @@ spec:
               path: /login
               port: 3000
           env:
+          - name: GF_SERVER_ROOT_URL
+            value: '%(protocol)s://%(domain)s:/istio/grafana/'
           - name: GRAFANA_PORT
             value: "3000"
           - name: GF_AUTH_BASIC_ENABLED


### PR DESCRIPTION
**Fixes:**
#3182

**Description:**
This PR makes changes to ensure that Istio VirtualServices are created for the various 
Kubeflow components.
In other words, verify that all components work with Istio enabled, for an on-prem scenario.

In order to test the routes, we port-forward the Istio gateway ingress service to localhost.
```bash
kubectl port-forward service/istio-ingressgateway -n istio-system 8080:80
```
I also tested with going directly to NodePort and it seems to work normally.

First, we edit kfctl to ensure that Istio is installed in case --use_istio is set.
This is a common behaviour, so it is done in the Apply function of the coordinator,
along with creating the namespace.

In short, this PR pulls common code out of the GCP platform and into every run
of kfctl apply.
After this PR, we should clean up platform GCP so it doesn't take unnecessary actions.
/cc @kkasravi 

Then, we notice that the default installation uses the ksonnet overlay in 
`config/overlays/ksonnet/kfctl_default.yaml`, which doesn't include all the necessary
componentParams for using Istio.
We add the necessary componentParams and also fix the invalid names for the minio and mysql PVs.

**Steps to test:**
1. [Checkout PR](https://help.github.com/en/articles/checking-out-pull-requests-locally)
2. Build the kfctl binary
```bash
KF_REPO=$(pwd)/kubeflow
cd $KF_REPO/bootstrap
make build-kfctl-container
```
3. Deploy according to the default guide:
```bash
cd $KF_REPO/bootstrap/bin
KFAPP=myapp
mkdir $KFAPP
export PATH=$(pwd):$PATH

kfctl init $KFAPP --verbose --repo $KF_REPO  
cd $KFAPP
kfctl generate all --verbose
kfctl apply all --verbose
```
4. Port forward the gateway ingress service:
```bash
kubectl port-forward service/istio-ingressgateway -n istio-system 8080:80
```
5. Open `http://localhost:8080/` in browser and check components.


**Components tested:**

* Notebooks
    - [x] Create a new notebook server
    - [x] Connect to notebook server
    - [x] Create a new notebook
    - [x] Run [an example](https://www.kubeflow.org/docs/notebooks/setup/) in python
* Pipelines
    - [x] Access pipelines UI
    - [x] Submit and run an example pipeline (parallel execution)
    - [x] Access Tensorboard
* TFJob
    - [x] Access dashboard
    - [x] Run a TFJob
* Katib
    - [x] Access dashboard
    - [x] Run a StudyJob
* Argo
    - [x] Access dashboard
* Grafana with Istio Dashboards
    - [x] Access grafana
* Tensorboard
    - [x] Access Tensorboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3376)
<!-- Reviewable:end -->
