### PR TITLE
Correctly set workingDir for jupyter_test

### DIFF
--- a/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
@@ -282,8 +282,14 @@ class Builder:
 
     argo_build_util.add_task_to_dag(workflow, dag_name, step, dependences)
 
-    return step
+    # Return the newly created template; add_task_to_dag makes a copy of the template
+    # So we need to fetch it from the workflow spec.
+    for t in workflow["spec"]["templates"]:
+      if t["name"] == name:
+        return t
+    workflow["spec"]["templates"].append(new_template)
 
+    return None
 
   def _build_tests_dag(self):
     """Build the dag for the set of tests to run against a KF deployment."""
@@ -577,7 +583,7 @@ class Builder:
                  # Increase the log level so that info level log statements show up.
                  "--log-cli-level=info",
                  # Test timeout in seconds.
-                 "--timeout=1800",                 
+                 "--timeout=1800",
                  "--junitxml=" + self.artifacts_dir + "/junit_endpoint-is-ready-test-" + self.config_name + ".xml",
                  # Test suite name needs to be unique based on parameters
                  "-o", "junit_suite_name=test_endpoint_is_ready_" + self.config_name,


### PR DESCRIPTION
* The test needs to modify workingDir before running jupyter_test.py
  otherwise we get an error (see #4221)

* There was a bug in the code and we weren't actually setting workingDir on
  the argo template. That's because argo_build_util.add_task_to_dag makes
  a copy of the template before adding the template to the graph.

  * So we need _build_step to refetch the template so we get an actual pointer
    to the template.

* Related to #4221

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4224)
<!-- Reviewable:end -->
