### PR TITLE
Adds new service config for tf-operator

### DIFF
--- a/kubeflow/tf-training/prototypes/tf-job-operator.jsonnet
+++ b/kubeflow/tf-training/prototypes/tf-job-operator.jsonnet
@@ -13,7 +13,6 @@
 // @optionalParam injectIstio string false Whether to inject istio sidecar; should be true or false.
 // @optionalParam clusterDomain string cluster.local DNS config to cluster domain.
 // @optionalParam monitoringPort string 8443 Port for monitoring agent to scrape metrics from.
-// @optionalParam enablePrometheus string false If set true, enable prometheus monitoring metrics reporting.
 
 local tfJobOperator = import "kubeflow/tf-training/tf-job-operator.libsonnet";
 local instance = tfJobOperator.new(env, params);

--- a/kubeflow/tf-training/prototypes/tf-job-operator.jsonnet
+++ b/kubeflow/tf-training/prototypes/tf-job-operator.jsonnet
@@ -13,6 +13,7 @@
 // @optionalParam injectIstio string false Whether to inject istio sidecar; should be true or false.
 // @optionalParam clusterDomain string cluster.local DNS config to cluster domain.
 // @optionalParam monitoringPort string 8443 Port for monitoring agent to scrape metrics from.
+// @optionalParam enablePrometheus string false If set true, enable prometheus monitoring metrics reporting.
 
 local tfJobOperator = import "kubeflow/tf-training/tf-job-operator.libsonnet";
 local instance = tfJobOperator.new(env, params);

--- a/kubeflow/tf-training/tests/tf-job_test.jsonnet
+++ b/kubeflow/tf-training/tests/tf-job_test.jsonnet
@@ -170,6 +170,42 @@ std.assertEqual(
 ) &&
 
 std.assertEqual(
+  tfjobv1.tfJobService,
+  {
+    apiVersion: 'v1',
+    kind: 'Service',
+    metadata: {
+      annotations: {
+        'prometheus.io/scrape': 'true',
+        'prometheus.io/path': '/metrics',
+        'prometheus.io/port': '8443',
+      },
+      labels: {
+        app: 'tf-job-operator',
+      },
+      name: 'tf-job-operator',
+      namespace: 'test-kf-001',
+    },
+    spec: {
+      ports: [
+        {
+          name: 'monitoring-port',
+          port: '8443',
+          targetPort: '8443',
+        },
+      ],
+      selector: {
+        name: 'tf-job-operator',
+      },
+      type: 'ClusterIP',
+    },
+    status: {
+      loadBalancer: {},
+    },
+  }
+) &&
+
+std.assertEqual(
   tfjobv1.tfUiDeployment,
   {
     apiVersion: "extensions/v1beta1",

--- a/kubeflow/tf-training/tests/tf-job_test.jsonnet
+++ b/kubeflow/tf-training/tests/tf-job_test.jsonnet
@@ -190,8 +190,8 @@ std.assertEqual(
       ports: [
         {
           name: 'monitoring-port',
-          port: '8443',
-          targetPort: '8443',
+          port: 8443,
+          targetPort: 8443,
         },
       ],
       selector: {

--- a/kubeflow/tf-training/tests/tf-job_test.jsonnet
+++ b/kubeflow/tf-training/tests/tf-job_test.jsonnet
@@ -199,9 +199,6 @@ std.assertEqual(
       },
       type: 'ClusterIP',
     },
-    status: {
-      loadBalancer: {},
-    },
   }
 ) &&
 

--- a/kubeflow/tf-training/tests/tf-job_test.jsonnet
+++ b/kubeflow/tf-training/tests/tf-job_test.jsonnet
@@ -110,21 +110,9 @@ std.assertEqual(
       namespace: "test-kf-001",
     },
     spec: {
-      ports: [
-        {
-          name: "monitoring-port",
-          port: "8443",
-          targetPort: "8443"
-        }
-      ],
       replicas: 1,
       template: {
         metadata: {
-          annotations: {
-            "prometheus.io/path": "/metrics",
-            "prometheus.io/port": "8443",
-            "prometheus.io/scrape": "true"
-          },
           labels: {
             name: "tf-job-operator",
           },

--- a/kubeflow/tf-training/tf-job-operator.libsonnet
+++ b/kubeflow/tf-training/tf-job-operator.libsonnet
@@ -157,22 +157,10 @@
       },
       spec: {
         replicas: 1,
-        ports: [
-          {
-            name: "monitoring-port",
-            port: params.monitoringPort,
-            targetPort: params.monitoringPort,
-          },
-        ],
         template: {
           metadata: {
             labels: {
               name: "tf-job-operator",
-            },
-            annotations: {
-              "prometheus.io/scrape": 'true',
-              "prometheus.io/path": "/metrics",
-              "prometheus.io/port": params.monitoringPort,
             },
           },
           spec: {
@@ -193,6 +181,38 @@
       },
     },
     tfJobDeployment:: tfJobDeployment,
+
+    local tfJobService = {
+      apiVersion: "v1",
+      kind: "Service",
+      metadata: {
+        labels: {
+          app: "tf-job-operator",
+        },
+        name: params.name,
+        namespace: params.namespace,
+        annotations: {}
+        + if util.toBool(params.enablePrometheus) then {
+          "prometheus.io/scrape": "true",
+          "prometheus.io/path": "/metrics",
+          "prometheus.io/port": params.monitoringPort,
+        } else {},  //annotations
+      },
+      spec: {
+        ports: [
+          {
+            name: "monitoring-port",
+            port: std.parseInt(params.monitoringPort),
+            targetPort: std.parseInt(params.monitoringPort)
+          }
+        ],
+        selector: {
+          name: "tf-job-operator",
+        },
+        type: "ClusterIP",
+      },
+    },  // tfJobService
+    tfJobService:: tfJobService,
 
     local tfConfigMap = {
       apiVersion: "v1",
@@ -571,6 +591,7 @@
     all:: [
       self.tfJobCrd,
       self.tfJobDeployment,
+      self.tfJobService,
       self.tfConfigMap,
       self.tfServiceAccount,
       self.tfOperatorRole,

--- a/kubeflow/tf-training/tf-job-operator.libsonnet
+++ b/kubeflow/tf-training/tf-job-operator.libsonnet
@@ -191,12 +191,11 @@
         },
         name: params.name,
         namespace: params.namespace,
-        annotations: {}
-        + if util.toBool(params.enablePrometheus) then {
+        annotations: {
           "prometheus.io/scrape": "true",
           "prometheus.io/path": "/metrics",
           "prometheus.io/port": params.monitoringPort,
-        } else {},  //annotations
+        },
       },
       spec: {
         ports: [


### PR DESCRIPTION
Moves port config to tf-operator service instead of deployment
Moves Prometheus config to service as well

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3408)
<!-- Reviewable:end -->
