### PR TITLE
Arrikto and AWS plugins should pull additional configuration files from kubeflow/manifests

### DIFF
--- a/bootstrap/pkg/kfapp/aws/aws.go
+++ b/bootstrap/pkg/kfapp/aws/aws.go
@@ -61,6 +61,9 @@ const (
 
 	// Plugin parameter constants
 	AwsPluginName = kftypes.AWS
+
+	// Path in manifests repo to where the additional configs are located
+	CONFIG_LOCAL_PATH = "aws/infra_configs"
 )
 
 // Aws implements KfApp Interface
@@ -300,14 +303,14 @@ func (aws *Aws) updateClusterConfig(clusterConfigFile string) error {
 // ${KUBEFLOW_SRC}/${KFAPP}/aws_config -> destDir (dest)
 func (aws *Aws) generateInfraConfigs() error {
 	// 1. Copy and Paste all files from `sourceDir` to `destDir`
-	repo, ok := aws.kfDef.Status.ReposCache[kftypes.KubeflowRepoName]
+	repo, ok := aws.kfDef.Status.ReposCache[kftypes.ManifestsRepoName]
 	if !ok {
-		err := fmt.Errorf("Repo %v not found in KfDef.Status.ReposCache", kftypes.KubeflowRepoName)
+		err := fmt.Errorf("Repo %v not found in KfDef.Status.ReposCache", kftypes.ManifestsRepoName)
 		log.Errorf("%v", err)
 		return errors.WithStack(err)
 	}
 
-	sourceDir := path.Join(repo.LocalPath, "deployment/aws/infra_configs")
+	sourceDir := path.Join(repo.LocalPath, CONFIG_LOCAL_PATH)
 	destDir := path.Join(aws.kfDef.Spec.AppDir, KUBEFLOW_AWS_INFRA_DIR)
 
 	if _, err := os.Stat(destDir); os.IsNotExist(err) {

--- a/bootstrap/pkg/kfapp/existing_arrikto/existing.go
+++ b/bootstrap/pkg/kfapp/existing_arrikto/existing.go
@@ -38,6 +38,9 @@ const (
 	KUBEFLOW_USER_EMAIL = "KUBEFLOW_USER_EMAIL"
 	KUBEFLOW_ENDPOINT   = "KUBEFLOW_ENDPOINT"
 	OIDC_ENDPOINT       = "OIDC_ENDPOINT"
+
+	// Path in manifests repo to where the additional configs are located
+	CONFIG_LOCAL_PATH = "kfdef/generic"
 )
 
 type Existing struct {
@@ -53,8 +56,8 @@ type manifest struct {
 
 func GetPlatform(kfdef *kfdefs.KfDef) (kftypesv3.Platform, error) {
 
-	kfRepoDir := kfdef.Status.ReposCache[kftypesv3.KubeflowRepoName].LocalPath
-	istioManifestsDir := path.Join(kfRepoDir, "deployment/existing/istio")
+	kfRepoDir := kfdef.Status.ReposCache[kftypesv3.ManifestsRepoName].LocalPath
+	istioManifestsDir := path.Join(kfRepoDir, CONFIG_LOCAL_PATH, "istio")
 	istioManifests := []manifest{
 		{
 			name: "Istio CRDs",
@@ -66,7 +69,7 @@ func GetPlatform(kfdef *kfdefs.KfDef) (kftypesv3.Platform, error) {
 		},
 	}
 
-	authOIDCManifestsDir := path.Join(kfRepoDir, "deployment/existing/auth_oidc")
+	authOIDCManifestsDir := path.Join(kfRepoDir, CONFIG_LOCAL_PATH, "auth_oidc")
 	authOIDCManifests := []manifest{
 		{
 			name: "Istio Gateway",
@@ -174,8 +177,8 @@ func (existing *Existing) Apply(resources kftypesv3.ResourceEnum) error {
 	}
 
 	// Generate YAML from the dex, authservice templates
-	kfRepoDir := existing.Status.ReposCache[kftypesv3.KubeflowRepo].LocalPath
-	authOIDCManifestsDir := path.Join(kfRepoDir, "deployment/existing/auth_oidc")
+	kfRepoDir := existing.Status.ReposCache[kftypesv3.ManifestsRepoName].LocalPath
+	authOIDCManifestsDir := path.Join(kfRepoDir, CONFIG_LOCAL_PATH, "auth_oidc")
 	err = generateFromGoTemplate(
 		path.Join(authOIDCManifestsDir, "authservice.tmpl"),
 		path.Join(authOIDCManifestsDir, "authservice.yaml"),


### PR DESCRIPTION
* kubeflow/manifests#353 moved the additional configuration files into the
  kubeflow/manifests repo

* The AWS and existing_arrikto plugins should pull the additional configuration
  files from that repo rather than the kubeflow/kubeflow repo

  * There are lot of reasons for doing this but a big one is downloading
    a single repository. Furthermore the kubeflow/kubeflow repo takes 100+M
    because we have vendored a bunch of dependencies into it.

* The existing_arrikto and AWS plugins are currently hard coding the paths
  so this PR just updates the paths to the new locations.

  * The better directoin long term is to define Plugin specs for each of
    these plugins and specify the location as part of the KFDef like we
    do for GCP see: kubeflow/kubeflow#4118

* Related to kubeflow/manifests#241

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4121)
<!-- Reviewable:end -->
