### PR TITLE
Fixes Jupyter Web App SDK namespace change doesn't trigger view update

### DIFF
--- a/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
+++ b/components/jupyter-web-app/kubeflow_jupyter/default/templates/notebooks.html
@@ -15,6 +15,7 @@
                 wrapper.classList.add('disabled');
                 handler.onNamespaceSelected = function(namespace){
                     ns.value = namespace;
+                    $(ns).trigger('change');
                 };
             });
         });

--- a/components/jupyter-web-app/kubeflow_jupyter/rok/templates/notebooks.html
+++ b/components/jupyter-web-app/kubeflow_jupyter/rok/templates/notebooks.html
@@ -15,6 +15,7 @@
                 wrapper.classList.add('disabled');
                 handler.onNamespaceSelected = function(namespace){
                     ns.value = namespace;
+                    $(ns).trigger('change');
                 };
             });
         });


### PR DESCRIPTION
## About
- The SDK was only changing the value of the selector, however, the view depends on a change event.
- We fire a change event when the value for namespace selector is updated now

---

/priority p0
/assign @avdaredevil 
/cc @prodonjs @kimwnasptd 
/area jupyter
/area front-end
/area centraldashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3427)
<!-- Reviewable:end -->
