### PR TITLE
kfctl: existing_arrikto: direct all 5556 traffic to Dex

### DIFF
--- a/deployment/existing/auth_oidc/gateway.yaml
+++ b/deployment/existing/auth_oidc/gateway.yaml
@@ -42,9 +42,7 @@ spec:
   - kubeflow-gateway
   http:
     - match:
-        - uri:
-            prefix: /dex/
-          port: 5556
+        - port: 5556
       route:
         - destination:
             port:


### PR DESCRIPTION
Fixes https://github.com/kubeflow/kubeflow/issues/3805

Right now, the following problem exists:
* Kubeflow VirtualServices get traffic from all ports.
* Dex VirtualService only gets traffic from 5556 AND prefix /dex.
* That way, if user hits :5556/, they will get the CentralDashboard page without logging in.

This PR fixes that by making sure all traffic to port 5556 goes to Dex.

cc @Jeffwan @tlkh @jlewi @kunmingg 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3885)
<!-- Reviewable:end -->
