### PR TITLE
[Centraldashboard v2] Env vars added to dockerfile

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -29,6 +29,7 @@ RUN npm rebuild && \
 # Step 2: Packages assets for serving
 FROM node:10-alpine AS serve
 
+ENV NODE_ENV=production
 WORKDIR /app
 COPY --from=build /centraldashboard .
 

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -11,7 +11,7 @@ import {getMetricsService} from './metrics_service_factory';
 
 const isProduction = process.env.NODE_ENV === 'production';
 const defaultKfam = isProduction
-? 'profiles-kfam'
+? 'profiles-kfam.kubeflow'
 : 'localhost';
 
 /* PROFILES_KFAM env vars will be set by Kubernetes if the Kfam service is

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -9,9 +9,10 @@ import {WorkgroupApi} from './api_workgroup';
 import {KubernetesService} from './k8s_service';
 import {getMetricsService} from './metrics_service_factory';
 
-const defaultKfam = process.env.NODE_ENV !== 'production'
-  ? 'localhost'
-  : 'profiles-kfam';
+const isProduction = process.env.NODE_ENV === 'production';
+const defaultKfam = isProduction
+? 'profiles-kfam'
+: 'localhost';
 
 /* PROFILES_KFAM env vars will be set by Kubernetes if the Kfam service is
  * available
@@ -52,7 +53,7 @@ async function main() {
   });
   app.listen(
       port,
-      () => console.info(`Server listening on port http://localhost:${port}`));
+      () => console.info(`Server listening on port http://localhost:${port} (in ${isProduction?'production':'development'} mode)`));
 }
 
 // This will allow us to inspect uncaught exceptions around the app


### PR DESCRIPTION
#### related to: https://github.com/kubeflow/manifests/pull/298

## About
Added production env var in docker file, and statement print in server init.

### Meta
/area centraldashboard
/area front-end
/priority p1
/assign @avdaredevil
/cc @prodonjs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3971)
<!-- Reviewable:end -->
