### PR TITLE
Fix multiple iframe-link behaviors.

### DIFF
--- a/components/centraldashboard/.eslintrc.json
+++ b/components/centraldashboard/.eslintrc.json
@@ -14,6 +14,7 @@
         "SharedArrayBuffer": "readonly"
     },
     "parserOptions": {
+        "ecmaVersion": 2017,
         "sourceType": "module",
         "ecmaFeatures": {
             "impliedStrict": true

--- a/components/centraldashboard/public/components/iframe-link.js
+++ b/components/centraldashboard/public/components/iframe-link.js
@@ -19,6 +19,7 @@ export class IframeLink extends PolymerElement {
                     @apply --iframe-link;
                 }
                 a {
+                    display: inline-block;
                     width: 100%
                 }
                 a, a:hover, a:active {
@@ -27,7 +28,7 @@ export class IframeLink extends PolymerElement {
                 }
             </style>
             <a id="link" href$="/[[prefix]][[href]]" tabindex="-1"
-                on-click="onClick"><slot></slot></a>`;
+                on-click="_onClick"><slot></slot></a>`;
     }
 
     static get properties() {
@@ -48,16 +49,11 @@ export class IframeLink extends PolymerElement {
         };
     }
 
-    ready() {
-        super.ready();
-        this.addEventListener('click', () => this.$.link.click());
-    }
-
     /**
      * Handles the anchor click event.
      * @param {MouseEvent} e
      */
-    onClick(e) {
+    _onClick(e) {
         // e.currentTarget is an HTMLAnchorElement
         const url = e.currentTarget.href.slice(e.currentTarget.origin.length);
         window.history.pushState({}, null, url);

--- a/components/centraldashboard/public/components/iframe-link.js
+++ b/components/centraldashboard/public/components/iframe-link.js
@@ -27,8 +27,9 @@ export class IframeLink extends PolymerElement {
                     color: inherit
                 }
             </style>
-            <a id="link" href$="/[[prefix]][[href]]" tabindex="-1"
-                on-click="_onClick"><slot></slot></a>`;
+            <a id="link" href$="/[[prefix]][[href]]" tabindex="-1">
+                <slot></slot>
+            </a>`;
     }
 
     static get properties() {
@@ -47,18 +48,6 @@ export class IframeLink extends PolymerElement {
                 reflectToAttribute: true,
             },
         };
-    }
-
-    /**
-     * Handles the anchor click event.
-     * @param {MouseEvent} e
-     */
-    _onClick(e) {
-        // e.currentTarget is an HTMLAnchorElement
-        const url = e.currentTarget.href.slice(e.currentTarget.origin.length);
-        window.history.pushState({}, null, url);
-        window.dispatchEvent(new CustomEvent('location-changed'));
-        e.preventDefault();
     }
 }
 

--- a/components/centraldashboard/public/components/iframe-link_test.js
+++ b/components/centraldashboard/public/components/iframe-link_test.js
@@ -41,21 +41,8 @@ describe('Iframe Link', () => {
             .toBe('/_/test-page');
     });
 
-    it('Forwards click event to the anchor element', (done) => {
-        iframeLink.href = '/test-page';
-        flush();
-        spyOn(iframeLink.shadowRoot.getElementById('link'), 'click');
 
-        iframeLink.addEventListener('click', () => {
-            expect(iframeLink.shadowRoot.getElementById('link').click)
-                .toHaveBeenCalled();
-            done();
-        });
-        iframeLink.click();
-    });
-
-
-    it('Pushes history when clicked clicked', async () => {
+    it('Pushes history when link is clicked', async () => {
         iframeLink.href = '/test-page';
         spyOn(window.history, 'pushState');
         const locationChanged = new Promise((resolve) => {
@@ -64,7 +51,7 @@ describe('Iframe Link', () => {
             });
         });
         flush();
-        iframeLink.click();
+        iframeLink.shadowRoot.getElementById('link').click();
         await locationChanged;
 
         expect(window.history.pushState)

--- a/components/centraldashboard/public/components/iframe-link_test.js
+++ b/components/centraldashboard/public/components/iframe-link_test.js
@@ -40,21 +40,4 @@ describe('Iframe Link', () => {
         expect(iframeLink.shadowRoot.getElementById('link').pathname)
             .toBe('/_/test-page');
     });
-
-
-    it('Pushes history when link is clicked', async () => {
-        iframeLink.href = '/test-page';
-        spyOn(window.history, 'pushState');
-        const locationChanged = new Promise((resolve) => {
-            window.addEventListener('location-changed', () => {
-                resolve();
-            });
-        });
-        flush();
-        iframeLink.shadowRoot.getElementById('link').click();
-        await locationChanged;
-
-        expect(window.history.pushState)
-            .toHaveBeenCalledWith({}, null, '/_/test-page');
-    });
 });

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -82,9 +82,11 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
                     },
                 ],
             },
