### PR TITLE
Automated cherry pick of #3438: Add OWNERS file under aws components 

### DIFF
--- a/deployment/aws/OWNERS
+++ b/deployment/aws/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - jeffwan
+  - mameshini

--- a/scripts/aws/OWNERS
+++ b/scripts/aws/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - jeffwan
+  - mameshini


### PR DESCRIPTION
Have 1-2 aws related PRs need to cherry-pick back to v0.5.1. 

I added owners files to master and like to cherry-pick back to v0.5.1 and then I can approve that PRs. 


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3457)
<!-- Reviewable:end -->
