### PR TITLE
kfctl: add --config flag for specifying a static config file

### DIFF
--- a/bootstrap/cmd/kfctl/cmd/init.go
+++ b/bootstrap/cmd/kfctl/cmd/init.go
@@ -62,6 +62,7 @@ or a <name>. If just <name>, a directory <name> will be created in the current d
 
 		useIstio := initCfg.GetBool(string(kftypes.USE_ISTIO))
 		disableUsageReport := initCfg.GetBool(string(kftypes.DISABLE_USAGE_REPORT))
+		config := initCfg.GetString(string(kftypes.CONFIG))
 
 		options := map[string]interface{}{
 			string(kftypes.PLATFORM):              platform,
@@ -75,6 +76,7 @@ or a <name>. If just <name>, a directory <name> will be created in the current d
 			string(kftypes.USE_ISTIO):             useIstio,
 			string(kftypes.DISABLE_USAGE_REPORT):  disableUsageReport,
 			string(kftypes.PACKAGE_MANAGER):       packageManager,
+			string(kftypes.CONFIG):                config,
 		}
 		kfApp, kfAppErr := coordinator.NewKfApp(options)
 		if kfAppErr != nil || kfApp == nil {
@@ -188,6 +190,18 @@ func init() {
 		initCmd.Flags().Lookup(string(kftypes.DISABLE_USAGE_REPORT)))
 	if bindErr != nil {
 		log.Errorf("couldn't set flag --%v: %v", string(kftypes.DISABLE_USAGE_REPORT), bindErr)
+		return
+	}
+
+	// Config file option
+	initCmd.Flags().String(string(kftypes.CONFIG), "",
+		`Static config file to use. Can be either a local path or a URL.
+For example:
+--config=https://github.com/kubeflow/kubeflow/tree/master/bootstrap/config/platform_existing.yaml
+--config=platform_gcp.yaml`)
+	bindErr = initCfg.BindPFlag(string(kftypes.CONFIG), initCmd.Flags().Lookup(string(kftypes.CONFIG)))
+	if bindErr != nil {
+		log.Errorf("couldn't set flag --%v: %v", string(kftypes.CONFIG), bindErr)
 		return
 	}
 }

--- a/bootstrap/go.mod
+++ b/bootstrap/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.3
 	github.com/spf13/viper v1.3.1
+	github.com/utahta/go-openuri v0.1.0
 	go.opencensus.io v0.18.1-0.20181204023538-aab39bd6a98b // indirect
 	golang.org/x/crypto v0.0.0
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a

--- a/bootstrap/go.sum
+++ b/bootstrap/go.sum
@@ -344,6 +344,8 @@ github.com/ugorji/go v0.0.0-20171019201919-bdcc60b419d1/go.mod h1:hnLbHMwcvSihnD
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
 github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
+github.com/utahta/go-openuri v0.1.0 h1:5t+GPGBjwEt7oRTMArC47QMIiXarzNO6W3PDy8nXGoM=
+github.com/utahta/go-openuri v0.1.0/go.mod h1:wg5kOkfgUWHGFacyyH+FsrEzB++WPpFyKrwDSeo69Ng=
 github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.opencensus.io v0.18.0/go.mod h1:vKdFvxhtzZ9onBp9VKHK8z/sRpBMnKAsufL7wlDrCOA=

--- a/bootstrap/pkg/apis/apps/group.go
+++ b/bootstrap/pkg/apis/apps/group.go
@@ -89,6 +89,7 @@ const (
 	DELETE_STORAGE        CliOption = "delete_storage"
 	DISABLE_USAGE_REPORT  CliOption = "disable_usage_report"
 	PACKAGE_MANAGER       CliOption = "package-manager"
+	CONFIG                CliOption = "config"
 )
 
 //

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kubeflow/kubeflow/bootstrap/v2/pkg/kfapp/kustomize"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
+	goopenuri "github.com/utahta/go-openuri"
 	"io/ioutil"
 	valid "k8s.io/apimachinery/v2/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/v2/pkg/apis/meta/v1"
@@ -255,6 +256,55 @@ func NewKfApp(options map[string]interface{}) (kftypes.KfApp, error) {
 			log.Fatalf("could not download repo to cache Error %v", cacheDirErr)
 		}
 	}
+
+	// If a config file is specified, construct the KfDef entirely from that.
+	configFile := options[string(kftypes.CONFIG)].(string)
+	if configFile != "" {
+		// Open config file
+		configFileReader, err := goopenuri.Open(configFile)
+		if err != nil {
+			return nil, &kfapis.KfError{
+				Code:    int(kfapis.INVALID_ARGUMENT),
+				Message: fmt.Sprintf("could not open specified config %s: %v", configFile, err),
+			}
+		}
+		// Read contents
+		configFileBytes, err := ioutil.ReadAll(configFileReader)
+		if err != nil {
+			return nil, &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: fmt.Sprintf("could not read from config file %s: %v", configFile, err),
+			}
+		}
+		// Unmarshal content onto KfDef struct
+		kfDef := &kfdefsv2.KfDef{}
+		if err := yaml.Unmarshal(configFileBytes, kfDef); err != nil {
+			return nil, &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: fmt.Sprintf("could not unmarshal config file onto KfDef struct: %v", err),
+			}
+		}
+
+		//TODO(yanniszark): sane defaults for missing fields
+		//TODO(yanniszark): validate KfDef
+
+		// Disable usage report if requested
+		disableUsageReport := options[string(kftypes.DISABLE_USAGE_REPORT)].(bool)
+		if disableUsageReport {
+			kfDef.Spec.Components = filterSpartakus(kfDef.Spec.Components)
+			delete(kfDef.Spec.ComponentParams, "spartakus")
+		}
+
+		// Override certain values
+		kfDef.Spec.AppDir = appDir
+		//TODO(yanniszark) Stop overriding this once we find a suitable way to
+		// represent the repos (https://github.com/kubeflow/kubeflow/issues/3471)
+		kfDef.Spec.Repo = path.Join(cacheDir, kftypes.KubeflowRepo)
+
+		pApp := GetKfApp(kfDef)
+		return pApp, nil
+	}
+
 	kfDef := &kfdefsv2.KfDef{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "KfDef",


### PR DESCRIPTION
As per the discussion in #3419, it seems that we want to move to an approach where:
* Each platform specifies its own set of static yamls files for the KfDef config.
* A user can specify a KfDef config to use, which should give us reproducibility, easy sharing of configs and is in-line with the GitOps philosophy.

This PR adds the `--config` flag to `kfctl`.
When set, `kfctl` will read the KfDef from the specified file instead of generating it using kustomize.
Platforms can also override this option and specify their own static file.

Partially related to: #2831 support pulling from a local repository
   * This will pull the config from a local repository but we still have to support adding and pulling
      all of the repos/manifests on which we depend from a local repo.

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3468)
<!-- Reviewable:end -->
