### PR TITLE
Fix the default poddefaults add-gcp-secret in v0.6-branch

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1568,31 +1568,31 @@ func generatePodDefault(group string, version string, kind string, namespace str
 			"name":      "add-gcp-secret",
 			"namespace": namespace,
 		},
-		"desc": "add gcp credential",
 		"spec": map[string]interface{}{
 			"selector": map[string]interface{}{
 				"matchLabels": map[string]interface{}{
 					"add-gcp-secret": "true",
 				},
 			},
-		},
-		"env": []interface{}{
-			map[string]interface{}{
-				"name":  "GOOGLE_APPLICATION_CREDENTIALS",
-				"value": "/secret/gcp/user-gcp-sa.json",
+			"desc": "add gcp credential",
+			"env": []interface{}{
+				map[string]interface{}{
+					"name":  "GOOGLE_APPLICATION_CREDENTIALS",
+					"value": "/secret/gcp/user-gcp-sa.json",
+				},
 			},
-		},
-		"volumeMounts": []interface{}{
-			map[string]interface{}{
-				"name":      "secret-volume",
-				"mountPath": "/secret/gcp",
+			"volumeMounts": []interface{}{
+				map[string]interface{}{
+					"name":      "secret-volume",
+					"mountPath": "/secret/gcp",
+				},
 			},
-		},
-		"volumes": []interface{}{
-			map[string]interface{}{
-				"name": "secret-volume",
-				"secret": map[string]interface{}{
-					"secretName": USER_SECRET_NAME,
+			"volumes": []interface{}{
+				map[string]interface{}{
+					"name": "secret-volume",
+					"secret": map[string]interface{}{
+						"secretName": USER_SECRET_NAME,
+					},
 				},
 			},
 		},

--- a/bootstrap/pkg/kfapp/gcp/gcp_test.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_test.go
@@ -372,31 +372,31 @@ func TestGcp_setPodDefault(t *testing.T) {
 			"name":      "add-gcp-secret",
 			"namespace": namespace,
 		},
-		"desc": "add gcp credential",
 		"spec": map[string]interface{}{
 			"selector": map[string]interface{}{
 				"matchLabels": map[string]interface{}{
 					"add-gcp-secret": "true",
 				},
 			},
-		},
-		"env": []interface{}{
-			map[string]interface{}{
-				"name":  "GOOGLE_APPLICATION_CREDENTIALS",
-				"value": "/secret/gcp/user-gcp-sa.json",
+			"desc": "add gcp credential",
+			"env": []interface{}{
+				map[string]interface{}{
+					"name":  "GOOGLE_APPLICATION_CREDENTIALS",
+					"value": "/secret/gcp/user-gcp-sa.json",
+				},
 			},
-		},
-		"volumeMounts": []interface{}{
-			map[string]interface{}{
-				"name":      "secret-volume",
-				"mountPath": "/secret/gcp",
+			"volumeMounts": []interface{}{
+				map[string]interface{}{
+					"name":      "secret-volume",
+					"mountPath": "/secret/gcp",
+				},
 			},
-		},
-		"volumes": []interface{}{
-			map[string]interface{}{
-				"name": "secret-volume",
-				"secret": map[string]interface{}{
-					"secretName": "user-gcp-sa",
+			"volumes": []interface{}{
+				map[string]interface{}{
+					"name": "secret-volume",
+					"secret": map[string]interface{}{
+						"secretName": "user-gcp-sa",
+					},
 				},
 			},
 		},


### PR DESCRIPTION
* The generated PodDefaults is not correct; various fields are top level and not in the spec.

Related to #3924

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3926)
<!-- Reviewable:end -->
