### PR TITLE
[Centraldashboard v2] Added a /debug route to dashboard for python e2e from Kubeflow

### DIFF
--- a/components/centraldashboard/app/attach_user_middleware.ts
+++ b/components/centraldashboard/app/attach_user_middleware.ts
@@ -9,7 +9,7 @@ export function attachUser(
   return (req: Request, _: Response, next: NextFunction) => {
     let email = 'anonymous@kubeflow.org';
     let auth: User.AuthObject;
-    if (req.header(userIdHeader)) {
+    if (userIdHeader && req.header(userIdHeader)) {
       email = req.header(userIdHeader).slice(userIdPrefix.length);
       auth = {[userIdHeader]: email};
     }

--- a/components/centraldashboard/app/attach_user_middleware_test.ts
+++ b/components/centraldashboard/app/attach_user_middleware_test.ts
@@ -31,11 +31,27 @@ describe('Attach User Middleware', () => {
     expect(mockNextFunction).toHaveBeenCalled();
   });
 
-  it('Should extract a default User when none is present', () => {
+  it('Should extract a default User when no user header is present in request', () => {
     const email = 'anonymous@kubeflow.org';
     mockRequest.header.withArgs(header).and.returnValue(null);
 
     middleware(mockRequest, null, mockNextFunction);
+
+    expect(mockRequest.user).toEqual({
+      auth: undefined,
+      domain: 'kubeflow.org',
+      email,
+      hasAuth: false,
+      username: 'anonymous',
+    });
+    expect(mockNextFunction).toHaveBeenCalled();
+  });
+
+  it('Should extract a default User when no userid header was passed in', () => {
+    const email = 'anonymous@kubeflow.org';
+    mockRequest.header.withArgs(header).and.returnValue(null);
+    const noHeaderMiddleware = attachUser('', '');
+    noHeaderMiddleware(mockRequest, null, mockNextFunction);
 
     expect(mockRequest.user).toEqual({
       auth: undefined,

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -52,6 +52,10 @@ async function main() {
       user: req.user,
       profilesServiceUrl,
       codeEnvironment,
+      headersForIdentity: {
+        USERID_HEADER,
+        USERID_PREFIX,
+      },
     });
   });
   app.use('/api', new Api(k8sService, workgroupApi, metricsService).routes());

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -1,5 +1,5 @@
 import {KubeConfig} from '@kubernetes/client-node';
-import express from 'express';
+import express, {Request, Response} from 'express';
 import {resolve} from 'path';
 
 import {Api} from './api';
@@ -10,6 +10,7 @@ import {KubernetesService} from './k8s_service';
 import {getMetricsService} from './metrics_service_factory';
 
 const isProduction = process.env.NODE_ENV === 'production';
+const codeEnvironment = isProduction?'production':'development';
 const defaultKfam = isProduction
 ? 'profiles-kfam.kubeflow'
 : 'localhost';
@@ -46,14 +47,20 @@ async function main() {
   app.use(express.json());
   app.use(express.static(frontEnd));
   app.use(attachUser(USERID_HEADER, USERID_PREFIX));
-  app.use(
-      '/api', new Api(k8sService, workgroupApi, metricsService).routes());
+  app.get('/debug', (req: Request, res: Response) => {
+    res.json({
+      user: req.user,
+      profilesServiceUrl,
+      codeEnvironment,
+    });
+  });
+  app.use('/api', new Api(k8sService, workgroupApi, metricsService).routes());
   app.get('/*', (_: express.Request, res: express.Response) => {
     res.sendFile(resolve(frontEnd, 'index.html'));
   });
   app.listen(
       port,
-      () => console.info(`Server listening on port http://localhost:${port} (in ${isProduction?'production':'development'} mode)`));
+      () => console.info(`Server listening on port http://localhost:${port} (in ${codeEnvironment} mode)`));
 }
 
 // This will allow us to inspect uncaught exceptions around the app


### PR DESCRIPTION
## About:
Added a `/debug` route to the dashboard for python e2e from Kubeflow

### Meta
/area centraldashboard
/area front-end
/priority p0
/assign @avdaredevil
/cc @prodonjs @gabrielwen @jlewi @abhi-g

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3980)
<!-- Reviewable:end -->
