### PR TITLE
[notebook-controller]Add an end slash in the prefix of virtual service to fix url route error

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -354,8 +354,8 @@ func virtualServiceName(kfName string, namespace string) string {
 func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructured, error) {
 	name := instance.Name
 	namespace := instance.Namespace
-	prefix := fmt.Sprintf("/notebook/%s/%s", namespace, name)
-	rewrite := fmt.Sprintf("/notebook/%s/%s", namespace, name)
+	prefix := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
+	rewrite := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
 	// TODO(gabrielwen): Make clusterDomain an option.
 	service := fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace)
 


### PR DESCRIPTION
In my test, if we create two notebooks named 'foo' and 'foobar', the url of notebook will only route to `foo`.

The reason is that in the notebook controller it use istio's `VirtualService` to add route for notebook. And now the prefix coded as `fmt.Sprintf("/notebook/%s/%s", namespace, name)`, 
 `/notebook/default/foo`  is the prefix of `/notebook/default/foobar` , so all the traffic will go to `/notebook/default/foo`.

To fix this bug, add an end slash for prefix and it works OK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4168)
<!-- Reviewable:end -->
