### PR TITLE
Automated cherry pick of #3885: kfctl: existing_arrikto: direct all 5556 traffic to Dex Cherry pick of #3885 on v0.6-branch. #3885: kfctl: existing_arrikto: direct all 5556 traffic to Dex

### DIFF
--- a/deployment/existing/auth_oidc/gateway.yaml
+++ b/deployment/existing/auth_oidc/gateway.yaml
@@ -42,9 +42,7 @@ spec:
   - kubeflow-gateway
   http:
     - match:
-        - uri:
-            prefix: /dex/
-          port: 5556
+        - port: 5556
       route:
         - destination:
             port:


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3955)
<!-- Reviewable:end -->
