### PR TITLE
Drastically reduce the presubmits triggered for kfctl to reduce pain.

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -29,48 +29,23 @@ workflows:
       installIstio: true
       workflowName: deployapp-istio
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-iap-endpoint
+    name: kfctl-go-iap
     job_types:
+      - presubmit
       - postsubmit
       - periodic
     include_dirs:
       - bootstrap/*
-      - deployment/*
-      - dependencies/*
-      - kubeflow/*
-      - testing/*
-    kwargs:
-      use_basic_auth: false
-      test_endpoint: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    component: kfctl_go_test
-    name: kfctl-go-iap-istio
-    job_types:
-      - presubmit
-    include_dirs:
-      - bootstrap/*
-      - kubeflow/*
-      - testing/*
-    kwargs:
-      use_basic_auth: false
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
-  # If the kfctl_e2e_workflow.py was modified then on presubmit we also want to run with test_endpoint true
-  # to ensure that test still pasess
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    component: kfctl_go_test
-    name: kfctl-gcp-e2e-changed
-    job_types:
-      - presubmit
-    include_dirs:
-      - bootstrap/*
-      - kubeflow/*
       - testing/*
       - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
     kwargs:
       use_basic_auth: false
+      # Run build and then apply rather than just apply
+      build_and_apply: true
+      # test_endpoint flag is actually deprecated; we use pytest annotations to skip on
+      # presubmit.
       test_endpoint: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml  
   # Run basic auth test as part of every periodic and postsubmit run. 
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-basic-auth
@@ -92,7 +67,10 @@ workflows:
     job_types:
       # Enable once we have confirmed the stability of the test
       # - presubmit
+      # TODO(jlewi): I don't think we want to enable on presubmit. 
+      # see https://github.com/kubeflow/kfctl/issues/57
       - postsubmit
+      - periodic
     include_dirs:
       - bootstrap/*
       - dependencies/*
@@ -108,35 +86,7 @@ workflows:
       configPath: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_existing_arrikto.yaml
       cluster_creation_script: create_existing_cluster.sh
       cluster_deletion_script: delete_existing_cluster.py
-      nameSuffix: existing_arrikto
-  # Only run  kfctl presubmit test with basic auth if
-  # files related to basic auth are modified.
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-build-deploy
-    job_types:
-      - presubmit
-    include_dirs:
-      # If kfctl is modified make sure basic auth still works
-      - bootstrap/*
-      - testing/kfctl/*
-    kwargs:
-      use_basic_auth: true
-      # test new semantics - kfctl build -f -> kfctl apply
-      build_and_apply: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_basic_auth.yaml
-  # Only run  kfctl presubmit test with basic auth if
-  # files related to basic auth are modified.
-  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-basic-auth
-    job_types:
-      - presubmit
-    include_dirs:
-      # If kfctl is modified make sure basic auth still works
-      - bootstrap/*
-      - testing/kfctl/*
-    kwargs:
-      use_basic_auth: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_basic_auth.yaml
+      nameSuffix: existing_arrikto  
   # Run unittests
   # TODO(jlewi): Need to add step to run go and python unittests
   - app_dir: kubeflow/kubeflow/testing/workflows

--- a/testing/kfctl/endpoint_ready_test.py
+++ b/testing/kfctl/endpoint_ready_test.py
@@ -15,6 +15,10 @@ from testing import gcp_util
 # TODO(https://github.com/kubeflow/kfctl/issues/42):
 # Test is failing pretty consistently.
 @pytest.mark.xfail
+# There's really no good reason to run test_endpoint during presubmits.
+# We shouldn't need it to feel confident that kfctl is working.
+@pytest.mark.skipif(os.getenv("JOB_TYPE") == "presubmit",
+                    reason="test endpoint doesn't run in presubmits")
 def test_endpoint_is_ready(project, app_name):
   """Test that Kubeflow was successfully deployed.
 


### PR DESCRIPTION
* See kubeflow/kfctl#57 kfctl testing is overly reliant on expensive, flaky
  E2E tests; right now we aren't testing kfctl so much as all of Kubeflow.

* This is cauing a lot of pain and negatively impacting velocity of kfctl.

* Right now we are running multiple variants of the same expensive e2e
  tests on presubmits.

  * These additional tests are providing minimal additional coverage on
    presubmit but the flakiness is a major drag on velocity

* Don't run kfctl-gcp-basic-auth on presubmit; this provides minimal
  additional coverage on presubmit

* Delete kfctl-go-build-deploy - the difference between this test
  and the other e2e tests is that it was invoking kfctl build followed by
  kfctl apply rather than just apply.

  * This provides minimal additional coverage
  * Instead just always run the 2 step process.
  * We should use unittests/mocks or some other cheaper solution to
    capture the differences with just running kfctl apply.

* Delete kfctl-gcp-e2e-changed

  * The only difference between this and kfctl-gcp-iap was that it was
    selectively enabling the endpoint test on some presubmits

  * We should just disable test_endpoint on all presubmits
  * the endpoint_test isn't a kfctl test so much as an all of Kubeflow test

  * Modify test_endpoint.py to use pytest annotations to selectively
    skip the test on presubmit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4337)
<!-- Reviewable:end -->
