### PR TITLE
Set default scopes to be used by node auto-provisioning

### DIFF
--- a/deployment/gke/deployment_manager_configs/cluster.jinja
+++ b/deployment/gke/deployment_manager_configs/cluster.jinja
@@ -92,6 +92,8 @@ resources:
       {% if properties['gkeApiVersion'] == 'v1beta1' and properties['autoprovisioning-config']['enabled'] %}
       autoscaling:
         enableNodeAutoprovisioning: true
+        autoprovisioningNodePoolDefaults:
+          oauthScopes: {{ VM_OAUTH_SCOPES }}
         resourceLimits:
         - resourceType: 'cpu'
           maximum: {{ properties['autoprovisioning-config']['max-cpu'] }}


### PR DESCRIPTION
Default OAuth scopes should be set to `VM_OAUTH_SCOPES` if node auto-provisioning is enabled, ow the node created by the auto provisioning will not have gcp storage access. I think this PR will fix issue https://github.com/kubeflow/kubeflow/issues/3517.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3696)
<!-- Reviewable:end -->
