### PR TITLE
Centraldashboard: Updates Stackdriver metrics and links for GKE deployments

### DIFF
--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -1979,6 +1979,15 @@
             "resolved": "https://registry.npmjs.org/@types/node/-/node-11.9.5.tgz",
             "integrity": "sha512-vVjM0SVzgaOUpflq4GYBvCpozes8OgIIS5gVXVka+OfK3hvnkC1i93U8WiY2OtNE4XUWyyy/86Kf6e0IHTQw1Q=="
         },
+        "@types/node-fetch": {
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.2.tgz",
+            "integrity": "sha512-djYYKmdNRSBtL1x4CiE9UJb9yZhwtI1VC+UxZD0psNznrUj80ywsxKlEGAE+QL1qvLjPbfb24VosjkYM6W4RSQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/range-parser": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
@@ -5660,7 +5669,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -5681,12 +5691,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -5701,17 +5713,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -5828,7 +5843,8 @@
                 "inherits": {
                     "version": "2.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -5840,6 +5856,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -5854,6 +5871,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -5861,12 +5879,14 @@
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -5885,6 +5905,7 @@
                     "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "0.0.8"
                     }
@@ -5965,7 +5986,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -5977,6 +5999,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -6062,7 +6085,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -6098,6 +6122,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -6117,6 +6142,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -6160,12 +6186,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.0.3",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -8936,21 +8964,6 @@
                 "chalk": "^2.0.1"
             }
         },
-        "lodash.toarray": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-            "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-            "dev": true
-        },
-        "log-symbols": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-            "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-            "dev": true,
-            "requires": {
-                "chalk": "^2.0.1"
-            }
-        },
         "log4js": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/log4js/-/log4js-4.1.1.tgz",
@@ -9536,9 +9549,9 @@
             }
         },
         "node-fetch": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.5.0.tgz",
-            "integrity": "sha512-YuZKluhWGJwCcUu4RlZstdAxr8bFfOVHakc1mplwHkk8J+tqM1Y5yraYvIUpeX8aY7+crCwiELJq7Vl0o0LWXw=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
         },
         "node-forge": {
             "version": "0.7.5",

--- a/components/centraldashboard/package.json
+++ b/components/centraldashboard/package.json
@@ -69,6 +69,7 @@
         "chart.js": "^2.8.0",
         "chartjs-plugin-crosshair": "^1.1.2",
         "express": "^4.16.4",
+        "node-fetch": "^2.6.0",
         "web-animations-js": "^2.3.1"
     },
     "devDependencies": {
@@ -80,6 +81,7 @@
         "@types/express": "^4.16.1",
         "@types/gapi.client.monitoring": "^3.0.1",
         "@types/jasmine": "^3.3.12",
+        "@types/node-fetch": "^2.5.2",
         "babel-loader": "^8.0.5",
         "clean-webpack-plugin": "^1.0.1",
         "concurrently": "^4.1.0",

--- a/components/centraldashboard/public/components/resources/cloud-platform-data.js
+++ b/components/centraldashboard/public/components/resources/cloud-platform-data.js
@@ -12,32 +12,34 @@ import '../../assets/gcp-logo.png';
  * @param {string} project
  * @return {object}
  */
-export const getGCPData = (project) => ({
-    links: [
-        {
-            headerText: 'Stackdriver Logging',
-            secondaryText: 'View cluster logs for the past hour',
-            link: `https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=${project}`,
-        },
-        {
-            headerText: 'Project Overview',
-            secondaryText: 'Manage your GCP Project',
-            link: `https://console.cloud.google.com/home/dashboard?project=${project}`,
-        },
-        {
-            headerText: 'Deployment Manager',
-            secondaryText: 'View your deployments',
-            link: `https://console.cloud.google.com/dm/deployments?project=${project}`,
-        },
-        {
-            headerText: 'Kubernetes Engine',
-            secondaryText: 'Administer your GKE clusters',
-            link: `https://console.cloud.google.com/kubernetes/list?project=${project}`,
-        },
-    ],
-    title: 'Google Cloud Platform',
-    logo: '/assets/gcp-logo.png',
-    name: 'GCP',
-    resourceChartsLink: `https://app.google.stackdriver.com/gke?project=${project}`,
-    resourceChartsLinkText: 'View in Stackdriver',
-});
+export function getGCPData(project) {
+    return {
+        links: [
+            {
+                headerText: 'Stackdriver Logging',
+                secondaryText: 'View cluster logs for the past hour',
+                link: `https://console.cloud.google.com/logs/viewer?resource=k8s_cluster&project=${project}`,
+            },
+            {
+                headerText: 'Project Overview',
+                secondaryText: 'Manage your GCP Project',
+                link: `https://console.cloud.google.com/home/dashboard?project=${project}`,
+            },
+            {
+                headerText: 'Deployment Manager',
+                secondaryText: 'View your deployments',
+                link: `https://console.cloud.google.com/dm/deployments?project=${project}`,
+            },
+            {
+                headerText: 'Kubernetes Engine',
+                secondaryText: 'Administer your GKE clusters',
+                link: `https://console.cloud.google.com/kubernetes/list?project=${project}`,
+            },
+        ],
+        title: 'Google Cloud Platform',
+        logo: '/assets/gcp-logo.png',
+        name: 'GCP',
+        resourceChartsLink: `https://app.google.stackdriver.com/kubernetes?project=${project}`,
+        resourceChartsLinkText: 'View in Stackdriver',
+    };
+}

--- a/components/centraldashboard/tsconfig.json
+++ b/components/centraldashboard/tsconfig.json
@@ -1,25 +1,25 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "esModuleInterop": true,
-        "target": "es6",
-        "noImplicitAny": true,
-        "moduleResolution": "node",
-        "sourceMap": true,
-        "outDir": "dist",
-        "baseUrl": ".",
-        "plugins": [
+    "compilerOptions":{
+        "module":"commonjs",
+        "esModuleInterop":true,
+        "target":"es6",
+        "noImplicitAny":true,
+        "moduleResolution":"node",
+        "sourceMap":true,
+        "outDir":"dist",
+        "baseUrl":".",
+        "plugins":[
             {
-                "name": "typescript-tslint-plugin"
+                "name":"typescript-tslint-plugin"
             }
         ]
     },
-    "include": [
+    "include":[
         "app",
         "types"
     ],
-    "exclude": [
+    "exclude":[
         "app/**/*_test.ts",
-        "app/**/test_resources.ts",
+        "app/**/test_resources.ts"
     ]
 }


### PR DESCRIPTION
Fixes #3535

- Uses new kubernetes.io metrics https://cloud.google.com/monitoring/api/metrics_kubernetes
- Metrics charts now link the new Kubernetes metrics dashboard in Stackdriver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4220)
<!-- Reviewable:end -->
