### PR TITLE
fix pre-submit

### DIFF
--- a/testing/kfctl/kfctl_go_test.py
+++ b/testing/kfctl/kfctl_go_test.py
@@ -88,7 +88,7 @@ def test_build_kfctl_go(app_path, project, use_basic_auth, use_istio):
   # pull the configs from the repo we checked out.
   run_with_retries([kfctl_path, "init", app_path, "-V", "--platform=gcp",
                     "--version=" + version,
-                    "--package-manager=kustomize",
+                    "--package-manager=kustomize@1e6b55258c678c6b151ea17a039acf6170706a23",
                     "--skip-init-gcp-project",
                     "--disable_usage_report",
                     "--project=" + project] + init_args, cwd=parent_dir)


### PR DESCRIPTION
Now our presubmit run with kustomize, 
katib hasn't migrate to kustomize yet so remove test steps to verify katib controller.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3474)
<!-- Reviewable:end -->
