### PR TITLE
Define some postsubmit and periodic jobs for the v0.7-branch

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -214,22 +214,22 @@ workflows:
   # to pull the kfdef specs from the v0.7 branch of manifests.
   #***************************************************************************************************************************************
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-  name: kfctl-go-iap-v07
-  job_types:
-    - postsubmit
-    - periodic
-  include_dirs:
-    - bootstrap/*
-    - testing/*
-    - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
-  kwargs:
-    use_basic_auth: false
-    # Run build and then apply rather than just apply
-    build_and_apply: true
-    # test_endpoint flag is actually deprecated; we use pytest annotations to skip on
-    # presubmit.
-    test_endpoint: true
-    config_path: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.yaml
+    name: kfctl-go-iap-v07
+    job_types:
+      - postsubmit
+      - periodic
+    include_dirs:
+      - bootstrap/*
+      - testing/*
+      - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
+    kwargs:
+      use_basic_auth: false
+      # Run build and then apply rather than just apply
+      build_and_apply: true
+      # test_endpoint flag is actually deprecated; we use pytest annotations to skip on
+      # presubmit.
+      test_endpoint: true
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.yaml
   # Run basic auth test as part of every periodic and postsubmit run. 
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-basic-auth-v07

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -205,7 +205,6 @@ workflows:
       step_image: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4"
     include_dirs:
       - components/jupyter-web-app/*
-
   #***************************************************************************************************************************************
   # v0-7 tests
   #
@@ -214,23 +213,23 @@ workflows:
   # is cut. At that point we should probably get rid of them and just update the tests earlier in this file
   # to pull the kfdef specs from the v0.7 branch of manifests.
   #***************************************************************************************************************************************
-    - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
-    name: kfctl-go-iap-v07
-    job_types:
-      - postsubmit
-      - periodic
-    include_dirs:
-      - bootstrap/*
-      - testing/*
-      - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
-    kwargs:
-      use_basic_auth: false
-      # Run build and then apply rather than just apply
-      build_and_apply: true
-      # test_endpoint flag is actually deprecated; we use pytest annotations to skip on
-      # presubmit.
-      test_endpoint: true
-      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.yaml
+  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
+  name: kfctl-go-iap-v07
+  job_types:
+    - postsubmit
+    - periodic
+  include_dirs:
+    - bootstrap/*
+    - testing/*
+    - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
+  kwargs:
+    use_basic_auth: false
+    # Run build and then apply rather than just apply
+    build_and_apply: true
+    # test_endpoint flag is actually deprecated; we use pytest annotations to skip on
+    # presubmit.
+    test_endpoint: true
+    config_path: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.yaml
   # Run basic auth test as part of every periodic and postsubmit run. 
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-basic-auth-v07

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -205,3 +205,71 @@ workflows:
       step_image: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4"
     include_dirs:
       - components/jupyter-web-app/*
+
+  #***************************************************************************************************************************************
+  # v0-7 tests
+  #
+  # TODO(https://github.com/kubeflow/testing/issues/498): The 0.7 tests are currently
+  # deefined on the master branch. They should move to an appropriate branch once the branch
+  # is cut. At that point we should probably get rid of them and just update the tests earlier in this file
+  # to pull the kfdef specs from the v0.7 branch of manifests.
+  #***************************************************************************************************************************************
+    - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
+    name: kfctl-go-iap-v07
+    job_types:
+      - postsubmit
+      - periodic
+    include_dirs:
+      - bootstrap/*
+      - testing/*
+      - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
+    kwargs:
+      use_basic_auth: false
+      # Run build and then apply rather than just apply
+      build_and_apply: true
+      # test_endpoint flag is actually deprecated; we use pytest annotations to skip on
+      # presubmit.
+      test_endpoint: true
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_iap.yaml
+  # Run basic auth test as part of every periodic and postsubmit run. 
+  - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
+    name: kfctl-go-basic-auth-v07
+    job_types:
+      - postsubmit
+      - periodic
+    include_dirs:
+      - bootstrap/*
+      - deployment/*
+      - kubeflow/*
+      - testing/*
+    kwargs:
+      use_basic_auth: true
+      config_path: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_basic_auth.yaml
+  # E2E tests for kfctl_existing_arrikto 
+  - app_dir: kubeflow/kubeflow/testing/workflows
+    component: kfctl_go_test
+    name: kfctl-go-existing-v07
+    job_types:
+      # Enable once we have confirmed the stability of the test
+      # - presubmit
+      # TODO(jlewi): I don't think we want to enable on presubmit. 
+      # see https://github.com/kubeflow/kfctl/issues/57
+      - postsubmit
+      - periodic
+    include_dirs:
+      - bootstrap/*
+      - dependencies/*
+      - kubeflow/*
+      - testing/*
+    params:
+      platform: gke
+      gkeApiVersion: v1
+      workflowName: kfctl-go
+      useBasicAuth: false
+      useIstio: true
+      testEndpoint: false
+      configPath: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_existing_arrikto.yaml
+      cluster_creation_script: create_existing_cluster.sh
+      cluster_deletion_script: delete_existing_cluster.py
+      nameSuffix: existing_arrikto    
+  


### PR DESCRIPTION
* Now that we have cut v0.7-branch of kubeflow/manifests we want to
  start periodicially testing kfctl with the v0.7-branch of manifests.

* We don't have a v0.7-branch yet for kfctl so for now we test against
  kubeflow/kubeflow master which is still where we are for kfctl.

* Related to kubeflow/testing#498

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4361)
<!-- Reviewable:end -->
