### PR TITLE
kfctl server integrate new kustomize apply

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -91,6 +91,8 @@ COPY config/default.yaml /opt/kubeflow/
 COPY image_registries.yaml /opt/kubeflow/
 
 RUN mkdir -p /opt/bootstrap
+# directory for cert file
+RUN mkdir -p /opt/ca
 RUN mkdir -p /opt/versioned_registries
 RUN chmod a+rx /opt/kubeflow/bootstrapper
 

--- a/bootstrap/cmd/bootstrap/app/kfctlServer.go
+++ b/bootstrap/cmd/bootstrap/app/kfctlServer.go
@@ -12,10 +12,13 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"github.com/cenkalti/backoff"
 	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
 	kftypes "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps"
 	kfdefsv3 "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfdef/v1alpha1"
+	"time"
+
 	//"github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfdef/v1alpha1"
 	"github.com/kubeflow/kubeflow/bootstrap/v3/pkg/kfapp/coordinator"
 	"github.com/kubeflow/kubeflow/bootstrap/v3/pkg/kfapp/gcp"
@@ -245,7 +248,14 @@ func (s *kfctlServer) handleDeployment(r kfdefsv3.KfDef) (*kfdefsv3.KfDef, error
 	kPluginSetter.SetK8sRestConfig(k8sRest)
 
 	log.Infof("Calling apply K8s")
-	if err := s.kfApp.Apply(kftypes.K8S); err != nil {
+
+	// Retry up to 3 times here; since apply k8s is most flaky step.
+	err = backoff.Retry(
+		func() error {
+			return s.kfApp.Apply(kftypes.K8S)
+		},
+		backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 3))
+	if err != nil {
 		log.Errorf("Calling apply K8s failed; %v", err)
 		return s.kfDefGetter.GetKfDef(), &httpError{
 			Message: "Internal service error please try again later.",


### PR DESCRIPTION
After https://github.com/kubeflow/kubeflow/pull/3957, `kustomize apply` use `kubectl apply` directly.
This PR make sure `kustomize apply` pick up config provided by `SetK8sRestConfig()` in kfctl server case (local `kube/config` file is not available):
- Within `kustomize apply`, `kubectl apply` will take host, token and cert as CLI flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4054)
<!-- Reviewable:end -->
