### PR TITLE
Fixed indentation in kfctl_existing_arrikto.0.6.yaml in v0.6-branch 

### DIFF
--- a/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.0.6.yaml
@@ -102,7 +102,7 @@ spec:
   useIstio: true
   repos:
   - name: kubeflow
-  root: kubeflow-0.6.1
+    root: kubeflow-0.6.1
     uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
     root: manifests-0.6.1


### PR DESCRIPTION
Incorrect indentation at line 106 in kfctl_existing_arrikto.0.6.yaml causing deployment to fail when using this config.

Resubmitting PR to fix issues with CLA bot detecting my email on commit correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3961)
<!-- Reviewable:end -->
