### PR TITLE
Revert "Apply with strawman reconcile (#4106)"

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -24,7 +24,6 @@ import (
 
 	"os"
 
-	"github.com/cenkalti/backoff"
 	"github.com/ghodss/yaml"
 	"github.com/kubeflow/kubeflow/bootstrap/v3/config"
 	kfapis "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis"
@@ -39,7 +38,6 @@ import (
 	log "github.com/sirupsen/logrus"
 	valid "k8s.io/apimachinery/pkg/api/validation"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"time"
 )
 
 // Builder defines the methods used to create KfApps.
@@ -206,45 +204,6 @@ func repoVersionToUri(repo string, version string) string {
 	tarballUrl := "https://github.com/kubeflow/" + repo + "/tarball/" + version + "?archive=tar.gz"
 
 	return tarballUrl
-}
-
-// A strawman approach for reconcile semantics. We keep retrying until the fn returns nil.
-type simpleReconcileReq struct {
-	Fn      func() error
-	Requeue bool
-}
-
-func newReconcileReq(fn func() error) simpleReconcileReq {
-	return simpleReconcileReq{
-		Fn:      fn,
-		Requeue: true,
-	}
-}
-
-func simpleReconcile(requests []simpleReconcileReq) error {
-	return backoff.Retry(func() error {
-		retry := false
-		for idx := range requests {
-			if requests[idx].Requeue == false {
-				continue
-			}
-
-			if err := requests[idx].Fn(); err == nil {
-				requests[idx].Requeue = false
-			} else {
-				log.Warnf("reconcile process has error: %v; retrying...", err)
-				requests[idx].Requeue = true
-				retry = true
-			}
-		}
-
-		if retry {
-			return fmt.Errorf("Retrying to reconcile in 10 seconds.")
-		} else {
-			// Exit the simple reconcile.
-			return nil
-		}
-	}, backoff.NewConstantBackOff(10*time.Second))
 }
 
 // CreateKfDefFromOptions creates a KfDef from the supplied options.
@@ -812,21 +771,24 @@ func (kfapp *coordinator) Apply(resources kftypesv3.ResourceEnum) error {
 		}
 	}
 
-	// TODO(gabrielwen): Move `gcpAddedConfig` back to gcp.go.
 	switch resources {
 	case kftypesv3.ALL:
-		return simpleReconcile([]simpleReconcileReq{
-			newReconcileReq(platform),
-			newReconcileReq(k8s),
-			newReconcileReq(gcpAddedConfig),
-		})
+		if err := platform(); err != nil {
+			return err
+		}
+		if err := k8s(); err != nil {
+			return err
+		}
+		return gcpAddedConfig()
 	case kftypesv3.PLATFORM:
 		return platform()
 	case kftypesv3.K8S:
-		return simpleReconcile([]simpleReconcileReq{
-			newReconcileReq(k8s),
-			newReconcileReq(gcpAddedConfig),
-		})
+		if err := k8s(); err != nil {
+			return err
+		}
+		// TODO(gabrielwen): Need to find a more proper way of injecting plugings.
+		// https://github.com/kubeflow/kubeflow/issues/3708
+		return gcpAddedConfig()
 	}
 	return nil
 }


### PR DESCRIPTION
This reverts commit 9a25c2bc72190fa2a5e68398cedf4b4a95ccb4db.

* The strawman reconcile (#4106) leads to a bug where we try to deply K8s
  resources even though cluster creation failed (#4195)

  * This is because the strawman implementation of reconcile uses errors
    to determine whether to keep retying or whether deployment is done.

* I think the way to fix this is to use conditions which is blocked on updating
  the code to use v1beta1.

  * The various plugins should use appropriate conditions (e.g. failed,
    succeeded, running) to signal to the apply function in coordinator.go
    whether apply.go should keep going, report a failure, etc...

* Related to #4056 - Implement reconcile semantics

* Related to #4195 - kfctl keeps going even though cluster creation failed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4204)
<!-- Reviewable:end -->
