### PR TITLE
Fix apply overrides custom changes after Build

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -2034,9 +2034,12 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 // Remind: Need to be thread-safe: this entry is share among kfctl and deploy app
 func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 	gcpDir := path.Join(gcp.kfDef.Spec.AppDir, GCP_CONFIG)
-	if _, err := os.Stat(gcpDir); !os.IsNotExist(err) {
+	if _, err := os.Stat(gcpDir); err == nil {
 		// Noop if the directory already exists.
 		return nil
+	} else if !os.IsNotExist(err) {
+		log.Errorf("Stat folder %v error: %v; try deleting it...", gcpDir, err)
+		_ = os.RemoveAll(gcpDir)
 	}
 
 	if err := gcp.kfDef.SyncCache(); err != nil {

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -2036,6 +2036,7 @@ func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 	gcpDir := path.Join(gcp.kfDef.Spec.AppDir, GCP_CONFIG)
 	if _, err := os.Stat(gcpDir); err == nil {
 		// Noop if the directory already exists.
+		log.Infof("folder %v exists, skip gcp.Generate", gcpDir)
 		return nil
 	} else if !os.IsNotExist(err) {
 		log.Errorf("Stat folder %v error: %v; try deleting it...", gcpDir, err)

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -2033,6 +2033,12 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 // Generate generates the gcp kfapp manifest.
 // Remind: Need to be thread-safe: this entry is share among kfctl and deploy app
 func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
+	gcpDir := path.Join(gcp.kfDef.Spec.AppDir, GCP_CONFIG)
+	if _, err := os.Stat(gcpDir); !os.IsNotExist(err) {
+		// Noop if the directory already exists.
+		return nil
+	}
+
 	if err := gcp.kfDef.SyncCache(); err != nil {
 		log.Errorf("Failed to synchronize the cache; error %v", err)
 		return errors.WithStack(err)

--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -295,10 +295,15 @@ func (kustomize *kustomize) Generate(resources kftypesv3.ResourceEnum) error {
 	generate := func() error {
 		kustomizeDir := path.Join(kustomize.kfDef.Spec.AppDir, outputDir)
 
-		if _, err := os.Stat(kustomizeDir); !os.IsNotExist(err) {
+		if _, err := os.Stat(kustomizeDir); err == nil {
 			// Noop if the directory already exists.
+			log.Infof("folder %v exists, skip kustomize.Generate", kustomizeDir)
 			return nil
+		} else if !os.IsNotExist(err) {
+			log.Errorf("Stat folder %v error: %v; try deleting it...", kustomizeDir, err)
+			_ = os.RemoveAll(kustomizeDir)
 		}
+
 		kustomizeDirErr := os.MkdirAll(kustomizeDir, os.ModePerm)
 		if kustomizeDirErr != nil {
 			return &kfapisv3.KfError{

--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -295,9 +295,9 @@ func (kustomize *kustomize) Generate(resources kftypesv3.ResourceEnum) error {
 	generate := func() error {
 		kustomizeDir := path.Join(kustomize.kfDef.Spec.AppDir, outputDir)
 
-		// idempotency
 		if _, err := os.Stat(kustomizeDir); !os.IsNotExist(err) {
-			_ = os.RemoveAll(kustomizeDir)
+			// Noop if the directory already exists.
+			return nil
 		}
 		kustomizeDirErr := os.MkdirAll(kustomizeDir, os.ModePerm)
 		if kustomizeDirErr != nil {


### PR DESCRIPTION
Related: #4368 

Decision:
1. Skip `kustomize.Generate` if the folder `kustomize/` already exists.
1. Skip `gcp.Generate` if the folder `gcp_configs/` already exists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4369)
<!-- Reviewable:end -->
