### PR TITLE
remove redundant function used by ksonnet

### DIFF
--- a/bootstrap/pkg/apis/apps/group.go
+++ b/bootstrap/pkg/apis/apps/group.go
@@ -115,8 +115,6 @@ type KfApp interface {
 //
 type Platform interface {
 	KfApp
-	// Return k8s config built with platform-specific ways; or nil to use default kube config
-	GetK8sConfig() (*rest.Config, *clientcmdapi.Config)
 }
 
 //


### PR DESCRIPTION
Removed the GetK8sConfig function in Platform interface
/cc @jlewi @kkasravi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4236)
<!-- Reviewable:end -->
