### PR TITLE
keep manifest in kfctl directory as kustomize pkg

### DIFF
--- a/bootstrap/go.mod
+++ b/bootstrap/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.0 // indirect
 	github.com/onrik/logrus v0.2.1
 	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
+	github.com/otiai10/copy v1.0.1
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/common v0.0.0-20181126121408-4724e9255275

--- a/bootstrap/go.sum
+++ b/bootstrap/go.sum
@@ -1,4 +1,5 @@
 bitbucket.org/ww/goautoneg v0.0.0-20120707110453-75cd24fc2f2c/go.mod h1:1vhO7Mn/FZMgOgDVGLy5X1mE6rq1HbkBdkF/yj8zkcg=
+bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.0.0-20160913182117-3b1ae45394a2/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.33.1/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -297,6 +298,9 @@ github.com/onsi/gomega v1.4.3 h1:RE1xgDvH7imwFD45h+u2SgIfERHlS2yNG4DObb5BSKU=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
+github.com/otiai10/copy v1.0.1 h1:gtBjD8aq4nychvRZ2CyJvFWAw0aja+VHazDdruZKGZA=
+github.com/otiai10/copy v1.0.1/go.mod h1:8bMCJrAqOtN/d9oyh5HR7HhLQMvcGMpGdwRDYsfOCHc=
+github.com/otiai10/mint v1.2.3/go.mod h1:YnfyPNhBvnY8bW4SGQHCs/aAFhkgySlMZbrF5U0bOVw=
 github.com/pborman/uuid v0.0.0-20150603214016-ca53cad383ca/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -114,6 +114,7 @@ func getConfigFromCache(pathDir string, kfDef *kfdefsv2.KfDef) ([]byte, error) {
 			Message: fmt.Sprintf("error writing to %v Error %v", configPath, resMapErr),
 		}
 	}
+	// TODO: Do we need to write to file here?
 	writeErr := kustomize.WriteKustomizationFile(kfDef.Name, configPath, resMap)
 	if writeErr != nil {
 		return nil, &kfapis.KfError{

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -106,12 +106,19 @@ func getConfigFromCache(pathDir string, kfDef *kfdefsv2.KfDef) ([]byte, error) {
 		overlays = append(overlays, config.NameValue{Name: "overlay", Value: "application"})
 	}
 	compPath := strings.Split(kftypes.DefaultConfigDir, "/")[1]
-	resMap, resMapErr := kustomize.GenerateKustomizationFile(kfDef,
+	genErr := kustomize.GenerateKustomizationFile(kfDef,
 		path.Dir(configPath), compPath, overlays)
+	if genErr != nil {
+		return nil, &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: fmt.Sprintf("error writing to kustomization.yaml %v Error %v", configPath, genErr),
+		}
+	}
+	resMap, resMapErr := kustomize.EvaluateKustomizeManifest(path.Join(path.Dir(configPath), compPath))
 	if resMapErr != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("error writing to %v Error %v", configPath, resMapErr),
+			Message: fmt.Sprintf("error getting manifest %v Error %v", configPath, resMapErr),
 		}
 	}
 	// TODO: Do we need to write to file here?

