### PR TITLE
[Centraldashboard v2] Correctly update Kubeflow Dashboard version from Kubeflow Resource

### DIFF
--- a/components/centraldashboard/app/k8s_service_test.ts
+++ b/components/centraldashboard/app/k8s_service_test.ts
@@ -214,7 +214,7 @@ describe('KubernetesService', () => {
         items: [{
           apiVersion: 'app.k8s.io/v1beta1',
           kind: 'Application',
-          spec: {descriptor: {version: '1.0.0'}}
+          spec: {descriptor: {type: 'kubeflow', version: '1.0.0'}}
         }]
       };
       mockApiClient.listNode.and.returnValue(Promise.resolve(
@@ -256,7 +256,7 @@ describe('KubernetesService', () => {
         items: [{
           apiVersion: 'app.k8s.io/v1beta1',
           kind: 'Application',
-          spec: {descriptor: {version: '1.0.0'}}
+          spec: {descriptor: {type: 'kubeflow', version: '1.0.0'}}
         }]
       };
       mockApiClient.listNode.and.returnValue(Promise.resolve(


### PR DESCRIPTION
#### closes #3875

## About:
Scan for Kubeflow application and fetch version from that resource

### Meta
/area centraldashboard
/area front-end
/priority p1
/assign @avdaredevil
/cc @prodonjs @gabrielwen @abhi-g

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3992)
<!-- Reviewable:end -->
