### PR TITLE
[WIP] Removes legacy ordering from kustomize.go

### DIFF
--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -53,7 +53,6 @@ import (
 	"sigs.k8s.io/kustomize/v3/pkg/target"
 	"sigs.k8s.io/kustomize/v3/pkg/types"
 	"sigs.k8s.io/kustomize/v3/pkg/validators"
-	"sigs.k8s.io/kustomize/v3/plugin/builtin"
 	"strings"
 	"time"
 
@@ -936,10 +935,6 @@ func EvaluateKustomizeManifest(compDir string) (resmap.ResMap, error) {
 		return nil, err
 	}
 	allResources, err := kt.MakeCustomizedResMap()
-	if err != nil {
-		return nil, err
-	}
-	err = builtin.NewLegacyOrderTransformerPlugin().Transform(allResources)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Keeps order of resources as-is in kustomization.yaml file
Overlay resources are applied before base resources and in the order mentioned in KfDef.

Resolves kubeflow/manifests#543
Related to  #4327

/assign @kkasravi @yanniszark

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4340)
<!-- Reviewable:end -->
