### PR TITLE
move pod default back to gcp

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -837,7 +837,7 @@ func (gcp *Gcp) Apply(resources kftypesv3.ResourceEnum) error {
 			}
 		}
 	}
-	if gcp.KfDef.Email == "" {
+	if gcp.kfDef.Spec.Email == "" {
 		return nil
 	}
 	if *p.EnableWorkloadIdentity {

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -837,8 +837,14 @@ func (gcp *Gcp) Apply(resources kftypesv3.ResourceEnum) error {
 			}
 		}
 	}
-
-	return nil
+	if gcp.KfDef.Email == "" {
+		return nil
+	}
+	if *p.EnableWorkloadIdentity {
+		return gcp.SetupDefaultNamespaceWorkloadIdentity()
+	} else {
+		return gcp.ConfigPodDefault()
+	}
 }
 
 // Try to get information for the deployment. If returned, delete it.


### PR DESCRIPTION
With `simpleReconcile` we don't need the hack to generate PodDefault anymore.

Relates to #4056 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4141)
<!-- Reviewable:end -->
