### PR TITLE
Create PodDefault if platform is GCP

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -783,6 +783,8 @@ func (kfapp *coordinator) Apply(resources kftypes.ResourceEnum) error {
 		if err := platform(); err != nil {
 			return err
 		}
+		// TODO(gabrielwen): Need to find a more proper way of injecting plugings.
+		// https://github.com/kubeflow/kubeflow/issues/3708
 		return gcpAddedConfig()
 	case kftypes.K8S:
 		return k8s()

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -756,14 +756,14 @@ func (kfapp *coordinator) Apply(resources kftypes.ResourceEnum) error {
 	}
 
 	gcpAddedConfig := func() error {
-		if kfapp.KfDef.Spec.Email == "" || kfapp.KfDef.Spec.Platform != "gcp" {
+		if kfapp.KfDef.Spec.Email == "" || kfapp.KfDef.Spec.Platform != kftypes.GCP {
 			return nil
 		}
 		p := kfapp.Platforms[kfapp.KfDef.Spec.Platform]
 		if p == nil {
 			return &kfapis.KfError{
 				Code:    int(kfapis.INTERNAL_ERROR),
-				Message: "gcp not in Platforms",
+				Message: "Platform GCP specified but not loaded.",
 			}
 		}
 		gcp := p.(*gcp.Gcp)

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -759,15 +759,16 @@ func (kfapp *coordinator) Apply(resources kftypes.ResourceEnum) error {
 		if kfapp.KfDef.Spec.Email == "" || kfapp.KfDef.Spec.Platform != kftypes.GCP {
 			return nil
 		}
-		p := kfapp.Platforms[kfapp.KfDef.Spec.Platform]
-		if p == nil {
+
+		if p, ok := kfapp.Platforms[kfapp.KfDef.Spec.Platform]; !ok {
 			return &kfapis.KfError{
 				Code:    int(kfapis.INTERNAL_ERROR),
 				Message: "Platform GCP specified but not loaded.",
 			}
+		} else {
+			gcp := p.(*gcp.Gcp)
+			return gcp.ConfigPodDefault()
 		}
-		gcp := p.(*gcp.Gcp)
-		return gcp.ConfigPodDefault()
 	}
 
 	switch resources {

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1592,7 +1592,7 @@ func generatePodDefault(group string, version string, kind string, namespace str
 			map[string]interface{}{
 				"name": "secret-volume",
 				"secret": map[string]interface{}{
-					"secretName": "user-gcp-sa",
+					"secretName": USER_SECRET_NAME,
 				},
 			},
 		},

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1926,5 +1926,6 @@ func (gcp *Gcp) Init(resources kftypes.ResourceEnum) error {
 			return initProjectErr
 		}
 	}
+
 	return nil
 }

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -806,15 +806,6 @@ func (gcp *Gcp) Apply(resources kftypes.ResourceEnum) error {
 				secretsErr.(*kfapis.KfError).Message),
 		}
 	}
-	// Configure and create PodDefault.
-	podDefaultErr := gcp.configPodDefault()
-	if podDefaultErr != nil {
-		return &kfapis.KfError{
-			Code: secretsErr.(*kfapis.KfError).Code,
-			Message: fmt.Sprintf("gcp apply could not config PodDefault Error %v",
-				secretsErr.(*kfapis.KfError).Message),
-		}
-	}
 
 	return nil
 }

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1622,6 +1622,8 @@ func (gcp *Gcp) configPodDefault() error {
 		return kfapis.NewKfErrorWithMessage(err, "Adding volumes is failed.")
 	}
 
