### PR TITLE
gatekeeper: decode base64 encoded username

### DIFF
--- a/components/gatekeeper/auth/AuthServer.go
+++ b/components/gatekeeper/auth/AuthServer.go
@@ -45,13 +45,17 @@ const LoginPageHeader = "x-from-login"
 const WhoAmIPath = "whoami"
 
 func NewAuthServer(opt *options.ServerOption) *authServer {
-	data, err := base64.StdEncoding.DecodeString(opt.Pwhash)
+	username, err := base64.StdEncoding.DecodeString(opt.Username)
 	if err != nil {
-		log.Fatal("error:", err)
+		log.Fatal("username decode error:", err)
+	}
+	pwhash, err := base64.StdEncoding.DecodeString(opt.Pwhash)
+	if err != nil {
+		log.Fatal("password hash error:", err)
 	}
 	server := &authServer{
-		username: opt.Username,
-		pwhash: string(data),
+		username: string(username),
+		pwhash: string(pwhash),
 		cookies: make(map[string]time.Time),
 		allowHttp: opt.AllowHttp,
 	}


### PR DESCRIPTION
Hello, I got login error when I tried to deploy basic auth component on Azure AKS. Then, I found a bug that username is not decoded from base64 to plain string.
I have confirmed that this fix resolves login error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3513)
<!-- Reviewable:end -->
