### PR TITLE
Fix typo in notebook creation form

### DIFF
--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-advanced-options/form-advanced-options.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-advanced-options/form-advanced-options.component.html
@@ -4,7 +4,7 @@
     Extra Resources
   </h3>
   <p>
-    Specify extra resoucres that might be needed in the Notebook Server.
+    Specify extra resources that might be needed in the Notebook Server.
   </p>
 
   <mat-slide-toggle formControlName="shm"


### PR DESCRIPTION
This fixes a typo in the notebook creation advanced options form.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3865)
<!-- Reviewable:end -->
