### PR TITLE
Removed TF-Job link from Central-Dashoard

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -73,10 +73,6 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
                         text: 'Notebook Servers',
                     },
                     {
-                        link: '/tfjobs/ui/',
-                        text: 'TF Jobs',
-                    },
-                    {
                         link: '/katib/',
                         text: 'Katib',
                     },


### PR DESCRIPTION
#### closes #3178

## About
As requested by @jlewi, this PR removes TF Jobs UI from Central-Dashboard, on account of it being very deprecated and not used.

---
/assign @avdaredevil 
/cc @prodonjs @jlewi 
/area front-end
/area central-dashboard
/priority p2

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3424)
<!-- Reviewable:end -->
