### PR TITLE
Some error and logging utilities.

### DIFF
--- a/bootstrap/pkg/utils/logging.go
+++ b/bootstrap/pkg/utils/logging.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+)
+
+// PrettyPrint returns a pretty format output of any value.
+func PrettyPrint(value interface{}) string {
+	if s, ok := value.(string); ok {
+		return s
+	}
+	valueJson, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		log.Errorf("Failed to marshal value; error %v", err)
+		return fmt.Sprintf("%+v", value)
+	}
+	return string(valueJson)
+}

--- a/bootstrap/v2/pkg/apis/kferrors.go
+++ b/bootstrap/v2/pkg/apis/kferrors.go
@@ -16,6 +16,7 @@ package apis
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
 )
 
 type StatusCode int
@@ -38,4 +39,26 @@ type KfError struct {
 func (e *KfError) Error() string {
 	return fmt.Sprintf(" (kubeflow.error): Code %d with message: %v",
 		e.Code, e.Message)
+}
+
+// NewKfErrorWithMessage will propogate the error with the given message.
+//
+// TODO(jlewi): Not sure this is the best way to propogate the error messages and turn them
+// into KfErrors. There was a lot of code that was doing this but not asserting that the error
+// was a KfError which was causing segmentation faults so I wrote this helper method.
+func NewKfErrorWithMessage(e error, msg string) error {
+	kErr, ok := e.(*KfError)
+
+	if !ok {
+		log.Infof("Error is not a KfError; %v", e)
+
+		return &KfError{
+			Code:    int(UNKNOWN),
+			Message: msg + "; " + e.Error(),
+		}
+	}
+	return &KfError{
+		Code:    kErr.Code,
+		Message: msg + "; " + kErr.Message,
+	}
 }

--- a/bootstrap/v2/pkg/utils/logging.go
+++ b/bootstrap/v2/pkg/utils/logging.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/sirupsen/logrus"
+)
+
+// PrettyPrint returns a pretty format output of any value.
+func PrettyPrint(value interface{}) string {
+	if s, ok := value.(string); ok {
+		return s
+	}
+	valueJson, err := json.MarshalIndent(value, "", "  ")
+	if err != nil {
+		log.Errorf("Failed to marshal value; error %v", err)
+		return fmt.Sprintf("%+v", value)
+	}
+	return string(valueJson)
+}


### PR DESCRIPTION
* Define a PrettyPrint function based on serializing to json.

* Define a helper method for KfErrors to combine an existing error with
  a message.

  * This is related to #3593; there are lots of places in GCP.go where
    we assume an error is of type KfError without asserting whether that's
    true

  * This helper method will help us fix those locations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3595)
<!-- Reviewable:end -->
