### PR TITLE
profile controller: enabling patch default workload identity plugins to all profiles.

### DIFF
--- a/components/profile-controller/controllers/plugin_workload_identity.go
+++ b/components/profile-controller/controllers/plugin_workload_identity.go
@@ -29,7 +29,7 @@ import (
 )
 
 // plugin kind
-const WORKLOAD_IDENTITY = "WorkloadIdentity"
+const KIND_WORKLOAD_IDENTITY = "WorkloadIdentity"
 
 const GCP_ANNOTATION_KEY = "iam.gke.io/gcp-service-account"
 const GCP_SA_SUFFIX = ".iam.gserviceaccount.com"

--- a/components/profile-controller/controllers/plugin_workload_identity_test.go
+++ b/components/profile-controller/controllers/plugin_workload_identity_test.go
@@ -18,8 +18,8 @@ package controllers
 
 import (
 	"fmt"
-	"google.golang.org/api/iam/v1"
 	"github.com/onsi/gomega"
+	"google.golang.org/api/iam/v1"
 	"reflect"
 	"testing"
 )


### PR DESCRIPTION
profile controller now has new flag `--workload-identity`
If it is not "", controller will patch it as default `workloadIdentity plugin` to all profiles who don't have `workloadIdentity plugin` in spec.

Cluster admin can still change GCP identity of certain profile later by editing the profile CR directly.

This PR is from https://github.com/kubeflow/kubeflow/pull/4258.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4261)
<!-- Reviewable:end -->
