### PR TITLE
[CentralDashboard v2] Error surfacing for profile controller errors

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -195,19 +195,27 @@ export class WorkgroupApi {
         .get(
             '/exists',
             async (req: Request, res: Response) => {
-                const response: HasWorkgroupResponse = {
-                    hasAuth: req.user.hasAuth,
-                    user: req.user.username,
-                    hasWorkgroup: false,
-                };
-                if (req.user.hasAuth) {
-                    const workgroup = await this.getWorkgroupInfo(
-                        req.user,
-                    );
-                    response.hasWorkgroup = !!(workgroup.namespaces || [])
-                        .find((w) => w.role === 'owner');
+                try {
+                    const response: HasWorkgroupResponse = {
+                        hasAuth: req.user.hasAuth,
+                        user: req.user.username,
+                        hasWorkgroup: false,
+                    };
+                    if (req.user.hasAuth) {
+                        const workgroup = await this.getWorkgroupInfo(
+                            req.user,
+                        );
+                        response.hasWorkgroup = !!(workgroup.namespaces || [])
+                            .find((w) => w.role === 'owner');
+                    }
+                    res.json(response);
+                } catch (err) {
+                    surfaceProfileControllerErrors({
+                        res,
+                        msg: 'Unable to contact Profile Controller',
+                        err,
+                    });
                 }
-                res.json(response);
             })
         .post('/create', async (req: Request, res: Response) => {
             const profile = req.body as CreateProfileRequest;

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -57,7 +57,7 @@ async function main() {
 
 // This will allow us to inspect uncaught exceptions around the app
 process.on('unhandledRejection', error => {
-  console.log('[SEVERE] unhandledRejection', error);
+  console.error('[SEVERE] unhandledRejection', error);
 });
 
 main();

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -55,4 +55,9 @@ async function main() {
       () => console.info(`Server listening on port http://localhost:${port}`));
 }
 
+// This will allow us to inspect uncaught exceptions around the app
+process.on('unhandledRejection', error => {
+  console.log('[SEVERE] unhandledRejection', error);
+});
+
 main();

--- a/components/centraldashboard/public/components/main-page.css
+++ b/components/centraldashboard/public/components/main-page.css
@@ -277,6 +277,22 @@ neon-animatable {
     transform: translateY(-50%);
 }
 
+#ErrorToast {
+    background: var(--google-red-500);
+    color: white;
+    padding: .75em 1.5em;
+    @apply --layout-horizontal;
+    @apply --layout-center;
+    --paper-icon-button: {
+        color: white;
+        margin-left: 1em;
+        padding: 5px;
+        width: 32px;
+        height: 32px;
+    }
+}
+
+
 [hides] {
     transition: opacity .25s
 }

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -167,6 +167,34 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
     }
 
     /**
+     * Show a toast error on main-page
+     * @param {string} err Error message to show
+     */
+    showError(err) {
+        const el = this.$.ErrorToast;
+        el.text = err;
+        el.show();
+    }
+
+    closeToast(ev) {
+        const t = ev.target;
+        const el = [t, t.parentNode, t.parentNode.parentNode]
+            .find((e) => e.tagName == 'PAPER-TOAST');
+        el.close();
+    }
+
+    /**
+     * Set state for loading registration flow in case no workgroup exists
+     * @param {Event} ev AJAX-response
+     */
+    _onHasWorkgroupError(ev) {
+        const error = ((ev.detail.request||{}).response||{}).error ||
+            ev.detail.error;
+        this.showError(error);
+        return;
+    }
+
+    /**
      * Set state for loading registration flow in case no workgroup exists
      * @param {Event} ev AJAX-response
      */

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -90,6 +90,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
                 value: 0,
                 observer: '_revertSidebarIndexIfExternal',
             },
+            errorText: {type: String, value: ''},
             buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
             platformInfo: Object,
@@ -171,16 +172,10 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
      * @param {string} err Error message to show
      */
     showError(err) {
-        const el = this.$.ErrorToast;
-        el.text = err;
-        el.show();
+        this.errorText = err;
     }
-
-    closeToast(ev) {
-        const t = ev.target;
-        const el = [t, t.parentNode, t.parentNode.parentNode]
-            .find((e) => e.tagName == 'PAPER-TOAST');
-        el.close();
+    closeError() {
+        this.errorText = '';
     }
 
     /**

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -76,7 +76,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
     iron-media-query(query='(max-width: 900px)', query-matches='{{sidebarBleed}}')
     iron-media-query(query='(max-width: 1270px)', query-matches='{{thinView}}')
 paper-toast#welcomeUser(duration=5000) Welcome, [[_extractLdap(user)]]!
-paper-toast#ErrorToast(duration=0, on-click='closeToast')
+paper-toast#ErrorToast(duration=0, opened='[[!empty(errorText)]]', on-click='closeError') [[errorText]]
     paper-icon-button(icon='close')
 template(is='dom-if', if='[[registrationFlow]]')
     registration-page(user-details='[[user]]' on-flowcomplete='resyncApp')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -1,5 +1,5 @@
 iron-ajax(auto, url='/api/workgroup/exists', handle-as='json',
-    on-response='_onHasWorkgroupResponse', loading='{{pageLoading}}')
+    on-response='_onHasWorkgroupResponse', on-error='_onHasWorkgroupError', loading='{{pageLoading}}')
 iron-ajax#envInfo(auto='[[_shouldFetchEnv]]', url='/api/env-info', handle-as='json',
     on-response='_onEnvInfoResponse')
 aside#PageLoader(hidden='{{!pageLoading}}')
@@ -76,5 +76,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
     iron-media-query(query='(max-width: 900px)', query-matches='{{sidebarBleed}}')
     iron-media-query(query='(max-width: 1270px)', query-matches='{{thinView}}')
 paper-toast#welcomeUser(duration=5000) Welcome, [[_extractLdap(user)]]!
+paper-toast#ErrorToast(duration=0, on-click='closeToast')
+    paper-icon-button(icon='close')
 template(is='dom-if', if='[[registrationFlow]]')
     registration-page(user-details='[[user]]' on-flowcomplete='resyncApp')

--- a/components/centraldashboard/public/components/utilities-mixin.js
+++ b/components/centraldashboard/public/components/utilities-mixin.js
@@ -80,4 +80,16 @@ export default (superClass) => class extends superClass {
             : new CustomEvent(name, {detail});
         this.dispatchEvent(ev);
     }
+
+    /**
+     * Allows the parent toast to be closed from that level or
+     * elements 3-levels deep
+     * @param {event} ev Event
+     */
+    closeToast(ev) {
+        const t = ev.target;
+        const el = [t, t.parentNode, t.parentNode.parentNode]
+            .find((e) => e.tagName == 'PAPER-TOAST');
+        el.close();
+    }
 };


### PR DESCRIPTION
#### closes #3524

## Feature Updates:
- Promise rejection from `/api/workgroup/exists` now caught
- All unhandled promises are printed
- Error handling logic added to main-page
- Error toast added, available for all components to use
- [intuititve] added a close button to toast since it's persistent

### Meta
/area centraldashboard
/area front-end
/priority p1
/assign @avdaredevil
/cc @prodonjs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3933)
<!-- Reviewable:end -->
