### PR TITLE
[Central-Dashboard v2] MUI Basic Auth Support

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -68,7 +68,7 @@ export function mapNamespacesToSimpleBinding (user: string, namespaces: V1Namesp
     return namespaces.map((n) => ({
         user,
         namespace: n.metadata.name,
-        role: roleMap.get('edit') as SimpleRole,
+        role: 'contributor',
     }));
 }
 
@@ -104,8 +104,23 @@ const surfaceProfileControllerErrors = (info: {res: Response, msg: string, err: 
     apiError({res, code, error: devError || msg});
 };
 
-export class ContributorApi {
+export class WorkgroupApi {
     constructor(private profilesService: DefaultApi) {}
+    /**
+     * Retrieves all namespaces in case of basic auth.
+     */
+    async getAllWorkgroups(fakeUser: string): Promise<SimpleBinding[]> {
+        const bindings = await this.profilesService.readBindings();
+        const namespaces = mapWorkgroupBindingToSimpleBinding(
+            bindings.body.bindings || []
+        );
+        const names = new Set(namespaces.map((n) => n.namespace));
+        return Array.from(names).map((n) => ({
+            namespace: n,
+            role: 'contributor',
+            user: fakeUser,
+        }));
+    }
     /**
      * Retrieves WorkgroupInfo from Profile Controller for the given user.
      */

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -5,7 +5,7 @@ import {resolve} from 'path';
 import {Api} from './api';
 import {attachUser} from './attach_user_middleware';
 import {DefaultApi} from './clients/profile_controller';
-import {ContributorApi} from './api_contributors';
+import {WorkgroupApi} from './api_workgroup';
 import {KubernetesService} from './k8s_service';
 import {getMetricsService} from './metrics_service_factory';
 
@@ -36,13 +36,13 @@ async function main() {
   const metricsService = await getMetricsService(k8sService);
   console.info(`Using Profiles service at ${profilesServiceUrl}`);
   const profilesService = new DefaultApi(profilesServiceUrl);
-  const contribApi = new ContributorApi(profilesService);
+  const workgroupApi = new WorkgroupApi(profilesService);
 
   app.use(express.json());
   app.use(express.static(frontEnd));
   app.use(attachUser(USERID_HEADER, USERID_PREFIX));
   app.use(
-      '/api', new Api(k8sService, profilesService, contribApi, metricsService).routes());
+      '/api', new Api(k8sService, workgroupApi, metricsService).routes());
   app.get('/*', (_: express.Request, res: express.Response) => {
     res.sendFile(resolve(frontEnd, 'index.html'));
   });


### PR DESCRIPTION
**_Add-on to #3758_** 
**_Resolves #3836_**

## Features
- Added support for communicating with Profile Controller for namespaces
- Renamed api_contributors to api_workgroup
- Updated nomenclature, removed unnecessary deps
- Fixed tests to work with new response structure

### Meta:
/assign @avdaredevil 
/cc @prodonjs @kunmingg @abhi-g 
/area front-end
/area centraldashboard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3842)
<!-- Reviewable:end -->
