### PR TITLE
jupyter-web-app: backend: fix default storage class detection

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
@@ -112,11 +112,12 @@ def get_default_storageclass():
 
         for key in keys:
             is_default = annotations.get(key, "false")
-        if is_default == "true":
-            return jsonify({
-                "success": True,
-                "defaultStorageClass": strgclss.metadata.name
-            })
+            
+            if is_default == "true":
+                return jsonify({
+                    "success": True,
+                    "defaultStorageClass": strgclss.metadata.name
+                })
 
     # No StorageClass is default
     return jsonify({


### PR DESCRIPTION
The default storage class detection code has a bug.
The bug causes it to not check for the `storageclass.kubernetes.io/is-default-class` annotation.

/assign @kimwnasptd 
cc @ioandr @jlewi 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3647)
<!-- Reviewable:end -->
