### PR TITLE
always create default profile; turn off istio rbac for kfctl_k8s_istio

### DIFF
--- a/bootstrap/config/kfctl_k8s_istio.yaml
+++ b/bootstrap/config/kfctl_k8s_istio.yaml
@@ -34,6 +34,9 @@ spec:
     name: istio-install
   # This component is the istio resources for Kubeflow (e.g. gateway), not about installing istio.
   - kustomizeConfig:
+      parameters:
+        - name: clusterRbacConfig
+          value: "OFF"
       repoRef:
         name: manifests
         path: istio/istio

--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -110,6 +110,7 @@ type kustomize struct {
 }
 
 const (
+	defaultUserId = "default"
 	outputDir = "kustomize"
 )
 
@@ -301,57 +302,63 @@ func (kustomize *kustomize) Apply(resources kftypesv3.ResourceEnum) error {
 		}
 	}
 
+	// Create default profile
+	// When user identity available, the user will be owner of the profile
+	// Otherwise the profile would be a public one.
+	userId := defaultUserId
 	if kustomize.kfDef.Spec.Email != "" {
-		// Profile name is also the namespace created.
-		defaultProfileNamespace := kftypesv3.EmailToDefaultName(kustomize.kfDef.Spec.Email)
-		profile := &profilev2.Profile{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Profile",
-				APIVersion: "kubeflow.org/v1alpha1",
+		// Use user email as user id if available.
+		// When platform == GCP, same user email is also identity in requests through IAP.
+		userId = kustomize.kfDef.Spec.Email
+	}
+	defaultProfileNamespace := kftypesv3.EmailToDefaultName(userId)
+	profile := &profilev2.Profile{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Profile",
+			APIVersion: "kubeflow.org/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultProfileNamespace,
+		},
+		Spec: profilev2.ProfileSpec{
+			Owner: rbacv2.Subject{
+				Kind: "User",
+				Name: userId,
 			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: defaultProfileNamespace,
-			},
-			Spec: profilev2.ProfileSpec{
-				Owner: rbacv2.Subject{
-					Kind: "User",
-					Name: kustomize.kfDef.Spec.Email,
-				},
-			},
+		},
+	}
+	_, nsMissingErr = clientset.CoreV1().Namespaces().Get(defaultProfileNamespace, metav1.GetOptions{})
+	if nsMissingErr != nil {
+		body, err := json.Marshal(profile)
+		if err != nil {
+			return err
 		}
-		_, nsMissingErr := clientset.CoreV1().Namespaces().Get(defaultProfileNamespace, metav1.GetOptions{})
-		if nsMissingErr != nil {
-			body, err := json.Marshal(profile)
-			if err != nil {
-				return err
+		resourcesErr := kustomize.deployResources(kustomize.restConfig, body)
+		if resourcesErr != nil {
+			return &kfapisv3.KfError{
+				Code:    int(kfapisv3.INTERNAL_ERROR),
+				Message: fmt.Sprintf("couldn't create default profile from %v Error: %v", profile, resourcesErr),
 			}
-			resourcesErr := kustomize.deployResources(kustomize.restConfig, body)
-			if resourcesErr != nil {
+		}
+		b := backoff.NewExponentialBackOff()
+		b.InitialInterval = 3 * time.Second
+		b.MaxInterval = 30 * time.Second
+		b.MaxElapsedTime = 5 * time.Minute
+		return backoff.Retry(func() error {
+			_, nsErr := clientset.CoreV1().Namespaces().Get(defaultProfileNamespace, metav1.GetOptions{})
+			if nsErr != nil {
+				msg := fmt.Sprintf("Could not find namespace %v, wait and retry: %v", defaultProfileNamespace, nsErr)
+				log.Warnf(msg)
 				return &kfapisv3.KfError{
-					Code:    int(kfapisv3.INTERNAL_ERROR),
-					Message: fmt.Sprintf("couldn't create default profile from %v Error: %v", profile, resourcesErr),
+					Code:    int(kfapisv3.INVALID_ARGUMENT),
+					Message: msg,
 				}
 			}
-			b := backoff.NewExponentialBackOff()
-			b.InitialInterval = 3 * time.Second
-			b.MaxInterval = 30 * time.Second
-			b.MaxElapsedTime = 5 * time.Minute
-			return backoff.Retry(func() error {
-				_, nsErr := clientset.CoreV1().Namespaces().Get(defaultProfileNamespace, metav1.GetOptions{})
-				if nsErr != nil {
-					msg := fmt.Sprintf("Could not find namespace %v, wait and retry: %v", defaultProfileNamespace, nsErr)
-					log.Warnf(msg)
-					return &kfapisv3.KfError{
-						Code:    int(kfapisv3.INVALID_ARGUMENT),
-						Message: msg,
-					}
-				}
-				return nil
-			}, b)
-		} else {
-			log.Infof("Default profile namespace already exists: %v within owner %v", defaultProfileNamespace,
-				profile.Spec.Owner.Name)
-		}
+			return nil
+		}, b)
+	} else {
+		log.Infof("Default profile namespace already exists: %v within owner %v", defaultProfileNamespace,
+			profile.Spec.Owner.Name)
 	}
 	return nil
 }

--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -110,7 +110,7 @@ type kustomize struct {
 }
 
 const (
-	defaultUserId = "default"
+	defaultUserId = "anonymous"
 	outputDir = "kustomize"
 )
 


### PR DESCRIPTION
* Always create a default profile by setting a default "anonymous" value for user id so that a profile would be created for user "anonymous"

* Turn off ISTIO RBAC in kfctl_k8s_istio because this config won't have the user's identity or JWTs so  ISTIO can't do service Authz.

related: https://github.com/kubeflow/kubeflow/issues/3893

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3959)
<!-- Reviewable:end -->
