### PR TITLE
Resolves manifest apply retry issues with kfctl

### DIFF
--- a/bootstrap/go.sum
+++ b/bootstrap/go.sum
@@ -82,6 +82,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
+github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
 github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=

--- a/bootstrap/pkg/utils/k8utils.go
+++ b/bootstrap/pkg/utils/k8utils.go
@@ -315,7 +315,6 @@ func (a *Apply) Apply(data []byte) error {
 func (a *Apply) run() error {
 	resourcesErr := a.options.Run()
 	if resourcesErr != nil {
-		cmdutil.CheckErr(resourcesErr)
 		return &kfapis.KfError{
 			Code:    int(kfapis.INTERNAL_ERROR),
 			Message: fmt.Sprintf("Apply.Run  Error %v", resourcesErr),


### PR DESCRIPTION
Resolves #4327 

[cmdutil.CheckErr](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go#L119) exits execution in apply.run(). 

Now CheckError has been moved to kustomization.go instead - so that retry is functional.

P.S. Credits to @johnugeorge for suggesting this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4359)
<!-- Reviewable:end -->
