### PR TITLE
Add monitoring.viewer role to enable dashboard utilzation graphs

### DIFF
--- a/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
+++ b/deployment/gke/deployment_manager_configs/iam_bindings_template.yaml
@@ -36,6 +36,8 @@ bindings:
   - roles/logging.logWriter
   # VM service account is used to write monitoring data
   - roles/monitoring.metricWriter
+  # VM service account can retrieve monitoring data
+  - roles/monitoring.viewer
   # VM service account is used to pull image from gcr
   - roles/storage.objectViewer
 - members:


### PR DESCRIPTION
closes #3597 

Enables utilization graphs to show on Central Dashboard for GKE deployments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3533)
<!-- Reviewable:end -->
