### PR TITLE
Fix make failing to 'build' in bootstrap/

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -97,7 +97,7 @@ func getConfigFromCache(pathDir string, kfDef *kfdefs.KfDef) ([]byte, error) {
 	if dataErr != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("can not encode as yaml Error %v", configPath, resMapErr),
+			Message: fmt.Sprintf("can not encode %v as yaml Error %v", configPath, resMapErr),
 		}
 	}
 	return data, nil


### PR DESCRIPTION
```
# github.com/kubeflow/kubeflow/bootstrap/pkg/kfapp/coordinator
pkg/kfapp/coordinator/coordinator.go:100:13: Sprintf call needs 1 arg but has 2 args
...
Makefile:141: recipe for target 'build' failed
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3395)
<!-- Reviewable:end -->
