### PR TITLE
set kfctl default version to v0.6

### DIFF
--- a/bootstrap/pkg/apis/apps/group.go
+++ b/bootstrap/pkg/apis/apps/group.go
@@ -42,7 +42,7 @@ import (
 const (
 	DefaultNamespace = "kubeflow"
 	// TODO: find the latest tag dynamically
-	DefaultVersion         = "master"
+	DefaultVersion         = "v0.6.0-rc.1"
 	KfConfigFile           = "app.yaml"
 	KustomizationFile      = "kustomization.yaml"
 	KustomizationParamFile = "params.env"

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -496,7 +496,7 @@ func backfillKfDefFromInitOptions(kfdef *kfdefsv2.KfDef, options map[string]inte
 	if strings.Contains(kfdef.Spec.PackageManager, kftypes.KUSTOMIZE) {
 		pFlag := kfdef.Spec.PackageManager
 		parts := strings.Split(pFlag, "@")
-		version := "master"
+		version := kftypesv2.DefaultVersion
 		if len(parts) == 2 {
 			version = parts[1]
 		}

--- a/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
@@ -2,6 +2,7 @@ package coordinator
 
 import (
 	"encoding/json"
+	"fmt"
 	config "github.com/kubeflow/kubeflow/bootstrap/config"
 	kftypes "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps"
 	kftypesv2 "github.com/kubeflow/kubeflow/bootstrap/v2/pkg/apis/apps"
@@ -165,8 +166,9 @@ func Test_backfillKfDefFromInitOptions(t *testing.T) {
 					Repos: []kfdefsv2.Repo{
 						{
 							Name: "manifests",
-							Uri:  "https://github.com/kubeflow/manifests/archive/master.tar.gz",
-							Root: "manifests-master",
+							Uri:  fmt.Sprintf("https://github.com/kubeflow/manifests/archive/%v.tar.gz",
+								kftypesv2.DefaultVersion),
+							Root: "manifests-" + kftypesv2.DefaultVersion,
 						},
 					},
 				},

--- a/bootstrap/v2/pkg/apis/apps/group.go
+++ b/bootstrap/v2/pkg/apis/apps/group.go
@@ -43,7 +43,7 @@ import (
 const (
 	DefaultNamespace = "kubeflow"
 	// TODO: find the latest tag dynamically
-	DefaultVersion         = "master"
+	DefaultVersion         = "v0.6.0"
 	KfConfigFile           = "app.yaml"
 	KustomizationFile      = "kustomization.yaml"
 	KustomizationParamFile = "params.env"


### PR DESCRIPTION
So on v0.6 branch kfctl will use v0.6.0 config

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3692)
<!-- Reviewable:end -->
