### PR TITLE
kfctl support relative path 

### DIFF
--- a/bootstrap/go.sum
+++ b/bootstrap/go.sum
@@ -213,6 +213,7 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kubeflow/kfctl/v3 v3.0.0-20190917231916-6ebaf60b014a h1:Ei8KwtQhDv3sZd9qGXRZ5C3bMEcJTsnLUGcX5nlw53k=
 github.com/kubeflow/kfctl/v3 v3.0.0-20190917231916-6ebaf60b014a/go.mod h1:Ae5GXOlxQv7BgEoLS9YM9i2c8HeqB5BaexQUJQhh1y4=
+github.com/kubeflow/kubeflow v0.6.2 h1:VmCSCFBGK4DpFPYuqBkwADT8CYXDlnVc82S9znP64uE=
 github.com/kubeflow/kubeflow/components/profile-controller v0.0.0-20190614045418-7ca3cfb39368 h1:gnKmaIcUJVpS2msVv0yZ1rn+LPcgbyDdOMFp77b8gTk=
 github.com/kubeflow/kubeflow/components/profile-controller v0.0.0-20190614045418-7ca3cfb39368/go.mod h1:8+oH8wqe/KytWmiHPYMkcJzl9wV6Ww1tJYlkty5DfhI=
 github.com/magiconair/properties v1.8.0 h1:LLgXmsheXeRoUOBOjtwPQCWIYqM/LU1ayDtDePerRcY=

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -265,7 +264,6 @@ func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
 
 	// If the config file is a remote URI, check to see if the current directory
 	// is empty because we will be generating the KfApp there.
-	cwd := ""
 	appFile := cfgfile
 	if isRemoteFile {
 		cwd, _ := os.Getwd()
@@ -342,20 +340,7 @@ func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
 		c.PackageManagers[kftypesv3.KUSTOMIZE] = pkg
 	}
 
-	// If the config file is downloaded remotely, use the current working directory to create the KfApp.
-	// Otherwise use the directory where the config file is stored.
-	if isRemoteFile {
-		cwd, err = os.Getwd()
-		if err != nil {
-			return nil, &kfapis.KfError{
-				Code:    int(kfapis.INTERNAL_ERROR),
-				Message: fmt.Sprintf("could not get current directory for KfDef %v", err),
-			}
-		}
-		c.KfDef.Spec.AppDir = cwd
-	} else {
-		c.KfDef.Spec.AppDir = path.Dir(cfgfile)
-	}
+	c.KfDef.Spec.AppDir = filepath.Dir(appFile)
 
 	// Set some defaults
 	// TODO(jlewi): This code doesn't belong here. It should probably be called from inside KfApp; e.g. from

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -146,15 +146,13 @@ func repoVersionToUri(repo string, version string) string {
 	return tarballUrl
 }
 
