### PR TITLE
Fix the error durning installation.

### DIFF
--- a/scripts/util.sh
+++ b/scripts/util.sh
@@ -18,7 +18,7 @@ usage() {
 check_installed_deps() {
   declare -a kf_deps=("ks" "kubectl")
 
-  for kf_dep in "${kf_app[@]}"; do
+  for kf_dep in "${kf_deps[@]}"; do
     if ! which "${kf_dep}" &>/dev/null && ! type -a "${kf_dep}" &>/dev/null ; then
       echo "You don't have ${kf_dep} installed. Please install ${kf_dep}."
       exit 1


### PR DESCRIPTION
I have got following errors when I install the kubeflow: 
os: MacOs
My CMD: `KUBEFLOW_REPO=${KUBEFLOW_SRC} ${KUBEFLOW_SRC}/scripts/kfctl.sh init ${KFAPP} --platform minikube`

Error: 
`++ head -1
/Users/llhu/kubeflow_src/scripts/util.sh: line 31: ks: command not found
+ ks_ver=
+ '[' '<' 0.11.0 ']'
/Users/llhu/kubeflow_src/scripts/util.sh: line 32: [: <: unary operator expected
+ [[ minikube == \g\c\p ]]
+ [[ minikube == \a\z\u\r\e ]]`

However, we except the error likes this :
`You don't have ks installed. Please install ks.` ,then `exit`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3690)
<!-- Reviewable:end -->
