### PR TITLE
Pin kubeflow/manifests and kubeflow/kubeflow commits on the v0.6-branch

### DIFF
--- a/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
@@ -101,9 +101,8 @@ spec:
   - profiles
   useIstio: true
   repos:
-  - name: manifests
-    root: manifests-0.6-branch
-    uri: https://github.com/kubeflow/manifests/archive/v0.6-branch.tar.gz
   - name: kubeflow
-    root: kubeflow-0.6-branch
-    uri: https://github.com/kubeflow/kubeflow/archive/v0.6-branch.tar.gz
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
+  - name: manifests
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz

--- a/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
@@ -102,7 +102,8 @@ spec:
   useIstio: true
   repos:
   - name: kubeflow
+  root: kubeflow-0.6.1
     uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    root: manifests-v0.6.1
+    root: manifests-0.6.1
     uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz

--- a/bootstrap/config/kfctl_gcp_basic_auth.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.yaml
@@ -310,9 +310,10 @@ spec:
   project: SET_PROJECT
   repos:
   - name: kubeflow
+    root: kubeflow-0.6.1
     uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    root: manifests-v0.6.1
+    root: manifests-0.6.1
     uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   skipInitProject: true
   useBasicAuth: true

--- a/bootstrap/config/kfctl_gcp_basic_auth.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.yaml
@@ -310,10 +310,10 @@ spec:
   project: SET_PROJECT
   repos:
   - name: kubeflow
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    root: manifests-master
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   skipInitProject: true
   useBasicAuth: true
   useIstio: true

--- a/bootstrap/config/kfctl_gcp_iap.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.yaml
@@ -292,10 +292,10 @@ spec:
   project: SET_PROJECT
   repos:
   - name: kubeflow
-    uri: https://github.com/kubeflow/kubeflow/archive/master.tar.gz
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    root: manifests-master
-    uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+    root: manifests-v0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   skipInitProject: true
   useBasicAuth: false
   useIstio: true

--- a/bootstrap/config/kfctl_gcp_iap.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.yaml
@@ -292,9 +292,10 @@ spec:
   project: SET_PROJECT
   repos:
   - name: kubeflow
+    root: kubeflow-0.6.1
     uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    root: manifests-v0.6.1
+    root: manifests-0.6.1
     uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   skipInitProject: true
   useBasicAuth: false

--- a/bootstrap/config/kfctl_k8s_istio.yaml
+++ b/bootstrap/config/kfctl_k8s_istio.yaml
@@ -145,8 +145,8 @@ spec:
   useIstio: true
   repos:
   - name: manifests
-    root: manifests-0.6-branch
-    uri: https://github.com/kubeflow/manifests/archive/v0.6-branch.tar.gz
+    root: manifests-0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   - name: kubeflow
-    root: kubeflow-0.6-branch
-    uri: https://github.com/kubeflow/kubeflow/archive/v0.6-branch.tar.gz
+    root: kubeflow-0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz

--- a/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
@@ -166,7 +166,7 @@ func Test_backfillKfDefFromInitOptions(t *testing.T) {
 					Repos: []kfdefsv2.Repo{
 						{
 							Name: "manifests",
-							Uri:  fmt.Sprintf("https://github.com/kubeflow/manifests/archive/%v.tar.gz",
+							Uri: fmt.Sprintf("https://github.com/kubeflow/manifests/archive/%v.tar.gz",
 								kftypesv2.DefaultVersion),
 							Root: "manifests-" + kftypesv2.DefaultVersion,
 						},


### PR DESCRIPTION
Related to #3859.

We don't want people deploying with kfctl to pick up changes to the manifests
until they've been tested.

kfctl should be pointing at the KFDef specs on the v0.6-branch.
So we need to pin the commits it points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3894)
<!-- Reviewable:end -->
