### PR TITLE
Account for optional pipelines/runs property in Pipelines card responses

### DIFF
--- a/components/centraldashboard/public/components/pipelines-card.js
+++ b/components/centraldashboard/public/components/pipelines-card.js
@@ -101,7 +101,8 @@ export class PipelinesCard extends PolymerElement {
      */
     _onResponse(responseEvent) {
         const response = responseEvent.detail.response;
-        const pipelines = response[this.artifactType].map((p) => {
+        const artifacts = response[this.artifactType] || [];
+        const pipelines = artifacts.map((p) => {
             const date = new Date(p.created_at);
             const iconTitle = p.status || '';
             let icon = 'kubeflow:pipeline';


### PR DESCRIPTION
Fixes console error when trying to map on a non-existent array property.

/assign @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3522)
<!-- Reviewable:end -->
