### PR TITLE
[centraldashboard] Clear iframe state when user navigates away.

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -239,6 +239,10 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         if (hideSidebar || isIframe !== this.inIframe || isIframe) {
             this.$.MainDrawer.close();
         }
+
+        if (!isIframe) {
+            this.iframeSrc = 'about:blank';
+        }
     }
 
     /**

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -247,4 +247,20 @@ describe('Main Page', () => {
         expect(mainPage.iframeSrc).toMatch(
             new RegExp(`${window.location.origin}/pipeline/?.*foo=bar${hash}`));
     });
+
+    it('Sets iframeSrc to about:blank when user navigates to non-iframe page',
+        () => {
+            mainPage.subRouteData.path = '/pipeline/';
+            mainPage._routePageChanged('_');
+            flush();
+
+            expect(mainPage.iframeSrc).toMatch(
+                new RegExp(`${window.location.origin}/pipeline/`));
+
+            mainPage.subRouteData.path = '';
+            mainPage._routePageChanged('activity');
+            flush();
+
+            expect(mainPage.iframeSrc).toBe('about:blank');
+        });
 });


### PR DESCRIPTION
Fixes #4334

This ensures that embedded apps like Pipelines and Metadata which
use hash-based routing reload when the user navigates away and comes
back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4341)
<!-- Reviewable:end -->
