### PR TITLE
Automated cherry pick of #3941: Fix the error link description when using kfctl install. Cherry pick of #3941 on v0.6-branch. #3941: Fix the error link description when using kfctl install.

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -174,13 +174,9 @@ func usageReportWarn(components []string) {
 		"To disable it\n" +
 		"If you have already deployed it run the following commands:\n" +
 		"  cd $(pwd)\n" +
-		"  ks delete default -c spartakus\n" +
 		"  kubectl -n ${K8S_NAMESPACE} delete deploy -l app=spartakus\n" +
 		"\n" +
-		"Then run the following command to remove it from your ksonnet app:\n" +
-		"  ks component rm spartakus\n" +
-		"\n" +
-		"For more info: https://www.kubeflow.org/docs/guides/usage-reporting/\n" +
+		"For more info: https://www.kubeflow.org/docs/other-guides/usage-reporting/\n" +
 		"****************************************************************\n" +
 		"\n"
 	for _, comp := range components {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3942)
<!-- Reviewable:end -->