+	// TODO(gabrielwen): Deploy to GKE.
+
 	return nil
 }
 

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1559,6 +1559,8 @@ func (gcp *Gcp) createSecrets() error {
 func generatePodDefault(group string, version string, kind string, namespace string) *unstructured.Unstructured {
 	log.Infof("Generating %v in namespace %v; APIVersion %v/%v", kind, namespace, group, version)
 
+	// TODO(gabrielwen): Clean up after v2 dependencies are fixed.
+	// https://github.com/kubeflow/kubeflow/issues/3713
 	unstructuredContent := map[string]interface{}{
 		"apiVersion": group + "/" + version,
 		"kind":       kind,

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1550,7 +1550,7 @@ func (gcp *Gcp) createSecrets() error {
 }
 
 // Configure PodDefault to add secret.
-func (gcp *Gcp) configPodDefault() error {
+func (gcp *Gcp) ConfigPodDefault() error {
 	if gcp.kfDef.Spec.Email == "" {
 		return nil
 	}

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	kftypes "github.com/kubeflow/kubeflow/bootstrap/pkg/apis/apps"
 	kfapis "github.com/kubeflow/kubeflow/bootstrap/v2/pkg/apis"
+	kftypesv2 "github.com/kubeflow/kubeflow/bootstrap/v2/pkg/apis/apps"
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/v2/pkg/apis/apps/kfdef/v1alpha1"
 	"github.com/kubeflow/kubeflow/bootstrap/v2/pkg/utils"
 	"github.com/pkg/errors"
@@ -1572,7 +1573,7 @@ func (gcp *Gcp) ConfigPodDefault() error {
 	if err != nil {
 		return kfapis.NewKfErrorWithMessage(err, "User service account secret is not created.")
 	}
-	defaultNamespace := "kubeflow-" + strings.NewReplacer(".", "-", "@", "-at-").Replace(gcp.kfDef.Spec.Email)
+	defaultNamespace := kftypesv2.EmailToDefaultName(gcp.kfDef.Spec.Email)
 	log.Infof("Creating secret %v to namespace %v", USER_SECRET_NAME, defaultNamespace)
 	if err = insertSecret(k8sClient, USER_SECRET_NAME, defaultNamespace, secret.Data); err != nil {
 		return kfapis.NewKfErrorWithMessage(err, fmt.Sprintf("cannot create secret %v in namespace %v", USER_SECRET_NAME, defaultNamespace))

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1566,7 +1566,7 @@ func (gcp *Gcp) ConfigPodDefault() error {
 	if err != nil {
 		return kfapis.NewKfErrorWithMessage(err, "User service account secret is not created.")
 	}
-	defaultNamespace := strings.NewReplacer(".", "-", "@", "-at-").Replace(gcp.kfDef.Spec.Email)
+	defaultNamespace := "kubeflow-" + strings.NewReplacer(".", "-", "@", "-at-").Replace(gcp.kfDef.Spec.Email)
 	log.Infof("Creating secret %v to namespace %v", USER_SECRET_NAME, defaultNamespace)
 	if err = insertSecret(k8sClient, USER_SECRET_NAME, defaultNamespace, secret.Data); err != nil {
 		return kfapis.NewKfErrorWithMessage(err, fmt.Sprintf("cannot create secret %v in namespace %v", USER_SECRET_NAME, defaultNamespace))

--- a/bootstrap/pkg/kfapp/gcp/gcp_test.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_test.go
@@ -360,6 +360,56 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 	}
 }
 
+func TestGcp_setPodDefault(t *testing.T) {
+	group := "kubeflow.org"
+	version := "v1alpha1"
+	kind := "PodDefault"
+	namespace := "foo-bar-baz"
+	expected := map[string]interface{}{
+		"apiVersion": group + "/" + version,
+		"kind":       kind,
+		"metadata": map[string]interface{}{
+			"name":      "add-gcp-secret",
+			"namespace": namespace,
+		},
+		"desc": "add gcp credential",
+		"spec": map[string]interface{}{
+			"selector": map[string]interface{}{
+				"matchLabels": map[string]interface{}{
+					"add-gcp-secret": "true",
+				},
+			},
+		},
+		"env": []interface{}{
+			map[string]interface{}{
+				"name":  "GOOGLE_APPLICATION_CREDENTIALS",
+				"value": "/secret/gcp/user-gcp-sa.json",
+			},
+		},
+		"volumeMounts": []interface{}{
+			map[string]interface{}{
+				"name":      "secret-volume",
+				"mountPath": "/secret/gcp",
+			},
+		},
+		"volumes": []interface{}{
+			map[string]interface{}{
+				"name": "secret-volume",
+				"secret": map[string]interface{}{
+					"secretName": "user-gcp-sa",
+				},
+			},
+		},
+	}
+
+	actual := generatePodDefault(group, version, kind, namespace)
+	if !reflect.DeepEqual(actual.UnstructuredContent(), expected) {
+		pGot, _ := Pformat(actual.UnstructuredContent())
+		pWant, _ := Pformat(expected)
+		t.Errorf("PodDefault not matching; got\n%v\nwant\n%v", pGot, pWant)
+	}
+}
+
 // Pformat returns a pretty format output of any value.
 // TODO(jlewi): Use utils.PrettyPrint
 func Pformat(value interface{}) (string, error) {

--- a/bootstrap/v2/pkg/apis/apps/group.go
+++ b/bootstrap/v2/pkg/apis/apps/group.go
@@ -275,6 +275,18 @@ func GetApiExtClientset(config *rest.Config) apiext.ApiextensionsV1beta1Interfac
 	return crdClient.ApiextensionsV1beta1()
 }
 
+// Remove unvalid characters to compile a valid name for default Profile. To prevent
+// violation to the naming length restriction, ignore everything after `@`.
+func EmailToDefaultName(email string) string {
+	name := strings.NewReplacer(".", "-").Replace(email)
+	splitted := strings.Split(name, "@")
+	if len(splitted) > 1 {
+		return "kubeflow-" + splitted[0]
+	} else {
+		return "kubeflow-" + name
+	}
+}
+
 // Capture replaces os.Stdout with a writer that buffers any data written
 // to os.Stdout. Call the returned function to cleanup and get the data
 // as a string. This is used in cases where the API we're calling writes to stdout

--- a/bootstrap/v2/pkg/apis/apps/group_test.go
+++ b/bootstrap/v2/pkg/apis/apps/group_test.go
@@ -1,0 +1,29 @@
+package apps
+
+import (
+	"testing"
+)
+
+func TestEmailToDefaultName_testCases(t *testing.T) {
+	testCases := [][]string{
+		// Strips after @
+		[]string{
+			"foo@bar.com", "kubeflow-foo",
+		},
+		// Keep everything if not having @
+		[]string{
+			"foo", "kubeflow-foo",
+		},
+		// Doesn't check if it's a valid email address.
+		[]string{
+			"bar@baz", "kubeflow-bar",
+		},
+	}
+
+	for _, c := range testCases {
+		o := EmailToDefaultName(c[0])
+		if o != c[1] {
+			t.Errorf("EmailToDefaultName test case error; input: %v; expect %v; get %v", c[0], c[1], o)
+		}
+	}
+}

--- a/bootstrap/v2/pkg/apis/apps/group_test.go
+++ b/bootstrap/v2/pkg/apis/apps/group_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestEmailToDefaultName_testCases(t *testing.T) {
+func TestEmailToDefaultName(t *testing.T) {
 	testCases := [][]string{
 		// Strips after @
 		[]string{

--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -18,8 +18,6 @@ package kustomize
 
 import (
 	"bufio"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"github.com/ghodss/yaml"
@@ -304,13 +302,6 @@ func (kustomize *kustomize) Apply(resources kftypes.ResourceEnum) error {
 	}
 
 	if kustomize.kfDef.Spec.Email != "" {
-		suffix, suffixErr := randomHex(3)
-		if suffixErr != nil {
-			return &kfapisv2.KfError{
-				Code:    int(kfapisv2.INTERNAL_ERROR),
-				Message: fmt.Sprintf("couldn't create random suffix %v", suffixErr),
-			}
-		}
 		defaultProfileNamespace := strings.NewReplacer(".", "-", "@", "-at-").Replace(kustomize.kfDef.Spec.Email)
 		profile := &profilev2.Profile{
 			TypeMeta: metav1.TypeMeta{
@@ -318,7 +309,7 @@ func (kustomize *kustomize) Apply(resources kftypes.ResourceEnum) error {
 				APIVersion: "kubeflow.org/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: defaultProfileNamespace + "-" + suffix,
+				Name: "kubeflow-" + defaultProfileNamespace,
 			},
 			Spec: profilev2.ProfileSpec{
 				Owner: rbacv2.Subject{
@@ -1250,15 +1241,6 @@ func readLines(path string) ([]string, error) {
 		lines = append(lines, scanner.Text())
 	}
 	return lines, scanner.Err()
-}
-
-// randoxHex reads how many bytes to return and returns a randox hex string of that length
-func randomHex(n int) (string, error) {
-	bytes := make([]byte, n)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	return hex.EncodeToString(bytes), nil
 }
 
 // writeLines writes a string array to the given file - one line per array entry.

--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -304,16 +304,15 @@ func (kustomize *kustomize) Apply(resources kftypes.ResourceEnum) error {
 	}
 
 	if kustomize.kfDef.Spec.Email != "" {
-		defaultProfileNamespace := kftypesv2.EmailToDefaultName(kustomize.kfDef.Spec.Email)
 		// Profile name is also the namespace created.
-		profileName := "kubeflow-" + defaultProfileNamespace
+		defaultProfileNamespace := kftypesv2.EmailToDefaultName(kustomize.kfDef.Spec.Email)
 		profile := &profilev2.Profile{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Profile",
 				APIVersion: "kubeflow.org/v1alpha1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: profileName,
+				Name: defaultProfileNamespace,
 			},
 			Spec: profilev2.ProfileSpec{
 				Owner: rbacv2.Subject{
@@ -340,9 +339,9 @@ func (kustomize *kustomize) Apply(resources kftypes.ResourceEnum) error {
 			b.MaxInterval = 30 * time.Second
 			b.MaxElapsedTime = 5 * time.Minute
 			return backoff.Retry(func() error {
-				_, nsErr := clientset.CoreV1().Namespaces().Get(profileName, metav1.GetOptions{})
+				_, nsErr := clientset.CoreV1().Namespaces().Get(defaultProfileNamespace, metav1.GetOptions{})
 				if nsErr != nil {
-					msg := fmt.Sprintf("Could not find namespace %v, wait and retry: %v", profileName, nsErr)
+					msg := fmt.Sprintf("Could not find namespace %v, wait and retry: %v", defaultProfileNamespace, nsErr)
 					log.Warnf(msg)
 					return &kfapisv2.KfError{
 						Code:    int(kfapisv2.INVALID_ARGUMENT),

--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -304,7 +304,7 @@ func (kustomize *kustomize) Apply(resources kftypes.ResourceEnum) error {
 	}
 
 	if kustomize.kfDef.Spec.Email != "" {
-		defaultProfileNamespace := strings.NewReplacer(".", "-", "@", "-at-").Replace(kustomize.kfDef.Spec.Email)
+		defaultProfileNamespace := kftypesv2.EmailToDefaultName(kustomize.kfDef.Spec.Email)
 		// Profile name is also the namespace created.
 		profileName := "kubeflow-" + defaultProfileNamespace
 		profile := &profilev2.Profile{


### PR DESCRIPTION
- [x] Remove random suffix from profile name and corresponding namespace.
- [x] Add a blocking wait for the namespace to be created.
- [x] Add `ConfigPodDefault` to deploy `PodDefault` to the default namespace.
- [x] Invoke `ConfigPodDefault` in coordinator.  This is because platform runs before k8s, but we need both to be run so that the deployment state is ready for `ConfigPodDefault` (secret and profile are both created).  Therefore invoking this in gcp is not an option.  I decided not to do this in kustomize to keep it cleaner and independent of GCP pkg.  coordinator is already depending on GCP pkg so I think it's ok to put it there.

Fixes #3640 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3693)
<!-- Reviewable:end -->
