### PR TITLE
Multi-User Isolation 2.0 - Manage Users

### DIFF
--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -47,7 +47,7 @@ export const ERRORS = {
   operation_not_supported: 'Operation not supported'
 };
 
-export const apiError = (a: {res: Response, error: string, code?: number}) => {
+export function apiError (a: {res: Response, error: string, code?: number}) {
   const {res, error} = a;
   const code = a.code || 400;
   return res.status(code).json({
@@ -58,7 +58,7 @@ export const apiError = (a: {res: Response, error: string, code?: number}) => {
 /**
  * Converts Workgroup Binding from Profile Controller to SimpleBinding
  */
-export const mapWorkgroupBindingToSimpleBinding = (bindings: WorkgroupBinding[]): SimpleBinding[] => {
+export function mapWorkgroupBindingToSimpleBinding (bindings: WorkgroupBinding[]): SimpleBinding[] {
   return bindings.map((n) => ({
     user: n.user.name,
     namespace: n.referredNamespace,
@@ -70,7 +70,7 @@ export const mapWorkgroupBindingToSimpleBinding = (bindings: WorkgroupBinding[])
  * Converts Kubernetes Namespace types to SimpleBinding to ensure
  * compatibility between identity-aware and non-identity aware clusters
  */
-export const mapNamespacesToSimpleBinding = (user: string, namespaces: V1Namespace[]): SimpleBinding[] => {
+export function mapNamespacesToSimpleBinding (user: string, namespaces: V1Namespace[]): SimpleBinding[] {
   return namespaces.map((n) => ({
     user,
     namespace: n.metadata.name,
@@ -81,7 +81,7 @@ export const mapNamespacesToSimpleBinding = (user: string, namespaces: V1Namespa
 /**
  * Converts SimpleBinding to Workgroup Binding from Profile Controller
  */
-export const mapSimpleBindingToWorkgroupBinding = (binding: SimpleBinding): WorkgroupBinding => {
+export function mapSimpleBindingToWorkgroupBinding (binding: SimpleBinding): WorkgroupBinding {
   const {user, namespace, role} = binding;
   return {
     user: {

--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -53,7 +53,7 @@ export function apiError (a: {res: Response, error: string, code?: number}) {
   return res.status(code).json({
     error,
   });
-};
+}
 
 /**
  * Converts Workgroup Binding from Profile Controller to SimpleBinding
@@ -64,7 +64,7 @@ export function mapWorkgroupBindingToSimpleBinding (bindings: WorkgroupBinding[]
     namespace: n.referredNamespace,
     role: roleMap.tr(n.roleRef.name),
   }));
-};
+}
 
 /**
  * Converts Kubernetes Namespace types to SimpleBinding to ensure
@@ -76,7 +76,7 @@ export function mapNamespacesToSimpleBinding (user: string, namespaces: V1Namesp
     namespace: n.metadata.name,
     role: roleMap.tr('edit'),
   }));
-};
+}
 
 /**
  * Converts SimpleBinding to Workgroup Binding from Profile Controller
@@ -94,7 +94,7 @@ export function mapSimpleBindingToWorkgroupBinding (binding: SimpleBinding): Wor
       name: roleMap.reverse(role),
     }
   };
-};
+}
 
 export class Api {
   private platformInfo: PlatformInfo;

--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -4,7 +4,7 @@ import {DefaultApi} from './clients/profile_controller';
 import {KubernetesService, PlatformInfo} from './k8s_service';
 import {Interval, MetricsService} from './metrics_service';
 import {
-  ContributorAPI,
+  ContributorApi,
   mapNamespacesToSimpleBinding,
   SimpleBinding,
 } from './api_contributors';
@@ -28,17 +28,13 @@ export function apiError(a: {res: Response, error: string, code?: number}) {
   });
 }
 
-export function NO_ROUTES(req: Request, res: Response, next: NextFunction) {
-  next();
-}
-
 export class Api {
   private platformInfo: PlatformInfo;
 
   constructor(
       private k8sService: KubernetesService,
       private profilesService: DefaultApi,
-      private contribApi?: ContributorAPI,
+      private contribApi?: ContributorApi,
       private metricsService?: MetricsService,
     ) {}
 
@@ -56,7 +52,7 @@ export class Api {
   private async getProfileAwareEnv(user: User.User): Promise<EnvironmentInfo> {
     const [platform, {namespaces, isClusterAdmin}] = await Promise.all([
       this.getPlatformInfo(),
-      ContributorAPI.getWorkgroupInfo(
+      ContributorApi.getWorkgroupInfo(
         this.profilesService,
         user,
       ),
@@ -144,7 +140,9 @@ export class Api {
             })
         .use('/workgroup', this.contribApi
           ? this.contribApi.routes()
-          : NO_ROUTES
+          : (req: Request, res: Response, next: NextFunction)  => {
+            next();
+          }
         )
         .use((req: Request, res: Response) => 
           apiError({

--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -52,8 +52,7 @@ export class Api {
   private async getProfileAwareEnv(user: User.User): Promise<EnvironmentInfo> {
     const [platform, {namespaces, isClusterAdmin}] = await Promise.all([
       this.getPlatformInfo(),
-      ContributorApi.getWorkgroupInfo(
-        this.profilesService,
+      this.contribApi.getWorkgroupInfo(
         user,
       ),
     ]);
@@ -93,7 +92,7 @@ export class Api {
                 const code = (err.response && err.response.statusCode) || 400;
                 const error =
                     err.body || 'Unexpected error getting environment info';
-                console.log(`Unable to get environment info: ${error}`);
+                console.log(`Unable to get environment info: ${error}${err.stack?'\n'+err.stack:''}`);
                 apiError({res, code, error});
               }
             })

--- a/components/centraldashboard/app/api_contributors.ts
+++ b/components/centraldashboard/app/api_contributors.ts
@@ -1,0 +1,184 @@
+import {Router, Request, Response, NextFunction} from 'express';
+import {DefaultApi} from './clients/profile_controller';
+import {
+    apiError,
+    mapWorkgroupBindingToSimpleBinding,
+    mapSimpleBindingToWorkgroupBinding,
+    ERRORS,
+} from './api';
+
+// Valid actions for handling a contributor
+type CONTRIBUTOR_ACTIONS = 'create' | 'remove';
+
+// Shape of the CreateProfileRequest body
+interface CreateProfileRequest {
+    namespace?: string;
+    user?: string;
+}
+
+// Shape of the AddContributorRequest body
+interface AddOrRemoveContributorRequest {
+    contributor?: string;
+}
+
+// From: https://www.w3resource.com/javascript/form/email-validation.php
+const EMAIL_RGX = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+
+/**
+ * Handles an exception in an async block and converts it to a JSON
+ * response sent back to client
+ */
+// tslint:disable-next-line: no-any
+const surfaceProfileControllerErrors = (info: {res: Response, msg: string, err: any}) => {
+    const {res, msg, err} = info;
+    const code = (err.response && err.response.statusCode) || 400;
+    const error = err.body || msg;
+    console.log(`${msg} ${error}`);
+    apiError({res, code, error});
+};
+
+/**
+ * Given an owned namespace, list all contributors under it
+ * @param namespace Namespace to find contributors for
+ * @param profilesService The instance of DefaultApi to use
+ */
+const getContributors = async (namespace: string, profilesService: DefaultApi) => {
+    const {body} = await profilesService
+        .readBindings(undefined, namespace);
+    const users = mapWorkgroupBindingToSimpleBinding(body.bindings)
+        .filter((b) => b.role === 'contributor')
+        .map((b) => b.user);
+    return users;
+};
+
+const handleContributor = async (action: CONTRIBUTOR_ACTIONS, profilesService: DefaultApi, req: Request, res: Response) => {
+    const {namespace} = req.params;
+    const {contributor} = req.body as AddOrRemoveContributorRequest;
+    if (!contributor || !namespace) {
+        return apiError({
+            res,
+            error: `Missing contributor / namespace fields.`,
+        });
+    }
+    if (!EMAIL_RGX.test(contributor)) {
+        return apiError({
+            res,
+            error: `Contributor doesn't look like a valid email address`,
+        });
+    }
+    let errIndex = 0;
+    try {
+        const binding = mapSimpleBindingToWorkgroupBinding({
+            user: contributor,
+            namespace,
+            role: 'contributor',
+        });
+        const {headers} = req;
+        delete headers['content-length'];
+        const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
+        await profilesService[actionAPI](binding, {headers});
+        errIndex++;
+        const users = await getContributors(namespace, profilesService);
+        res.json(users);
+    } catch (err) {
+        const errMessage = [
+            `Unable to add new contributor for ${namespace}: ${err.stack || err}`,
+            `Unable to fetch contributors for ${namespace}: ${err.stack || err}`,
+        ][errIndex];
+        surfaceProfileControllerErrors({
+            res,
+            msg: errMessage,
+            err,
+        });
+    }
+};
+
+export const contributorAPI = (profilesService: DefaultApi) => Router()
+    .post('/create', async (req: Request, res: Response) => {
+        console.log('Recieved a call');
+        if (!req.user.hasAuth) {
+            return apiError({
+                res,
+                code: 405,
+                error: ERRORS.operation_not_supported,
+            });
+        }
+        
+        console.log('No Error');
+        const profile = req.body as CreateProfileRequest;
+        console.log('Good body');
+        try {
+            const namespace = profile.namespace || req.user.username;
+            // Use the request body if provided, fallback to auth headers
+            console.log('Creating profile');
+            await profilesService.createProfile({
+                metadata: {
+                    name: namespace,
+                },
+                spec: {
+                    owner: {
+                        kind: 'User',
+                        name: profile.user || req.user.email,
+                    }
+                },
+            });
+            console.log('Done');
+            res.json({message: `Created namespace ${namespace}`});
+        } catch (err) {
+            console.log('ERROR');
+            surfaceProfileControllerErrors({
+                res,
+                msg: 'Unexpected error creating profile',
+                err,
+            });
+        }
+    })
+    .get('/get-all-namespaces', async (req: Request, res: Response) => {
+        try {
+            const {body} = await profilesService.readBindings();
+            // tslint:disable-next-line: no-any
+            const namespaces = {} as any;
+            const bindings = mapWorkgroupBindingToSimpleBinding(
+                body.bindings
+            );
+            bindings.forEach((b) => {
+                const name = b.namespace;
+                if (!namespaces[name]) {namespaces[name] = {contributors: []};}
+                const namespace = namespaces[name];
+                if (b.role === 'owner') {namespace.owner = b.user; return;}
+                namespaces[name].contributors.push(b.user);
+            });
+            const tabular = Object.keys(namespaces).map(namespace => [
+                namespace,
+                namespaces[namespace].owner,
+                namespaces[namespace].contributors.join(', '),
+            ]);
+            res.json(tabular);
+        } catch (err) {
+            surfaceProfileControllerErrors({
+                res,
+                msg: `Unable to fetch all workgroup data`,
+                err,
+            });
+        }
+    })
+
+    .get('/get-contributors/:namespace', async (req: Request, res: Response) => {
+            const {namespace} = req.params;
+            try {
+                const users = await getContributors(namespace, profilesService);
+                res.json(users);
+            } catch (err) {
+                surfaceProfileControllerErrors({
+                    res,
+                    msg: `Unable to fetch contributors for ${namespace}`,
+                    err,
+                });
+            }
+        })
+    .post('/add-contributor/:namespace', async (req: Request, res: Response) => {
+        handleContributor('create', profilesService, req, res);
+    })
+    .delete('/remove-contributor/:namespace', async (req: Request, res: Response) => {
+        handleContributor('remove', profilesService, req, res);
+    });

--- a/components/centraldashboard/app/api_contributors.ts
+++ b/components/centraldashboard/app/api_contributors.ts
@@ -92,7 +92,7 @@ export class ContributorAPI {
             .filter((b) => b.role === 'contributor')
             .map((b) => b.user);
         return users;
-    };
+    }
     routes() {return Router()
         .post('/create', async (req: Request, res: Response) => {
             if (!req.user.hasAuth) {

--- a/components/centraldashboard/app/api_contributors.ts
+++ b/components/centraldashboard/app/api_contributors.ts
@@ -33,152 +33,147 @@ const surfaceProfileControllerErrors = (info: {res: Response, msg: string, err: 
     const {res, msg, err} = info;
     const code = (err.response && err.response.statusCode) || 400;
     const error = err.body || msg;
-    console.log(`${msg} ${error}`);
+    console.error(`${msg} ${error}`);
     apiError({res, code, error});
 };
 
-/**
- * Given an owned namespace, list all contributors under it
- * @param namespace Namespace to find contributors for
- * @param profilesService The instance of DefaultApi to use
- */
-const getContributors = async (namespace: string, profilesService: DefaultApi) => {
-    const {body} = await profilesService
-        .readBindings(undefined, namespace);
-    const users = mapWorkgroupBindingToSimpleBinding(body.bindings)
-        .filter((b) => b.role === 'contributor')
-        .map((b) => b.user);
-    return users;
-};
-
-const handleContributor = async (action: CONTRIBUTOR_ACTIONS, profilesService: DefaultApi, req: Request, res: Response) => {
-    const {namespace} = req.params;
-    const {contributor} = req.body as AddOrRemoveContributorRequest;
-    if (!contributor || !namespace) {
-        return apiError({
-            res,
-            error: `Missing contributor / namespace fields.`,
-        });
-    }
-    if (!EMAIL_RGX.test(contributor)) {
-        return apiError({
-            res,
-            error: `Contributor doesn't look like a valid email address`,
-        });
-    }
-    let errIndex = 0;
-    try {
-        const binding = mapSimpleBindingToWorkgroupBinding({
-            user: contributor,
-            namespace,
-            role: 'contributor',
-        });
-        const {headers} = req;
-        delete headers['content-length'];
-        const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
-        await profilesService[actionAPI](binding, {headers});
-        errIndex++;
-        const users = await getContributors(namespace, profilesService);
-        res.json(users);
-    } catch (err) {
-        const errMessage = [
-            `Unable to add new contributor for ${namespace}: ${err.stack || err}`,
-            `Unable to fetch contributors for ${namespace}: ${err.stack || err}`,
-        ][errIndex];
-        surfaceProfileControllerErrors({
-            res,
-            msg: errMessage,
-            err,
-        });
-    }
-};
-
-export const contributorAPI = (profilesService: DefaultApi) => Router()
-    .post('/create', async (req: Request, res: Response) => {
-        console.log('Recieved a call');
-        if (!req.user.hasAuth) {
+export class ContributorAPI {
+    constructor(private profilesService: DefaultApi) {}
+    async handleContributor(action: CONTRIBUTOR_ACTIONS, req: Request, res: Response) {
+        const {namespace} = req.params;
+        const {contributor} = req.body as AddOrRemoveContributorRequest;
+        const {profilesService} = this;
+        if (!contributor || !namespace) {
             return apiError({
                 res,
-                code: 405,
-                error: ERRORS.operation_not_supported,
+                error: `Missing contributor / namespace fields.`,
             });
         }
-        
-        console.log('No Error');
-        const profile = req.body as CreateProfileRequest;
-        console.log('Good body');
-        try {
-            const namespace = profile.namespace || req.user.username;
-            // Use the request body if provided, fallback to auth headers
-            console.log('Creating profile');
-            await profilesService.createProfile({
-                metadata: {
-                    name: namespace,
-                },
-                spec: {
-                    owner: {
-                        kind: 'User',
-                        name: profile.user || req.user.email,
-                    }
-                },
-            });
-            console.log('Done');
-            res.json({message: `Created namespace ${namespace}`});
-        } catch (err) {
-            console.log('ERROR');
-            surfaceProfileControllerErrors({
+        if (!EMAIL_RGX.test(contributor)) {
+            return apiError({
                 res,
-                msg: 'Unexpected error creating profile',
-                err,
+                error: `Contributor doesn't look like a valid email address`,
             });
         }
-    })
-    .get('/get-all-namespaces', async (req: Request, res: Response) => {
+        let errIndex = 0;
         try {
-            const {body} = await profilesService.readBindings();
-            // tslint:disable-next-line: no-any
-            const namespaces = {} as any;
-            const bindings = mapWorkgroupBindingToSimpleBinding(
-                body.bindings
-            );
-            bindings.forEach((b) => {
-                const name = b.namespace;
-                if (!namespaces[name]) {namespaces[name] = {contributors: []};}
-                const namespace = namespaces[name];
-                if (b.role === 'owner') {namespace.owner = b.user; return;}
-                namespaces[name].contributors.push(b.user);
-            });
-            const tabular = Object.keys(namespaces).map(namespace => [
+            const binding = mapSimpleBindingToWorkgroupBinding({
+                user: contributor,
                 namespace,
-                namespaces[namespace].owner,
-                namespaces[namespace].contributors.join(', '),
-            ]);
-            res.json(tabular);
+                role: 'contributor',
+            });
+            const {headers} = req;
+            delete headers['content-length'];
+            const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
+            await profilesService[actionAPI](binding, {headers});
+            errIndex++;
+            const users = await this.getContributors(namespace);
+            res.json(users);
         } catch (err) {
+            const errMessage = [
+                `Unable to add new contributor for ${namespace}: ${err.stack || err}`,
+                `Unable to fetch contributors for ${namespace}: ${err.stack || err}`,
+            ][errIndex];
             surfaceProfileControllerErrors({
                 res,
-                msg: `Unable to fetch all workgroup data`,
+                msg: errMessage,
                 err,
             });
         }
-    })
-
-    .get('/get-contributors/:namespace', async (req: Request, res: Response) => {
-            const {namespace} = req.params;
+    }
+    /**
+     * Given an owned namespace, list all contributors under it
+     * @param namespace Namespace to find contributors for
+     */
+    async getContributors(namespace: string) {
+        const {body} = await this.profilesService
+            .readBindings(undefined, namespace);
+        const users = mapWorkgroupBindingToSimpleBinding(body.bindings)
+            .filter((b) => b.role === 'contributor')
+            .map((b) => b.user);
+        return users;
+    };
+    routes() {return Router()
+        .post('/create', async (req: Request, res: Response) => {
+            if (!req.user.hasAuth) {
+                return apiError({
+                    res,
+                    code: 405,
+                    error: ERRORS.operation_not_supported,
+                });
+            }
+            const profile = req.body as CreateProfileRequest;
             try {
-                const users = await getContributors(namespace, profilesService);
-                res.json(users);
+                const namespace = profile.namespace || req.user.username;
+                // Use the request body if provided, fallback to auth headers
+                await this.profilesService.createProfile({
+                    metadata: {
+                        name: namespace,
+                    },
+                    spec: {
+                        owner: {
+                            kind: 'User',
+                            name: profile.user || req.user.email,
+                        }
+                    },
+                });
+                res.json({message: `Created namespace ${namespace}`});
             } catch (err) {
                 surfaceProfileControllerErrors({
                     res,
-                    msg: `Unable to fetch contributors for ${namespace}`,
+                    msg: 'Unexpected error creating profile',
                     err,
                 });
             }
         })
-    .post('/add-contributor/:namespace', async (req: Request, res: Response) => {
-        handleContributor('create', profilesService, req, res);
-    })
-    .delete('/remove-contributor/:namespace', async (req: Request, res: Response) => {
-        handleContributor('remove', profilesService, req, res);
-    });
+        .get('/get-all-namespaces', async (req: Request, res: Response) => {
+            try {
+                const {body} = await this.profilesService.readBindings();
+                // tslint:disable-next-line: no-any
+                const namespaces = {} as any;
+                const bindings = mapWorkgroupBindingToSimpleBinding(
+                    body.bindings
+                );
+                bindings.forEach((b) => {
+                    const name = b.namespace;
+                    if (!namespaces[name]) {namespaces[name] = {contributors: []};}
+                    const namespace = namespaces[name];
+                    if (b.role === 'owner') {namespace.owner = b.user; return;}
+                    namespaces[name].contributors.push(b.user);
+                });
+                const tabular = Object.keys(namespaces).map(namespace => [
+                    namespace,
+                    namespaces[namespace].owner,
+                    namespaces[namespace].contributors.join(', '),
+                ]);
+                res.json(tabular);
+            } catch (err) {
+                surfaceProfileControllerErrors({
+                    res,
+                    msg: `Unable to fetch all workgroup data`,
+                    err,
+                });
+            }
+        })
+
+        .get('/get-contributors/:namespace', async (req: Request, res: Response) => {
+                const {namespace} = req.params;
+                try {
+                    const users = await this.getContributors(namespace);
+                    res.json(users);
+                } catch (err) {
+                    surfaceProfileControllerErrors({
+                        res,
+                        msg: `Unable to fetch contributors for ${namespace}`,
+                        err,
+                    });
+                }
+            })
+        .post('/add-contributor/:namespace', async (req: Request, res: Response) => {
+            this.handleContributor('create', req, res);
+        })
+        .delete('/remove-contributor/:namespace', async (req: Request, res: Response) => {
+            this.handleContributor('remove', req, res);
+        });
+    }
+}

--- a/components/centraldashboard/app/api_contributors.ts
+++ b/components/centraldashboard/app/api_contributors.ts
@@ -1,5 +1,5 @@
 import {V1Namespace} from '@kubernetes/client-node';
-import {Router, Request, Response} from 'express';
+import {Router, Request, Response, NextFunction} from 'express';
 import {Binding as WorkgroupBinding, DefaultApi} from './clients/profile_controller';
 
 import {
@@ -195,7 +195,7 @@ export class ContributorApi {
                 }
                 res.json(response);
             })
-        .post('/create', async (req: Request, res: Response) => {
+        .use((req: Request, res: Response, next: NextFunction) => {
             if (!req.user.hasAuth) {
                 return apiError({
                     res,
@@ -203,6 +203,9 @@ export class ContributorApi {
                     error: ERRORS.operation_not_supported,
                 });
             }
+            next();
+        })
+        .post('/create', async (req: Request, res: Response) => {
             const profile = req.body as CreateProfileRequest;
             try {
                 const namespace = profile.namespace || req.user.username;

--- a/components/centraldashboard/app/api_contributors.ts
+++ b/components/centraldashboard/app/api_contributors.ts
@@ -11,7 +11,7 @@ import {
 const EMAIL_RGX = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
 
 // Valid actions for handling a contributor
-type CONTRIBUTOR_ACTIONS = 'create' | 'remove';
+type ContributorActions = 'create' | 'remove';
 
 interface CreateProfileRequest {
     namespace?: string;
@@ -104,7 +104,7 @@ const surfaceProfileControllerErrors = (info: {res: Response, msg: string, err: 
     apiError({res, code, error: devError || msg});
 };
 
-export class ContributorAPI {
+export class ContributorApi {
     constructor(private profilesService: DefaultApi) {}
     /**
      * Retrieves WorkgroupInfo from Profile Controller for the given user.
@@ -122,7 +122,7 @@ export class ContributorAPI {
             namespaces,
         };
     }
-    async handleContributor(action: CONTRIBUTOR_ACTIONS, req: Request, res: Response) {
+    async handleContributor(action: ContributorActions, req: Request, res: Response) {
         const {namespace} = req.params;
         const {contributor} = req.body as AddOrRemoveContributorRequest;
         const {profilesService} = this;
@@ -186,7 +186,7 @@ export class ContributorAPI {
                     hasWorkgroup: false,
                 };
                 if (req.user.hasAuth) {
-                    const workgroup = await ContributorAPI.getWorkgroupInfo(
+                    const workgroup = await ContributorApi.getWorkgroupInfo(
                         this.profilesService,
                         req.user,
                     );

--- a/components/centraldashboard/app/api_contributors.ts
+++ b/components/centraldashboard/app/api_contributors.ts
@@ -109,10 +109,10 @@ export class ContributorApi {
     /**
      * Retrieves WorkgroupInfo from Profile Controller for the given user.
      */
-    static async getWorkgroupInfo(profilesService: DefaultApi, user: User.User): Promise<WorkgroupInfo> {
+    async getWorkgroupInfo(user: User.User): Promise<WorkgroupInfo> {
         const [adminResponse, bindings] = await Promise.all([
-            profilesService.v1RoleClusteradminGet(user.email),
-            profilesService.readBindings(user.email),
+            this.profilesService.v1RoleClusteradminGet(user.email),
+            this.profilesService.readBindings(user.email),
         ]);
         const namespaces = mapWorkgroupBindingToSimpleBinding(
             bindings.body.bindings || []
@@ -186,8 +186,7 @@ export class ContributorApi {
                     hasWorkgroup: false,
                 };
                 if (req.user.hasAuth) {
-                    const workgroup = await ContributorApi.getWorkgroupInfo(
-                        this.profilesService,
+                    const workgroup = await this.getWorkgroupInfo(
                         req.user,
                     );
                     response.hasWorkgroup = !!(workgroup.namespaces || [])

--- a/components/centraldashboard/app/api_test.ts
+++ b/components/centraldashboard/app/api_test.ts
@@ -7,7 +7,7 @@ import {attachUser} from './attach_user_middleware';
 import {DefaultApi} from './clients/profile_controller';
 import {KubernetesService} from './k8s_service';
 import {Interval, MetricsService} from './metrics_service';
-import {ContributorAPI} from './api_contributors';
+import {ContributorApi} from './api_contributors';
 import {MetricServiceClient} from '@google-cloud/monitoring';
 
 // Helper function to send a test request and return a Promise for the response
@@ -42,7 +42,7 @@ describe('Dashboard API', () => {
   const newAPI = (withMetrics = false) => new Api(
     mockK8sService,
     mockProfilesService,
-    new ContributorAPI(mockProfilesService),
+    new ContributorApi(mockProfilesService),
     withMetrics ? mockMetricsService : undefined
   );
 
@@ -379,7 +379,7 @@ describe('Dashboard API', () => {
         [header]: `${prefix}test@testdomain.com`,
       };
       const response = await sendTestRequest(url, headers, 405, 'post');
-      expect(JSON.stringify(response)).toEqual(JSON.stringify({error: 'Unexpected error creating profile'}));
+      expect(response).toEqual({error: 'Unexpected error creating profile'});
     });
   });
 

--- a/components/centraldashboard/app/api_test.ts
+++ b/components/centraldashboard/app/api_test.ts
@@ -8,7 +8,6 @@ import {DefaultApi} from './clients/profile_controller';
 import {KubernetesService} from './k8s_service';
 import {Interval, MetricsService} from './metrics_service';
 import {ContributorApi} from './api_contributors';
-import {MetricServiceClient} from '@google-cloud/monitoring';
 
 // Helper function to send a test request and return a Promise for the response
 function sendTestRequest(
@@ -420,8 +419,7 @@ describe('Dashboard API', () => {
       testApp.use(express.json());
       testApp.use(
           '/api',
-          newAPI(true)
-              .routes());
+          newAPI(true).routes());
       const addressInfo = testApp.listen(0).address();
       if (typeof addressInfo === 'string') {
         throw new Error(

--- a/components/centraldashboard/app/api_test.ts
+++ b/components/centraldashboard/app/api_test.ts
@@ -301,7 +301,7 @@ describe('Dashboard API', () => {
             'Unable to determine system-assigned port for test API server');
       }
       port = addressInfo.port;
-      url = `http://localhost:${port}/api/create-workgroup`;
+      url = `http://localhost:${port}/api/workgroup/create`;
     });
 
     it('Should return a 405 status for a non-identity aware cluster',

--- a/components/centraldashboard/app/api_test.ts
+++ b/components/centraldashboard/app/api_test.ts
@@ -96,14 +96,14 @@ describe('Dashboard API', () => {
            isClusterAdmin: true,
            namespaces: [
              {
-               user: {kind: 'user', name: 'anonymous@kubeflow.org'},
-               referredNamespace: 'default',
-               roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'editor'}
+               user: 'anonymous@kubeflow.org',
+               namespace: 'default',
+               role: 'contributor',
              },
              {
-               user: {kind: 'user', name: 'anonymous@kubeflow.org'},
-               referredNamespace: 'kubeflow',
-               roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'editor'}
+               user: 'anonymous@kubeflow.org',
+               namespace: 'kubeflow',
+               role: 'contributor',
              },
            ],
          };
@@ -134,7 +134,7 @@ describe('Dashboard API', () => {
                  bindings: [{
                    user: {kind: 'user', name: 'test@testdomain.com'},
                    referredNamespace: 'test',
-                   roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'editor'}
+                   roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'edit'}
                  }]
                },
              }));
@@ -152,9 +152,9 @@ describe('Dashboard API', () => {
            isClusterAdmin: false,
            namespaces: [
              {
-               user: {kind: 'user', name: 'test@testdomain.com'},
-               referredNamespace: 'test',
-               roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'editor'}
+               user: 'test@testdomain.com',
+               namespace: 'test',
+               role: 'contributor',
              },
            ],
          };
@@ -181,7 +181,7 @@ describe('Dashboard API', () => {
               bindings: [{
                 user: {kind: 'user', name: 'test@testdomain.com'},
                 referredNamespace: 'test',
-                roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'editor'}
+                roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'edit'}
               }]
             },
           }));
@@ -241,7 +241,7 @@ describe('Dashboard API', () => {
                  bindings: [{
                    user: {kind: 'user', name: 'test@testdomain.com'},
                    referredNamespace: 'test',
-                   roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'editor'}
+                   roleRef: {apiGroup: '', kind: 'ClusterRole', name: 'admin'}
                  }]
                },
              }));

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -5,7 +5,7 @@ import {resolve} from 'path';
 import {Api} from './api';
 import {attachUser} from './attach_user_middleware';
 import {DefaultApi} from './clients/profile_controller';
-import {ContributorAPI} from './api_contributors';
+import {ContributorApi} from './api_contributors';
 import {KubernetesService} from './k8s_service';
 import {getMetricsService} from './metrics_service_factory';
 
@@ -36,8 +36,7 @@ async function main() {
   const metricsService = await getMetricsService(k8sService);
   console.info(`Using Profiles service at ${profilesServiceUrl}`);
   const profilesService = new DefaultApi(profilesServiceUrl);
-  const contribApi = new ContributorAPI(profilesService);
-
+  const contribApi = new ContributorApi(profilesService);
 
   app.use(express.json());
   app.use(express.static(frontEnd));

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -5,6 +5,7 @@ import {resolve} from 'path';
 import {Api} from './api';
 import {attachUser} from './attach_user_middleware';
 import {DefaultApi} from './clients/profile_controller';
+import {ContributorAPI} from './api_contributors';
 import {KubernetesService} from './k8s_service';
 import {getMetricsService} from './metrics_service_factory';
 
@@ -34,13 +35,15 @@ async function main() {
   const k8sService = new KubernetesService(new KubeConfig());
   const metricsService = await getMetricsService(k8sService);
   console.info(`Using Profiles service at ${profilesServiceUrl}`);
-  const profilesServices = new DefaultApi(profilesServiceUrl);
+  const profilesService = new DefaultApi(profilesServiceUrl);
+  const contribApi = new ContributorAPI(profilesService);
+
 
   app.use(express.json());
   app.use(express.static(frontEnd));
   app.use(attachUser(USERID_HEADER, USERID_PREFIX));
   app.use(
-      '/api', new Api(k8sService, profilesServices, metricsService).routes());
+      '/api', new Api(k8sService, profilesService, contribApi, metricsService).routes());
   app.get('/*', (_: express.Request, res: express.Response) => {
     res.sendFile(resolve(frontEnd, 'index.html'));
   });

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -95,6 +95,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             platformInfo: Object,
             inIframe: {type: Boolean, value: false, readOnly: true},
             hideTabs: {type: Boolean, value: false, readOnly: true},
+            hideSidebar: {type: Boolean, value: false, readOnly: true},
             hideNamespaces: {type: Boolean, value: false, readOnly: true},
             allNamespaces: {type: Boolean, value: false, readOnly: true},
             notFoundInIframe: {type: Boolean, value: false, readOnly: true},
@@ -189,6 +190,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         let hideTabs = true;
         let hideNamespaces = false;
         let allNamespaces = false;
+        let hideSidebar = false;
 
         switch (newPage) {
         case 'activity':
@@ -208,6 +210,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this.page = 'manage-users';
             hideTabs = true;
             allNamespaces = true;
+            hideSidebar = true;
             break;
         case '':
             this.sidebarItemIndex = 0;
@@ -227,10 +230,11 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         this._setAllNamespaces(allNamespaces);
         this._setHideNamespaces(hideNamespaces);
         this._setInIframe(isIframe);
+        this._setHideSidebar(hideSidebar);
 
         this._iframeConnected = this._iframeConnected && isIframe;
         // If iframe <-> [non-frame OR other iframe]
-        if (isIframe !== this.inIframe || isIframe) {
+        if (hideSidebar || isIframe !== this.inIframe || isIframe) {
             this.$.MainDrawer.close();
         }
     }

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -43,13 +43,6 @@ import {MESSAGE, PARENT_CONNECTED_EVENT, IFRAME_CONNECTED_EVENT,
     NAMESPACE_SELECTED_EVENT} from '../library.js';
 import {IFRAME_LINK_PREFIX} from './iframe-link.js';
 
-export const roleMap = {
-    admin: 'owner',
-    editor: 'contributor',
-    tr(a) {
-        return this[a] || a;
-    },
-};
 
 /**
  * Entry point for application UI.
@@ -103,6 +96,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             inIframe: {type: Boolean, value: false, readOnly: true},
             hideTabs: {type: Boolean, value: false, readOnly: true},
             hideNamespaces: {type: Boolean, value: false, readOnly: true},
+            allNamespaces: {type: Boolean, value: false, readOnly: true},
             notFoundInIframe: {type: Boolean, value: false, readOnly: true},
             registrationFlow: {type: Boolean, value: false, readOnly: true},
             workgroupStatusHasLoaded: {
@@ -194,6 +188,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         let notFoundInIframe = false;
         let hideTabs = true;
         let hideNamespaces = false;
+        let allNamespaces = false;
 
         switch (newPage) {
         case 'activity':
@@ -212,6 +207,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this.sidebarItemIndex = 6;
             this.page = 'manage-users';
             hideTabs = true;
+            allNamespaces = true;
             break;
         case '':
             this.sidebarItemIndex = 0;
@@ -228,6 +224,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         }
         this._setNotFoundInIframe(notFoundInIframe);
         this._setHideTabs(hideTabs);
+        this._setAllNamespaces(allNamespaces);
         this._setHideNamespaces(hideNamespaces);
         this._setInIframe(isIframe);
 
@@ -319,11 +316,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         const {platform, user,
             namespaces, isClusterAdmin} = responseEvent.detail.response;
         Object.assign(this, {user, isClusterAdmin});
-        this.namespaces = namespaces.map((n) => ({
-            user: n.user.name,
-            namespace: n.referredNamespace,
-            role: roleMap.tr(n.roleRef.name),
-        }));
+        this.namespaces = namespaces;
         if (this.namespaces.length) {
             this._setRegistrationFlow(false);
         }

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -36,6 +36,7 @@ import './namespace-selector.js';
 import './dashboard-view.js';
 import './activity-view.js';
 import './not-found-view.js';
+import './manage-users-view.js';
 import './resources/kubeflow-icons.js';
 import utilitiesMixin from './utilities-mixin.js';
 import {MESSAGE, PARENT_CONNECTED_EVENT, IFRAME_CONNECTED_EVENT,
@@ -206,6 +207,11 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             hideNamespaces = this.subRouteData.path.startsWith('/pipeline');
             this._setActiveMenuLink(this.subRouteData.path);
             this._setIframeLocation();
+            break;
+        case 'manage-users':
+            this.sidebarItemIndex = 6;
+            this.page = 'manage-users';
+            hideTabs = true;
             break;
         case '':
             this.sidebarItemIndex = 0;

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -47,7 +47,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         |!{logo}
                 namespace-selector#NamespaceSelector(
                     query-params='{{queryParams}}', namespaces='[[namespaces]]'
-                    selected='{{namespace}}', hides, hidden$='[[hideNamespaces]]')
+                    selected='{{namespace}}', hides, hidden$='[[hideNamespaces]]'
+                    all-namespaces='[[allNamespaces]]')
                 footer#User-Badge
                     iron-image.image(sizing='contain', fade,
                         src='/assets/anon-user.png', title='[[user]]')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -4,7 +4,7 @@ iron-ajax#envInfo(auto='[[_shouldFetchEnv]]', url='/api/env-info', handle-as='js
     on-response='_onEnvInfoResponse')
 aside#PageLoader(hidden='{{!pageLoading}}')
 app-drawer-layout.flex(narrow='{{narrowMode}}',
-        force-narrow='[[or(inIframe, thinView, notFoundInIframe)]]',
+        force-narrow='[[or(inIframe, thinView, notFoundInIframe, hideSidebar)]]',
         bleed$='[[sidebarBleed]]')
     app-location(route='{{route}}', query-params='{{queryParams}}')
     app-route(route='{{route}}', pattern='/:page', data='{{routeData}}',
@@ -21,7 +21,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
             template(is='dom-if', if='[[equals(isolationMode, "multi-user")]]')
                 aside.divider
                 a(href$='[[buildHref("/manage-users", queryParams)]]', tabindex='-1')
-                    paper-item.menu-item Manage Users
+                    paper-item.menu-item Manage Contributors
             aside.divider
             a(href='https://github.com/kubeflow/kubeflow',
                 tabindex='-1', target="_blank")

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -18,6 +18,10 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
             template(is='dom-repeat', items='[[menuLinks]]')
                 iframe-link(href$="[[buildHref(item.link, queryParams)]]")
                     paper-item.menu-item [[item.text]]
+            template(is='dom-if', if='[[equals(isolationMode, "multi-user")]]')
+                aside.divider
+                a(href$='[[buildHref("/manage-users", queryParams)]]', tabindex='-1')
+                    paper-item.menu-item Manage Users
             aside.divider
             a(href='https://github.com/kubeflow/kubeflow',
                 tabindex='-1', target="_blank")
@@ -62,6 +66,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         platform-info='[[platformInfo]]')
                 neon-animatable(page='activity')
                     activity-view(namespace='[[queryParams.ns]]')
+                neon-animatable(page='manage-users')
+                    manage-users-view(user='[[user]]', namespaces='[[namespaces]]', is-cluster-admin='[[isClusterAdmin]]', owned-namespace='[[ownedNamespace]]')
                 neon-animatable(page='iframe')
                     iframe#PageFrame.flex
                 neon-animatable(page='not_found')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -1,4 +1,4 @@
-iron-ajax(auto, url='/api/has-workgroup', handle-as='json',
+iron-ajax(auto, url='/api/workgroup/exists', handle-as='json',
     on-response='_onHasWorkgroupResponse', loading='{{pageLoading}}')
 iron-ajax#envInfo(auto='[[_shouldFetchEnv]]', url='/api/env-info', handle-as='json',
     on-response='_onEnvInfoResponse')

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -210,7 +210,7 @@ describe('Main Page', () => {
         const getHasWorkgroup = mockRequest(mainPage, {
             status: 200,
             responseText: JSON.stringify(hasWorkgroup),
-        }, false, '/api/has-workgroup');
+        }, false, '/api/workgroup/exists');
         const getEnvInfo = mockRequest(mainPage, {
             status: 200,
             responseText: JSON.stringify(envInfo),

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -176,31 +176,19 @@ describe('Main Page', () => {
     it('Sets information when platform info is received', async () => {
         const namespaces = [
             {
-                user: {kind: 'user', name: 'testuser'},
-                referredNamespace: 'default',
-                roleRef: {
-                    apiGroup: '',
-                    kind: 'ClusterRole',
-                    name: 'editor',
-                },
+                user: 'testuser',
+                namespace: 'default',
+                role: 'editor',
             },
             {
-                user: {kind: 'user', name: 'testuser'},
-                referredNamespace: 'kubeflow',
-                roleRef: {
-                    apiGroup: '',
-                    kind: 'ClusterRole',
-                    name: 'editor',
-                },
+                user: 'testuser',
+                namespace: 'kubeflow',
+                role: 'editor',
             },
             {
-                user: {kind: 'user', name: 'testuser'},
-                referredNamespace: 'namespace-2',
-                roleRef: {
-                    apiGroup: '',
-                    kind: 'ClusterRole',
-                    name: 'editor',
-                },
+                user: 'testuser',
+                namespace: 'namespace-2',
+                role: 'editor',
             },
         ];
         const user = 'anonymous@kubeflow.org';

--- a/components/centraldashboard/public/components/manage-users-view.css
+++ b/components/centraldashboard/public/components/manage-users-view.css
@@ -54,6 +54,7 @@ vaadin-grid {
     padding: .5em;
     position: relative;
     flex-wrap: wrap;
+    min-height: 2.5em;
     @apply --layout-horizontal;
 }
 #Contribs[error] {

--- a/components/centraldashboard/public/components/manage-users-view.css
+++ b/components/centraldashboard/public/components/manage-users-view.css
@@ -8,8 +8,7 @@
 }
 h1, h2 {
     font-family: Google Sans;
-    font-weight: 500;
-    font-size: 1.1em;
+    font-size: 1.2em;
     margin: 0;
 }
 h1 {
@@ -27,17 +26,23 @@ h2 {
     @apply --layout-horizontal;
     @apply --layout-center;
     font-size: 1em;
+    font-weight: 500;
     color: var(--subheading-color);
     margin: .5em 0;
 }
 h2 .icon {
     color: var(--accent-color);
     margin-right: 1rem;
+    /* Because Hamburger icon has a padding area for ripple*/
+    padding-left: .6rem;
 }
 .content {
-    margin-left: calc(1rem + 24px);
+    margin-left: calc(1.6rem + 24px);
     color: var(--content-color);
     font-size: .9em;
+}
+.content.small {
+    max-width: 640px;
 }
 vaadin-grid {
     --lumo-font-size-m: 1em;
@@ -47,49 +52,12 @@ vaadin-grid {
 #ContribError {
     background: #F44336
 }
-#Contribs {
-    --action-color: var(--accent-color);
-    border: 2px solid var(--action-color);
-    border-radius: 3px;
-    padding: .5em;
-    position: relative;
-    flex-wrap: wrap;
-    min-height: 2.5em;
-    @apply --layout-horizontal;
-}
-#Contribs[error] {
-    --action-color: #F44336
-}
-#Contribs > figcaption {
-    position: absolute;
-    top: 0;
-    left: .75em;
-    transform: translateY(-50%);
-    font-size: .8em;
-    background: white;
-    padding: .25em;
-    color: var(--action-color);
-    font-weight: 400;
-}
-#Contribs input {
-    border: 0;
-    padding: 0;
-    outline: 0;
-    margin: .25em .5em;
-    flex: 1;
-    caret-color: var(--action-color);
-}
-#Contribs input::placeholder {
-    font-style: italic;
-}
-#Contribs .Error {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    transform: translateY(100%);
-    padding: .5em 0;
-    font-size: .8em;
-    color: var(--action-color);
+
+md2-input {
+    width: 100%;
+    --md2-input-box: {
+        min-height: 2.5em;
+    }
 }
 
 [hidden] {display: none !important}

--- a/components/centraldashboard/public/components/manage-users-view.css
+++ b/components/centraldashboard/public/components/manage-users-view.css
@@ -3,6 +3,8 @@
     background: white;
     --content-color: #717479;
     --subheading-color: #404447;
+    overflow: auto;
+    @apply --layout-fit;
 }
 h1, h2 {
     font-family: Google Sans;

--- a/components/centraldashboard/public/components/manage-users-view.css
+++ b/components/centraldashboard/public/components/manage-users-view.css
@@ -1,0 +1,92 @@
+:host {
+    @apply --layout-fit;
+    background: white;
+    --content-color: #717479;
+    --subheading-color: #404447;
+}
+h1, h2 {
+    font-family: Google Sans;
+    font-weight: 500;
+    font-size: 1.1em;
+    margin: 0;
+}
+h1 {
+    color: black;
+    padding: 1rem;
+    border-bottom: 1px solid var(--border-color);
+}
+#Main-Content {
+    padding: 1rem;
+}
+article:not(:first-of-type) {
+    margin-top: 1.5em;
+}
+h2 {
+    @apply --layout-horizontal;
+    @apply --layout-center;
+    font-size: 1em;
+    color: var(--subheading-color);
+    margin: .5em 0;
+}
+h2 .icon {
+    color: var(--accent-color);
+    margin-right: 1rem;
+}
+.content {
+    margin-left: calc(1rem + 24px);
+    color: var(--content-color);
+    font-size: .9em;
+}
+vaadin-grid {
+    --lumo-font-size-m: 1em;
+    --lumo-body-text-color: currentColor;
+}
+#NoNamespaceError {margin-top: 1em}
+#ContribError {
+    background: #F44336
+}
+#Contribs {
+    --action-color: var(--accent-color);
+    border: 2px solid var(--action-color);
+    border-radius: 3px;
+    padding: .5em;
+    position: relative;
+    flex-wrap: wrap;
+    @apply --layout-horizontal;
+}
+#Contribs[error] {
+    --action-color: #F44336
+}
+#Contribs > figcaption {
+    position: absolute;
+    top: 0;
+    left: .75em;
+    transform: translateY(-50%);
+    font-size: .8em;
+    background: white;
+    padding: .25em;
+    color: var(--action-color);
+    font-weight: 400;
+}
+#Contribs input {
+    border: 0;
+    padding: 0;
+    outline: 0;
+    margin: .25em .5em;
+    flex: 1;
+    caret-color: var(--action-color);
+}
+#Contribs input::placeholder {
+    font-style: italic;
+}
+#Contribs .Error {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    transform: translateY(100%);
+    padding: .5em 0;
+    font-size: .8em;
+    color: var(--action-color);
+}
+
+[hidden] {display: none !important}

--- a/components/centraldashboard/public/components/manage-users-view.js
+++ b/components/centraldashboard/public/components/manage-users-view.js
@@ -1,0 +1,115 @@
+import '@polymer/iron-ajax/iron-ajax.js';
+import '@polymer/iron-icon/iron-icon.js';
+import '@polymer/iron-icons/iron-icons.js';
+import '@polymer/iron-icons/social-icons.js';
+import '@polymer/paper-toast/paper-toast.js';
+import '@polymer/paper-ripple/paper-ripple.js';
+import '@polymer/paper-item/paper-icon-item.js';
+import '@polymer/paper-icon-button/paper-icon-button.js';
+import '@vaadin/vaadin-grid/vaadin-grid.js';
+import '@vaadin/vaadin-grid/vaadin-grid-selection-column.js';
+import '@vaadin/vaadin-grid/vaadin-grid-sort-column.js';
+
+import {html, PolymerElement} from '@polymer/polymer';
+
+import './resources/paper-chip.js';
+import css from './manage-users-view.css';
+import template from './manage-users-view.pug';
+import utilitiesMixin from './utilities-mixin.js';
+
+export class ManageUsersView extends utilitiesMixin(PolymerElement) {
+    static get template() {
+        return html([`
+            <style>${css.toString()}</style>
+            ${template()}
+        `]);
+    }
+
+    /**
+     * Object describing property-related metadata used by Polymer features
+     */
+    static get properties() {
+        return {
+            user: {type: String, value: 'Loading...'},
+            isClusterAdmin: {type: Boolean, value: false},
+            namespaces: Array,
+            ownedNamespace: {type: Object, value: () => ({})},
+            newContribEmail: String,
+            contribError: Object,
+            contributorInputEl: Object,
+        };
+    }
+    /**
+     * Main ready method for Polymer Elements.
+     */
+    ready() {
+        super.ready();
+        this.contributorInputEl = this.$.ContribEmail;
+    }
+    /**
+     * Returns 1 to 2 rows containing owner and contributor rows for namespaces
+     * @param {[object]} ns Namespaces array.
+     * @return {[string, [string]]} rows for namespace table.
+     */
+    nsBreakdown(ns) {
+        const {ownedNamespace, namespaces} = this;
+        if (!ownedNamespace) return;
+        const arr = [
+            ['Owner', ownedNamespace.namespace],
+        ];
+        if (ns.length <= 1) return arr;
+        const otherNamespaces = namespaces
+            .filter((n) => n != ownedNamespace)
+            .map((i) => i.namespace).join(', ');
+        arr.push(
+            ['Contributor', otherNamespaces],
+        );
+        return arr;
+    }
+    /**
+     * Triggers an API call to create a new Contributor
+     * @param {Event} e
+     */
+    addNewContrib(e) {
+        const api = this.$.AddContribAjax;
+        api.body = {contributor: this.newContribEmail};
+        api.generateRequest();
+    }
+    /**
+     * Takes an event from iron-ajax and isolates the error from a request that
+     * failed
+     * @param {IronAjaxEvent} e
+     * @return {string}
+     */
+    _isolateErrorFromIronRequest(e) {
+        return (e.detail.request.response||{}).error ||
+            e.detail.error || e.detail;
+    }
+    /**
+     * Iron-Ajax response / error handler for addNewContributor
+     * @param {IronAjaxEvent} e
+     */
+    handleContribCreate(e) {
+        if (e.detail.error) {
+            const error = this._isolateErrorFromIronRequest(e);
+            this.contribCreateError = error;
+            return;
+        }
+        this.contributorList = e.detail.response;
+        this.newContribEmail = this.contribCreateError = '';
+    }
+    /**
+     * Iron-Ajax error handler for getContributors
+     * @param {IronAjaxEvent} e
+     */
+    onContribFetchError(e) {
+        const error = this._isolateErrorFromIronRequest(e);
+        this.contribError = error;
+        this.$.ContribError.show();
+        // todo: remove
+        this.contributorList = ['apv.123@google.com', 'foo_bar12@google.com',
+            'dsoadopsa@google.com'];
+    }
+}
+
+customElements.define('manage-users-view', ManageUsersView);

--- a/components/centraldashboard/public/components/manage-users-view.js
+++ b/components/centraldashboard/public/components/manage-users-view.js
@@ -13,6 +13,7 @@ import '@vaadin/vaadin-grid/vaadin-grid-sort-column.js';
 import {html, PolymerElement} from '@polymer/polymer';
 
 import './resources/paper-chip.js';
+import './resources/md2-input/md2-input.js';
 import css from './manage-users-view.css';
 import template from './manage-users-view.pug';
 import utilitiesMixin from './utilities-mixin.js';
@@ -55,14 +56,14 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
         const {ownedNamespace, namespaces} = this;
         if (!ownedNamespace || !namespaces) return;
         const arr = [
-            ['Owner', ownedNamespace.namespace],
+            ['Owner of', ownedNamespace.namespace],
         ];
         if (ns.length <= 1) return arr;
         const otherNamespaces = namespaces
             .filter((n) => n != ownedNamespace)
             .map((i) => i.namespace).join(', ');
         arr.push(
-            ['Contributor', otherNamespaces],
+            ['Contributor in', otherNamespaces],
         );
         return arr;
     }

--- a/components/centraldashboard/public/components/manage-users-view.js
+++ b/components/centraldashboard/public/components/manage-users-view.js
@@ -53,7 +53,7 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
      */
     nsBreakdown(ns) {
         const {ownedNamespace, namespaces} = this;
-        if (!ownedNamespace) return;
+        if (!ownedNamespace || !namespaces) return;
         const arr = [
             ['Owner', ownedNamespace.namespace],
         ];
@@ -82,8 +82,8 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
      * @return {string}
      */
     _isolateErrorFromIronRequest(e) {
-        return (e.detail.request.response||{}).error ||
-            e.detail.error || e.detail;
+        const bd = e.detail.request.response||{};
+        return bd.error || e.detail.error || e.detail;
     }
     /**
      * Iron-Ajax response / error handler for addNewContributor
@@ -106,9 +106,24 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
         const error = this._isolateErrorFromIronRequest(e);
         this.contribError = error;
         this.$.ContribError.show();
-        // todo: remove
-        this.contributorList = ['apv.123@google.com', 'foo_bar12@google.com',
-            'dsoadopsa@google.com'];
+    }
+    /**
+     * Iron-Ajax error handler for getContributors
+     * @param {IronAjaxEvent} e
+     */
+    onAllNamespaceFetchError(e) {
+        const error = this._isolateErrorFromIronRequest(e);
+        this.allNamespaceError = error;
+        this.$.AllNamespaceError.show();
+    }
+    /**
+     * [ComputedProp] Should the ajax call for all namespaces run?
+     * @param {object} ownedNamespace
+     * @param {boolean} isClusterAdmin
+     * @return {boolean}
+     */
+    shouldFetchAllNamespaces(ownedNamespace, isClusterAdmin) {
+        return isClusterAdmin && !this.empty(ownedNamespace);
     }
 }
 

--- a/components/centraldashboard/public/components/manage-users-view.js
+++ b/components/centraldashboard/public/components/manage-users-view.js
@@ -68,11 +68,19 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
     }
     /**
      * Triggers an API call to create a new Contributor
-     * @param {Event} e
      */
-    addNewContrib(e) {
+    addNewContrib() {
         const api = this.$.AddContribAjax;
         api.body = {contributor: this.newContribEmail};
+        api.generateRequest();
+    }
+    /**
+     * Triggers an API call to remove a Contributor
+     * @param {Event} e
+     */
+    removeContributor(e) {
+        const api = this.$.RemoveContribAjax;
+        api.body = {contributor: e.model.item};
         api.generateRequest();
     }
     /**
@@ -90,6 +98,19 @@ export class ManageUsersView extends utilitiesMixin(PolymerElement) {
      * @param {IronAjaxEvent} e
      */
     handleContribCreate(e) {
+        if (e.detail.error) {
+            const error = this._isolateErrorFromIronRequest(e);
+            this.contribCreateError = error;
+            return;
+        }
+        this.contributorList = e.detail.response;
+        this.newContribEmail = this.contribCreateError = '';
+    }
+    /**
+     * Iron-Ajax response / error handler for removeContributor
+     * @param {IronAjaxEvent} e
+     */
+    handleContribDelete(e) {
         if (e.detail.error) {
             const error = this._isolateErrorFromIronRequest(e);
             this.contribCreateError = error;

--- a/components/centraldashboard/public/components/manage-users-view.pug
+++ b/components/centraldashboard/public/components/manage-users-view.pug
@@ -1,4 +1,6 @@
 h1 Manage Contributors
+iron-ajax#RemoveContribAjax(method='DELETE', url='/api/remove-contributor/[[ownedNamespace.namespace]]',
+    on-response='handleContribDelete', on-error='handleContribDelete', handle-as='json', content-type='application/json')
 iron-ajax#AddContribAjax(method='POST', url='/api/add-contributor/[[ownedNamespace.namespace]]',
     on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')
 iron-ajax(auto='[[!empty(ownedNamespace)]]', url='/api/get-contributors/[[ownedNamespace.namespace]]',
@@ -30,7 +32,7 @@ section#Main-Content
             section#Contribs(error$='[[!empty(contribCreateError)]]')
                 figcaption Email Addresses
                 template(is='dom-repeat', items='[[contributorList]]')
-                    paper-chip [[item]]
+                    paper-chip(on-remove='removeContributor') [[item]]
                 input(value='{{newContribEmail::input}}', placeholder='... Add Contributor email')
                 iron-a11y-keys#keys(target='[[contributorInputEl]]', keys='enter', on-keys-pressed='addNewContrib')
                 aside.Error [[contribCreateError]]

--- a/components/centraldashboard/public/components/manage-users-view.pug
+++ b/components/centraldashboard/public/components/manage-users-view.pug
@@ -1,0 +1,35 @@
+h1 Manage Contributors
+iron-ajax#AddContribAjax(method='POST', url='/api/add-contributor', on-response='handleContribCreate', on-error='handleContribCreate')
+iron-ajax(auto='[[!empty(ownedNamespace)]]', url='/api/get-contributors/[[ownedNamespace.namespace]]', last-response='{{contributorList}}', on-error='onContribFetchError')
+section#Main-Content
+    article.Acct-Info
+        h2
+            iron-icon.icon(icon='social:person-outline')
+            span.text Account Info
+            span(hidden$='[[!isClusterAdmin]]') &nbsp; (Cluster Admin)
+        .content
+            span [[user]]
+    h2#NoNamespaceError(hidden$='[[!empty(ownedNamespace)]]') You have no owned namespaces!
+    article.Namespaces(hidden$='[[empty(ownedNamespace)]]')
+        h2
+            iron-icon.icon(icon='kubeflow:namespace')
+            span.text Namespaces
+        .content
+            vaadin-grid(items='[[nsBreakdown(namespaces)]]', theme="no-border", height-by-rows, multi-sort)
+                vaadin-grid-column(width='9em', path='0', header='Role')
+                vaadin-grid-column(width='15em', path='1', flex-grow='2', header='Namespaces')
+    article.Contributors(hidden$='[[empty(ownedNamespace)]]')
+        h2
+            iron-icon.icon(icon='kubeflow:namespace')
+            span.text Contributors to your namespace - [[ownedNamespace.namespace]]
+        .content
+            section#Contribs(error$='[[!empty(contribCreateError)]]')
+                figcaption Email Addresses
+                template(is='dom-repeat', items='[[contributorList]]')
+                    paper-chip [[item]]
+                input#ContribEmail(is='iron-input', value='{{newContribEmail}}', type='email', placeholder='... Add Contributor email')
+                iron-a11y-keys#keys(target='[[contributorInputEl]]', keys='enter', on-keys-pressed='addNewContrib')
+                aside.Error [[contribCreateError]]
+paper-toast#ContribError(duration=5000)
+    | Failed to fetch contributor list for {{ownedNamespace.namespace}}, because: 
+    strong [[contribError]]

--- a/components/centraldashboard/public/components/manage-users-view.pug
+++ b/components/centraldashboard/public/components/manage-users-view.pug
@@ -1,11 +1,11 @@
 h1 Manage Contributors
-iron-ajax#RemoveContribAjax(method='DELETE', url='/api/remove-contributor/[[ownedNamespace.namespace]]',
+iron-ajax#RemoveContribAjax(method='DELETE', url='/api/workgroup/remove-contributor/[[ownedNamespace.namespace]]',
     on-response='handleContribDelete', on-error='handleContribDelete', handle-as='json', content-type='application/json')
-iron-ajax#AddContribAjax(method='POST', url='/api/add-contributor/[[ownedNamespace.namespace]]',
+iron-ajax#AddContribAjax(method='POST', url='/api/workgroup/add-contributor/[[ownedNamespace.namespace]]',
     on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')
-iron-ajax(auto='[[!empty(ownedNamespace)]]', url='/api/get-contributors/[[ownedNamespace.namespace]]',
+iron-ajax(auto='[[!empty(ownedNamespace)]]', url='/api/workgroup/get-contributors/[[ownedNamespace.namespace]]',
     last-response='{{contributorList}}', on-error='onContribFetchError', handle-as='json')
-iron-ajax(auto='[[shouldFetchAllNamespaces(ownedNamespace, isClusterAdmin)]]', url='/api/get-all-namespaces',
+iron-ajax(auto='[[shouldFetchAllNamespaces(ownedNamespace, isClusterAdmin)]]', url='/api/workgroup/get-all-namespaces',
     last-response='{{allNamespaces}}', on-error='onAllNamespaceFetchError', handle-as='json')
 section#Main-Content
     article.Acct-Info

--- a/components/centraldashboard/public/components/manage-users-view.pug
+++ b/components/centraldashboard/public/components/manage-users-view.pug
@@ -1,6 +1,10 @@
 h1 Manage Contributors
-iron-ajax#AddContribAjax(method='POST', url='/api/add-contributor', on-response='handleContribCreate', on-error='handleContribCreate')
-iron-ajax(auto='[[!empty(ownedNamespace)]]', url='/api/get-contributors/[[ownedNamespace.namespace]]', last-response='{{contributorList}}', on-error='onContribFetchError')
+iron-ajax#AddContribAjax(method='POST', url='/api/add-contributor/[[ownedNamespace.namespace]]',
+    on-response='handleContribCreate', on-error='handleContribCreate', handle-as='json', content-type='application/json')
+iron-ajax(auto='[[!empty(ownedNamespace)]]', url='/api/get-contributors/[[ownedNamespace.namespace]]',
+    last-response='{{contributorList}}', on-error='onContribFetchError', handle-as='json')
+iron-ajax(auto='[[shouldFetchAllNamespaces(ownedNamespace, isClusterAdmin)]]', url='/api/get-all-namespaces',
+    last-response='{{allNamespaces}}', on-error='onAllNamespaceFetchError', handle-as='json')
 section#Main-Content
     article.Acct-Info
         h2
@@ -15,7 +19,7 @@ section#Main-Content
             iron-icon.icon(icon='kubeflow:namespace')
             span.text Namespaces
         .content
-            vaadin-grid(items='[[nsBreakdown(namespaces)]]', theme="no-border", height-by-rows, multi-sort)
+            vaadin-grid(items='[[nsBreakdown(namespaces, ownedNamespace)]]', theme="no-border", height-by-rows, multi-sort)
                 vaadin-grid-column(width='9em', path='0', header='Role')
                 vaadin-grid-column(width='15em', path='1', flex-grow='2', header='Namespaces')
     article.Contributors(hidden$='[[empty(ownedNamespace)]]')
@@ -27,9 +31,21 @@ section#Main-Content
                 figcaption Email Addresses
                 template(is='dom-repeat', items='[[contributorList]]')
                     paper-chip [[item]]
-                input#ContribEmail(is='iron-input', value='{{newContribEmail}}', type='email', placeholder='... Add Contributor email')
+                input(value='{{newContribEmail::input}}', placeholder='... Add Contributor email')
                 iron-a11y-keys#keys(target='[[contributorInputEl]]', keys='enter', on-keys-pressed='addNewContrib')
                 aside.Error [[contribCreateError]]
+    article.Cluster-Namespaces(hidden$='[[empty(isClusterAdmin)]]')
+        h2
+            iron-icon.icon(icon='kubeflow:namespace')
+            span.text Cluster namespaces
+        .content
+            vaadin-grid(items='[[allNamespaces]]', theme="no-border", height-by-rows, multi-sort)
+                vaadin-grid-column(width='9em', path='0', header='Namespace')
+                vaadin-grid-column(width='10em', path='1', header='Owner')
+                vaadin-grid-column(width='15em', path='2', flex-grow='2', header='Contributors')
 paper-toast#ContribError(duration=5000)
     | Failed to fetch contributor list for {{ownedNamespace.namespace}}, because: 
     strong [[contribError]]
+paper-toast#AllNamespaceError(duration=5000)
+    | Failed to fetch all namespaces, because:
+    strong [[allNamespaceError]]

--- a/components/centraldashboard/public/components/manage-users-view.pug
+++ b/components/centraldashboard/public/components/manage-users-view.pug
@@ -19,8 +19,8 @@ section#Main-Content
     article.Namespaces(hidden$='[[empty(ownedNamespace)]]')
         h2
             iron-icon.icon(icon='kubeflow:namespace')
-            span.text Namespaces
-        .content
+            span.text Namespace Memberships
+        .content.small
             vaadin-grid(items='[[nsBreakdown(namespaces, ownedNamespace)]]', theme="no-border", height-by-rows, multi-sort)
                 vaadin-grid-column(width='9em', path='0', header='Role')
                 vaadin-grid-column(width='15em', path='1', flex-grow='2', header='Namespaces')
@@ -28,14 +28,18 @@ section#Main-Content
         h2
             iron-icon.icon(icon='kubeflow:namespace')
             span.text Contributors to your namespace - [[ownedNamespace.namespace]]
-        .content
-            section#Contribs(error$='[[!empty(contribCreateError)]]')
-                figcaption Email Addresses
-                template(is='dom-repeat', items='[[contributorList]]')
-                    paper-chip(on-remove='removeContributor') [[item]]
-                input(value='{{newContribEmail::input}}', placeholder='... Add Contributor email')
-                iron-a11y-keys#keys(target='[[contributorInputEl]]', keys='enter', on-keys-pressed='addNewContrib')
-                aside.Error [[contribCreateError]]
+        .content.small
+            //- section#Contribs(error$='[[!empty(contribCreateError)]]')
+            //-     figcaption Email Addresses
+            //-     template(is='dom-repeat', items='[[contributorList]]')
+            //-         paper-chip(on-remove='removeContributor') [[item]]
+            //-     input(value='{{newContribEmail::input}}', placeholder='Add by email address')
+            //-     iron-a11y-keys#keys(target='[[contributorInputEl]]', keys='enter', on-keys-pressed='addNewContrib')
+            //-     aside.Error [[contribCreateError]]
+            md2-input(label='Email Addresses', value='{{newContribEmail}}', on-submit='addNewContrib', placeholder='Add by email address', error$='[[contribCreateError]]')
+                .prefix(slot='prefix')
+                    template(is='dom-repeat', items='[[contributorList]]')
+                        paper-chip(on-remove='removeContributor') [[item]]
     article.Cluster-Namespaces(hidden$='[[empty(isClusterAdmin)]]')
         h2
             iron-icon.icon(icon='kubeflow:namespace')

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -15,13 +15,19 @@ export class NamespaceSelector extends PolymerElement {
     static get template() {
         return html`
             <style>
+                :host {
+                    --icon-colors: #5f6062;
+                    --primary-background-color: var(--icon-colors);
+                }
                 paper-menu-button {
                     --paper-menu-button: {
                         font-size: 14px;
                         color: #3c4043
                     }
                 }
-
+                iron-icon {
+                    color: var(--icon-colors)
+                }
                 #dropdown-trigger {
                     @apply --layout-horizontal;
                     @apply --layout-center;
@@ -49,7 +55,7 @@ export class NamespaceSelector extends PolymerElement {
                     display: flex;
                     @apply --layout-center;
                 }
-                [owner]:after {
+                [owner]:not([all-namespaces]):after {
                     content: '(Owner)';
                     margin-left: .25em;
                     font-size: .8em;
@@ -62,13 +68,15 @@ export class NamespaceSelector extends PolymerElement {
                     --paper-button-ink-color: var(--accent-color);
                 }
             </style>
-            <paper-menu-button no-overlap horizontal-align="left">
+            <paper-menu-button no-overlap horizontal-align="left"
+                    disabled='[[allNamespaces]]'>
                 <paper-button id="dropdown-trigger" slot="dropdown-trigger">
                     <iron-icon icon="kubeflow:namespace"></iron-icon>
                     <article id="SelectedNamespace">
                         <span class='text'
-                                owner$='[[selectedNamespaceIsOwned]]'>
-                            [[getNamespaceText(selected)]]
+                            all-namespaces$='[[allNamespaces]]'
+                            owner$='[[selectedNamespaceIsOwned]]'>
+                            [[getNamespaceText(selected, allNamespaces)]]
                         </span>
                     </article>
                     <iron-icon icon="arrow-drop-down"></iron-icon>
@@ -99,6 +107,7 @@ export class NamespaceSelector extends PolymerElement {
                 value: '',
                 notify: true,
             },
+            allNamespaces: {type: Boolean, value: false},
             selectedNamespaceIsOwned: {
                 type: Boolean,
                 readOnly: true,
@@ -131,9 +140,11 @@ export class NamespaceSelector extends PolymerElement {
     /**
      * Check if role is owner
      * @param {string} selected
+     * @param {boolean} allNamespaces
      * @return {string} Text that should show in namespace selector
      */
-    getNamespaceText(selected) {
+    getNamespaceText(selected, allNamespaces) {
+        if (allNamespaces) return 'All Namespaces';
         if (!selected) return 'Select namespace';
         return selected;
     }

--- a/components/centraldashboard/public/components/registration-page.css
+++ b/components/centraldashboard/public/components/registration-page.css
@@ -15,7 +15,7 @@
 }
 h1,h2,h3 {margin: 0;font-family: Google Sans;color: var(--heading-color);font-weight: 400}
 h2 {font-size: 1.25em}
-h2+aside {font-size: .7em;color: var(--subtext-color)}
+h2+aside {font-size: .7em;color: var(--subtext-color);margin-bottom: 1em}
 #MainCard {
     background: white;
     padding: 0 40px;
@@ -61,21 +61,6 @@ neon-animatable {
 }
 .actions > paper-button:first-of-type[disabled] {
     background: var(--paper-grey-500);
-}
-.finish {
-    @apply --layout-horizontal;
-    @apply --layout-center-center;
-}
-.finish #ApiMessage {
-    width: 0;
-    transition: width .25s;
-    color: var(--accent-color);
-    font-size: .75em;
-    overflow: hidden;
-    white-space: nowrap;
-}
-animated-checkmark {
-    margin: 1em .5em;
 }
 carousel-indicator {
     margin: 1em;

--- a/components/centraldashboard/public/components/registration-page.css
+++ b/components/centraldashboard/public/components/registration-page.css
@@ -13,9 +13,26 @@
     --subtext-color: #80868b;
     background: var(--primary-background-color);
 }
-h1,h2,h3 {margin: 0;font-family: Google Sans;color: var(--heading-color);font-weight: 400}
-h2 {font-size: 1.25em}
-h2+aside {font-size: .7em;color: var(--subtext-color);margin-bottom: 1em}
+
+h1,
+h2,
+h3 {
+    margin: 0;
+    font-family: Google Sans;
+    color: var(--heading-color);
+    font-weight: 400
+}
+
+h2 {
+    font-size: 1.25em
+}
+
+h2+aside {
+    font-size: .7em;
+    color: var(--subtext-color);
+    margin-bottom: 1em
+}
+
 #MainCard {
     background: white;
     padding: 0 40px;
@@ -29,39 +46,49 @@ h2+aside {font-size: .7em;color: var(--subtext-color);margin-bottom: 1em}
     margin: 0;
     padding: 3em 0 4em;
 }
-#Logo>svg * {fill: currentColor}
+
+#Logo>svg * {
+    fill: currentColor
+}
 
 #MainCard .Main-Content {
     height: 275px;
 }
+
 neon-animatable {
     @apply --layout-vertical;
 }
+
 .actions {
     margin-top: 1.5em;
     flex: 1;
     @apply --layout-horizontal-reverse;
     @apply --layout-end;
 }
-.actions > paper-button {
+
+.actions>paper-button {
     height: 2.5em;
     font-size: .75em;
     padding: .7em 1em;
     color: var(--accent-color);
     text-transform: none;
 }
-.actions > paper-button:first-of-type {
+
+.actions>paper-button:first-of-type {
     background: var(--accent-color);
     color: white;
     margin-left: 0;
 }
-.actions > paper-button[disabled] {
+
+.actions>paper-button[disabled] {
     cursor: not-allowed;
     background: var(--paper-grey-200);
 }
-.actions > paper-button:first-of-type[disabled] {
+
+.actions>paper-button:first-of-type[disabled] {
     background: var(--paper-grey-500);
 }
+
 carousel-indicator {
     margin: 1em;
 }
@@ -80,13 +107,16 @@ carousel-indicator {
     @apply --layout-horizontal;
     @apply --layout-around-justified;
 }
+
 #Links a {
     text-decoration: none;
     color: inherit;
 }
+
 #Links a:hover {
     text-decoration: underline;
 }
+
 #Namespace {
     --paper-input-error: {
         white-space: unset;

--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -85,7 +85,7 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
             el.style.width = `${el.scrollWidth}px`;
         });
         this.sleep(2000).then(async () => {
-            this.fire('flowcomplete');
+            this.fireEvent('flowcomplete');
         });
         this.sleep(6000).then(async () => {
             this.$.ApiMessage.style.width = 0;

--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -11,6 +11,7 @@ import '@polymer/neon-animation/animations/fade-out-animation.js';
 
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 
+import './resources/md2-input/md2-input.js';
 import './resources/carousel-indicator.js';
 import './resources/animated-checkmark.js';
 import css from './registration-page.css';
@@ -84,7 +85,7 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
             el.style.width = `${el.scrollWidth}px`;
         });
         this.sleep(2000).then(async () => {
-            this.dispatchEvent(new CustomEvent('flowcomplete'));
+            this.fire('flowcomplete');
         });
         this.sleep(6000).then(async () => {
             this.$.ApiMessage.style.width = 0;

--- a/components/centraldashboard/public/components/registration-page.pug
+++ b/components/centraldashboard/public/components/registration-page.pug
@@ -13,8 +13,8 @@ paper-card#MainCard
         neon-animatable
             h2 Namespace
             aside A namespace is a collection of Kubeflow services. Resources created within a namespace are isolated to that namespace. By default, a namespace will be created for you.
-            paper-input#Namespace(label='Namespace Name', value='{{namespaceName}}', allowed-pattern='[[_namespaceValidationRegex]]',
-                invalid='[[error.response.error]]', error-message='[[error.response.error]]', disabled='[[submittingWorkgroup]]', maxlength=253)
+            md2-input#Namespace(label='Namespace Name', value='{{namespaceName}}', allowed-pattern='[[_namespaceValidationRegex]]',
+                error='[[error.response.error]]', disabled='[[submittingWorkgroup]]', maxlength=253)
             iron-a11y-keys#keys(target='[[namespaceInput]]', keys='enter', on-keys-pressed='finishSetup')
             .finish
                 animated-checkmark(show='[[flowComplete]]')

--- a/components/centraldashboard/public/components/registration-page.pug
+++ b/components/centraldashboard/public/components/registration-page.pug
@@ -1,4 +1,4 @@
-iron-ajax#MakeNamespace(method='POST', url='/api/create-workgroup', handle-as='json', last-error='{{error}}', last-response='{{resp}}',
+iron-ajax#MakeNamespace(method='POST', url='/api/workgroup/create', handle-as='json', last-error='{{error}}', last-response='{{resp}}',
     on-response='_successSetup', content-type='application/json', loading='{{submittingWorkgroup}}', on-input='clearInvalidation')
 paper-card#MainCard
     figure#Logo !{logo}

--- a/components/centraldashboard/public/components/resources/md2-input/md2-input.css
+++ b/components/centraldashboard/public/components/resources/md2-input/md2-input.css
@@ -1,0 +1,55 @@
+:host {
+    --action-color: var(--google-grey-500);
+    position: relative;
+    display: inline-block;
+    padding-top: .5em;
+}
+:host([focused]) {
+    --action-color: var(--accent-color)
+}
+:host([has-error]) {
+    --action-color: #F44336
+}
+.input-box {
+    @apply --layout-horizontal;
+    position: relative;
+    padding: .5em;
+    flex-wrap: wrap;
+    border: 2px solid var(--action-color);
+    border-radius: 3px;
+    transition: border-color .25s;
+    @apply --md2-input-box;
+}
+label {
+    position: absolute;
+    top: 0;
+    left: .75em;
+    transform: translateY(-50%);
+    font-size: .8em;
+    background: white;
+    padding: .25em;
+    color: var(--action-color);
+    transition: color .25s;
+    font-weight: 400;
+}
+iron-input {
+    
+    margin: .25em .5em;
+    font-size: 1em;
+    flex: 1;
+    caret-color: var(--action-color);
+    @apply --layout-horizontal;
+}
+input {
+    flex: 1;
+    outline: 0;
+    border: 0;
+    padding: 0;
+}
+.Error {
+    padding: .5em 0;
+    font-size: .8em;
+    color: var(--action-color);
+    @apply --paper-input-error;
+    @apply --md2-error;
+}

--- a/components/centraldashboard/public/components/resources/md2-input/md2-input.js
+++ b/components/centraldashboard/public/components/resources/md2-input/md2-input.js
@@ -1,0 +1,90 @@
+import '@polymer/iron-input/iron-input.js';
+
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+
+import css from './md2-input.css';
+import htmlContainer from './md2-input.pug';
+import utilitiesMixin from '../../utilities-mixin.js';
+
+export class Md2Input extends utilitiesMixin(PolymerElement) {
+    static get template() {
+        return html([
+            `<style>${css.toString()}</style>${htmlContainer()}`,
+        ]);
+    }
+    static get properties() {
+        return {
+            label: String,
+            placeholder: String,
+            error: {type: String, value: ''},
+            value: {
+                type: String,
+                value: '',
+                notify: true,
+                observer: 'validateRange',
+            },
+            inputElement: {type: Object, notify: true, readOnly: true},
+            disabled: {type: Boolean, value: false},
+            hasError: {
+                type: Boolean,
+                notify: true,
+                reflectToAttribute: true,
+                computed: '_hasError(error)',
+            },
+            focused: {
+                type: Boolean,
+                value: false,
+                reflectToAttribute: true,
+                readOnly: true,
+            },
+            maxlength: {type: Number, value: -1},
+            minlength: {type: Number, value: -1},
+            allowedPattern: String,
+        };
+    }
+    static get observers() {
+        return [
+            'validateRange(value, maxlength, minlength)',
+        ];
+    }
+    ready() {
+        super.ready();
+        this.inputElement = this.$.inputElement;
+    }
+    _hasError(e) {
+        return !!e;
+    }
+    inputBlurred() {
+        this._setFocused(false);
+    }
+    inputFocused() {
+        this._setFocused(true);
+    }
+    validateRange(e) {
+        if (e && !this.$.ironInput._isPrintable(e)) {
+            return true;
+        }
+        const len = this.value.length;
+        const {minlength, maxlength} = this;
+        if (minlength >= maxlength) {
+            if (minlength == -1) {
+                return;
+            }
+            // eslint-disable-next-line
+            console.warn(`The length ranges provided are invalid [${minlength} < ${maxlength}]`);
+            return true;
+        }
+        const isValid = (len > minlength || minlength == -1) &&
+                            (len < maxlength || maxlength == -1);
+        if (isValid) return;
+        e instanceof Event && e.preventDefault();
+        if (len > maxlength && maxlength != -1) {
+            this.value = this.value.slice(0, maxlength);
+        }
+        return false;
+    }
+    fireEnter() {
+        this.fire('submit');
+    }
+}
+window.customElements.define('md2-input', Md2Input);

--- a/components/centraldashboard/public/components/resources/md2-input/md2-input.js
+++ b/components/centraldashboard/public/components/resources/md2-input/md2-input.js
@@ -84,7 +84,7 @@ export class Md2Input extends utilitiesMixin(PolymerElement) {
         return false;
     }
     fireEnter() {
-        this.fire('submit');
+        this.fireEvent('submit');
     }
 }
 window.customElements.define('md2-input', Md2Input);

--- a/components/centraldashboard/public/components/resources/md2-input/md2-input.pug
+++ b/components/centraldashboard/public/components/resources/md2-input/md2-input.pug
@@ -1,0 +1,9 @@
+.input-box
+    label(hidden$='[[!label]]') [[label]]
+    slot(name='prefix', slot='prefix')
+    iron-input#ironInput(allowed-pattern='[[allowedPattern]]', bind-value='{{value}}')
+        input#inputElement(placeholder='[[placeholder]]', maxlength$='[[maxlength]]'
+            on-focus='inputFocused', on-blur='inputBlurred', on-keydown='validateRange')
+    slot(name='suffix', slot='suffix')
+    iron-a11y-keys#keys(target='[[inputElement]]', keys='enter', on-keys-pressed='fireEnter')
+aside.Error [[error]]

--- a/components/centraldashboard/public/components/resources/paper-chip.js
+++ b/components/centraldashboard/public/components/resources/paper-chip.js
@@ -53,7 +53,7 @@ export class PaperChip extends utilitiesMixin(PolymerElement) {
         this.selected = typeof e == 'number'?e:e.model.index;
     }
     fireRemove(e) {
-        this.fire('remove', e.detail);
+        this.fireEvent('remove', e.detail);
     }
 }
 

--- a/components/centraldashboard/public/components/resources/paper-chip.js
+++ b/components/centraldashboard/public/components/resources/paper-chip.js
@@ -53,7 +53,7 @@ export class PaperChip extends utilitiesMixin(PolymerElement) {
         this.selected = typeof e == 'number'?e:e.model.index;
     }
     fireRemove(e) {
-        this.dispatchEvent(new CustomEvent('remove'));
+        this.fire('remove', e.detail);
     }
 }
 

--- a/components/centraldashboard/public/components/resources/paper-chip.js
+++ b/components/centraldashboard/public/components/resources/paper-chip.js
@@ -35,7 +35,8 @@ export class PaperChip extends utilitiesMixin(PolymerElement) {
         </style>
         <section id='Wrapper'>
             <slot class='label' slot='label'></slot>
-            <paper-icon-button class='close' icon='close'></paper-icon-button>
+            <paper-icon-button class='close' icon='close'
+                on-click='fireRemove'></paper-icon-button>
         </section>`;
     }
 
@@ -50,6 +51,9 @@ export class PaperChip extends utilitiesMixin(PolymerElement) {
     }
     selectIndex(e) {
         this.selected = typeof e == 'number'?e:e.model.index;
+    }
+    fireRemove(e) {
+        this.dispatchEvent(new CustomEvent('remove'));
     }
 }
 

--- a/components/centraldashboard/public/components/utilities-mixin.js
+++ b/components/centraldashboard/public/components/utilities-mixin.js
@@ -68,4 +68,16 @@ export default (superClass) => class extends superClass {
         }
         return url.href.slice(url.origin.length);
     }
+
+    /**
+     * Fire a custom event from an element
+     * @param {string|event} name Event Name
+     * @param {object|undefined} detail Event Details
+     */
+    fire(name, detail) {
+        const ev = name instanceof Event
+            ? name
+            : new CustomEvent(name, {detail});
+        this.dispatchEvent(ev);
+    }
 };

--- a/components/centraldashboard/public/components/utilities-mixin.js
+++ b/components/centraldashboard/public/components/utilities-mixin.js
@@ -74,7 +74,7 @@ export default (superClass) => class extends superClass {
      * @param {string|event} name Event Name
      * @param {object|undefined} detail Event Details
      */
-    fire(name, detail) {
+    fireEvent(name, detail) {
         const ev = name instanceof Event
             ? name
             : new CustomEvent(name, {detail});


### PR DESCRIPTION
#### child of #3503 

## Features (some exist in #3503):
- Vaadin charts and paper-toast added
- Profile Controller promise handler created
- `/get-contributors` api route created
- Namespace icon added
- Manage Users page added
- Dashboard made aware of cluster admin status and `isolationMode`
- `Manage Users` sidebar entry only when isolationMode is multi
- New `empty` macro added to utilities mixin
- Paper-chip element added
- TSLint remove any warnings
- Updated failing api_tests.ts
- Corrected the fields being used to/from server for registration
- Corrected sidebar entries for Manage-Users
- Manage Users contrib action color now toggles based on status (error support)
- Rollback errors when successfully added contributor
- Paper-chip border-color updated
- Paper-chip ripple updated to accent color

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3758)
<!-- Reviewable:end -->
