### PR TITLE
jupyter-web-app: Fix 400 error

### DIFF
--- a/components/jupyter-web-app/kubeflow_jupyter/default/app.py
+++ b/components/jupyter-web-app/kubeflow_jupyter/default/app.py
@@ -34,9 +34,10 @@ def get_notebooks(namespace):
 @app.route("/api/namespaces/<namespace>/notebooks", methods=['POST'])
 def post_notebook(namespace):
   data = {"success": True, "log": ""}
-  body = request.form
+  body = dict(request.form)
 
-  namespace = body["ns"]
+  # Use the namespace from the route in the form
+  body["ns"] = namespace
   poddefaultLabels = api.get_poddefaults_labels(namespace)
 
   # Template
@@ -47,7 +48,7 @@ def post_notebook(namespace):
   # todo: jupyter-web-app should add the poddefault labels that user selected
   #  (https://github.com/kubeflow/kubeflow/issues/2992)
   utils.set_notebook_poddefaults_labels(notebook, poddefaultLabels)
-  
+
   # Set Name and Namespace
   utils.set_notebook_names(notebook, body)
 

--- a/components/jupyter-web-app/kubeflow_jupyter/rok/app.py
+++ b/components/jupyter-web-app/kubeflow_jupyter/rok/app.py
@@ -35,7 +35,10 @@ def list_notebooks_route(namespace):
 @app.route("/api/namespaces/<namespace>/notebooks", methods=['POST'])
 def post_notebook(namespace):
   data = {"success": True, "log": ""}
-  body = request.form
+  body = dict(request.form)
+
+  # Use the namespace from the route in the form
+  body["ns"] = namespace
 
   # Template
   notebook = utils.create_notebook_template()


### PR DESCRIPTION
In order to communicate the namespace with the dashboard, we disable the namespace input.
The backend should be able to deduce the namespace from the route and use it when necessary 

/assign kimwnasptd
/assign jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3507)
<!-- Reviewable:end -->
