### PR TITLE
Use info message when waiting for the namespace

### DIFF
--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -314,12 +314,13 @@ func (kustomize *kustomize) Apply(resources kftypesv3.ResourceEnum) error {
 			return backoff.Retry(func() error {
 				if !apply.DefaultProfileNamespace(defaultProfileNamespace) {
 					msg := fmt.Sprintf("Could not find namespace %v, wait and retry", defaultProfileNamespace)
-					log.Warnf(msg)
+					log.Infof(msg)
 					return &kfapisv3.KfError{
 						Code:    int(kfapisv3.INVALID_ARGUMENT),
 						Message: msg,
 					}
 				}
+                                log.Infof(fmt.Sprintf("Found namespace %v", defaultProfileNamespace))
 				return nil
 			}, b)
 		} else {


### PR DESCRIPTION
During a normal installation flow, the default profile creation
waits for the target namespace to be created and only after that
continues with the creation. Before this commit, user would see
a warning message about a namespace not found, but not anything
indicating whether the system was able to recover.

With this commit, there will be informational logging until the
namespace is available and a final informational message once
the namespace is found which means that in a normal installation
(without the -V flag) there won't be warnings presented to the user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4050)
<!-- Reviewable:end -->
