### PR TITLE
Addresses PatchesJson6902 patches issue while merging multiple targets

### DIFF
--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -969,7 +969,6 @@ func MergeKustomizations(kfDef *kfdefsv3.KfDef, compDir string, overlayParams []
 			}
 		}
 		kustomization.PatchesJson6902 = make([]types.PatchJson6902, 0)
-		aggregatedPatchOps := make([]byte, 0)
 		patchFile := ""
 		for key, values := range patches {
 			aggregatedPatch := new(types.PatchJson6902)
@@ -989,14 +988,13 @@ func MergeKustomizations(kfDef *kfdefsv3.KfDef, compDir string, overlayParams []
 					if err != nil {
 						return nil, err
 					}
-					aggregatedPatchOps = append(aggregatedPatchOps, data...)
+					patchErr := ioutil.WriteFile(patchFile, data, 0644)
+					if patchErr != nil {
+						return nil, patchErr
+					}
 				}
 			}
 			kustomization.PatchesJson6902 = append(kustomization.PatchesJson6902, *aggregatedPatch)
-		}
-		patchErr := ioutil.WriteFile(patchFile, aggregatedPatchOps, 0644)
-		if patchErr != nil {
-			return nil, patchErr
 		}
 	}
 	return kustomization, nil


### PR DESCRIPTION
Resolves #4136 
Creating different patch files for each PatchesJson6902 ops instead of aggregatepatch in single patch file.

Creating new PR due to some issues(notebook-test failure which is unrelated to kfctl chanegs-might be due to rebase) with PR #4137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4225)
<!-- Reviewable:end -->
