### PR TITLE
[3772][notebook-controller] Reissue pod and sts events as notebook events

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-logr/logr"
 	reconcilehelper "github.com/kubeflow/kubeflow/components/common/reconcilehelper"
@@ -27,17 +28,20 @@ import (
 	"github.com/kubeflow/kubeflow/components/notebook-controller/pkg/metrics"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
@@ -63,9 +67,10 @@ func ignoreNotFound(err error) error {
 // NotebookReconciler reconciles a Notebook object
 type NotebookReconciler struct {
 	client.Client
-	Log     logr.Logger
-	Scheme  *runtime.Scheme
-	Metrics *metrics.Metrics
+	Log           logr.Logger
+	Scheme        *runtime.Scheme
+	Metrics       *metrics.Metrics
+	EventRecorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
@@ -77,6 +82,24 @@ type NotebookReconciler struct {
 func (r *NotebookReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log.WithValues("notebook", req.NamespacedName)
+
+	event := &v1.Event{}
+	var getEventErr error
+	getEventErr = r.Get(ctx, req.NamespacedName, event)
+	if getEventErr == nil {
+		involvedNotebook := &v1beta1.Notebook{}
+		involvedNotebookKey := types.NamespacedName{Name: nbNameFromInvolvedObject(&event.InvolvedObject), Namespace: req.Namespace}
+		if err := r.Get(ctx, involvedNotebookKey, involvedNotebook); err != nil {
+			log.Error(err, "unable to fetch Notebook by looking at event")
+			return ctrl.Result{}, ignoreNotFound(err)
+		}
+		r.EventRecorder.Eventf(involvedNotebook, event.Type, event.Reason,
+			"Reissued from %s/%s: %s", strings.ToLower(event.InvolvedObject.Kind), event.InvolvedObject.Name, event.Message)
+	}
+	if getEventErr != nil && !apierrs.IsNotFound(getEventErr) {
+		return ctrl.Result{}, getEventErr
+	}
+	// If not found, continue. Is not an event.
 
 	instance := &v1beta1.Notebook{}
 	if err := r.Get(ctx, req.NamespacedName, instance); err != nil {
@@ -436,6 +459,27 @@ func (r *NotebookReconciler) reconcileVirtualService(instance *v1beta1.Notebook)
 
 	return nil
 }
+
+func isStsOrPodEvent(event *v1.Event) bool {
+	return event.InvolvedObject.Kind == "Pod" || event.InvolvedObject.Kind == "StatefulSet"
+}
+
+func nbNameFromInvolvedObject(object *v1.ObjectReference) string {
+	nbName := object.Name
+	if object.Kind == "Pod" {
+		nbName = nbName[:strings.LastIndex(nbName, "-")]
+	}
+	return nbName
+}
+
+func nbNameExists(client client.Client, nbName string, namespace string) bool {
+	if err := client.Get(context.Background(), types.NamespacedName{namespace, nbName}, &v1beta1.Notebook{}); err != nil {
+		// If error != NotFound, trigger the reconcile call anyway to avoid loosing a potential relevant event
+		return !apierrs.IsNotFound(err)
+	}
+	return true
+}
+
 func (r *NotebookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&v1beta1.Notebook{}).
@@ -481,10 +525,48 @@ func (r *NotebookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return true
 		},
 	}
-	return c.Watch(
+
+	eventToRequest := handler.ToRequestsFunc(
+		func(a handler.MapObject) []ctrl.Request {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{
+					Name:      a.Meta.GetName(),
+					Namespace: a.Meta.GetNamespace(),
+				}},
+			}
+		})
+
+	eventsPredicates := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			event := e.ObjectNew.(*v1.Event)
+			return e.ObjectOld != e.ObjectNew &&
+				isStsOrPodEvent(event) &&
+				nbNameExists(r.Client, nbNameFromInvolvedObject(&event.InvolvedObject), e.MetaNew.GetNamespace())
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			event := e.Object.(*v1.Event)
+			return isStsOrPodEvent(event) &&
+				nbNameExists(r.Client, nbNameFromInvolvedObject(&event.InvolvedObject), e.Meta.GetNamespace())
+		},
+	}
+
+	if err = c.Watch(
 		&source.Kind{Type: &corev1.Pod{}},
 		&handler.EnqueueRequestsFromMapFunc{
 			ToRequests: mapFn,
 		},
-		p)
+		p); err != nil {
+		return err
+	}
+
+	if err = c.Watch(
+		&source.Kind{Type: &v1.Event{}},
+		&handler.EnqueueRequestsFromMapFunc{
+			ToRequests: eventToRequest,
+		},
+		eventsPredicates); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/components/notebook-controller/main.go
+++ b/components/notebook-controller/main.go
@@ -65,10 +65,11 @@ func main() {
 	}
 
 	if err = (&controllers.NotebookReconciler{
-		Client:  mgr.GetClient(),
-		Log:     ctrl.Log.WithName("controllers").WithName("Notebook"),
-		Scheme:  mgr.GetScheme(),
-		Metrics: controller_metrics.NewMetrics(mgr.GetClient()),
+		Client:        mgr.GetClient(),
+		Log:           ctrl.Log.WithName("controllers").WithName("Notebook"),
+		Scheme:        mgr.GetScheme(),
+		Metrics:       controller_metrics.NewMetrics(mgr.GetClient()),
+		EventRecorder: mgr.GetEventRecorderFor("notebook-controller"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Notebook")
 		os.Exit(1)


### PR DESCRIPTION
This PR is a partial fix of https://github.com/kubeflow/kubeflow/issues/3772. The notebook-controller creates notebook events by propagating both StatefulSet and Pod events. The UI should fetch these events to determine the status of the notebook server (see complete discussion in the linked issue).

How `kubectl -n kubeflow get events --sort-by=.metadata.creationTimestamp` looks like for different scenarios.

**A. Happy path (pod can be scheduled)**

A.1 Notebook Server creation
```text
LAST SEEN   TYPE     REASON                  OBJECT                                          MESSAGE
7s          Normal   ProvisioningSucceeded   persistentvolumeclaim/workspace-everything-ok   Successfully provisioned volume pvc-7701080a-f089-485b-beef-e62b610bee81
7s          Normal   Provisioning            persistentvolumeclaim/workspace-everything-ok   External provisioner is provisioning volume for claim "kubeflow/workspace-everything-ok"
7s          Normal   SuccessfulCreate        statefulset/everything-ok                       create Pod everything-ok-0 in StatefulSet everything-ok successful
7s          Normal   ExternalProvisioning    persistentvolumeclaim/workspace-everything-ok   waiting for a volume to be created, either by external provisioner "k8s.io/minikube-hostpath" or manually created by system administrator
6s          Normal   Pulled                  pod/everything-ok-0                             Container image "gcr.io/kubeflow-images-public/tensorflow-1.13.1-notebook-cpu:v0.5.0" already present on machine
6s          Normal   Created                 pod/everything-ok-0                             Created container everything-ok
6s          Normal   Scheduled               pod/everything-ok-0                             Successfully assigned kubeflow/everything-ok-0 to minikube
5s          Normal   Created                 notebook/everything-ok                          Reissued from pod/everything-ok-0: Created container everything-ok
5s          Normal   Pulled                  notebook/everything-ok                          Reissued from pod/everything-ok-0: Container image "gcr.io/kubeflow-images-public/tensorflow-1.13.1-notebook-cpu:v0.5.0" already present on machine
5s          Normal   Started                 notebook/everything-ok                          Reissued from pod/everything-ok-0: Started container everything-ok
5s          Normal   SuccessfulCreate        notebook/everything-ok                          Reissued from statefulset/everything-ok: create Pod everything-ok-0 in StatefulSet everything-ok successful
5s          Normal   Started                 pod/everything-ok-0                             Started container everything-ok
5s          Normal   Scheduled               notebook/everything-ok                          Reissued from pod/everything-ok-0: Successfully assigned kubeflow/everything-ok-0 to minikube
```

A.2 Notebook Server deletion
```text
13s         Normal    Killing                 pod/everything-ok-0                             Stopping container everything-ok
7s          Normal    SuccessfulCreate        statefulset/everything-ok                       create Pod everything-ok-0 in StatefulSet everything-ok successful
7s          Warning   FailedCreate            statefulset/everything-ok                       create Pod everything-ok-0 in StatefulSet everything-ok failed error: The POST operation against Pod could not be completed at this time, please try again.
7s          Normal    Scheduled               pod/everything-ok-0                             Successfully assigned kubeflow/everything-ok-0 to minikube
```

**B. Service Account not found (sts cannot create pod)**

```text
LAST SEEN   TYPE     REASON                  OBJECT                                          MESSAGE
1s          Warning   FailedCreate            statefulset/delete-sa                       create Pod delete-sa-0 in StatefulSet delete-sa failed error: pods "delete-sa-0" is forbidden: error looking up service account kubeflow/default-editor: serviceaccount "default-editor" not found
6s          Warning   FailedCreate            notebook/delete-sa                          Reissued from statefulset/delete-sa: create Pod delete-sa-0 in StatefulSet delete-sa failed error: pods "delete-sa-0" is forbidden: error looking up service account kubeflow/default-editor: serviceaccount "default-editor" not found
2s          Normal    ExternalProvisioning    persistentvolumeclaim/workspace-delete-sa   waiting for a volume to be created, either by external provisioner "k8s.io/minikube-hostpath" or manually created by system administrator
2s          Normal    Provisioning            persistentvolumeclaim/workspace-delete-sa   External provisioner is provisioning volume for claim "kubeflow/workspace-delete-sa"
2s          Normal    ProvisioningSucceeded   persistentvolumeclaim/workspace-delete-sa   Successfully provisioned volume pvc-2d980201-4cf1-4d76-abb9-1bebcff8c520
```

**C. Insufficient CPU (sts OK but pod cannot be scheduled)**

```text
LAST SEEN   TYPE      REASON             OBJECT                 MESSAGE
13s         Warning   FailedScheduling   pod/high-cpu-0         0/1 nodes are available: 1 Insufficient cpu.
13s         Normal    SuccessfulCreate   statefulset/high-cpu   create Pod high-cpu-0 in StatefulSet high-cpu successful
12s         Warning   FailedScheduling   notebook/high-cpu      Reissued from pod/high-cpu-0: 0/1 nodes are available: 1 Insufficient cpu.
12s         Normal    SuccessfulCreate   notebook/high-cpu      Reissued from statefulset/high-cpu: create Pod high-cpu-0 in StatefulSet high-cpu successful
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4139)
<!-- Reviewable:end -->
