### PR TITLE
fix auto release for central dashboard

### DIFF
--- a/releasing/releaser/app.yaml
+++ b/releasing/releaser/app.yaml
@@ -20,12 +20,6 @@ libraries:
       refSpec: master
     name: automation
     registry: kubeflow
-  core:
-    gitVersion:
-      commitSha: 5c35580d76092788b089cb447be3f3097cffe60b
-      refSpec: master
-    name: core
-    registry: kubeflow
 name: test-infra
 registries:
   incubator:


### PR DESCRIPTION
Get rid of deprecated dependency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3682)
<!-- Reviewable:end -->
