### PR TITLE
Add Metadata UI links to Central Dashboard

### DIFF
--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -98,11 +98,6 @@ export class DashboardView extends PolymerElement {
                         link: `/jupyter/new?namespace=kubeflow`,
                     },
                     {
-                        text: 'View all TF Jobs',
-                        desc: 'TF Jobs',
-                        link: `/tfjobs/ui/`,
-                    },
-                    {
                         text: 'View Katib Studies',
                         desc: 'Katib',
                         link: `/katib/`,

--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -107,6 +107,11 @@ export class DashboardView extends PolymerElement {
                         desc: 'Katib',
                         link: `/katib/`,
                     },
+                    {
+                        text: 'View Metadata Artifacts',
+                        desc: 'Artifact Store',
+                        link: `/metadata/`,
+                    },
                 ],
             },
             platformDetails: Object,

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -76,6 +76,10 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
                         link: '/katib/',
                         text: 'Katib',
                     },
+                    {
+                        link: '/metadata/',
+                        text: 'Artifact Store',
+                    },
                 ],
             },
             sidebarItemIndex: {


### PR DESCRIPTION
/area frontend
/area centraldashboard

**Artifact store** was the name for the link in @ajayalfred 's [mocks](https://gallery.googleplex.com/projects/MCHbtQVoQ2HCZYbjDGnaKqEC/files/MCEJu8Y2hyDScRKM1oyOOWQSEJJUv10bnK4)
![so2ZBZKB6v9](https://user-images.githubusercontent.com/6835846/60300285-a8a3d300-98fc-11e9-813e-5478d923bf6e.png)

/cc @rileyjbauer 
/cc @zhenghuiwang 

Hold until manifests changes are ready with the cluster-level route to Metadata-UI working.
/hold

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3569)
<!-- Reviewable:end -->
