### PR TITLE
GCPPlugin spec should allow specifying location of deployment manager…

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
@@ -19,6 +19,9 @@ type GcpPluginSpec struct {
 	// EnableWorkloadIdentity indicates whether to enable workload identity.
 	// Use a pointer so we can distinguish unset values.
 	EnableWorkloadIdentity *bool `json:"enableWorkloadIdentity,omitempty"`
+
+	// DeploymentManagerConfig provides location of the deployment manager configs.
+	DeploymentManagerConfig *DeploymentManagerConfig `json:"deploymentManagerConfig,omitempty"`
 }
 
 type Auth struct {
@@ -34,6 +37,10 @@ type BasicAuth struct {
 type IAP struct {
 	OAuthClientId     string            `json:"oAuthClientId,omitempty"`
 	OAuthClientSecret *kfdefs.SecretRef `json:"oAuthClientSecret,omitempty"`
+}
+
+type DeploymentManagerConfig struct {
+	RepoRef *kfdefs.RepoRef `json:"repoRef,omitempty"`
 }
 
 // IsValid returns true if the spec is a valid and complete spec.

--- a/bootstrap/pkg/kfapp/gcp/gcp_test.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_test.go
@@ -138,6 +138,12 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						},
 					},
 				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "kubeflow",
+						Path: "deployment/gke/deployment_manager_configs",
+					},
+				},
 			},
 		},
 		{
@@ -161,6 +167,12 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						},
 					},
 				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "kubeflow",
+						Path: "deployment/gke/deployment_manager_configs",
+					},
+				},
 			},
 		},
 		{
@@ -182,6 +194,12 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						OAuthClientSecret: &kfdefs.SecretRef{
 							Name: CLIENT_SECRET,
 						},
+					},
+				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "kubeflow",
+						Path: "deployment/gke/deployment_manager_configs",
 					},
 				},
 			},
@@ -210,6 +228,12 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						OAuthClientSecret: &kfdefs.SecretRef{
 							Name: CLIENT_SECRET,
 						},
+					},
+				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "kubeflow",
+						Path: "deployment/gke/deployment_manager_configs",
 					},
 				},
 			},
@@ -242,6 +266,12 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						OAuthClientSecret: &kfdefs.SecretRef{
 							Name: CLIENT_SECRET,
 						},
+					},
+				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "kubeflow",
+						Path: "deployment/gke/deployment_manager_configs",
 					},
 				},
 			},
@@ -281,6 +311,12 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						},
 					},
 				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "kubeflow",
+						Path: "deployment/gke/deployment_manager_configs",
+					},
+				},
 			},
 		},
 		{
@@ -312,6 +348,57 @@ func TestGcp_setGcpPluginDefaults(t *testing.T) {
 						Password: &kfdefs.SecretRef{
 							Name: "original_secret",
 						},
+					},
+				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "kubeflow",
+						Path: "deployment/gke/deployment_manager_configs",
+					},
+				},
+			},
+		},
+		{
+			Name: "dm-configs-not-overwritten",
+			Input: &kfdefs.KfDef{
+				Spec: kfdefs.KfDefSpec{
+					UseBasicAuth: false,
+				},
+			},
+			InputSpec: &GcpPluginSpec{
+				Auth: &Auth{
+					BasicAuth: &BasicAuth{
+						Username: "original_user",
+						Password: &kfdefs.SecretRef{
+							Name: "original_secret",
+						},
+					},
+				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "somerepo",
+						Path: "somepath",
+					},
+				},
+			},
+			Env: map[string]string{
+				CLIENT_ID: "someclient",
+			},
+			Expected: &GcpPluginSpec{
+				CreatePipelinePersistentStorage: proto.Bool(true),
+				EnableWorkloadIdentity:          proto.Bool(false),
+				Auth: &Auth{
+					BasicAuth: &BasicAuth{
+						Username: "original_user",
+						Password: &kfdefs.SecretRef{
+							Name: "original_secret",
+						},
+					},
+				},
+				DeploymentManagerConfig: &DeploymentManagerConfig{
+					RepoRef: &kfdefs.RepoRef{
+						Name: "somerepo",
+						Path: "somepath",
 					},
 				},
 			},


### PR DESCRIPTION
… configs.

* Currently kfctl hard codes the repository and location within the repository
  of the deployment manager configs.

* This PR changes that so the location of the deployment manager configs
  can be provided using a RepoRef.

* For backwards compatibility the location defaults to the current location.

* The immediate need is we want to move all the manifests to kubeflow/manifests
  Related to kubeflow/manifests#241