### PR TITLE
Revert "Update cofig file versions (#3978)"

### DIFF
--- a/bootstrap/config/kfctl_existing_arrikto.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.yaml
@@ -102,7 +102,8 @@ spec:
   useIstio: true
   repos:
   - name: kubeflow
-    root: kubeflow-0.6.2
-    uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
+    root: kubeflow-0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/104c5b8c8e1df2bd09a827c4e25295ce945e3459.tar.gz
+    root: manifests-0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz

--- a/bootstrap/config/kfctl_gcp_basic_auth.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.yaml
@@ -310,10 +310,11 @@ spec:
   project: SET_PROJECT
   repos:
   - name: kubeflow
-    root: kubeflow-0.6.2
-    uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
+    root: kubeflow-0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/104c5b8c8e1df2bd09a827c4e25295ce945e3459.tar.gz
+    root: manifests-0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   skipInitProject: true
   useBasicAuth: true
   useIstio: true

--- a/bootstrap/config/kfctl_gcp_iap.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.yaml
@@ -292,10 +292,11 @@ spec:
   project: SET_PROJECT
   repos:
   - name: kubeflow
-    root: kubeflow-0.6.2
-    uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
+    root: kubeflow-0.6.1
+    uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/104c5b8c8e1df2bd09a827c4e25295ce945e3459.tar.gz
+    root: manifests-0.6.1
+    uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   skipInitProject: true
   useBasicAuth: false
   useIstio: true

--- a/bootstrap/config/kfctl_k8s_istio.yaml
+++ b/bootstrap/config/kfctl_k8s_istio.yaml
@@ -8,11 +8,12 @@ metadata:
   namespace: kubeflow
 spec:
   repos:
-    - name: manifests
-      uri: https://github.com/kubeflow/manifests/archive/104c5b8c8e1df2bd09a827c4e25295ce945e3459.tar.gz
     - name: kubeflow
-      root: kubeflow-0.6.2
-      uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
+      root: kubeflow-0.6.1
+      uri: https://github.com/kubeflow/kubeflow/archive/v0.6.1.tar.gz
+    - name: manifests
+      root: manifests-0.6.1
+      uri: https://github.com/kubeflow/manifests/archive/v0.6.1.tar.gz
   applications:
     # Istio install. If not needed, comment out istio-crds and istio-install.
     - kustomizeConfig:


### PR DESCRIPTION
This is a partial reverts commit c3199d931b9b82c8717057c7aca883d76bb5e1d5.

Updating the configs on the v0.6.2 branch is not safe right now because our
v0.6.1 instructions may not be telling users to pin to a specific commit.
They may be pulling in the latest configs from the branch. So they
might be prematurely exposed to changes.

To be safe we should revert the changes to the YAML files. We can keep the .go changes. We can also keep the 0.6.2rc.yaml files.

We can then roll forward these changes by create ".0.6.2.yaml" versions of
the files with these changes.

Revert some files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3987)
<!-- Reviewable:end -->
