### PR TITLE
Update e2e tests

### DIFF
--- a/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
@@ -133,21 +133,21 @@ func Test_repoVersionToRepoStruct(t *testing.T) {
 
 func Test_nameFromAppFile(t *testing.T) {
 	type testCase struct {
-		appFile string
+		appFile      string
 		expectedName string
 	}
 
 	testCases := []testCase{
 		{
-			appFile: "/mykfapp/kfctl.yaml",
+			appFile:      "/mykfapp/kfctl.yaml",
 			expectedName: "mykfapp",
 		},
 		{
-			appFile: "/parentdir/subapp/app.yaml",
+			appFile:      "/parentdir/subapp/app.yaml",
 			expectedName: "subapp",
 		},
 		{
-			appFile:     "/kfctl.yaml",
+			appFile:      "/kfctl.yaml",
 			expectedName: "",
 		},
 	}

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -28,59 +28,32 @@ workflows:
     params:
       installIstio: true
       workflowName: deployapp-istio
+  ### GCP IAP
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-iap-endpoint
     job_types:
+      - presubmit
       - postsubmit
       - periodic
     include_dirs:
       - bootstrap/*
-      - deployment/*
-      - dependencies/*
       - kubeflow/*
       - testing/*
+      - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
     kwargs:
       use_basic_auth: false
       test_endpoint: true
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    component: kfctl_go_test
-    name: kfctl-go-iap-istio
-    job_types:
-      - presubmit
-    include_dirs:
-      - bootstrap/*
-      - kubeflow/*
-      - testing/*
-    kwargs:
-      use_basic_auth: false
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
-  # If the kfctl_e2e_workflow.py was modified then on presubmit we also want to run with test_endpoint true
-  # to ensure that test still pasess
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    component: kfctl_go_test
-    name: kfctl-gcp-e2e-changed
-    job_types:
-      - presubmit
-    include_dirs:
-      - bootstrap/*
-      - kubeflow/*
-      - testing/*
-      - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
-    kwargs:
-      use_basic_auth: false
-      test_endpoint: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
-  # Run basic auth test as part of every periodic and postsubmit run. 
+  ### GCP BasicAuth
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-basic-auth
     job_types:
+      - presubmit
       - postsubmit
       - periodic
     include_dirs:
+      # If kfctl is modified make sure basic auth still works
       - bootstrap/*
-      - deployment/*
-      - kubeflow/*
       - testing/*
     kwargs:
       use_basic_auth: true
@@ -109,34 +82,6 @@ workflows:
       cluster_creation_script: create_existing_cluster.sh
       cluster_deletion_script: delete_existing_cluster.py
       nameSuffix: existing_arrikto
-  # Only run  kfctl presubmit test with basic auth if
-  # files related to basic auth are modified.
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-build-deploy
-    job_types:
-      - presubmit
-    include_dirs:
-      # If kfctl is modified make sure basic auth still works
-      - bootstrap/*
-      - testing/kfctl/*
-    kwargs:
-      use_basic_auth: true
-      # test new semantics - kfctl build -f -> kfctl apply
-      build_and_apply: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_basic_auth.yaml
-  # Only run  kfctl presubmit test with basic auth if
-  # files related to basic auth are modified.
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-basic-auth
-    job_types:
-      - presubmit
-    include_dirs:
-      # If kfctl is modified make sure basic auth still works
-      - bootstrap/*
-      - testing/kfctl/*
-    kwargs:
-      use_basic_auth: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_basic_auth.yaml
   # Run unittests
   # TODO(jlewi): Need to add step to run go and python unittests
   - app_dir: kubeflow/kubeflow/testing/workflows

--- a/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
@@ -73,7 +73,7 @@ class Builder:
                bucket="kubeflow-ci_temp",
                test_endpoint=False,
                use_basic_auth=False,
-               build_and_apply=False,
+               build_and_apply=True,
                kf_app_name=None, delete_kf=True,):
     """Initialize a builder.
 


### PR DESCRIPTION
- always use build_and_apply, since the old semantic is not supported 
- kfctl-go-iap-istio is covered by kfctl-gcp-e2e-changed, and kfctl-gcp-e2e-changed is the same as kfctl-go-iap-endpoint, so combine them.
- combine basic_auth pre and post submit, and remove build_deploy since build_and_apply is true

/cc @kunmingg @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4318)
<!-- Reviewable:end -->