-            sidebarItemIndex: {type: Number, value: 0,
-                observer: '_revertSidebarIndexIfExternal'},
-            iframeUrl: {type: String, value: ''},
+            sidebarItemIndex: {
+                type: Number,
+                value: 0,
+                observer: '_revertSidebarIndexIfExternal',
+            },
             buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
             platformInfo: Object,
@@ -136,7 +138,6 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         let notFoundInIframe = false;
         let hideTabs = true;
         let hideNamespaces = false;
-        let iframeUrl;
 
         switch (newPage) {
         case 'activity':
@@ -146,13 +147,10 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             break;
         case IFRAME_LINK_PREFIX:
             this.page = 'iframe';
-            iframeUrl = new URL(this.subRouteData.path, window.location.origin);
-            iframeUrl.hash = window.location.hash;
-            iframeUrl.search = window.location.search;
-            this.iframeUrl = iframeUrl.toString();
             isIframe = true;
             hideNamespaces = this.subRouteData.path.startsWith('/pipeline');
             this._setActiveMenuLink(this.subRouteData.path);
+            this._setIframeLocation();
             break;
         case '':
             this.sidebarItemIndex = 0;
@@ -213,6 +211,23 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this.sidebarItemIndex = menuLinkIndex + 1;
         } else {
             this.sidebarItemIndex = -1;
+        }
+    }
+
+    /**
+     * Sets the location of the emebedded iframe based on the current route.
+     * This method avoids including the ns query parameter to the iframe,
+     * and only replaces the location when it has changed.
+     */
+    _setIframeLocation() {
+        const iframeUrl = new URL(this.subRouteData.path,
+            window.location.origin);
+        const iframeLocation = this.$.PageFrame.contentWindow.location;
+        iframeUrl.hash = window.location.hash;
+        iframeUrl.search = window.location.search;
+        iframeUrl.searchParams.delete('ns');
+        if (iframeUrl.toString() !== iframeLocation.toString()) {
+            iframeLocation.replace(iframeUrl.toString());
         }
     }
 

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -61,8 +61,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         platform-info='[[platformInfo]]')
                 neon-animatable(page='activity')
                     activity-view(namespace='[[queryParams.ns]]')
-                neon-animatable#iframe-page(page='iframe')
-                    iframe#PageFrame.flex(src='[[iframeUrl]]')
+                neon-animatable(page='iframe')
+                    iframe#PageFrame.flex
                 neon-animatable(page='not_found')
                     not-found-view(path="[[route.path]]")
     iron-media-query(query='(max-width: 900px)', query-matches='{{sidebarBleed}}')

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -34,7 +34,7 @@ describe('Main Page', () => {
     });
 
     afterEach(() => {
-        mainPage.set('queryParams', null);
+        mainPage.set('queryParams.ns', null);
         document.getElementById(FIXTURE_ID).restore();
     });
 
@@ -96,16 +96,27 @@ describe('Main Page', () => {
     it('Sets view state when iframe page is active', () => {
         spyOn(mainPage.$.MainDrawer, 'close');
 
+        const locationSpy = jasmine.createSpyObj('spyLocation', ['replace']);
+        spyOnProperty(mainPage.$.PageFrame, 'contentWindow')
+            .and.returnValue({location: locationSpy});
+
+        mainPage.set('queryParams.ns', 'test');
         mainPage.subRouteData.path = '/jupyter/';
         mainPage._routePageChanged('_');
         flush();
 
+        expect(window.location.search).toContain('ns=test');
         expect(mainPage.page).toBe('iframe');
         expect(mainPage.sidebarItemIndex).toBe(2);
         expect(mainPage.inIframe).toBe(true);
         expect(mainPage.shadowRoot.getElementById('ViewTabs')
             .hasAttribute('hidden')).toBe(true);
         expect(mainPage.$.MainDrawer.close).toHaveBeenCalled();
+
+        const expected = new RegExp(`^${window.location.origin}/jupyter/`);
+        const calledWith = locationSpy.replace.calls.argsFor(0);
+        expect(calledWith).toMatch(expected);
+        expect(calledWith).not.toContain('ns=test');
     });
 
     it('Sets view state when an invalid page is specified from an iframe',


### PR DESCRIPTION
- Removes redundant forwarder for iframe-links. This was resulting in pushing
  the same state to history twice, which would require the user to issue two
  back button clicks in their browser if they wished to return to the previous URL.
- In addition, we now set the iframe's location programmatically rather than by
  changing the src attribute, which could also result in history states being
  pushed inadvertantly.
- We also avoid passing the ns query parameter down to avoid unncessary reloads
  of iframed-content in favor of using our message passing library.

/area centraldashboard
/area front-end
/cc @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3402)
<!-- Reviewable:end -->
