### PR TITLE
kfctl: existing_arrikto: update config and enable multi-user identity awareness

### DIFF
--- a/bootstrap/config/kfctl_existing_arrikto.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.yaml
@@ -33,6 +33,9 @@ spec:
         path: argo
     name: argo
   - kustomizeConfig:
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       overlays:
       - istio
       repoRef:
@@ -53,6 +56,9 @@ spec:
         path: admission-webhook/bootstrap
     name: bootstrap
   - kustomizeConfig:
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       overlays:
       - istio
       - application
@@ -193,6 +199,9 @@ spec:
         path: pipeline/scheduledworkflow
     name: scheduledworkflow
   - kustomizeConfig:
+      parameters:
+      - name: userid-header
+        value: kubeflow-userid
       overlays:
       - istio
       repoRef:

--- a/bootstrap/config/kfctl_existing_arrikto.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.yaml
@@ -1,105 +1,212 @@
+# This is the config to install Kubeflow on an existing K8s cluster, with support
+# for multi-user and LDAP auth using Dex.
+
 apiVersion: kfdef.apps.kubeflow.org/v1alpha1
 kind: KfDef
 metadata:
   name: demo
   namespace: kubeflow
 spec:
-  # Platform existing for pre-existing K8s
+  applications:
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: application/application-crds
+    name: application-crds
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: application/application
+    name: application
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: metacontroller
+    name: metacontroller
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: argo
+    name: argo
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: common/centraldashboard
+    name: centraldashboard
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: admission-webhook/webhook
+    name: webhook
+  - kustomizeConfig:
+      parameters:
+      - name: webhookNamePrefix
+        value: admission-webhook-
+      repoRef:
+        name: manifests
+        path: admission-webhook/bootstrap
+    name: bootstrap
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: jupyter/jupyter-web-app
+    name: jupyter-web-app
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib-v1alpha2/katib-db
+    name: katib-db
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib-v1alpha2/katib-manager
+    name: katib-manager
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib-v1alpha2/katib-controller
+    name: katib-controller
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: katib-v1alpha2/katib-ui
+    name: katib-ui
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: metadata
+    name: metadata
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib-v1alpha2/metrics-collector
+    name: metrics-collector
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: katib-v1alpha2/suggestion
+    name: suggestion
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: jupyter/notebook-controller
+    name: notebook-controller
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-job-crds
+    name: pytorch-job-crds
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pytorch-job/pytorch-operator
+    name: pytorch-operator
+  - kustomizeConfig:
+      parameters:
+      - initRequired: true
+        name: usageId
+        value: <randomly-generated-id>
+      - initRequired: true
+        name: reportUsage
+        value: "true"
+      repoRef:
+        name: manifests
+        path: common/spartakus
+    name: spartakus
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: tensorboard
+    name: tensorboard
+  - kustomizeConfig:
+      overlays:
+      - istio
+      - application
+      repoRef:
+        name: manifests
+        path: tf-training/tf-job-operator
+    name: tf-job-operator
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/api-service
+    name: api-service
+  - kustomizeConfig:
+      parameters:
+      - name: minioPvcName
+        value: minio-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/minio
+    name: minio
+  - kustomizeConfig:
+      parameters:
+      - name: mysqlPvcName
+        value: mysql-pv-claim
+      repoRef:
+        name: manifests
+        path: pipeline/mysql
+    name: mysql
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/persistent-agent
+    name: persistent-agent
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-runner
+    name: pipelines-runner
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-ui
+    name: pipelines-ui
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/pipelines-viewer
+    name: pipelines-viewer
+  - kustomizeConfig:
+      repoRef:
+        name: manifests
+        path: pipeline/scheduledworkflow
+    name: scheduledworkflow
+  - kustomizeConfig:
+      overlays:
+      - istio
+      repoRef:
+        name: manifests
+        path: profiles
+    name: profiles
+  - kustomizeConfig:
+      overlays:
+      - application
+      repoRef:
+        name: manifests
+        path: seldon/seldon-core-operator
+    name: seldon-core-operator
   platform: existing_arrikto
