### PR TITLE
update kubeflow repo versions

### DIFF
--- a/bootstrap/config/kfctl_existing_arrikto.0.6.2.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.0.6.2.yaml
@@ -218,6 +218,6 @@ spec:
   platform: existing_arrikto
   repos:
   - name: kubeflow
-    uri: https://github.com/kubeflow/kubeflow/archive/77381fe66ae7bb1e83a48beacf7f3c20b4c289d8.tar.gz
+    uri: https://github.com/kubeflow/kubeflow/archive/47a0e4c7532ee7b93eef662cecb3d376b5f84ca7.tar.gz
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/56e2fb15db286198f7a53723cb1fbfecf3fe83fb.tar.gz

--- a/bootstrap/config/kfctl_existing_arrikto.0.6.2.yaml
+++ b/bootstrap/config/kfctl_existing_arrikto.0.6.2.yaml
@@ -218,6 +218,6 @@ spec:
   platform: existing_arrikto
   repos:
   - name: kubeflow
-    uri: https://github.com/kubeflow/kubeflow/archive/47a0e4c7532ee7b93eef662cecb3d376b5f84ca7.tar.gz
+    uri: https://github.com/kubeflow/kubeflow/archive/77381fe66ae7bb1e83a48beacf7f3c20b4c289d8.tar.gz
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/56e2fb15db286198f7a53723cb1fbfecf3fe83fb.tar.gz

--- a/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml
@@ -310,7 +310,7 @@ spec:
   project: SET_PROJECT
   repos:
   - name: kubeflow
-    uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
+    uri: https://github.com/kubeflow/kubeflow/archive/47a0e4c7532ee7b93eef662cecb3d376b5f84ca7.tar.gz
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/56e2fb15db286198f7a53723cb1fbfecf3fe83fb.tar.gz
   skipInitProject: true

--- a/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
@@ -310,7 +310,7 @@ spec:
   # project: <Your GCP project>
   repos:
   - name: kubeflow
-    uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
+    uri: https://github.com/kubeflow/kubeflow/archive/47a0e4c7532ee7b93eef662cecb3d376b5f84ca7.tar.gz
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/56e2fb15db286198f7a53723cb1fbfecf3fe83fb.tar.gz
   skipInitProject: true

--- a/bootstrap/config/kfctl_k8s_istio.0.6.2.yaml
+++ b/bootstrap/config/kfctl_k8s_istio.0.6.2.yaml
@@ -11,7 +11,7 @@ spec:
     - name: manifests
       uri: https://github.com/kubeflow/manifests/archive/56e2fb15db286198f7a53723cb1fbfecf3fe83fb.tar.gz
     - name: kubeflow
-      uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
+      uri: https://github.com/kubeflow/kubeflow/archive/47a0e4c7532ee7b93eef662cecb3d376b5f84ca7.tar.gz
   applications:
     # Istio install. If not needed, comment out istio-crds and istio-install.
     - kustomizeConfig:


### PR DESCRIPTION
Update commit hash to pick up config changes:
- kfctl: existing_arrikto: rename config file (#3884)
- always create default profile; turn off istio rbac for kfctl_k8s_istio (#3959)
- Create 0.6.2 versions of all config files. (#3991)
- Set userid prefix and header for IAP and pull in the latest fixes to the applications repo for GCP configs (#3994)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4027)
<!-- Reviewable:end -->
