### PR TITLE
Paper-menu-dropdown is aligned left

### DIFF
--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -56,7 +56,7 @@ export class NamespaceSelector extends PolymerElement {
                     --paper-button-ink-color: var(--accent-color);
                 }
             </style>
-            <paper-menu-button no-overlap horizontal-align="right">
+            <paper-menu-button no-overlap horizontal-align="left">
                 <paper-button id="dropdown-trigger" slot="dropdown-trigger">
                     <iron-icon icon="group-work"></iron-icon>
                     <span>[[selected]]</span>


### PR DESCRIPTION
#### Fixes #3698

## About
- Paper-Menu-Button had the dropdown aligned `right`. This would allow it to flow into the sidebar, the new config should not let this happen

### Meta:
/area centraldashboard
/area front-end
/priority p0
/assign @avdaredevil 
/cc @prodonjs @paveldournov

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3742)
<!-- Reviewable:end -->
