### PR TITLE
jupyter-web-app: Use PodDefault's name as backup

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
@@ -42,7 +42,11 @@ def get_poddefaults(namespace):
     pdefaults = []
     for pd in data["poddefaults"]["items"]:
         label = list(pd["spec"]["selector"]["matchLabels"].keys())[0]
-        desc = pd["spec"]["desc"]
+        if "desc" in pd["spec"]:
+            desc = pd["spec"]["desc"]
+        else:
+            desc = pd["metadata"]["name"]
+
         pdefaults.append({"label": label, "desc": desc})
 
     logger.info("Found poddefaults: {}".format(pdefaults))


### PR DESCRIPTION
closes #3770 

If the `desc` field is not present in the PodDefault, show the CR's name
instead in the UI.

/cc @lluunn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3845)
<!-- Reviewable:end -->
