### PR TITLE
gatekeeper: not decode pwhash

### DIFF
--- a/components/gatekeeper/auth/AuthServer.go
+++ b/components/gatekeeper/auth/AuthServer.go
@@ -45,13 +45,9 @@ const LoginPageHeader = "x-from-login"
 const WhoAmIPath = "whoami"
 
 func NewAuthServer(opt *options.ServerOption) *authServer {
-	data, err := base64.StdEncoding.DecodeString(opt.Pwhash)
-	if err != nil {
-		log.Fatal("error:", err)
-	}
 	server := &authServer{
 		username: opt.Username,
-		pwhash: string(data),
+		pwhash: opt.Pwhash,
 		cookies: make(map[string]time.Time),
 		allowHttp: opt.AllowHttp,
 	}


### PR DESCRIPTION
Hello, I found a bug that `opt.Pwhash` is passed as base64 decoded bcrypt string but is assumed to be passed as base64 encoded string.
In current implementation, base64 decode error occurs when gatekeeper initializes. I confirmed that this fix resolves it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3514)
<!-- Reviewable:end -->
