### PR TITLE
[KUBEFLOW-3808] Create the default namespace on GKE

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -521,6 +521,10 @@ func (gcp *Gcp) ConfigK8s() error {
 	if err = createNamespace(k8sClientset, gcp.getIstioNamespace()); err != nil {
 		return kfapis.NewKfErrorWithMessage(err, fmt.Sprintf("cannot create istio namespace"))
 	}
+	defaultNamespace := kftypesv2.EmailToDefaultName(gcp.kfDef.Spec.Email)
+	if err = createNamespace(k8sClientset, defaultNamespace); err != nil {
+		return err
+	}
 	// For deploy app, request will use service account credential instead of user credential.
 	bindAccount := gcp.kfDef.Spec.Email
 


### PR DESCRIPTION
Right now we make some but not all of the required namespaces in gcp.go.
Create the missing default namespace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3809)
<!-- Reviewable:end -->
