### PR TITLE
Add a list of Applications to KfDef.

### DIFF
--- a/bootstrap/v2/pkg/apis/apps/kfdef/v1alpha1/application_types.go
+++ b/bootstrap/v2/pkg/apis/apps/kfdef/v1alpha1/application_types.go
@@ -70,12 +70,32 @@ type KfDefSpec struct {
 	Repos              []Repo   `json:"repos,omitempty"`
 	Secrets            []Secret `json:"secrets,omitempty"`
 	Plugins            []Plugin `json:"plugins,omitempty"`
+
+	// Applications defines a list of applications to install
+	Applications []Application `json:"applications,omitempty"`
 }
 
 var DefaultRegistry = RegistryConfig{
 	Name: "kubeflow",
 	Repo: "https://github.com/kubeflow/kubeflow.git",
 	Path: "kubeflow",
+}
+
+// Application defines an application to install
+type Application struct {
+	Name            string           `json:"name,omitempty"`
+	KustomizeConfig *KustomizeConfig `json:"kustomizeConfig,omitempty"`
+}
+
+type KustomizeConfig struct {
+	RepoRef    *RepoRef           `json:"repoRef,omitempty"`
+	Overlays   []string           `json:"overlays,omitempty"`
+	Parameters []config.NameValue `json:"parameters,omitempty"`
+}
+
+type RepoRef struct {
+	Name string `json:"name,omitempty"`
+	Path string `json:"path,omitempty"`
 }
 
 // Plugin can be used to customize the generation and deployment of Kubeflow
@@ -650,3 +670,4 @@ func IsSecretNotFound(e error) bool {
 	_, ok := e.(*SecretNotFound)
 	return ok
 }
+


### PR DESCRIPTION
* Application is intended as a replacemnt for the fields packages, components,
  componentParams.

* See #3491; discovery logic for kustomize is broken.

  * The new Application type allows us to specify in the YAML spec the
    repository and path within the repository of the kustomize package to use

  * This will allow us to address that issue because we will be able to
    stop relying on the discovery logic and instead just specify the packages
    in the app.yaml that we need.

* This PR just defines the type

* Forthcoming PRs

  * A PR to backfill Application based on packages, components & componentParams
    so that we don't break compatibility with existing specs.

  * Update kustomize.go to use Application

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3581)
<!-- Reviewable:end -->
