### PR TITLE
setup_backend.sh: select CURR_NODE_PORT by name, not index

### DIFF
--- a/kubeflow/gcp/setup_backend.sh
+++ b/kubeflow/gcp/setup_backend.sh
@@ -68,7 +68,7 @@ checkBackend() {
   . /var/shared/healthz.env
 
   # If node port or backend id change, so does the JWT audience.
-  CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[0].nodePort}')
+  CURR_NODE_PORT=$(kubectl --namespace=${NAMESPACE} get svc ${SERVICE} -o jsonpath='{.spec.ports[?(@.name=="'${PORT_NAME}'")].nodePort}')
   read -ra toks <<<"$(gcloud compute --project=${PROJECT} backend-services list --filter=name~k8s-be-${CURR_NODE_PORT}- --format='value(id,timeoutSec)')"
   CURR_BACKEND_ID="${toks[0]}"
   CURR_BACKEND_TIMEOUT="${toks[1]}"


### PR DESCRIPTION
The script selects the nodePort based on [the name of the port earlier in the script](https://github.com/kubeflow/kubeflow/blob/e6944f35149f7c362d32fb9d57fc9f3842a46347/kubeflow/gcp/setup_backend.sh#L26), but the query in the `checkBackend` function assumes that the port number is the first in the Service.

I believe this fixes #3628

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3691)
<!-- Reviewable:end -->
