### PR TITLE
[CentralDashboard] Update Dockerfile to run all tests apart from built image

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,18 +1,35 @@
-FROM node:10
+# Step 1: Builds and tests
+FROM node:10-alpine AS test
 
+# Installs latest Chromium package and configures environment for testing
+RUN apk update && apk upgrade && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
+    echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
+    apk add --no-cache bash chromium@edge nss@edge \
+    freetype@edge \
+    harfbuzz@edge \
+    ttf-freefont@edge
+ENV CHROME_BIN=/usr/bin/chromium-browser
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+
+COPY . /centraldashboard
 WORKDIR /centraldashboard
 
-COPY app/ ./app
-COPY types/ ./types
-COPY public/ ./public
-COPY webpack.config.js *.json .nycrc ./
+RUN npm rebuild && npm install && npm test
+
+# Step 2: Packages assets for serving
+FROM node:10-alpine AS build
+
+COPY --from=test /centraldashboard /centraldashboard/
+WORKDIR /centraldashboard
 
 ARG kubeflowversion
 ARG commit
 ENV BUILD_VERSION=$kubeflowversion
 ENV BUILD_COMMIT=$commit
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN npm install && npm run build && npm prune --production
+RUN npm run build && npm prune --production
 
 EXPOSE 8082
 

--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,5 +1,12 @@
 # Step 1: Builds and tests
-FROM node:10-alpine AS test
+FROM node:10-alpine AS build
+
+ARG kubeflowversion
+ARG commit
+ENV BUILD_VERSION=$kubeflowversion
+ENV BUILD_COMMIT=$commit
+ENV CHROME_BIN=/usr/bin/chromium-browser
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # Installs latest Chromium package and configures environment for testing
 RUN apk update && apk upgrade && \
@@ -9,28 +16,21 @@ RUN apk update && apk upgrade && \
     freetype@edge \
     harfbuzz@edge \
     ttf-freefont@edge
-ENV CHROME_BIN=/usr/bin/chromium-browser
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 COPY . /centraldashboard
 WORKDIR /centraldashboard
 
-RUN npm rebuild && npm install && npm test
+RUN npm rebuild && \
+    npm install && \
+    npm test && \
+    npm run build && \
+    npm prune --production
 
 # Step 2: Packages assets for serving
-FROM node:10-alpine AS build
+FROM node:10-alpine AS serve
 
-COPY --from=test /centraldashboard /centraldashboard/
-WORKDIR /centraldashboard
-
-ARG kubeflowversion
-ARG commit
-ENV BUILD_VERSION=$kubeflowversion
-ENV BUILD_COMMIT=$commit
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-
-RUN npm run build && npm prune --production
+WORKDIR /app
+COPY --from=build /centraldashboard .
 
 EXPOSE 8082
-
 ENTRYPOINT ["npm", "start"]

--- a/components/centraldashboard/Makefile
+++ b/components/centraldashboard/Makefile
@@ -30,7 +30,7 @@ test: build-local
 
 # To build without the cache set the environment variable
 # export DOCKER_BUILD_OPTS=--no-cache
-build: test
+build:
 	docker build ${DOCKER_BUILD_OPTS} -t $(IMG):$(TAG) . \
 	  --build-arg kubeflowversion=$(shell git describe --abbrev=0 --tags) \
 	  --build-arg commit=$(shell git rev-parse HEAD) \

--- a/components/centraldashboard/karma.conf.js
+++ b/components/centraldashboard/karma.conf.js
@@ -13,7 +13,13 @@ webpackConfig.module.rules.push({
 
 module.exports = (config) => config.set({
     basePath: '',
-    browsers: ['ChromeHeadless'],
+    browsers: ['ChromeHeadlessTest'],
+    customLaunchers: {
+        ChromeHeadlessTest: {
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox'],
+        },
+    },
     frameworks: ['jasmine'],
     files: [
         'public/index_test.js',


### PR DESCRIPTION
This ensures that all unit tests are run during the image build process, which is invoked during pre/post submit tests.

/area centraldashboard
/area front-end
/cc @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3541)
<!-- Reviewable:end -->
