### PR TITLE
Consolidate initial state retrieval and retrieve user email from IAP headers

### DIFF
--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -3,72 +3,100 @@ import express from 'express';
 import {KubernetesService, PlatformInfo} from './k8s_service';
 import {Interval, MetricsService} from './metrics_service';
 
-interface UserInfo {
-  email: string;
-  image: string;
-}
-
 interface EnvironmentInfo {
-  user: UserInfo;
+  namespaces: string[];
   platform: PlatformInfo;
+  user: string;
 }
 
-/** Function that provides user information back */
-function getUserInfo() {
-  return {
-    email: 'user@kubeflow.org',
-  };
-}
+const IAP_HEADER = 'X-Goog-Authenticated-User-Email';
+const IAP_PREFIX = 'accounts.google.com:';
 
-/** API routes exposing information from Kubernetes */
-export function api(
-    k8sService: KubernetesService,
-    metricsService?: MetricsService): express.Router {
-  return express.Router()
-      .get(
-          '/env-info',
-          async (_: express.Request, res: express.Response) => {
-            const [platform, user] = await Promise.all([
-              k8sService.getPlatformInfo(),
-              getUserInfo(),
-            ]);
-            const returnPayoad = {platform, user} as EnvironmentInfo;
-            res.json(returnPayoad);
-          })
-      .get(
-          '/metrics/:type((node|podcpu|podmem))',
-          async (req: express.Request, res: express.Response) => {
-            let interval = Interval.Last15m;
-            if (Interval[req.query.interval] !== undefined) {
-              interval = Number(Interval[req.query.interval]);
-            }
-            if (metricsService) {
-              switch (req.params.type) {
-                case 'node':
-                  res.json(
-                      await metricsService.getNodeCpuUtilization(interval));
-                  break;
-                case 'podcpu':
-                  res.json(await metricsService.getPodCpuUtilization(interval));
-                  break;
-                case 'podmem':
-                  res.json(await metricsService.getPodMemoryUsage(interval));
-                  break;
-                default:
+export class Api {
+  private platformInfo: PlatformInfo;
+
+  constructor(
+      private k8sService: KubernetesService,
+      private metricsService?: MetricsService) {}
+
+  /** Retrieves and memoizes the PlatformInfo. */
+  private async getPlatformInfo(): Promise<PlatformInfo> {
+    if (!this.platformInfo) {
+      this.platformInfo = await this.k8sService.getPlatformInfo();
+    }
+    return this.platformInfo;
+  }
+
+  /**
+   * Retrieves user information from headers.
+   * Supports:
+   *  GCP IAP (https://cloud.google.com/iap/docs/identity-howto)
+   */
+  private getUser(req: express.Request): string {
+    let email = 'anonymous@kubeflow.org';
+    if (req.header(IAP_HEADER)) {
+      email = req.header(IAP_HEADER).slice(IAP_PREFIX.length);
+    }
+    return email;
+  }
+
+  /**
+   * Returns the Express router for the API routes.
+   */
+  routes(): express.Router {
+    return express.Router()
+        .get(
+            '/env-info',
+            async (req: express.Request, res: express.Response) => {
+              console.log('getting env-info');
+              const [platform, user, namespaces] = await Promise.all([
+                this.getPlatformInfo(),
+                this.getUser(req),
+                this.k8sService.getNamespaces(),
+              ]);
+              res.json({
+                platform,
+                user,
+                namespaces: namespaces.map((n) => n.metadata.name),
+              });
+            })
+        .get(
+            '/metrics/:type((node|podcpu|podmem))',
+            async (req: express.Request, res: express.Response) => {
+              let interval = Interval.Last15m;
+              if (Interval[req.query.interval] !== undefined) {
+                interval = Number(Interval[req.query.interval]);
               }
-            } else {
-              res.sendStatus(405);
-            }
-          })
-      .get(
-          '/namespaces',
-          async (_: express.Request, res: express.Response) => {
-            res.json(await k8sService.getNamespaces());
-          })
-      .get(
-          '/activities/:namespace',
-          async (req: express.Request, res: express.Response) => {
-            res.json(
-                await k8sService.getEventsForNamespace(req.params.namespace));
-          });
+              if (this.metricsService) {
+                switch (req.params.type) {
+                  case 'node':
+                    res.json(await this.metricsService.getNodeCpuUtilization(
+                        interval));
+                    break;
+                  case 'podcpu':
+                    res.json(await this.metricsService.getPodCpuUtilization(
+                        interval));
+                    break;
+                  case 'podmem':
+                    res.json(
+                        await this.metricsService.getPodMemoryUsage(interval));
+                    break;
+                  default:
+                }
+              } else {
+                res.sendStatus(405);
+              }
+            })
+        .get(
+            '/namespaces',
+            async (_: express.Request, res: express.Response) => {
+              res.json(await this.k8sService.getNamespaces());
+            })
+        .get(
+            '/activities/:namespace',
+            async (req: express.Request, res: express.Response) => {
+              res.json(await this.k8sService.getEventsForNamespace(
+                  req.params.namespace));
+            });
+  }
 }

--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -48,7 +48,6 @@ export class Api {
         .get(
             '/env-info',
             async (req: express.Request, res: express.Response) => {
-              console.log('getting env-info');
               const [platform, user, namespaces] = await Promise.all([
                 this.getPlatformInfo(),
                 this.getUser(req),
@@ -63,28 +62,29 @@ export class Api {
         .get(
             '/metrics/:type((node|podcpu|podmem))',
             async (req: express.Request, res: express.Response) => {
+              if (!this.metricsService) {
+                res.sendStatus(405);
+                return;
+              }
+
               let interval = Interval.Last15m;
               if (Interval[req.query.interval] !== undefined) {
                 interval = Number(Interval[req.query.interval]);
               }
-              if (this.metricsService) {
-                switch (req.params.type) {
-                  case 'node':
-                    res.json(await this.metricsService.getNodeCpuUtilization(
-                        interval));
-                    break;
-                  case 'podcpu':
-                    res.json(await this.metricsService.getPodCpuUtilization(
-                        interval));
-                    break;
-                  case 'podmem':
-                    res.json(
-                        await this.metricsService.getPodMemoryUsage(interval));
-                    break;
-                  default:
-                }
-              } else {
-                res.sendStatus(405);
+              switch (req.params.type) {
+                case 'node':
+                  res.json(await this.metricsService.getNodeCpuUtilization(
+                      interval));
+                  break;
+                case 'podcpu':
+                  res.json(
+                      await this.metricsService.getPodCpuUtilization(interval));
+                  break;
+                case 'podmem':
+                  res.json(
+                      await this.metricsService.getPodMemoryUsage(interval));
+                  break;
+                default:
               }
             })
         .get(

--- a/components/centraldashboard/app/api_test.ts
+++ b/components/centraldashboard/app/api_test.ts
@@ -1,7 +1,8 @@
+import {V1Namespace} from '@kubernetes/client-node';
 import express from 'express';
 import {get} from 'http';
 
-import {api} from './api';
+import {Api} from './api';
 import {KubernetesService} from './k8s_service';
 import {Interval, MetricsService} from './metrics_service';
 
@@ -11,13 +12,112 @@ describe('Dashboard API', () => {
   let testApp: express.Application;
   let port: number;
 
+  describe('Environment Information', () => {
+    beforeEach(() => {
+      mockK8sService = jasmine.createSpyObj<KubernetesService>([
+        'getPlatformInfo',
+        'getNamespaces',
+      ]);
+      const namespaces = [
+        {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: {
+            name: 'default',
+          },
+        },
+        {
+          apiVersion: 'v1',
+          kind: 'Namespace',
+          metadata: {
+            name: 'kubeflow',
+          },
+        },
+      ] as V1Namespace[];
+      mockK8sService.getNamespaces.and.returnValue(Promise.resolve(namespaces));
+      mockK8sService.getPlatformInfo.and.returnValue(Promise.resolve({
+        provider: 'onprem',
+        providerName: 'onprem',
+        kubeflowVersion: '1.0.0',
+      }));
+
+      testApp = express();
+      testApp.use(express.json());
+      testApp.use('/api', new Api(mockK8sService).routes());
+      const addressInfo = testApp.listen(0).address();
+      if (typeof addressInfo === 'string') {
+        throw new Error(
+            'Unable to determine system-assigned port for test API server');
+      }
+      port = addressInfo.port;
+    });
+
+    const getResponse = (headers?: {[header: string]: string}) =>
+        new Promise((resolve) => {
+          get(`http://localhost:${port}/api/env-info`, {headers}, (res) => {
+            expect(res.statusCode).toBe(200);
+            expect(mockK8sService.getNamespaces).toHaveBeenCalled();
+            let body = '';
+            res.on('data', (chunk) => body += String(chunk));
+            res.on('end', () => {
+              resolve(JSON.parse(body));
+            });
+          });
+        });
+
+    it('Should retrieve and cache information', async () => {
+      let response = await getResponse();
+      expect(response).toEqual({
+        platform: {
+          provider: 'onprem',
+          providerName: 'onprem',
+          kubeflowVersion: '1.0.0',
+        },
+        user: 'anonymous@kubeflow.org',
+        namespaces: ['default', 'kubeflow'],
+      });
+      expect(mockK8sService.getPlatformInfo).toHaveBeenCalled();
+
+      // Second call should use cached platform information
+      response = await getResponse();
+      expect(response).toEqual({
+        platform: {
+          provider: 'onprem',
+          providerName: 'onprem',
+          kubeflowVersion: '1.0.0',
+        },
+        user: 'anonymous@kubeflow.org',
+        namespaces: ['default', 'kubeflow'],
+      });
+      expect(mockK8sService.getNamespaces.calls.count()).toBe(2);
+      expect(mockK8sService.getPlatformInfo.calls.count()).toBe(1);
+    });
+
+    it('Should parse email from IAP header', async () => {
+      const headers = {
+        'X-Goog-Authenticated-User-Email':
+            'accounts.google.com:test@testdomain.com',
+      };
+      const response = await getResponse(headers);
+      expect(response).toEqual({
+        platform: {
+          provider: 'onprem',
+          providerName: 'onprem',
+          kubeflowVersion: '1.0.0',
+        },
+        user: 'test@testdomain.com',
+        namespaces: ['default', 'kubeflow'],
+      });
+    });
+  });
+
   describe('Without a Metrics Service', () => {
     beforeEach(() => {
       mockK8sService = jasmine.createSpyObj<KubernetesService>(['']);
 
       testApp = express();
       testApp.use(express.json());
-      testApp.use('/api', api(mockK8sService));
+      testApp.use('/api', new Api(mockK8sService).routes());
       const addressInfo = testApp.listen(0).address();
       if (typeof addressInfo === 'string') {
         throw new Error(
@@ -43,7 +143,7 @@ describe('Dashboard API', () => {
 
       testApp = express();
       testApp.use(express.json());
-      testApp.use('/api', api(mockK8sService, mockMetricsService));
+      testApp.use('/api', new Api(mockK8sService, mockMetricsService).routes());
       const addressInfo = testApp.listen(0).address();
       if (typeof addressInfo === 'string') {
         throw new Error(

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -2,7 +2,7 @@ import {KubeConfig} from '@kubernetes/client-node';
 import express from 'express';
 import {resolve} from 'path';
 
-import {api} from './api';
+import {Api} from './api';
 import {KubernetesService} from './k8s_service';
 import {getMetricsService} from './metrics_service_factory';
 
@@ -17,7 +17,7 @@ async function main() {
 
   app.use(express.json());
   app.use(express.static(frontEnd));
-  app.use('/api', api(k8sService, metricsService));
+  app.use('/api', new Api(k8sService, metricsService).routes());
   app.get('/*', (_: express.Request, res: express.Response) => {
     res.sendFile(resolve(frontEnd, 'index.html'));
   });

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -94,8 +94,9 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             hideTabs: {type: Boolean, value: false, readOnly: true},
             hideNamespaces: {type: Boolean, value: false, readOnly: true},
             notFoundInIframe: {type: Boolean, value: false, readOnly: true},
+            namespaces: Array,
             namespace: {type: String, observer: '_namespaceChanged'},
-            user: Object,
+            user: String,
         };
     }
 
@@ -244,10 +245,9 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
      * @param {Event} responseEvent AJAX-response
      */
     _onEnvInfoResponse(responseEvent) {
-        const {platform, user} = responseEvent.detail.response;
-        // ensures that iron-image doesn't  make a request if no image is set
-        if (!user.image) user.image = '';
+        const {platform, user, namespaces} = responseEvent.detail.response;
         this.user = user;
+        this.namespaces = namespaces;
         this.platformInfo = platform;
         if (this.platformInfo.kubeflowVersion) {
             this.buildVersion = this.platformInfo.kubeflowVersion;

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -39,13 +39,11 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     figure.Logo
                         |!{logo}
                 namespace-selector#NamespaceSelector(
-                    query-params='{{queryParams}}', selected="{{namespace}}",
-                    hides, hidden$='[[hideNamespaces]]')
+                    query-params='{{queryParams}}', namespaces='[[namespaces]]'
+                    selected='{{namespace}}', hides, hidden$='[[hideNamespaces]]')
                 footer#User-Badge
-                    iron-image.image(sizing='contain', fade, preload,
-                        placeholder='/assets/anon-user.png',
-                        preventLoad='[[!user.image]]', src='[[user.image]]',
-                        title='[[user.email]]')
+                    iron-image.image(sizing='contain', fade,
+                        src='/assets/anon-user.png', title='[[user]]')
         main#Content
             section#ViewTabs(hidden$='[[hideTabs]]')
                 paper-tabs(selected='[[page]]', attr-for-selected='page')

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -175,14 +175,13 @@ describe('Main Page', () => {
 
     it('Sets information when platform info is received', async () => {
         const envInfo = {
+            namespaces: ['default', 'kubeflow', 'namespace-2'],
             platform: {
                 provider: 'gce://test-project/us-east1-c/gke-kubeflow-node-123',
                 providerName: 'gce',
                 kubeflowVersion: '1.0.0',
             },
-            user: {
-                email: 'user@kubeflow.org',
-            },
+            user: 'anonymous@kubeflow.org',
         };
         const responsePromise = mockRequest(mainPage, {
             status: 200,
@@ -197,7 +196,13 @@ describe('Main Page', () => {
         // hidden
         expect(buildVersion.textContent).toEqual('1.0.0');
         expect(mainPage.shadowRoot.querySelector('#User-Badge iron-image')
-            .title).toBe('user@kubeflow.org');
+            .title).toBe('anonymous@kubeflow.org');
+        const namespaceSelector = mainPage.shadowRoot
+            .getElementById('NamespaceSelector');
+        expect(Array.from(namespaceSelector.shadowRoot
+            .querySelectorAll('paper-item'))
+            .map((n) => n.innerText))
+            .toEqual(['default', 'kubeflow', 'namespace-2']);
     });
 
     it('Communicates with iframed page after it connects', async () => {

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -1,4 +1,3 @@
-import '@polymer/iron-ajax/iron-ajax.js';
 import '@polymer/iron-icon/iron-icon.js';
 import '@polymer/iron-icons/iron-icons.js';
 import '@polymer/paper-button/paper-button.js';
@@ -57,10 +56,6 @@ export class NamespaceSelector extends PolymerElement {
                     --paper-button-ink-color: var(--accent-color);
                 }
             </style>
-            <iron-ajax auto url="/api/namespaces" handle-as="json"
-                on-response="_onResponse">
-            </iron-ajax>
-            <app-route query-params="{{queryParams}}"></app-route>
             <paper-menu-button no-overlap horizontal-align="right">
                 <paper-button id="dropdown-trigger" slot="dropdown-trigger">
                     <iron-icon icon="group-work"></iron-icon>
@@ -70,9 +65,7 @@ export class NamespaceSelector extends PolymerElement {
                 <paper-listbox slot="dropdown-content"
                     attr-for-selected="name" selected="{{selected}}">
                     <template is="dom-repeat" items="{{namespaces}}">
-                        <paper-item name="[[item.name]]">
-                            [[item.name]]
-                        </paper-item>
+                        <paper-item name="[[item]]">[[item]]</paper-item>
                     </template>
                 </paper-listbox>
             </paper-menu-button>
@@ -85,10 +78,7 @@ export class NamespaceSelector extends PolymerElement {
     static get properties() {
         return {
             queryParams: Object,
-            namespaces: {
-                type: Array,
-                value: [],
-            },
+            namespaces: Array,
             selected: {
                 type: String,
                 observer: '_onSelected',
@@ -116,17 +106,6 @@ export class NamespaceSelector extends PolymerElement {
         if (namespace && this.selected !== namespace) {
             this.selected = namespace;
         }
-    }
-
-    /**
-     * Handles the Activities response to set date format and icon.
-     * @param {Event} responseEvent
-     */
-    _onResponse(responseEvent) {
-        const {response} = responseEvent.detail;
-        this.namespaces = response.map((n) => {
-            return {name: n.metadata.name, id: n.metadata.uid};
-        });
     }
 
     /**

--- a/components/centraldashboard/public/components/namespace-selector_test.js
+++ b/components/centraldashboard/public/components/namespace-selector_test.js
@@ -1,9 +1,7 @@
 import '@polymer/test-fixture/test-fixture';
-import 'jasmine-ajax';
 import {flush} from '@polymer/polymer/lib/utils/flush.js';
 
 import './namespace-selector';
-import {mockRequest} from '../ajax_test_helper';
 
 const FIXTURE_ID = 'namespace-selector-fixture';
 const NAMESPACE_SELECTOR_ID = 'test-namespace-selector';
@@ -25,56 +23,12 @@ describe('Namespace Selector', () => {
     });
 
     beforeEach(() => {
-        jasmine.Ajax.install();
         document.getElementById(FIXTURE_ID).create();
         namespaceSelector = document.getElementById(NAMESPACE_SELECTOR_ID);
     });
 
     afterEach(() => {
         document.getElementById(FIXTURE_ID).restore();
-        jasmine.Ajax.uninstall();
-    });
-
-    it('Shows Namespaces from /api/namespaces', async () => {
-        const responsePromise = mockRequest(namespaceSelector, {
-            status: 200,
-            responseText: JSON.stringify([
-                {
-                    metadata: {
-                        uid: '1',
-                        name: 'default',
-                    },
-                },
-                {
-                    metadata: {
-                        uid: '2',
-                        name: 'other-namespace',
-                    },
-                },
-            ]),
-        });
-        await responsePromise;
-        flush();
-
-        const namespaces = [];
-        namespaceSelector.shadowRoot.querySelectorAll('paper-item')
-            .forEach((n) => {
-                namespaces.push(n.innerText.trim());
-            });
-        expect(namespaces).toEqual(['default', 'other-namespace']);
-    });
-
-    it('Shows empty list when error is received', async () => {
-        const responsePromise = mockRequest(namespaceSelector, {
-            status: 500,
-            responseText: '{"error": "Bad thing happened"}',
-        }, true);
-        await responsePromise;
-        flush();
-
-        const items = namespaceSelector.shadowRoot
-            .querySelectorAll('paper-item');
-        expect(items.length).toBe(0);
     });
 
     it('Sets queryParams.ns when selected', async () => {


### PR DESCRIPTION
- Eliminates separate call to fetch namespaces.
- Retrieves user email address from deployments secured by IAP.

/area front-end
/area centraldashboard
/cc @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3420)
<!-- Reviewable:end -->
