### PR TITLE
cleanup coordinator interface

### DIFF
--- a/bootstrap/cmd/kfctl/cmd/apply.go
+++ b/bootstrap/cmd/kfctl/cmd/apply.go
@@ -62,7 +62,7 @@ var applyCmd = &cobra.Command{
 		}
 		switch kind {
 		case string(kftypes.KFDEF):
-			kfApp, err = coordinator.BuildKfAppFromURI(configFilePath)
+			kfApp, err = coordinator.NewLoadKfAppFromURI(configFilePath)
 			if err != nil {
 				return fmt.Errorf("failed to build kfApp from URI %s: %v", configFilePath, err)
 			}

--- a/bootstrap/cmd/kfctl/cmd/build.go
+++ b/bootstrap/cmd/kfctl/cmd/build.go
@@ -46,7 +46,7 @@ var buildCmd = &cobra.Command{
 		}
 
 		if kind == string(kftypes.KFDEF) {
-			_, err = coordinator.BuildKfAppFromURI(configFilePath)
+			_, err = coordinator.NewLoadKfAppFromURI(configFilePath)
 		} else if kind == string(kftypes.KFUPGRADE) {
 			kfUpgrade, kfUpgradeErr := kfupgrade.NewKfUpgrade(configFilePath)
 			if kfUpgradeErr != nil {

--- a/bootstrap/cmd/kfctl/cmd/delete.go
+++ b/bootstrap/cmd/kfctl/cmd/delete.go
@@ -41,7 +41,8 @@ var deleteCmd = &cobra.Command{
 		if configFilePath == "" {
 			return fmt.Errorf("Must pass in -f configFile")
 		}
-		kfApp, err = coordinator.BuildKfAppFromURI(configFilePath)
+		// TODO: should we check if the configFilePath is local?
+		kfApp, err = coordinator.NewLoadKfAppFromURI(configFilePath)
 		if err != nil || kfApp == nil {
 			return fmt.Errorf("error loading kfapp: %v", err)
 		}

--- a/bootstrap/cmd/kfctl/cmd/show.go
+++ b/bootstrap/cmd/kfctl/cmd/show.go
@@ -40,7 +40,7 @@ var showCmd = &cobra.Command{
 		if resourceErr != nil {
 			return fmt.Errorf("invalid resource: %v", resourceErr)
 		}
-		kfApp, kfAppErr := coordinator.LoadKfAppCfgFile(configFilePath)
+		kfApp, kfAppErr := coordinator.NewLoadKfAppFromURI(configFilePath)
 		if kfAppErr != nil {
 			return fmt.Errorf("couldn't load KfApp: %v", kfAppErr)
 		}

--- a/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator_test.go
@@ -91,7 +91,7 @@ func Test_CreateKfAppCfgFile(t *testing.T) {
 		}
 
 		c.Input.Spec.AppDir = tDir
-		cfgFile, err := CreateKfAppCfgFile(&c.Input)
+		cfgFile, err := createKfAppCfgFile(&c.Input)
 
 		pCase, _ := Pformat(c)
 		hasError := err != nil

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1997,7 +1997,7 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 		gcp.kfDef.Spec.Email = strings.TrimSpace(email)
 		pluginSpec.Email = strings.TrimSpace(email)
 		log.Infof("Setting Email to default: %v", gcp.kfDef.Spec.Email)
-	} else {
+	} else if gcp.kfDef.Spec.Email == "" {
 		log.Warnf("gcpAccountGetter not set; can't get default email")
 	}
 	// Set the project
@@ -2010,7 +2010,7 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 		gcp.kfDef.Spec.Project = strings.TrimSpace(project)
 		pluginSpec.Project = strings.TrimSpace(project)
 		log.Infof("Setting Project to default: %v", gcp.kfDef.Spec.Project)
-	} else {
+	} else if gcp.kfDef.Spec.Project == "" {
 		log.Warnf("gcpProjectGetter not set; can't get default project")
 	}
 	// Set the zone
@@ -2023,7 +2023,7 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 		gcp.kfDef.Spec.Zone = strings.TrimSpace(zone)
 		pluginSpec.Zone = strings.TrimSpace(zone)
 		log.Infof("Setting Zone to default: %v", gcp.kfDef.Spec.Zone)
-	} else {
+	} else if gcp.kfDef.Spec.Zone == "" {
 		log.Warnf("gcpZoneGetter not set; can't get default zone")
 	}
 


### PR DESCRIPTION
https://github.com/kubeflow/kfctl/issues/55

- commands (build, apply) call NewLoadKfAppFromURI as entrypoint
- move steps in LoadKfAppCfgFile to NewLoadKfAppFromURI, and delete LoadKfAppCfgFile
- createKfAppCfgFile is now private

/cc @gabrielwen @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4370)
<!-- Reviewable:end -->
