### PR TITLE
kfctl: existing_arrikto: add self-signed https certificates

### DIFF
--- a/bootstrap/v2/pkg/kfapp/existing_arrikto/existing_test.go
+++ b/bootstrap/v2/pkg/kfapp/existing_arrikto/existing_test.go
@@ -1,0 +1,49 @@
+package existing_arrikto
+
+import (
+	"crypto/tls"
+	"log"
+	"testing"
+)
+
+func TestGenerateCert(t *testing.T) {
+	cases := []struct {
+		name        string
+		addr        string
+		expectError bool
+	}{
+		{
+			name:        "ip",
+			addr:        "10.0.93.8",
+			expectError: false,
+		},
+		{
+			name:        "dns domain",
+			addr:        "customdnsdomain.com",
+			expectError: false,
+		},
+		{
+			name:        "invalid ip",
+			addr:        "451.4.4",
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			certPEM, keyPEM, err := generateCert(c.addr)
+			if err != nil {
+				if !c.expectError {
+					t.Fatalf("Unexpected error occured: %+v", err)
+				} else {
+					return
+				}
+			}
+
+			cert, err := tls.X509KeyPair(certPEM, keyPEM)
+			if err != nil {
+				log.Fatalf("Unexpected error while loading keypair: %+v", cert)
+			}
+		})
+	}
+}

--- a/deployment/existing/auth_oidc/authservice.tmpl
+++ b/deployment/existing/auth_oidc/authservice.tmpl
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: authservice
-  namespace: kubeflow
+  namespace: istio-system
 spec:
   type: ClusterIP
   selector:
@@ -13,13 +13,16 @@ spec:
     name: http-authservice
     targetPort: http-api
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: authservice
-  namespace: kubeflow
+  namespace: istio-system
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: authservice
   strategy:
     type: RollingUpdate
   template:
@@ -29,14 +32,27 @@ spec:
       labels:
         app: authservice
     spec:
+      volumes:
+        - name: custom-ca
+          secret:
+            secretName: istio-ingressgateway-certs
+            items:
+              - key: tls.crt
+                path: tls.crt
       containers:
       - name: authservice
-        image: gcr.io/arrikto/kubeflow/oidc-authservice:v0.1
+        image: gcr.io/arrikto/kubeflow/oidc-authservice:v0.2
         imagePullPolicy: Always
         ports:
         - name: http-api
           containerPort: 8080
+        volumeMounts:
+          - name: custom-ca
+            mountPath: /etc/custom-ca
+            readOnly: true
         env:
+          - name: OIDC_PROVIDER_CA_FILE
+            value: "/etc/custom-ca/tls.crt"
           - name: DISABLE_USERINFO
             value: "true"
           - name: PORT

--- a/deployment/existing/auth_oidc/dex.tmpl
+++ b/deployment/existing/auth_oidc/dex.tmpl
@@ -11,7 +11,7 @@ spec:
   - name: http
     port: 5556
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deployment/existing/auth_oidc/envoy-filter.yaml
+++ b/deployment/existing/auth_oidc/envoy-filter.yaml
@@ -11,8 +11,8 @@ spec:
   - filterConfig:
       httpService:
         serverUri:
-          uri: http://authservice.kubeflow.svc.cluster.local
-          cluster: outbound|8080||authservice.kubeflow.svc.cluster.local
+          uri: http://authservice.istio-system.svc.cluster.local
+          cluster: outbound|8080||authservice.istio-system.svc.cluster.local
           failureModeAllow: false
           timeout: 10s
         authorizationRequest: 
@@ -26,5 +26,5 @@ spec:
     insertPosition:
       index: FIRST
     listenerMatch:
-      portNumber: 80
+      portNumber: 443
       listenerType: GATEWAY

--- a/deployment/existing/auth_oidc/gateway.yaml
+++ b/deployment/existing/auth_oidc/gateway.yaml
@@ -9,16 +9,24 @@ spec:
   servers:
   - port:
       number: 5556
-      name: dex
-      protocol: HTTP
+      name: https-dex
+      protocol: HTTPS
     hosts:
     - "*"
+    tls:
+      mode: SIMPLE
+      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+      privateKey: /etc/istio/ingressgateway-certs/tls.key
   - port:
-      number: 80
-      name: http
-      protocol: HTTP
+      number: 443
+      name: https
+      protocol: HTTPS
     hosts:
     - "*"
+    tls:
+      mode: SIMPLE
+      serverCertificate: /etc/istio/ingressgateway-certs/tls.crt
+      privateKey: /etc/istio/ingressgateway-certs/tls.key    
 
 --- 
 

--- a/deployment/existing/istio/istio-noauth.yaml
+++ b/deployment/existing/istio/istio-noauth.yaml
@@ -15627,7 +15627,7 @@ spec:
     istio: ingressgateway
   ports:
     - 
-      name: dex
+      name: https-dex
       port: 5556
       targetPort: 5556
     -


### PR DESCRIPTION
This PR adds self-signed HTTPS certificates to secure the Istio gateway.
Currently, these certificates are for the LoadBalancer IP.
In the near future, it will be possible to use a DNS domain and trusted certificates.

Some remarks:
* The AuthService and Istio Gateway Deployment now live in the same namespace (istio-system) in order to share the cert secret.

/assign @jlewi

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3598)
<!-- Reviewable:end -->
