### PR TITLE
coordinator should load packagemanagers and platform KfApps once at construction time

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -22,7 +22,6 @@ import (
 	"github.com/kubeflow/kubeflow/bootstrap/config"
 	kftypes "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps"
 	"github.com/kubeflow/kubeflow/bootstrap/pkg/kfapp/gcp"
-	"github.com/kubeflow/kubeflow/bootstrap/pkg/kfapp/ksonnet"
 	"github.com/kubeflow/kubeflow/bootstrap/pkg/kfapp/minikube"
 	kfapis "github.com/kubeflow/kubeflow/bootstrap/v2/pkg/apis"
 	kftypesv2 "github.com/kubeflow/kubeflow/bootstrap/v2/pkg/apis/apps"
@@ -33,8 +32,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	valid "k8s.io/apimachinery/v2/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/v2/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"os"
 	"path"
 	"path/filepath"
@@ -52,37 +49,6 @@ type DefaultBuilder struct {
 
 func (b *DefaultBuilder) LoadKfAppCfgFile(cfgFile string) (kftypes.KfApp, error) {
 	return LoadKfAppCfgFile(cfgFile)
-}
-
-// The common entry point used to retrieve an implementation of KfApp.
-// In this case it returns a composite class (coordinator) which aggregates
-// platform and package manager implementations in Children.
-//
-// TODO(jlewi): I don't think this should be an exported method. Callers should
-// probably use NewKfApp if we are starting from scratch; e.g. Creating an app.yaml file.
-// Or LoadKfApp if creating it from an app.yaml on disk.
-// If creating from a KfDef the steps should probably be
-// 1. Persist it to disk using CreateKfAppDir
-// 2. Call LoadKfApp.
-func GetKfApp(kfdef *kfdefsv2.KfDef) kftypes.KfApp {
-	_coordinator := &coordinator{
-		Platforms:       make(map[string]kftypes.Platform),
-		PackageManagers: nil,
-		KfDef:           kfdef,
-	}
-	// Fetch the platform [gcp,minikube]
-	platform := _coordinator.KfDef.Spec.Platform
-	if platform != "" {
-		_platform, _platformErr := getPlatform(_coordinator.KfDef)
-		if _platformErr != nil {
-			log.Fatalf("could not get platform %v Error %v **", platform, _platformErr)
-			return nil
-		}
-		if _platform != nil {
-			_coordinator.Platforms[platform] = _platform
-		}
-	}
-	return _coordinator
 }
 
 func getConfigFromCache(pathDir string, kfDef *kfdefsv2.KfDef) ([]byte, error) {
@@ -108,6 +74,7 @@ func getConfigFromCache(pathDir string, kfDef *kfdefsv2.KfDef) ([]byte, error) {
 	compPath := strings.Split(kftypes.DefaultConfigDir, "/")[1]
 	genErr := kustomize.GenerateKustomizationFile(kfDef,
 		path.Dir(configPath), compPath, overlays)
+
 	if genErr != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
@@ -118,7 +85,7 @@ func getConfigFromCache(pathDir string, kfDef *kfdefsv2.KfDef) ([]byte, error) {
 	if resMapErr != nil {
 		return nil, &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
-			Message: fmt.Sprintf("error getting manifest %v Error %v", configPath, resMapErr),
+			Message: fmt.Sprintf("error writing to %v Error %v", configPath, resMapErr),
 		}
 	}
 	// TODO: Do we need to write to file here?
@@ -158,9 +125,8 @@ func getPlatform(kfdef *kfdefsv2.KfDef) (kftypes.Platform, error) {
 }
 
 func (coord *coordinator) getPackageManagers(kfdef *kfdefsv2.KfDef) *map[string]kftypes.KfApp {
-	platform := coord.Platforms[coord.KfDef.Spec.Platform]
 	var packagemanagers = make(map[string]kftypes.KfApp)
-	_packagemanager, _packagemanagerErr := getPackageManager(kfdef, platform)
+	_packagemanager, _packagemanagerErr := getPackageManager(kfdef)
 	if _packagemanagerErr != nil {
 		log.Fatalf("could not get packagemanager %v Error %v **", kfdef.Spec.PackageManager, _packagemanagerErr)
 	}
@@ -173,18 +139,13 @@ func (coord *coordinator) getPackageManagers(kfdef *kfdefsv2.KfDef) *map[string]
 // getPackageManager will return an implementation of kftypes.KfApp that matches the packagemanager string
 // It looks for statically compiled-in implementations, otherwise it delegates to
 // kftypes.LoadKfApp which will try and dynamically load a .so
-func getPackageManager(kfdef *kfdefsv2.KfDef, platform kftypes.Platform) (kftypes.KfApp, error) {
-	var restconf *rest.Config = nil
-	var apiconf *clientcmdapi.Config = nil
-	if platform != nil {
-		restconf, apiconf = platform.GetK8sConfig()
-	}
-
+//
+func getPackageManager(kfdef *kfdefsv2.KfDef) (kftypes.KfApp, error) {
 	switch kfdef.Spec.PackageManager {
 	case kftypes.KUSTOMIZE:
 		return kustomize.GetKfApp(kfdef), nil
 	case kftypes.KSONNET:
-		return ksonnet.GetKfApp(kfdef, restconf, apiconf), nil
+		return nil, fmt.Errorf("Support for ksonnet is no longer implemented")
 	default:
 		log.Infof("** loading %v.so for package manager %v **", kfdef.Spec.PackageManager, kfdef.Spec.PackageManager)
 		return kftypesv2.LoadKfApp(kfdef.Spec.PackageManager, kfdef)
@@ -225,6 +186,28 @@ func usageReportWarn(components []string) {
 			return
 		}
 	}
+}
+
+// repoVersionToRepoStruct converts the name of a repo and the old style version
+// into a new go-getter style syntax and a Repo spec
+//
+//   master
+//	 tag
+//	 pull/<ID>[/head]
+//
+func repoVersionToUri(repo string, version string) string {
+	// Version can be
+	// --version master
+	// --version tag
+	// --version pull/<ID>/head
+	if strings.HasPrefix(version, "pull") {
+		if !strings.HasSuffix(version, "head") {
+			version = version + "/head"
+		}
+	}
+	tarballUrl := "https://github.com/kubeflow/" + repo + "/tarball/" + version + "?archive=tar.gz"
+
+	return tarballUrl
 }
 
 // CreateKfDefFromOptions creates a KfDef from the supplied options.
@@ -312,6 +295,7 @@ func CreateKfDefFromOptions(options map[string]interface{}) (*kfdefsv2.KfDef, er
 			}
 		} else {
 			var cacheDirErr error
+			// TODO(jlewi): We should call repoVersionToUri and pass the value to DownloadToCache
 			cacheDir, cacheDirErr = kftypes.DownloadToCache(appDir, kftypes.KubeflowRepo, version)
 			if cacheDirErr != nil || cacheDir == "" {
 				log.Fatalf("could not download repo to cache Error %v", cacheDirErr)
@@ -358,6 +342,17 @@ func CreateKfDefFromOptions(options map[string]interface{}) (*kfdefsv2.KfDef, er
 		kfDef.Spec.UseBasicAuth = useBasicAuth
 		kfDef.Spec.UseIstio = useIstio
 		kfDef.Spec.PackageManager = packageManager
+
+		// Add the repo
+		if kfDef.Spec.Repos == nil {
+			kfDef.Spec.Repos = []kfdefsv2.Repo{}
+		}
+
+		repoUri := repoVersionToUri(kftypes.KubeflowRepo, version)
+		kfDef.Spec.Repos = append(kfDef.Spec.Repos, kfdefsv2.Repo{
+			Name: kftypes.KubeflowRepoName,
+			Uri:  repoUri,
+		})
 	}
 	kfDef.Spec.AppDir = appDir
 
@@ -659,8 +654,38 @@ func LoadKfAppCfgFile(cfgfile string) (kftypes.KfApp, error) {
 		}
 	}
 
-	pApp := GetKfApp(kfdef)
-	return pApp, nil
+	c := &coordinator{
+		Platforms:       make(map[string]kftypes.Platform),
+		PackageManagers: make(map[string]kftypes.KfApp),
+		KfDef:           kfdef,
+	}
+	// fetch the platform [gcp,minikube]
+	platform := c.KfDef.Spec.Platform
+	if platform != "" {
+		_platform, _platformErr := getPlatform(c.KfDef)
+		if _platformErr != nil {
+			log.Fatalf("could not get platform %v Error %v **", platform, _platformErr)
+			return nil, _platformErr
+		}
+		if _platform != nil {
+			c.Platforms[platform] = _platform
+		}
+	}
+
+	packageManager := c.KfDef.Spec.PackageManager
+
+	if packageManager != "" {
+		pkg, pkgErr := getPackageManager(c.KfDef)
+		if pkgErr != nil {
+			log.Fatalf("could not get package manager %v Error %v **", packageManager, pkgErr)
+			return nil, pkgErr
+		}
+		if pkg != nil {
+			c.PackageManagers[packageManager] = pkg
+		}
+	}
+
+	return c, nil
 }
 
 // this type holds platform implementations of KfApp
@@ -718,7 +743,6 @@ func (kfapp *coordinator) Apply(resources kftypes.ResourceEnum) error {
 	}
 
 	k8s := func() error {
-		kfapp.PackageManagers = *kfapp.getPackageManagers(kfapp.KfDef)
 		for packageManagerName, packageManager := range kfapp.PackageManagers {
 			packageManagerErr := packageManager.Apply(kftypes.K8S)
 			if packageManagerErr != nil {
@@ -771,7 +795,6 @@ func (kfapp *coordinator) Delete(resources kftypes.ResourceEnum) error {
 	}
 
 	k8s := func() error {
-		kfapp.PackageManagers = *kfapp.getPackageManagers(kfapp.KfDef)
 		for packageManagerName, packageManager := range kfapp.PackageManagers {
 			packageManagerErr := packageManager.Delete(kftypes.K8S)
 			if packageManagerErr != nil {
@@ -835,7 +858,6 @@ func (kfapp *coordinator) Generate(resources kftypes.ResourceEnum) error {
 	}
 
 	k8s := func() error {
-		kfapp.PackageManagers = *kfapp.getPackageManagers(kfapp.KfDef)
 		for packageManagerName, packageManager := range kfapp.PackageManagers {
 			packageManagerErr := packageManager.Generate(kftypes.K8S)
 			if packageManagerErr != nil {
@@ -891,7 +913,6 @@ func (kfapp *coordinator) Init(resources kftypes.ResourceEnum) error {
 	}
 
 	k8s := func() error {
-		kfapp.PackageManagers = *kfapp.getPackageManagers(kfapp.KfDef)
 		for packageManagerName, packageManager := range kfapp.PackageManagers {
 			packageManagerErr := packageManager.Init(kftypes.K8S)
 			if packageManagerErr != nil {
@@ -952,7 +973,6 @@ func (kfapp *coordinator) Show(resources kftypes.ResourceEnum, options map[strin
 					kfapp.KfDef.Spec.Platform),
 			}
 		}
-		kfapp.PackageManagers = *kfapp.getPackageManagers(kfapp.KfDef)
 		for packageManagerName, packageManager := range kfapp.PackageManagers {
 			show, ok := packageManager.(kftypes.KfShow)
 			if ok && show != nil {

--- a/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
@@ -370,6 +370,37 @@ func Test_backfillKfDefFromGenerateOptions(t *testing.T) {
 	}
 }
 
+func Test_repoVersionToRepoStruct(t *testing.T) {
+	type testCase struct {
+		name     string
+		version  string
+		expected string
+	}
+
+	testCases := []testCase{
+		{
+			name:     "kubeflow",
+			version:  "master",
+			expected: "https://github.com/kubeflow/kubeflow/tarball/master?archive=tar.gz",
+		},
+		{
+			name:     "manifests",
+			version:  "pull/189",
+			expected: "https://github.com/kubeflow/manifests/tarball/pull/189/head?archive=tar.gz",
+		},
+	}
+
+	for _, c := range testCases {
+		actual := repoVersionToUri(c.name, c.version)
+
+		if !reflect.DeepEqual(actual, c.expected) {
+			pGot, _ := Pformat(actual)
+			pWant, _ := Pformat(c.expected)
+			t.Errorf("Error converting got;\n%v\nwant;\n%v", pGot, pWant)
+		}
+	}
+}
+
 // Pformat returns a pretty format output of any value.
 func Pformat(value interface{}) (string, error) {
 	if s, ok := value.(string); ok {

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1294,9 +1294,15 @@ func (gcp *Gcp) generateDMConfigs() error {
 			Message: fmt.Sprintf("cannot create directory %v", gcpConfigDirErr),
 		}
 	}
-	repo := gcp.kfDef.Spec.Repo
-	parentDir := path.Dir(repo)
-	sourceDir := path.Join(parentDir, "deployment/gke/deployment_manager_configs")
+	repo, ok := gcp.kfDef.Status.ReposCache[kftypes.KubeflowRepoName]
+
+	if !ok {
+		err := fmt.Errorf("Repo %v not found in KfDef.Status.ReposCache", kftypes.KubeflowRepoName)
+		log.Errorf("%v", err)
+		return errors.WithStack(err)
+	}
+
+	sourceDir := path.Join(repo.LocalPath, "deployment/gke/deployment_manager_configs")
 	files := []string{"cluster.jinja", "cluster.jinja.schema", "storage.jinja",
 		"storage.jinja.schema"}
 	for _, file := range files {
@@ -1703,6 +1709,11 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 // Generate generates the gcp kfapp manifest.
 // Remind: Need to be thread-safe: this entry is share among kfctl and deploy app
 func (gcp *Gcp) Generate(resources kftypes.ResourceEnum) error {
+	if err := gcp.kfDef.SyncCache(); err != nil {
+		log.Errorf("Failed to synchronize the cache; error %v", err)
+		return errors.WithStack(err)
+	}
+	
 	if err := gcp.setGcpPluginDefaults(); err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
* coordinator go was dynamically recreating the KfApp for the package manager whenever the
actions init/generate/apply/delete were called.

* This prevents storing state in the KfApp's representing the platform and package manager.

* Coordinator also stores maps Coordinator.platforms and Coordinator.packageManagers so why not
  just get them from there?

* I suspect this was legacy code and might have been required when we were embedding the KfDef inside
  the Kustomize/Ksonnet/Gcp structs rather than just storing a pointer.
  * As a result I think we had to dynamically recreate them in order to pick up the changes to KfDef.

* Change the code so KfApps are constructed once in LoadCfgAppFile and after that we get them
  from the appropriate fields in Coordinator.

* Move the code in GetKfApp to  LoadCfgAppFile.

* Remove import ksonnet from coordinator.go
  
  * ksonnet no longer works on master so rather than try to update code to continue to support ksonnet
    we can just return NotSupported errors for any code branches that are ksonnet only


Related to #2152

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3651)
<!-- Reviewable:end -->