-  componentParams:
-    argo:
-    - name: overlay
-      value: istio
-    centraldashboard:
-    - name: overlay
-      value: istio
-    jupyter-web-app:
-    - name: overlay
-      value: istio
-    katib-ui: # Issue: https://github.com/kubeflow/manifests/issues/151
-    - name: overlay
-      value: istio
-    metadata:
-    - name: overlay
-      value: istio
-    minio:
-    - name: minioPvName
-      value: minio-pv
-    - name: minioPvcName
-      value: minio-pv-claim
-    mysql:
-    - name: mysqlPvName
-      value: mysql-pv
-    - name: mysqlPvcName
-      value: mysql-pv-claim
-    notebook-controller:
-    - name: overlay
-      value: istio
-    pipelines-ui:
-    - name: overlay
-      value: istio
-    spartakus:
-    - initRequired: true
-      name: usageId
-      value: <randomly-generated-id>
-    - initRequired: true
-      name: reportUsage
-      value: "true"
-    tensorboard:
-    - name: overlay
-      value: istio
-    tf-job-operator:
-    - name: overlay
-      value: istio
-  components:
-  - metacontroller
-  - argo
-  - centraldashboard
-  - bootstrap
-  - webhook
-  - jupyter-web-app
-  - katib-db
-  - katib-manager
-  - katib-controller
-  - katib-ui
-  - metadata
-  - metrics-collector
-  - suggestion
-  - notebook-controller
-  - pytorch-job-crds
-  - pytorch-operator
-  - spartakus
-  - tensorboard
-  - tf-job-operator
-  - api-service
-  - minio
-  - mysql
-  - persistent-agent
-  - pipelines-runner
-  - pipelines-ui
-  - pipelines-viewer
-  - scheduledworkflow
-  - profiles
-  packageManager: kustomize
-  packages:
-  - argo
-  - common
-  - examples
-  - admission-webhook
-  - jupyter
-  - katib-v1alpha2
-  - metacontroller
-  - metadata
-  - modeldb
-  - mpi-job
-  - pytorch-job
-  - seldon
-  - tensorboard
-  - tf-serving
-  - tf-training
-  - pipeline
-  - profiles
-  useIstio: true
   repos:
   - name: manifests
     root: manifests-master

--- a/deployment/existing/auth_oidc/authservice.tmpl
+++ b/deployment/existing/auth_oidc/authservice.tmpl
@@ -41,7 +41,7 @@ spec:
                 path: tls.crt
       containers:
       - name: authservice
-        image: gcr.io/arrikto/kubeflow/oidc-authservice:v0.2
+        image: gcr.io/arrikto/kubeflow/oidc-authservice:v0.3
         imagePullPolicy: Always
         ports:
         - name: http-api
@@ -51,6 +51,10 @@ spec:
             mountPath: /etc/custom-ca
             readOnly: true
         env:
+          - name: USERID_HEADER
+            value: "kubeflow-userid"
+          - name: USERID_PREFIX
+            value: ""
           - name: OIDC_PROVIDER_CA_FILE
             value: "/etc/custom-ca/tls.crt"
           - name: DISABLE_USERINFO

--- a/deployment/existing/auth_oidc/envoy-filter.yaml
+++ b/deployment/existing/auth_oidc/envoy-filter.yaml
@@ -19,6 +19,10 @@ spec:
           allowedHeaders:
             patterns:
             - exact: "cookie"
+        authorizationResponse:
+          allowedUpstreamHeaders:
+            patterns:
+            - exact: "kubeflow-userid"
       statusOnError:
         code: GatewayTimeout
     filterName: envoy.ext_authz

--- a/deployment/existing/istio/istio-noauth.yaml
+++ b/deployment/existing/istio/istio-noauth.yaml
@@ -18981,3 +18981,9 @@ spec:
         maxRequestsPerConnection: 10000
 ---
 
+apiVersion: rbac.istio.io/v1alpha1
+kind: ClusterRbacConfig
+metadata:
+  name: default
+spec:
+  mode: 'ON'


### PR DESCRIPTION
Depends on https://github.com/kubeflow/manifests/pull/274

* Update `kfctl_existing_arrikto.yaml` to use the applications spec. 
* The AuthService adds the header `kubeflow-userid` in every request.
* Parameters are added to each application so that it looks for the `kubeflow-userid` header.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3904)
<!-- Reviewable:end -->
