### PR TITLE
pick up manifest config fix on v0.6 branch

### DIFF
--- a/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
+++ b/bootstrap/config/kfctl_gcp_iap.0.6.2.yaml
@@ -312,7 +312,7 @@ spec:
   - name: kubeflow
     uri: https://github.com/kubeflow/kubeflow/archive/0dbd2550372c003ba69069aeee283bd59fb1341f.tar.gz
   - name: manifests
-    uri: https://github.com/kubeflow/manifests/archive/56e2fb15db286198f7a53723cb1fbfecf3fe83fb.tar.gz
+    uri: https://github.com/kubeflow/manifests/archive/0fa9c0126f62392d1c27f31711e513b22ef28cbc.tar.gz
   skipInitProject: true
   useBasicAuth: false
   useIstio: true


### PR DESCRIPTION
Part 2 of https://github.com/kubeflow/kubeflow/pull/4122
So config version is consistent on GCP

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4130)
<!-- Reviewable:end -->
