### PR TITLE
Kfctl: Add default label for all resources created by kfctl

### DIFF
--- a/bootstrap/OWNERS
+++ b/bootstrap/OWNERS
@@ -3,3 +3,4 @@ approvers:
   - kkasravi
   - kunmingg
 reviewers:
+  - hougangliu

--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -1002,6 +1002,8 @@ func GenerateKustomizationFile(kfDef *kfdefsv2.KfDef, root string,
 		kustomization.CommonLabels = map[string]string {
 			kftypesv2.DefaultAppLabel: kfDef.Name,
 		}
+	} else {
+		kustomization.CommonLabels[kftypesv2.DefaultAppLabel] = kfDef.Name
 	}
 	//TODO(#2685) we may want to delegate this to separate tooling so kfctl is not dynamically mixing in overlays.
 	if len(kustomization.PatchesStrategicMerge) > 0 {


### PR DESCRIPTION
we need add label "app.kubernetes.io/name: $name" to all resources created by kfctl kustomize package manager so that we can delete all of them including global resources when we run 'kfctl delete'

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3454)
<!-- Reviewable:end -->
