### PR TITLE
reverts gcp config from env vars for E2E test

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1963,19 +1963,19 @@ func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 	// Added an alternate way to set using enironment variables
 	if gcp.kfDef.Spec.Project == "" {
 		return &kfapis.KfError{
-			Code:    kftypesv3.INVALID_ARGUMENT,
+			Code:    int(kfapis.INVALID_ARGUMENT),
 			Message: "GCP Project is not set, please set it in KFDef.",
 		}
 	}
 	if gcp.kfDef.Spec.Email == "" {
 		return &kfapis.KfError{
-			Code:    kftypesv3.INVALID_ARGUMENT,
+			Code:    int(kfapis.INVALID_ARGUMENT),
 			Message: "GCP account could not be determined, please set Email in KFDef.",
 		}
 	}
 	if gcp.kfDef.Spec.Zone == "" {
 		return &kfapis.KfError{
-			Code:    kftypesv3.INVALID_ARGUMENT,
+			Code:    int(kfapis.INVALID_ARGUMENT),
 			Message: "GCP Zone is not set, please set it in KFDef.",
 		}
 	}

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1962,13 +1962,22 @@ func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 	// the runGetGCPCredentials don't seem to work because those are shelled out commands
 	// Added an alternate way to set using enironment variables
 	if gcp.kfDef.Spec.Project == "" {
-		log.Warnf("GCP Project is not set, please set it in KFDef.")
+		return &kfapis.KfError{
+			Code:    kftypesv3.INVALID_ARGUMENT,
+			Message: "GCP Project is not set, please set it in KFDef.",
+		}
 	}
 	if gcp.kfDef.Spec.Email == "" {
-		log.Warnf("GCP account could not be determined, please set Email in KFDef.")
+		return &kfapis.KfError{
+			Code:    kftypesv3.INVALID_ARGUMENT,
+			Message: "GCP account could not be determined, please set Email in KFDef.",
+		}
 	}
 	if gcp.kfDef.Spec.Zone == "" {
-		log.Warnf("GCP Zone is not set, please set it in KFDef.")
+		return &kfapis.KfError{
+			Code:    kftypesv3.INVALID_ARGUMENT,
+			Message: "GCP Zone is not set, please set it in KFDef.",
+		}
 	}
 	// Set default IPName and Hostname
 	// This needs to happen before calling generateDM configs.

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1961,26 +1961,14 @@ func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 	}
 	// the runGetGCPCredentials don't seem to work because those are shelled out commands
 	// Added an alternate way to set using enironment variables
-	gcp.kfDef.Spec.Project = os.Getenv("PROJECT")
 	if gcp.kfDef.Spec.Project == "" {
-		return &kfapis.KfError{
-			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: "Project not specified.",
-		}
+		log.Warnf("GCP Project is not set, please set it in KFDef.")
 	}
-	gcp.kfDef.Spec.Zone = os.Getenv("EMAIL")
 	if gcp.kfDef.Spec.Email == "" {
-		return &kfapis.KfError{
-			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: "email not specified.",
-		}
+		log.Warnf("GCP account could not be determined, please set Email in KFDef.")
 	}
-	gcp.kfDef.Spec.Zone = os.Getenv("ZONE")
 	if gcp.kfDef.Spec.Zone == "" {
-		return &kfapis.KfError{
-			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: "zone not specified.",
-		}
+		log.Warnf("GCP Zone is not set, please set it in KFDef.")
 	}
 	// Set default IPName and Hostname
 	// This needs to happen before calling generateDM configs.

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -196,7 +196,6 @@ def kfctl_deploy_kubeflow(app_path, project, use_basic_auth, use_istio, config_p
   logging.info("kfctl path %s", kfctl_path)
   # TODO(nrchakradhar): Probably move all the environ sets to set_env_init_args
   zone = 'us-central1-a'
-  os.environ["ZONE"] = zone
   if not zone:
     raise ValueError("Could not get zone being used")
 
@@ -208,11 +207,9 @@ def kfctl_deploy_kubeflow(app_path, project, use_basic_auth, use_istio, config_p
 
   if not email:
     raise ValueError("Could not determine GCP account being used.")
-  os.environ["EMAIL"] = email
   if not project:
     raise ValueError("Could not get project being used")
-  os.environ["PROJECT"] = project
-
+  
   config_spec = get_config_spec(config_path, project, email, app_path)
   with open(os.path.join(parent_dir, "tmp.yaml"), "w") as f:
     yaml.dump(config_spec, f)

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -128,7 +128,7 @@ def filter_spartakus(spec):
       break
   return spec
 
-def get_config_spec(config_path, project, email, app_path):
+def get_config_spec(config_path, project, email, zone, app_path):
   """Generate KfDef spec.
 
   Args:
@@ -137,6 +137,7 @@ def get_config_spec(config_path, project, email, app_path):
     https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
     project: The GCP project to use.
     email: a valid email of the GCP account
+    zone: a valid GCP zone for the cluster.
     app_path: The path to the Kubeflow app.
   Returns:
     config_spec: Updated KfDef spec
@@ -147,6 +148,7 @@ def get_config_spec(config_path, project, email, app_path):
   config_spec = load_config(config_path)
   config_spec["spec"]["project"] = project
   config_spec["spec"]["email"] = email
+  config_spec["spec"]["zone"] = zone
   config_spec["spec"] = filter_spartakus(config_spec["spec"])
 
   # Set KfDef name to be unique
@@ -210,7 +212,7 @@ def kfctl_deploy_kubeflow(app_path, project, use_basic_auth, use_istio, config_p
   if not project:
     raise ValueError("Could not get project being used")
   
-  config_spec = get_config_spec(config_path, project, email, app_path)
+  config_spec = get_config_spec(config_path, project, email, zone, app_path)
   with open(os.path.join(parent_dir, "tmp.yaml"), "w") as f:
     yaml.dump(config_spec, f)
   # TODO(jlewi): When we switch to KfDef v1beta1 this logic will need to change because


### PR DESCRIPTION
Fixes: https://github.com/kubeflow/kubeflow/issues/4240
The E2E test was previously ignoring GCP creds set in the KFDef. This reverts that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4252)
<!-- Reviewable:end -->
