### PR TITLE
kfctl: pin configs to v0.6.1

### DIFF
--- a/bootstrap/config/kfctl_aws.yaml
+++ b/bootstrap/config/kfctl_aws.yaml
@@ -252,11 +252,12 @@ spec:
   enableApplications: true
   packageManager: kustomize
   repos:
-    - name: kubeflow
-      uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
-    - name: manifests
-      root: manifests-master
-      uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+  - name: manifests
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
+  - name: kubeflow
+    root: kubeflow-v0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   useBasicAuth: false
   useIstio: true
   version: master

--- a/bootstrap/config/kfctl_aws_cognito.yaml
+++ b/bootstrap/config/kfctl_aws_cognito.yaml
@@ -254,11 +254,12 @@ spec:
   enableApplications: true
   packageManager: kustomize
   repos:
-    - name: kubeflow
-      uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
-    - name: manifests
-      root: manifests-master
-      uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+  - name: manifests
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
+  - name: kubeflow
+    root: kubeflow-v0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   useBasicAuth: false
   useIstio: true
   version: master

--- a/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
@@ -102,8 +102,8 @@ spec:
   useIstio: true
   repos:
   - name: manifests
-    root: manifests-master
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
+    root: kubeflow-v0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz

--- a/bootstrap/config/kfctl_gcp_basic_auth.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: kubeflow
 spec:
   repos:
-  - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
   - name: manifests
-    root: master/
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
+  - name: kubeflow
+    root: kubeflow-v0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   appdir: /tmp/myapp2

--- a/bootstrap/config/kfctl_gcp_iap.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.yaml
@@ -7,12 +7,12 @@ metadata:
   namespace: kubeflow
 spec:
   repos:
-  - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
   - name: manifests
-    root: master/
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
+  - name: kubeflow
+    root: kubeflow-v0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
     # To get manifest at a PR:
     #uri: https://github.com/kubeflow/manifests/archive/pull/235/head.tar.gz
   appdir: /tmp/myapp2

--- a/bootstrap/config/kfctl_k8s_istio.yaml
+++ b/bootstrap/config/kfctl_k8s_istio.yaml
@@ -9,11 +9,11 @@ metadata:
 spec:
   repos:
   - name: manifests
-    root: manifests-master
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   - name: kubeflow
-    root: kubeflow-master
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
+    root: kubeflow-v0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   applications:
   # Istio install. If not needed, comment out istio-crds and istio-install.
   - kustomizeConfig:


### PR DESCRIPTION
Fixes #3862 

This PR pins the kubeflow and manifests repo versions to v0.6.1 (which is the latest release) for all configs.

/assign @abhi-g @lluunn 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3864)
<!-- Reviewable:end -->
