### PR TITLE
[KUBEFLOW-3797] When copying files fails provide correct error message

### DIFF
--- a/bootstrap/pkg/kfapp/aws/aws.go
+++ b/bootstrap/pkg/kfapp/aws/aws.go
@@ -226,7 +226,7 @@ func copyFile(source string, dest string) error {
 	if err != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("cannot create directory: %v", err),
+			Message: fmt.Sprintf("cannot open input file for copying: %v", err),
 		}
 	}
 	defer from.Close()

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1036,7 +1036,7 @@ func (gcp *Gcp) copyFile(source string, dest string) error {
 	if err != nil {
 		return &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("cannot create directory: %v", err),
+			Message: fmt.Sprintf("cannot open input for copying: %v", err),
 		}
 	}
 	defer from.Close()
@@ -1279,8 +1279,9 @@ func (gcp *Gcp) generateDMConfigs() error {
 	gcpConfigDirErr := os.MkdirAll(gcpConfigDir, os.ModePerm)
 	if gcpConfigDirErr != nil {
 		return &kfapis.KfError{
-			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("cannot create directory %v", gcpConfigDirErr),
+			Code: int(kfapis.INVALID_ARGUMENT),
+			Message: fmt.Sprintf("cannot create directory %v using appdir %v",
+				gcpConfigDirErr, appDir),
 		}
 	}
 	repo, ok := gcp.kfDef.Status.ReposCache[kftypes.KubeflowRepoName]
@@ -1301,8 +1302,8 @@ func (gcp *Gcp) generateDMConfigs() error {
 		if copyErr != nil {
 			return &kfapis.KfError{
 				Code: copyErr.(*kfapis.KfError).Code,
-				Message: fmt.Sprintf("could not copy %v to %v Error %v",
-					sourceFile, destFile, copyErr.(*kfapis.KfError).Message),
+				Message: fmt.Sprintf("could not copy %v to %v using repo local path %v Error %v",
+					sourceFile, destFile, repo.LocalPath, copyErr.(*kfapis.KfError).Message),
 			}
 		}
 	}


### PR DESCRIPTION
Fix the error messages provided to clarify when the error is not being able to
read the input file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3801)
<!-- Reviewable:end -->
