### PR TITLE
WIP statefulset GC and deployment status query endpoint

### DIFF
--- a/bootstrap/cmd/bootstrap/app/options/options.go
+++ b/bootstrap/cmd/bootstrap/app/options/options.go
@@ -70,6 +70,6 @@ func (s *ServerOption) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&s.InstallIstio, "install-istio", false, "Whether to install istio.")
 
 	// Options below are related to the new API and router + backend design
-	fs.StringVar(&s.Mode, "mode", "router", "What mode to start the binary in. Options are router and kfctl.")
+	fs.StringVar(&s.Mode, "mode", "router", "What mode to start the binary in. Options are router, kfctl and gc.")
 	fs.StringVar(&s.KfctlAppsNamespace, "kfctl-apps-namespace", "", "The namespace where the kfctl apps will be created.")
 }


### PR DESCRIPTION
- have `--mode=gc`, which will keep looping over statefulsets and try to freeze them. If freeze succeeded (no ongoing request), will delete them.
- kfctlserver: add `FreezeSvc` endpoint
- kfctlserver: add `QueryStatus` endpoint
 