--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize_test.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize_test.go
@@ -1,0 +1,88 @@
+// Copyright 2018 The Kubeflow Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kustomize
+
+import (
+	"bytes"
+	"io/ioutil"
+	"path"
+	"testing"
+
+	"github.com/kubeflow/kubeflow/bootstrap/config"
+	kfdefsv2 "github.com/kubeflow/kubeflow/bootstrap/v2/pkg/apis/apps/kfdef/v1alpha1"
+	"github.com/otiai10/copy"
+	"github.com/prometheus/common/log"
+	metav1 "k8s.io/apimachinery/v2/pkg/apis/meta/v1"
+)
+
+// This test tests that GenerateKustomizationFile will produce correct kustomization.yaml
+func TestGenerateKustomizationFile(t *testing.T) {
+	type testCase struct {
+		kfDef  *kfdefsv2.KfDef
+		params []config.NameValue
+		// The directory of a (testing) kustomize package
+		packageDir string
+		// Expected kustomization.yaml
+		expectedFile string
+	}
+	testCases := []testCase{
+		{
+			kfDef: &kfdefsv2.KfDef{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "kubeflow",
+				},
+				Spec: kfdefsv2.KfDefSpec{
+					EnableApplications: true,
+					PackageManager:     "kustomize",
+				},
+			},
+			params: []config.NameValue{
+				{
+					Name:  "overlay",
+					Value: "application",
+				},
+			},
+			packageDir:   "testdata/kustomizeExample/pytorch-operator",
+			expectedFile: "testdata/kustomizeExample/pytorch-operator/expected/kustomization.yaml",
+		},
+	}
+	packageName := "dummy"
+	for _, c := range testCases {
+		testDir, err := ioutil.TempDir("", "")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		log.Infof("testdir: %v", testDir)
+		err = copy.Copy(c.packageDir, path.Join(testDir, packageName))
+		if err != nil {
+			t.Fatalf("Failed to copy package to temp dir: %v", err)
+		}
+		err = GenerateKustomizationFile(c.kfDef, testDir, packageName, c.params)
+		if err != nil {
+			t.Fatalf("Failed to GenerateKustomizationFile: %v", err)
+		}
+		data, err := ioutil.ReadFile(path.Join(testDir, packageName, "kustomization.yaml"))
+		if err != nil {
+			t.Fatalf("Failed to read kustomization.yaml: %v", err)
+		}
+		expected, err := ioutil.ReadFile(c.expectedFile)
+		if err != nil {
+			t.Fatalf("Failed to read expected kustomization.yaml: %v", err)
+		}
+		if bytes.Compare(data, expected) != 0 {
+			t.Fatalf("kustomization.yaml is different from expected.")
+		}
+	}
+}

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/cluster-role-binding.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/cluster-role-binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: pytorch-operator
+  name: pytorch-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pytorch-operator
+subjects:
+- kind: ServiceAccount
+  name: pytorch-operator

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/cluster-role.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/cluster-role.yaml
@@ -1,0 +1,50 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  labels:
+    app: pytorch-operator
+  name: pytorch-operator
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - pytorchjobs
+  - pytorchjobs/status
+  verbs:
+  - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  verbs:
+  - '*'
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - '*'

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/config-map.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/config-map.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+data:
+  controller_config_file.yaml: |-
+    {
+
+    }
+kind: ConfigMap
+metadata:
+  name: pytorch-operator-config

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/deployment.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/deployment.yaml
@@ -1,0 +1,39 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: pytorch-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: pytorch-operator
+  template:
+    metadata:
+      labels:
+        name: pytorch-operator
+    spec:
+      containers:
+      - command:
+        - /pytorch-operator.v1
+        - --alsologtostderr
+        - -v=1
+        - --monitoring-port=8443
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: gcr.io/kubeflow-images-public/pytorch-operator:v0.5.1-5-ge775742
+        name: pytorch-operator
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+      serviceAccountName: pytorch-operator
+      volumes:
+      - configMap:
+          name: pytorch-operator-config
+        name: config-volume

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/kustomization.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/kustomization.yaml
@@ -1,0 +1,16 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- config-map.yaml
+- deployment.yaml
+- service-account.yaml
+- service.yaml
+commonLabels:
+  kustomize.component: pytorch-operator
+images:
+  - name: gcr.io/kubeflow-images-public/pytorch-operator
+    newName: gcr.io/kubeflow-images-public/pytorch-operator
+    #newTag: v0.5.0-7-g6d7ed35

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/params.env
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/params.env
@@ -1,0 +1,3 @@
+pytorchDefaultImage=null
+deploymentScope=cluster
+deploymentNamespace=null

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/service-account.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/service-account.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: pytorch-operator
+  name: pytorch-operator

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/service.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/base/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    prometheus.io/path: /metrics
+    prometheus.io/port: "8443"
+    prometheus.io/scrape: "true"
+  labels:
+    app: pytorch-operator
+  name: pytorch-operator
+spec:
+  ports:
+  - name: monitoring-port
+    port: 8443
+    targetPort: 8443
+  selector:
+    name: pytorch-operator
+  type: ClusterIP
+

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/expected/kustomization.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/expected/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- base
+commonLabels:
+  app.kubernetes.io/component: pytorch
+  app.kubernetes.io/instance: pytorch-operator
+  app.kubernetes.io/managed-by: kfctl
+  app.kubernetes.io/name: pytorch-operator-application
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/version: v0.6.0
+kind: Kustomization
+namespace: kubeflow
+resources:
+- overlays/application/application.yaml

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/overlays/application/application.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/overlays/application/application.yaml
@@ -1,0 +1,18 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: pytorch-operator-application
+spec:
+  type: pytorch-operator
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: ServiceAccount
+  description: pytorch-operator allows users to create a custom resource \"PyTorchJob\".
+  keywords:
+   - pytorch-job
+   - pytorch-operator
+  version: v1alpha1

--- a/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/overlays/application/kustomization.yaml
+++ b/bootstrap/v2/pkg/kfapp/kustomize/testdata/kustomizeExample/pytorch-operator/overlays/application/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- application.yaml
+commonLabels:
+  app.kubernetes.io/name: pytorch-operator-application
+  app.kubernetes.io/instance: pytorch-operator
+  app.kubernetes.io/version: v0.6.0
+  app.kubernetes.io/component: pytorch
+  app.kubernetes.io/part-of: kubeflow
+  app.kubernetes.io/managed-by: kfctl


### PR DESCRIPTION
Fix #3558 

Generate now only copies the pkg dir to kustomize/
Apply will call GenerateKustomizationFile to get the manifest.

```
kf0702/kustomize$ ls
api-service         cert-manager-crds   jupyter-web-app     minio               profiles            tf-job-operator
application         cloud-endpoints     katib-controller    mysql               pytorch-job-crds    webhook
application-crds    gpu-driver          katib-db            notebook-controller pytorch-operator
argo                iap-ingress         katib-manager       persistent-agent    scheduledworkflow
bootstrap           istio               katib-ui            pipelines-runner    spartakus
centraldashboard    istio-crds          metacontroller      pipelines-ui        suggestion
cert-manager        istio-install       metrics-collector   pipelines-viewer    tensorboard

kf0702/kustomize$ ls pytorch-operator/
base               kustomization.yaml overlays
```

/cc @jlewi @kkasravi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3601)
<!-- Reviewable:end -->
