### PR TITLE
create a default profile for the gcp platform

### DIFF
--- a/bootstrap/config/kfctl_gcp_iap.0.6.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.0.6.yaml
@@ -36,6 +36,9 @@ spec:
     cloud-endpoints:
     - name: secretName
       value: admin-gcp-sa
+    - initRequired: true
+      name: email
+      value: email
     iap-ingress:
     - name: namespace
       value: istio-system

--- a/bootstrap/config/overlays/basic_auth/kfctl_default.yaml
+++ b/bootstrap/config/overlays/basic_auth/kfctl_default.yaml
@@ -11,9 +11,11 @@ spec:
   - gpu-driver
   - basic-auth
   - basic-auth-ingress
+  - profiles
   packages:
   - cert-manager
   - gcp
+  - profiles
   componentParams:
     ambassador:
     - name: ambassadorServiceType
@@ -28,6 +30,9 @@ spec:
     cloud-endpoints:
     - name: secretName
       value: admin-gcp-sa
+    - name: email
+      value: email
+      initRequired: true
     basic-auth-ingress:
     - name: ipName
       # TODO change value on the fly: value of ipName need to match resource name in deployment entry.

--- a/bootstrap/config/overlays/gcp/kfctl_default.yaml
+++ b/bootstrap/config/overlays/gcp/kfctl_default.yaml
@@ -23,6 +23,9 @@ spec:
     cloud-endpoints:
     - name: secretName
       value: admin-gcp-sa
+    - name: email
+      value: email
+      initRequired: true
     iap-ingress:
     - name: ipName
       # TODO change value on the fly: value of ipName need to match resource name in deployment entry.

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1749,6 +1749,9 @@ func (gcp *Gcp) Generate(resources kftypes.ResourceEnum) error {
 	if gcp.kfDef.Spec.Hostname == "" {
 		gcp.kfDef.Spec.Hostname = gcp.kfDef.Name + ".endpoints." + gcp.kfDef.Spec.Project + ".cloud.goog"
 	}
+	if gcp.kfDef.Spec.Email != "" {
+		gcp.kfDef.Spec.ComponentParams["cloud-endpoints"] = setNameVal(gcp.kfDef.Spec.ComponentParams["cloud-endpoints"], "email", gcp.kfDef.Spec.Email, true)
+	}
 	if gcp.kfDef.Spec.UseBasicAuth {
 		gcp.kfDef.Spec.ComponentParams["basic-auth-ingress"] = setNameVal(gcp.kfDef.Spec.ComponentParams["basic-auth-ingress"], "ipName", gcp.kfDef.Spec.IpName, true)
 		gcp.kfDef.Spec.ComponentParams["basic-auth-ingress"] = setNameVal(gcp.kfDef.Spec.ComponentParams["basic-auth-ingress"], "hostname", gcp.kfDef.Spec.Hostname, true)

--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -1037,6 +1037,7 @@ func GenerateKustomizationFile(kfDef *kfdefsv2.KfDef, root string,
 			//TODO look at sort options
 			//See https://github.com/kubernetes-sigs/kustomize/issues/821
 			//TODO upgrade to v2.0.4 when available
+			baseKfDef.Spec.Components = moveToFront("profiles", baseKfDef.Spec.Components)
 			if kfDef.Spec.EnableApplications {
 				baseKfDef.Spec.Components = moveToFront("application", baseKfDef.Spec.Components)
 				baseKfDef.Spec.Components = moveToFront("application-crds", baseKfDef.Spec.Components)

--- a/testing/kfctl/kfctl_go_test.py
+++ b/testing/kfctl/kfctl_go_test.py
@@ -86,10 +86,10 @@ def test_build_kfctl_go(app_path, project, use_basic_auth, use_istio):
   if os.getenv("REPO_NAME") != "manifests":
     if os.getenv("PULL_NUMBER"):
       version = "pull/{0}".format(os.getenv("PULL_NUMBER"))
-  pull_sha = "@7cf5587dd9e2ec523bbdc99642d530f42fec4361"
+  pull_manifests = "@pull/207/head"
   if os.getenv("REPO_NAME") == "manifests":
     if os.getenv("PULL_PULL_SHA"):
-      pull_sha = "@" + os.getenv("PULL_PULL_SHA")
+      pull_manifests = "@" + os.getenv("PULL_PULL_SHA"
 
   # username and password are passed as env vars and won't appear in the logs
   # TODO(https://github.com/kubeflow/kubeflow/issues/2831): Once kfctl
@@ -101,7 +101,7 @@ def test_build_kfctl_go(app_path, project, use_basic_auth, use_istio):
   # already exists. So retrying ends up masking the original error message
   util.run([
       kfctl_path, "init", app_path, "-V", "--platform=gcp",
-      "--version=" + version, "--package-manager=kustomize" + pull_sha,
+      "--version=" + version, "--package-manager=kustomize" + pull_manifests,
       "--skip-init-gcp-project", "--disable_usage_report",
       "--project=" + project
       ] + init_args, cwd=parent_dir)


### PR DESCRIPTION
fixes #3639, dependencies: kubeflow/manifests#207 

- [x] add a --dry-run to apply so that output can be saved into an output directory
- [x] reorder profiles in the component list
- [x] add email parameter to cloud-endpoints
- [x] add profile.yaml to cloud-endpoints

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3645)
<!-- Reviewable:end -->
