### PR TITLE
* Update jupyter web-app CD scripts to run in the kf-releasing namespace

### DIFF
--- a/py/kubeflow/kubeflow/ci/application_util.py
+++ b/py/kubeflow/kubeflow/ci/application_util.py
@@ -82,7 +82,7 @@ def regenerate_manifest_tests(manifests_dir):
     os.symlink(manifests_dir, target)
 
   test_dir = os.path.join(target, "tests")
-  with tempfile.NamedTemporaryFile(delete=False) as hf:
+  with tempfile.NamedTemporaryFile(delete=False, mode="w") as hf:
     hf.write("#!/bin/bash\n")
     hf.write("set -ex\n")
     hf.write("cd {0}\n".format(test_dir))

--- a/releasing/auto-update/README.md
+++ b/releasing/auto-update/README.md
@@ -30,7 +30,9 @@ Here's how this works
   * We use 
 
     * **project**: kubeflow-releasing
-  	* **cluster**: kf-releasing
+  	* **cluster**: kf-releasing-v-0-6-2
+    * **kf-releasing**: This is a Kubeflow profile created namespace
+    * This is a kubeflow v0.6.2 cluster; configs should be checked in kubeflow/testing/release-infra
 
 * The ssh keys are stored as K8s secret and configured via init containers
 
@@ -39,7 +41,7 @@ Here's how this works
 1. Create secrets in the cluster containing the GitHub ssh keys.
 
     ```
-    kubectl create secret generic kubeflow-bot-ssh --from-file=id_rsa=kubeflow-bot --from-file=id_rsa.pub=kubeflow-bot.pub 
+    kubectl create -n ${NAMESPACE} secret generic kubeflow-bot-ssh --from-file=id_rsa=kubeflow-bot --from-file=id_rsa.pub=kubeflow-bot.pub 
     ```
 
     * Use a public/private SSH key that has been added to the kubeflow-bot GitHub account

--- a/releasing/auto-update/base/params.env
+++ b/releasing/auto-update/base/params.env
@@ -1,1 +1,0 @@
-repos=kubeflow/kubeflow@HEAD:3958,kubeflow/fairing@HEAD,kubeflow/testing@HEAD,kubeflow/manifests@HEAD

--- a/releasing/auto-update/base/params.yaml
+++ b/releasing/auto-update/base/params.yaml
@@ -6,4 +6,4 @@ metadata:
   name: params
 data:
   # TODO(jlewi): change to kubeflow/kubeflow@HEAD when PR #3958 is merged
-  repos: "kubeflow/kubeflow@HEAD:3958,kubeflow/fairing@HEAD,kubeflow/testing@HEAD,kubeflow/manifests@HEAD"
+  repos: "kubeflow/kubeflow@HEAD:4029,kubeflow/fairing@HEAD,kubeflow/testing@HEAD,kubeflow/manifests@HEAD"

--- a/releasing/auto-update/overlays/cron/kustomization.yaml
+++ b/releasing/auto-update/overlays/cron/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: kf-releasing
 bases:
   - ../../base
 resources:
@@ -5,4 +6,4 @@ resources:
 images:
 - name: gcr.io/kubeflow-releasing/test-worker
   newName: gcr.io/kubeflow-releasing/test-worker
-  newTag: v20190820-54db950-dirty-c63672
+  newTag: v20190905-cff62af-dirty-f45ce7

--- a/releasing/auto-update/overlays/cron/update_job_cron.yaml
+++ b/releasing/auto-update/overlays/cron/update_job_cron.yaml
@@ -15,6 +15,8 @@ spec:
     spec:
       template:
         metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
           labels:
             app: jupyter-updater-cron
         spec:
@@ -25,6 +27,9 @@ spec:
             # TODO(jlewi): Stop checking out the jlewi fork once it is merged
             - --repos=$(REPOS)
             - --src_dir=/src
+            # Don't do a shallow clone because we need to compute when files were modified and shallow clones prevent pushing
+            # branches.
+            - --depth=all
             name: checkout
             image: gcr.io/kubeflow-releasing/test-worker
             volumeMounts:
@@ -72,6 +77,8 @@ spec:
                 secretKeyRef:
                   name: github-token
                   key: github_token
+            - name: GOPATH
+              value: /src/go
             volumeMounts:
             - mountPath: /src
               name: src

--- a/releasing/auto-update/overlays/job/kustomization.yaml
+++ b/releasing/auto-update/overlays/job/kustomization.yaml
@@ -1,3 +1,4 @@
+namespace: kf-releasing
 bases:
   - ../../base
 resources:  
@@ -5,4 +6,4 @@ resources:
 images:
 - name: gcr.io/kubeflow-releasing/test-worker
   newName: gcr.io/kubeflow-releasing/test-worker
-  newTag: v20190820-54db950-dirty-c63672
+  newTag: v20190905-cff62af-dirty-f45ce7

--- a/releasing/auto-update/overlays/job/update_job.yaml
+++ b/releasing/auto-update/overlays/job/update_job.yaml
@@ -12,6 +12,9 @@ metadata:
   name: jupyter
 spec:
   template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
     spec:
       initContainers:
       # This init container checks out the source code.
@@ -22,6 +25,9 @@ spec:
         #- --repos=kubeflow/kubeflow@HEAD:3958,kubeflow/fairing@HEAD,kubeflow/testing@HEAD,kubeflow/manifests@HEAD
         - --repos=$(REPOS)
         - --src_dir=/src
+        # Don't do a shallow clone because we need to compute when files were modified and shallow clones prevent pushing
+        # branches.
+        - --depth=all
         name: checkout
         image: gcr.io/kubeflow-releasing/test-worker
         volumeMounts:
@@ -51,15 +57,8 @@ spec:
           readOnly: true
       containers:
       - command:
-        - python3 
-        - -m 
-        - kubeflow.kubeflow.ci.update_jupyter_web_app
-        - all
-        - --build-project=kubeflow-releasing
-        - --registry-project=kubeflow-images-public
-        - --remote-fork=git@github.com:kubeflow-bot/manifests.git 
-        - --kustomize_file=/src/kubeflow/manifests/jupyter/jupyter-web-app/base/kustomization.yaml 
-        - --add-github-host=true
+        - bash
+        - /scripts/update_jupyter.sh
         image: gcr.io/kubeflow-releasing/test-worker
         name: update
         env:
@@ -76,6 +75,8 @@ spec:
             secretKeyRef:
               name: github-token
               key: github_token
+        - name: GOPATH
+          value: /src/go
         volumeMounts:
         - mountPath: /src
           name: src
@@ -84,6 +85,8 @@ spec:
           readOnly: true
         - mountPath: /root/.ssh
           name: ssh-config
+        - mountPath: /scripts
+          name: scripts
       restartPolicy: Never
       volumes:
       - name: ssh-config
@@ -97,3 +100,6 @@ spec:
       - name: ssh
         secret:
           secretName: kubeflow-bot-ssh
+      - name: scripts
+        configMap:
+          name: auto-update-scripts


### PR DESCRIPTION
Fix a bunch of issues with CD for the jupyter web app

* Update jupyter web-app CD scripts to run in the kf-releasing namespace
* Fix a bug in applicaiton_util; open temporary file in write mode

* Clone the repos in full depth so that we properly compute the last commit
  that modified the jupyter web app.

* Requires building a new docker image using kubeflow/testing#458 which
  has an updated version of checkout_repos.sh

* Related to: #3829

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4029)
<!-- Reviewable:end -->
