### PR TITLE
Set userid prefix and header for IAP and pull in the latest fixes to the applications repo for GCP configs

### DIFF
--- a/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml
@@ -313,7 +313,7 @@ spec:
     root: kubeflow-0.6.2
     uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/104c5b8c8e1df2bd09a827c4e25295ce945e3459.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/1099a06.tar.gz
   skipInitProject: true
   useBasicAuth: true
   useIstio: true

--- a/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
@@ -58,6 +58,11 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: X-Goog-Authenticated-User-Email
+      - name: userid-prefix
+        value: accounts.google.com
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -79,6 +84,11 @@ spec:
       overlays:
       - istio
       - application
+      parameters:
+      - name: userid-header
+        value: X-Goog-Authenticated-User-Email
+      - name: userid-prefix
+        value: accounts.google.com
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -259,7 +269,11 @@ spec:
       parameters:
       - initRequired: true
         name: admin
-        # value: SET_EMAIL
+        # value: SET_EMAIL      
+      - name: userid-header
+        value: X-Goog-Authenticated-User-Email
+      - name: userid-prefix
+        value: accounts.google.com
       repoRef:
         name: manifests
         path: profiles

--- a/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
@@ -300,7 +300,7 @@ spec:
     # Commit for v0.6.2-rc.1
     uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/104c5b8c8e1df2bd09a827c4e25295ce945e3459.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/1099a06.tar.gz
   skipInitProject: true
   useBasicAuth: false
   useIstio: true

--- a/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
@@ -62,7 +62,7 @@ spec:
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
-        value: accounts.google.com
+        value: "accounts.google.com:"
       repoRef:
         name: manifests
         path: common/centraldashboard
@@ -88,7 +88,7 @@ spec:
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
-        value: accounts.google.com
+        value: "accounts.google.com:"
       repoRef:
         name: manifests
         path: jupyter/jupyter-web-app
@@ -273,7 +273,7 @@ spec:
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
-        value: accounts.google.com
+        value: ""accounts.google.com:":"
       repoRef:
         name: manifests
         path: profiles

--- a/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
@@ -273,7 +273,7 @@ spec:
       - name: userid-header
         value: X-Goog-Authenticated-User-Email
       - name: userid-prefix
-        value: ""accounts.google.com:":"
+        value: "accounts.google.com:"
       repoRef:
         name: manifests
         path: profiles


### PR DESCRIPTION
* This should pull in the fix to #3986 (centraldashboard not set with userid correctly).

* We are only changing the GCP configs because that is the only thing I have manually tested and verified.

* Now that we cherrypicked #302 onto the v0.6-branch of manifests; we need to
set userid-prefix and userid-header parameters for the applications
jupyter-webapp, profiles, and centraldashboard in the IAP config.

Otherwise we end up setting those to the empty string and it thinks we
are an anonymous user.

Related to: kubeflow/kubeflow#3986

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/3994)
<!-- Reviewable:end -->
