### PR TITLE
add profile and kfam API to kfctl default component

### DIFF
--- a/bootstrap/config/kfctl_iap.yaml
+++ b/bootstrap/config/kfctl_iap.yaml
@@ -20,6 +20,7 @@ packages:
   - tensorboard
   - tf-serving
   - tf-training
+  - profiles
 components:
 # ordering is important
   - metacontroller
@@ -38,6 +39,7 @@ components:
   - spartakus
   - tensorboard
   - tf-job-operator
+  - profiles
 componentParams:
   argo:
   - initRequired: true
@@ -100,4 +102,8 @@ componentParams:
   - initRequired: true
     name: injectIstio
     value: "false"
+  profiles:
+  - initRequired: true
+    name: admin
+    value: ""
 platform: gcp

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1472,6 +1472,7 @@ func (gcp *Gcp) Generate(resources kftypes.ResourceEnum) error {
 	} else {
 		gcp.Spec.ComponentParams["iap-ingress"] = setNameVal(gcp.Spec.ComponentParams["iap-ingress"], "ipName", gcp.Spec.IpName, true)
 		gcp.Spec.ComponentParams["iap-ingress"] = setNameVal(gcp.Spec.ComponentParams["iap-ingress"], "hostname", gcp.Spec.Hostname, true)
+		gcp.Spec.ComponentParams["profiles"] = setNameVal(gcp.Spec.ComponentParams["profiles"], "admin", gcp.Spec.Email, true)
 	}
 
 	minioPdName := gcp.Name + "-storage-artifact-store"

--- a/kubeflow/jupyter/prototypes/notebook_controller.jsonnet
+++ b/kubeflow/jupyter/prototypes/notebook_controller.jsonnet
@@ -3,7 +3,7 @@
 // @description notebook controller
 // @shortDescription notebooks
 // @param name string Name
-// @optionalParam controllerImage string gcr.io/kubeflow-images-public/notebook-controller:v20190603-v0-175-geeca4530-e3b0c4 The image to use for the notebook controller
+// @optionalParam controllerImage string gcr.io/kubeflow-images-public/notebook-controller:v20190614-v0-160-g386f2749-e3b0c4 The image to use for the notebook controller
 // @optionalParam injectGcpCredentials string true Whether to inject gcp credentials
 // @optionalParam injectIstio string false Whether to inject istio sidecar; should be true or false.
 


### PR DESCRIPTION
With this one, kfctl will deploy profile and kfam API by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3473)
<!-- Reviewable:end -->
