### PR TITLE
Fix 403 forbidden response when downloading file from JupyterLab in Google Chrome

### DIFF
--- a/components/tensorflow-notebook-image/jupyter_notebook_config.py
+++ b/components/tensorflow-notebook-image/jupyter_notebook_config.py
@@ -47,3 +47,4 @@ if 'GEN_CERT' in os.environ:
   # Restrict access to the file
   os.chmod(pem_file, stat.S_IRUSR | stat.S_IWUSR)
   c.NotebookApp.certfile = pem_file
+  c.NotebookApp.allow_remote_access = True


### PR DESCRIPTION
Setting `c.NotebookApp.allow_remote_access = True` in `jupyter_notebook_config.py` to fix the inability to download file to local disk from JupyterLab in kubeflow. Previously, without that configuration, user is not able to download file in Google Chrome and an error message of `Failed-Forbidden` is received.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3551)
<!-- Reviewable:end -->
