### PR TITLE
Separate installing istio and using istio to 2 overlays

### DIFF
--- a/bootstrap/cmd/kfctl/cmd/init.go
+++ b/bootstrap/cmd/kfctl/cmd/init.go
@@ -61,6 +61,7 @@ or a <name>. If just <name>, a directory <name> will be created in the current d
 		}
 
 		useIstio := initCfg.GetBool(string(kftypes.USE_ISTIO))
+		installIstio := initCfg.GetBool(string(kftypes.INSTALL_ISTIO))
 		disableUsageReport := initCfg.GetBool(string(kftypes.DISABLE_USAGE_REPORT))
 		config := initCfg.GetString(string(kftypes.CONFIG))
 
@@ -74,6 +75,7 @@ or a <name>. If just <name>, a directory <name> will be created in the current d
 			string(kftypes.SKIP_INIT_GCP_PROJECT): init_gcp,
 			string(kftypes.USE_BASIC_AUTH):        useBasicAuth,
 			string(kftypes.USE_ISTIO):             useIstio,
+			string(kftypes.INSTALL_ISTIO):         installIstio,
 			string(kftypes.DISABLE_USAGE_REPORT):  disableUsageReport,
 			string(kftypes.PACKAGE_MANAGER):       packageManager,
 			string(kftypes.CONFIG):                config,
@@ -180,6 +182,15 @@ func init() {
 	bindErr = initCfg.BindPFlag(string(kftypes.USE_ISTIO), initCmd.Flags().Lookup(string(kftypes.USE_ISTIO)))
 	if bindErr != nil {
 		log.Errorf("couldn't set flag --%v: %v", string(kftypes.USE_ISTIO), bindErr)
+		return
+	}
+
+	// Install Istio
+	initCmd.Flags().Bool(string(kftypes.INSTALL_ISTIO), true,
+		string(kftypes.INSTALL_ISTIO)+" install istio.")
+	bindErr = initCfg.BindPFlag(string(kftypes.INSTALL_ISTIO), initCmd.Flags().Lookup(string(kftypes.INSTALL_ISTIO)))
+	if bindErr != nil {
+		log.Errorf("couldn't set flag --%v: %v", string(kftypes.INSTALL_ISTIO), bindErr)
 		return
 	}
 

--- a/bootstrap/config/overlays/install_istio/kfctl_default.yaml
+++ b/bootstrap/config/overlays/install_istio/kfctl_default.yaml
@@ -1,0 +1,9 @@
+apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+kind: KfDef
+metadata:
+  name: config
+spec:
+  components:
+  - istio-crds
+  - istio-install
+  - istio

--- a/bootstrap/config/overlays/install_istio/kustomization.yaml
+++ b/bootstrap/config/overlays/install_istio/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- kfctl_default.yaml

--- a/bootstrap/config/overlays/istio/kfctl_default.yaml
+++ b/bootstrap/config/overlays/istio/kfctl_default.yaml
@@ -3,10 +3,6 @@ kind: KfDef
 metadata:
   name: config
 spec:
-  components:
-  - istio-crds
-  - istio-install
-  - istio
   componentParams:
     argo:
     - name: overlay

--- a/bootstrap/pkg/apis/apps/group.go
+++ b/bootstrap/pkg/apis/apps/group.go
@@ -88,6 +88,7 @@ const (
 	ZONE                  CliOption = "zone"
 	USE_BASIC_AUTH        CliOption = "use_basic_auth"
 	USE_ISTIO             CliOption = "use_istio"
+	INSTALL_ISTIO         CliOption = "install_istio"
 	DELETE_STORAGE        CliOption = "delete_storage"
 	DISABLE_USAGE_REPORT  CliOption = "disable_usage_report"
 	PACKAGE_MANAGER       CliOption = "package-manager"

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -85,8 +85,8 @@ func GetKfApp(kfdef *kfdefsv2.KfDef) kftypes.KfApp {
 	return _coordinator
 }
 
-// Config itself is a kustomize package, https://github.com/kubeflow/kubeflow/tree/master/bootstrap/config.
 // getConfigFromCache returns the KfDef yaml (in bytes) with overlays applied, and also writes it to app.yaml.
+// Config itself is a kustomize package, https://github.com/kubeflow/kubeflow/tree/master/bootstrap/config.
 func getConfigFromCache(pathDir string, kfDef *kfdefsv2.KfDef) ([]byte, error) {
 
 	configPath := filepath.Join(pathDir, kftypes.DefaultConfigDir)

--- a/bootstrap/v2/pkg/apis/apps/kfdef/v1alpha1/application_types.go
+++ b/bootstrap/v2/pkg/apis/apps/kfdef/v1alpha1/application_types.go
@@ -62,6 +62,7 @@ type KfDefSpec struct {
 	UseBasicAuth       bool     `json:"useBasicAuth"`
 	SkipInitProject    bool     `json:"skipInitProject,omitempty"`
 	UseIstio           bool     `json:"useIstio"`
+	InstallIstio       bool     `json:"installIstio"`
 	EnableApplications bool     `json:"enableApplications"`
 	ServerVersion      string   `json:"serverVersion,omitempty"`
 	DeleteStorage      bool     `json:"deleteStorage,omitempty"`


### PR DESCRIPTION
When running kfctl on an existing cluster, we might already have istio installed, but we still want the components to use istio features.

Related to https://github.com/kubeflow/kubeflow/issues/3618 and https://github.com/kubeflow/kubeflow/issues/3626

/cc @jlewi @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3627)
<!-- Reviewable:end -->