-// isCwdEmpty - quick check to determine if the working directory is empty
-// if the current working directory
-func isCwdEmpty() string {
-	cwd, _ := os.Getwd()
-	files, _ := ioutil.ReadDir(cwd)
+// isDirEmpty - quick check to determine if the  directory is empty
+func isDirEmpty(dir string) bool {
+	files, _ := ioutil.ReadDir(dir)
 	if len(files) > 1 {
-		return ""
+		return false
 	}
-	return cwd
+	return true
 }
 
 // NewLoadKfAppFromURI takes in a config file and constructs the KfApp
@@ -270,12 +268,11 @@ func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
 	cwd := ""
 	appFile := cfgfile
 	if isRemoteFile {
-		cwd = isCwdEmpty()
-		if cwd == "" {
-			wd, _ := os.Getwd()
+		cwd, _ := os.Getwd()
+		if !isDirEmpty(cwd) {
 			return nil, &kfapis.KfError{
 				Code:    int(kfapis.INVALID_ARGUMENT),
-				Message: fmt.Sprintf("current directory %v not empty, please switch directories", wd),
+				Message: fmt.Sprintf("current directory %v not empty, please switch directories", cwd),
 			}
 		}
 

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -19,7 +19,6 @@ package coordinator
 import (
 	"fmt"
 	"io/ioutil"
-	netUrl "net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -36,6 +35,7 @@ import (
 	"github.com/kubeflow/kubeflow/bootstrap/v3/pkg/kfapp/gcp"
 	"github.com/kubeflow/kubeflow/bootstrap/v3/pkg/kfapp/kustomize"
 	"github.com/kubeflow/kubeflow/bootstrap/v3/pkg/kfapp/minikube"
+	"github.com/kubeflow/kubeflow/bootstrap/v3/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -260,22 +260,14 @@ func nameFromAppFile(appFile string) string {
 
 // LoadKfAppCfgFile constructs a KfApp by loading the provided app.yaml file.
 func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
-	url, err := netUrl.Parse(cfgfile)
-	isRemoteFile := false
-	cwd := ""
+	isRemoteFile, err := utils.IsRemoteFile(cfgfile)
 	if err != nil {
-		return nil, &kfapis.KfError{
-			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("Error parsing config file path: %v", err),
-		}
-	} else {
-		if url.Scheme != "" {
-			isRemoteFile = true
-		}
+		return nil, err
 	}
 
 	// If the config file is a remote URI, check to see if the current directory
 	// is empty because we will be generating the KfApp there.
+	cwd := ""
 	appFile := cfgfile
 	if isRemoteFile {
 		cwd = isCwdEmpty()

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -260,7 +260,7 @@ func nameFromAppFile(appFile string) string {
 
 // LoadKfAppCfgFile constructs a KfApp by loading the provided app.yaml file.
 func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
-	url, err := netUrl.ParseRequestURI(cfgfile)
+	url, err := netUrl.Parse(cfgfile)
 	isRemoteFile := false
 	cwd := ""
 	if err != nil {

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -300,6 +300,7 @@ func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
 		}
 	}
 
+	kfdef.Spec.AppDir = filepath.Dir(appFile)
 	// Since we know we have a local file we can set a default name if none is set based on the local directory
 	if kfdef.Name == "" {
 		kfdef.Name = nameFromAppFile(appFile)
@@ -339,8 +340,6 @@ func LoadKfAppCfgFile(cfgfile string) (kftypesv3.KfApp, error) {
 	if pkg != nil {
 		c.PackageManagers[kftypesv3.KUSTOMIZE] = pkg
 	}
-
-	c.KfDef.Spec.AppDir = filepath.Dir(appFile)
 
 	// Set some defaults
 	// TODO(jlewi): This code doesn't belong here. It should probably be called from inside KfApp; e.g. from
@@ -553,7 +552,8 @@ func (kfapp *coordinator) Generate(resources kftypesv3.ResourceEnum) error {
 							kfapp.KfDef.Spec.Platform, platformErr),
 					}
 				}
-				createConfigErr := configconverters.WriteConfigToFile(*kfapp.KfDef, kftypesv3.KfConfigFile)
+				createConfigErr := configconverters.WriteConfigToFile(
+					*kfapp.KfDef, filepath.Join(kfapp.KfDef.Spec.AppDir, kftypesv3.KfConfigFile))
 				if createConfigErr != nil {
 					return &kfapis.KfError{
 						Code: createConfigErr.(*kfapis.KfError).Code,
@@ -623,7 +623,8 @@ func (kfapp *coordinator) Init(resources kftypesv3.ResourceEnum) error {
 							kfapp.KfDef.Spec.Platform, platformErr),
 					}
 				}
-				createConfigErr := configconverters.WriteConfigToFile(*kfapp.KfDef, kftypesv3.KfConfigFile)
+				createConfigErr := configconverters.WriteConfigToFile(
+					*kfapp.KfDef, filepath.Join(kfapp.KfDef.Spec.AppDir, kftypesv3.KfConfigFile))
 				if createConfigErr != nil {
 					return &kfapis.KfError{
 						Code: createConfigErr.(*kfapis.KfError).Code,

--- a/bootstrap/pkg/utils/k8utils.go
+++ b/bootstrap/pkg/utils/k8utils.go
@@ -121,23 +121,29 @@ func CreateResourceFromFile(config *rest.Config, filename string, elems ...confi
 	return nil
 }
 
-func GetObjectKindFromUri(configFile string) (string, error) {
+// Checks if the path configFile is remote (e.g. http://github...)
+func IsRemoteFile(configFile string) (bool, error) {
 	if configFile == "" {
-		return "", fmt.Errorf("config file must be a URI or a path")
+		return false, fmt.Errorf("config file must be a URI or a path")
 	}
-
-	// Check if configFile is a remote file.
 	url, err := netUrl.Parse(configFile)
-	isRemoteFile := false
 	if err != nil {
-		return "", &kfapis.KfError{
+		return false, &kfapis.KfError{
 			Code:    int(kfapis.INVALID_ARGUMENT),
-			Message: fmt.Sprintf("Error parsing config file path: %v", err),
+			Message: fmt.Sprintf("Error parsing file path: %v", err),
 		}
 	} else {
 		if url.Scheme != "" {
-			isRemoteFile = true
+			return true, nil
 		}
+		return false, nil
+	}
+}
+
+func GetObjectKindFromUri(configFile string) (string, error) {
+	isRemoteFile, err := IsRemoteFile(configFile)
+	if err != nil {
+		return "", err
 	}
 
 	// We will read from appFile.

--- a/bootstrap/pkg/utils/k8utils.go
+++ b/bootstrap/pkg/utils/k8utils.go
@@ -132,12 +132,11 @@ func IsRemoteFile(configFile string) (bool, error) {
 			Code:    int(kfapis.INVALID_ARGUMENT),
 			Message: fmt.Sprintf("Error parsing file path: %v", err),
 		}
-	} else {
-		if url.Scheme != "" {
-			return true, nil
-		}
-		return false, nil
 	}
+	if url.Scheme != "" {
+		return true, nil
+	}
+	return false, nil
 }
 
 func GetObjectKindFromUri(configFile string) (string, error) {

--- a/bootstrap/pkg/utils/k8utils_test.go
+++ b/bootstrap/pkg/utils/k8utils_test.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"testing"
+)
+
+func Test_IsRemoteFile(t *testing.T) {
+	type testCase struct {
+		filePath string
+		isRemote bool
+	}
+
+	testCases := []testCase{
+		{
+			filePath: "http://github.com",
+			isRemote: true,
+		},
+		{
+			filePath: "../abc.txt",
+			isRemote: false,
+		},
+		{
+			filePath: "/ab/c.txt",
+			isRemote: false,
+		},
+	}
+
+	for _, test := range testCases {
+		isRemote, err := IsRemoteFile(test.filePath)
+		if err != nil {
+			t.Errorf("Error checking IsRemoteFile: %v", err)
+		}
+		if isRemote != test.isRemote {
+			t.Errorf("check if path %v is remote; expect %v, got %v", test.filePath, test.isRemote, isRemote)
+		}
+	}
+}

--- a/bootstrap/pkg/utils/k8utils_test.go
+++ b/bootstrap/pkg/utils/k8utils_test.go
@@ -23,6 +23,10 @@ func Test_IsRemoteFile(t *testing.T) {
 			filePath: "/ab/c.txt",
 			isRemote: false,
 		},
+		{
+			filePath: "abc.txt",
+			isRemote: false,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
use neturl.Parse instead of ParseRequestURI because the latter only works with abs path.

https://golang.org/pkg/net/url/#ParseRequestURI

/cc @jlewi @richardsliu 

https://github.com/kubeflow/kfctl/issues/49

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4331)
<!-- Reviewable:end -->
