### PR TITLE
Kubeflow deployment name should default to the directory name.

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -362,7 +362,7 @@ func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
 		kfdef.Name = nameFromAppFile(appFile)
 		if kfdef.Name == "" {
 			return nil, &kfapis.KfError{
-				Code:    int(kfapis.INTERNAL_ERROR),
+				Code:    int(kfapis.INVALID_ARGUMENT),
 				Message: fmt.Sprintf("KfDef.Name isn't set and there was a problem inferring the name based on the path %v\nPlease set the name explicitly in the KFDef spec.", appFile),
 			}
 		}

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -335,6 +335,23 @@ func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
 		}
 	}
 
+	// Since we know we have a local file we can set a default name if none is set based on the local directory
+	if kfdef.Name == "" {
+		absAppPath, err := filepath.Abs(appFile)
+
+		if err != nil {
+			return nil, &kfapis.KfError{
+				Code:    int(kfapis.INTERNAL_ERROR),
+				Message: fmt.Sprintf("KfDef.Name isn't set and there was a problem inferring the name based on the path %v; error: %v\nPlease set the name explicitly in the KFDef spec.", appFile, err),
+			}
+		}
+
+		appDir := filepath.Dir(absAppPath)
+
+		kfdef.Name = filepath.Base(appDir)
+		log.Infof("No name specified in KfDef.Metadata.Name; defaulting to %v based on location of config file: %v.", kfdef.Name, appFile)
+	}
+
 	c := &coordinator{
 		Platforms:       make(map[string]kftypesv3.Platform),
 		PackageManagers: make(map[string]kftypesv3.KfApp),

--- a/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
@@ -118,6 +118,36 @@ func Test_repoVersionToRepoStruct(t *testing.T) {
 	}
 }
 
+func Test_nameFromAppFile(t *testing.T) {
+	type testCase struct {
+		appFile string
+		expectedName string
+	}
+
+	testCases := []testCase{
+		{
+			appFile: "/mykfapp/kfctl.yaml",
+			expectedName: "mykfapp",
+		},
+		{
+			appFile: "/parentdir/subapp/app.yaml",
+			expectedName: "subapp",
+		},
+		{
+			appFile:     "/kfctl.yaml",
+			expectedName: "",
+		},
+	}
+
+	for _, c := range testCases {
+		actual := nameFromAppFile(c.appFile)
+
+		if actual != c.expectedName {
+			t.Errorf("Error getting name from %v got;\n%v\nwant;\n%v", c.appFile, actual, c.expectedName)
+		}
+	}
+}
+
 // Pformat returns a pretty format output of any value.
 func Pformat(value interface{}) (string, error) {
 	if s, ok := value.(string); ok {

--- a/components/gatekeeper/go.mod
+++ b/components/gatekeeper/go.mod
@@ -5,3 +5,5 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	golang.org/x/crypto v0.0.0-20180904163835-0709b304e793
 )
+
+go 1.13

--- a/testing/kfctl/kf_is_ready_test.py
+++ b/testing/kfctl/kf_is_ready_test.py
@@ -12,13 +12,21 @@ import pytest
 from kubeflow.testing import util
 from testing import deploy_utils
 
+def set_logging():
+  logging.basicConfig(level=logging.INFO,
+                      format=('%(levelname)s|%(asctime)s'
+                              '|%(pathname)s|%(lineno)d| %(message)s'),
+                      datefmt='%Y-%m-%dT%H:%M:%S',
+                      )
+  logging.getLogger().setLevel(logging.INFO)
+
 def test_kf_is_ready(namespace, use_basic_auth, use_istio, app_path):
   """Test that Kubeflow was successfully deployed.
 
   Args:
     namespace: The namespace Kubeflow is deployed to.
   """
-
+  set_logging()
   logging.info("Using namespace %s", namespace)
 
   # Need to activate account for scopes.

--- a/testing/kfctl/kfctl_delete_test.py
+++ b/testing/kfctl/kfctl_delete_test.py
@@ -19,7 +19,7 @@ from oauth2client.client import GoogleCredentials
 # TODO(gabrielwen): Move this to a separate test "kfctl_go_check_post_delete"
 def get_endpoints_list(project):
   cred = GoogleCredentials.get_application_default()
-  services_mgt = discovery.build('servicemanagement', 'v1', credentials=cred)
+  services_mgt = discovery.build('servicemanagement', 'v1', credentials=cred, cache_discovery=False)
   services = services_mgt.services()
   next_page_token = None
   endpoints = []

--- a/testing/kfctl/kfctl_delete_test.py
+++ b/testing/kfctl/kfctl_delete_test.py
@@ -62,6 +62,8 @@ def test_kfctl_delete(kfctl_path, app_path, project, cluster_deletion_script):
     util.run([kfctl_path, "delete", "--delete_storage", "-V"],
              cwd=app_path)
 
+  run_delete()
+
   # Use services.list instead of services.get because error returned is not
   # 404, it's 403 which is confusing.
   name = os.path.basename(app_path)

--- a/testing/kfctl/kfctl_delete_test.py
+++ b/testing/kfctl/kfctl_delete_test.py
@@ -54,8 +54,13 @@ def test_kfctl_delete(kfctl_path, app_path, project, cluster_deletion_script):
   logging.info("Using kfctl path %s", kfctl_path)
   logging.info("Using app path %s", app_path)
 
-  util.run([kfctl_path, "delete", "--delete_storage", "-V"],
-           cwd=app_path)
+  # We see failures because delete will try to update the IAM policy which only allows
+  # 1 update at a time. To deal with this we do retries.
+  # This has a potential downside of hiding errors that are fixed by retrying.
+  @retry(stop_max_delay=60*3*1000)
+  def run_delete():
+    util.run([kfctl_path, "delete", "--delete_storage", "-V"],
+             cwd=app_path)
 
   # Use services.list instead of services.get because error returned is not
   # 404, it's 403 which is confusing.


### PR DESCRIPTION
* This matches 0.6 semantics by defaulting.

* More importantly this enables a user to do

  mkdir ${KFAPP}
  kfctl apply -V -f https://...

* Related to kubeflow/kfctl#52

* #4275 needs to be merged first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4287)
<!-- Reviewable:end -->
