### PR TITLE
Add gcp-credential and cert overlay

### DIFF
--- a/bootstrap/config/kfctl_gcp_basic_auth.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.yaml
@@ -256,6 +256,8 @@ spec:
         path: cert-manager/cert-manager
     name: cert-manager
   - kustomizeConfig:
+      overlays:
+      - gcp-credential
       parameters:
       - name: secretName
         value: admin-gcp-sa
@@ -308,6 +310,8 @@ spec:
         path: common/basic-auth
     name: basic-auth
   - kustomizeConfig:
+      overlays:
+      - gcp-credential
       parameters:
       - name: namespace
         value: istio-system

--- a/bootstrap/config/kfctl_gcp_basic_auth.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.yaml
@@ -311,6 +311,7 @@ spec:
     name: basic-auth
   - kustomizeConfig:
       overlays:
+      - certmanager
       - gcp-credential
       parameters:
       - name: namespace

--- a/bootstrap/config/kfctl_gcp_iap.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.yaml
@@ -283,6 +283,7 @@ spec:
     name: gpu-driver
   - kustomizeConfig:
       overlays:
+      - certmanager
       - gcp-credential
       parameters:
       - name: namespace

--- a/bootstrap/config/kfctl_gcp_iap.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.yaml
@@ -256,6 +256,8 @@ spec:
         path: cert-manager/cert-manager
     name: cert-manager
   - kustomizeConfig:
+      overlays:
+      - gcp-credential
       parameters:
       - name: secretName
         value: admin-gcp-sa
@@ -280,6 +282,8 @@ spec:
         path: gcp/gpu-driver
     name: gpu-driver
   - kustomizeConfig:
+      overlays:
+      - gcp-credential
       parameters:
       - name: namespace
         value: istio-system

--- a/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/v2/pkg/kfapp/kustomize/kustomize.go
@@ -1068,6 +1068,8 @@ func MergeKustomizations(kfDef *kfdefsv2.KfDef, compDir string, overlayParams []
 					Message: fmt.Sprintf("error merging kustomization at %v Error %v", overlayDir, err),
 				}
 			}
+		} else {
+			log.Warnf("No overlay %v for component at %v, skipping...", overlayParam, compDir)
 		}
 	}
 	if len(kustomization.PatchesJson6902) > 0 {


### PR DESCRIPTION
GCP credential
The overlay is at https://github.com/kubeflow/manifests/pull/245, but we should submit this before the overlay.
for #3638 . 

Certificate
Overlay at https://github.com/kubeflow/manifests/pull/246. For https://github.com/kubeflow/kubeflow/issues/3079

/cc @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3779)
<!-- Reviewable:end -->
