### PR TITLE
Removing unnecessary rbac authorization for pytorch operator

### DIFF
--- a/kubeflow/pytorch-job/pytorch-operator.libsonnet
+++ b/kubeflow/pytorch-job/pytorch-operator.libsonnet
@@ -1,7 +1,6 @@
 {
   all(params, env):: [
     $.parts(params, env).crd,
-    $.parts(params, env).configMap(params.pytorchDefaultImage),
     $.parts(params, env).serviceAccount,
     $.parts(params, env).operatorRole(params.deploymentScope, params.deploymentNamespace, params.enableGangScheduling),
     $.parts(params, env).operatorRoleBinding(params.deploymentScope, params.deploymentNamespace),
@@ -150,23 +149,9 @@
                 ]),
                 image: image,
                 name: "pytorch-operator",
-                volumeMounts: [
-                  {
-                    mountPath: "/etc/config",
-                    name: "config-volume",
-                  },
-                ],
               },
             ],
             serviceAccountName: "pytorch-operator",
-            volumes: [
-              {
-                configMap: {
-                  name: "pytorch-operator-config",
-                },
-                name: "config-volume",
-              },
-            ],
           },
         },
       },
@@ -199,26 +184,6 @@
           name: "pytorch-operator",
         },
         type: "ClusterIP",
-      },
-    },
-
-    // Default value for
-    defaultControllerConfig(pytorchDefaultImage):: if pytorchDefaultImage != "" && pytorchDefaultImage != "null" then
-      {
-        pytorchImage: pytorchDefaultImage,
-      }
-    else
-      {},
-
-    configMap(pytorchDefaultImage): {
-      apiVersion: "v1",
-      data: {
-        "controller_config_file.yaml": std.manifestJson($.parts(params, env).defaultControllerConfig(pytorchDefaultImage)),
-      },
-      kind: "ConfigMap",
-      metadata: {
-        name: "pytorch-operator-config",
-        namespace: namespace,
       },
     },
 
@@ -260,60 +225,13 @@
                },
                {
                  apiGroups: [
-                   "apiextensions.k8s.io",
-                 ],
-                 resources: [
-                   "customresourcedefinitions",
-                 ],
-                 verbs: [
-                   "*",
-                 ],
-               },
-               {
-                 apiGroups: [
-                   "storage.k8s.io",
-                 ],
-                 resources: [
-                   "storageclasses",
-                 ],
-                 verbs: [
-                   "*",
-                 ],
-               },
-               {
-                 apiGroups: [
-                   "batch",
-                 ],
-                 resources: [
-                   "jobs",
-                 ],
-                 verbs: [
-                   "*",
-                 ],
-               },
-               {
-                 apiGroups: [
                    "",
                  ],
                  resources: [
-                   "configmaps",
                    "pods",
                    "services",
                    "endpoints",
-                   "persistentvolumeclaims",
                    "events",
-                 ],
-                 verbs: [
-                   "*",
-                 ],
-               },
-               {
-                 apiGroups: [
-                   "apps",
-                   "extensions",
-                 ],
-                 resources: [
-                   "deployments",
                  ],
                  verbs: [
                    "*",

--- a/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
+++ b/kubeflow/pytorch-job/tests/pytorch-job_test.jsonnet
@@ -156,23 +156,9 @@ local testCases = [
                 ],
                 image: "pyControllerImage",
                 name: "pytorch-operator",
-                volumeMounts: [
-                  {
-                    mountPath: "/etc/config",
-                    name: "config-volume",
-                  },
-                ],
               },
             ],
             serviceAccountName: "pytorch-operator",
-            volumes: [
-              {
-                configMap: {
-                  name: "pytorch-operator-config",
-                },
-                name: "config-volume",
-              },
-            ],
           },
         },
       },


### PR DESCRIPTION
Configmaps are not used in operator anymore. Unnecessary rules are also removed

/hold

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3564)
<!-- Reviewable:end -->
