### PR TITLE
kfctl: minor bug fixes

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -899,6 +899,13 @@ func (kfapp *coordinator) Apply(resources kftypesv3.ResourceEnum) error {
 		}
 	}
 
+	if err := kfapp.KfDef.SyncCache(); err != nil {
+		return &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: fmt.Sprintf("could not sync cache. Error: %v", err),
+		}
+	}
+
 	switch resources {
 	case kftypesv3.ALL:
 		if err := platform(); err != nil {
@@ -957,6 +964,13 @@ func (kfapp *coordinator) Delete(resources kftypesv3.ResourceEnum) error {
 			}
 		}
 		return nil
+	}
+
+	if err := kfapp.KfDef.SyncCache(); err != nil {
+		return &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: fmt.Sprintf("could not sync cache. Error: %v", err),
+		}
 	}
 
 	switch resources {
@@ -1024,6 +1038,13 @@ func (kfapp *coordinator) Generate(resources kftypesv3.ResourceEnum) error {
 
 	// Print out warning message if using usage reporting component.
 	usageReportWarn(kfapp.KfDef.Spec.Components)
+
+	if err := kfapp.KfDef.SyncCache(); err != nil {
+		return &kfapis.KfError{
+			Code:    int(kfapis.INTERNAL_ERROR),
+			Message: fmt.Sprintf("could not sync cache. Error: %v", err),
+		}
+	}
 
 	switch resources {
 	case kftypesv3.ALL:

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -396,6 +396,11 @@ func NewLoadKfAppFromURI(configFile string) (kftypesv3.KfApp, error) {
 	if isPlatformGCP && os.Getenv("ZONE") == "" {
 		log.Warn("you need to set the environment variable `ZONE` to the GCP zone you want to use")
 	}
+
+	if kfDef.Spec.PackageManager == "" {
+		kfDef.Spec.PackageManager = kftypesv3.KUSTOMIZE
+	}
+
 	appFile, err := CreateKfAppCfgFile(kfDef)
 	if err != nil {
 		return nil, &kfapis.KfError{

--- a/bootstrap/pkg/kfapp/existing_arrikto/existing.go
+++ b/bootstrap/pkg/kfapp/existing_arrikto/existing.go
@@ -56,6 +56,10 @@ type manifest struct {
 
 func GetPlatform(kfdef *kfdefs.KfDef) (kftypesv3.Platform, error) {
 
+	if err := kfdef.SyncCache(); err != nil {
+		return nil, internalError(err)
+	}
+
 	kfRepoDir := kfdef.Status.ReposCache[kftypesv3.ManifestsRepoName].LocalPath
 	istioManifestsDir := path.Join(kfRepoDir, CONFIG_LOCAL_PATH, "istio")
 	istioManifests := []manifest{


### PR DESCRIPTION
Some minor bug fixes for kfctl:
1. Call SyncCache() when retrieving the KfApp. existing_arrikto was broken because GetPlaform() depended on the cache being ready. Plus it makes sense to sync the cache at that time.
2. Default to kustomize if a package manager isn't given. We only support kustomize so it makes the most sense.

/assign @swiftdiaries 
/assign @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4244)
<!-- Reviewable:end -->
