### PR TITLE
Turn on IAP endpoint testing postsubmit

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -44,7 +44,7 @@ workflows:
       workflowName: kfctl-go
       useBasicAuth: false
       useIstio: true
-      testEndpoint: false
+      testEndpoint: true
       configPath: bootstrap/config/kfctl_gcp_iap.yaml
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: kfctl_go_test


### PR DESCRIPTION
* #3482 added a postsubmit to test IAP; but it looks like that isn't actually
  running because we didn't set testEndpoint to true.

Related to #3905