### PR TITLE
fix kfctl corner cases

### DIFF
--- a/bootstrap/cmd/kfctl/cmd/apply.go
+++ b/bootstrap/cmd/kfctl/cmd/apply.go
@@ -92,13 +92,14 @@ func init() {
 
 	// Config file option
 	applyCmd.PersistentFlags().StringVarP(&configFilePath, string(kftypes.FILE), "f", "",
-		`Static config file to use. Can be either a local path or a URL.
-For example:
-export CONFIG=`+arritkoConfig+`
-export CONFIG=`+awsConfig+`
-export CONFIG=`+gcpConfig+`
-export CONFIG=`+k8sConfig+`
-kfctl apply -V --file=${CONFIG}`)
+		`Static config file to use. Can be either a local path:
+		export CONFIG=./kfctl_gcp_iap.yaml
+	or a URL:
+		export CONFIG=`+gcpConfig+`
+		export CONFIG=`+arritkoConfig+`
+		export CONFIG=`+awsConfig+`
+		export CONFIG=`+k8sConfig+`
+	kfctl apply -V --file=${CONFIG}`)
 
 	// verbose output
 	applyCmd.Flags().BoolP(string(kftypes.VERBOSE), "V", false,

--- a/bootstrap/cmd/kfctl/cmd/build.go
+++ b/bootstrap/cmd/kfctl/cmd/build.go
@@ -74,13 +74,14 @@ func init() {
 
 	// Config file option
 	buildCmd.PersistentFlags().StringVarP(&configFilePath, string(kftypes.FILE), "f", "",
-		`Static config file to use. Can be either a local path or a URL.
-	For example:
-	export CONFIG=`+arritkoConfig+`
-	export CONFIG=`+awsConfig+`
-	export CONFIG=`+gcpConfig+`
-	export CONFIG=`+k8sConfig+`
-	kfctl apply -V --file=${CONFIG}`)
+		`Static config file to use. Can be either a local path:
+		export CONFIG=./kfctl_gcp_iap.yaml
+	or a URL:
+		export CONFIG=`+gcpConfig+`
+		export CONFIG=`+arritkoConfig+`
+		export CONFIG=`+awsConfig+`
+		export CONFIG=`+k8sConfig+`
+	kfctl build -V --file=${CONFIG}`)
 
 	// verbose output
 	buildCmd.Flags().BoolP(string(kftypes.VERBOSE), "V", false,

--- a/bootstrap/pkg/apis/apps/kfconfig/types.go
+++ b/bootstrap/pkg/apis/apps/kfconfig/types.go
@@ -571,11 +571,10 @@ func (c *KfConfig) SetApplicationParameter(appName string, paramName string, val
 
 			return nil
 		}
-		log.Warnf("Application %v not found", appName)
-		return nil
-	}
 
-	return &AppNotFound{Name: appName}
+	}
+	log.Warnf("Application %v not found", appName)
+	return nil
 }
 
 // SetSecret sets the specified secret; if a secret with the given name already exists it is overwritten.

--- a/bootstrap/pkg/apis/apps/kfconfig/types.go
+++ b/bootstrap/pkg/apis/apps/kfconfig/types.go
@@ -571,6 +571,8 @@ func (c *KfConfig) SetApplicationParameter(appName string, paramName string, val
 
 			return nil
 		}
+		log.Warnf("Application %v not found", appName)
+		return nil
 	}
 
 	return &AppNotFound{Name: appName}

--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -204,7 +204,9 @@ func (kustomize *kustomize) Apply(resources kftypesv3.ResourceEnum) error {
 		}
 		return nil
 	}, b)
-	log.Warnf("Default namespace creation skipped")
+	if err != nil {
+		log.Warnf("Default namespace creation skipped")
+	}
 	return nil
 }
 

--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -193,7 +193,7 @@ func (kustomize *kustomize) Apply(resources kftypesv3.ResourceEnum) error {
 	// Default user namespace when multi-tenancy disabled
 	anonymousNamespace := "anonymous"
 	b := utils.NewDefaultBackoff()
-	return backoff.Retry(func() error {
+	err = backoff.Retry(func() error {
 		if !(apply.IfNamespaceExist(defaultProfileNamespace) || apply.IfNamespaceExist(anonymousNamespace)) {
 			msg := "Default user namespace pending creation..."
 			log.Warnf(msg)
@@ -204,6 +204,8 @@ func (kustomize *kustomize) Apply(resources kftypesv3.ResourceEnum) error {
 		}
 		return nil
 	}, b)
+	log.Warnf("Default namespace creation skipped")
+	return nil
 }
 
 // deleteGlobalResources is called from Delete and deletes CRDs, ClusterRoles, ClusterRoleBindings


### PR DESCRIPTION
* SetApplicationParameter will not throw error if application not found.
  * application might be deleted from config file on purpose
* For same reason we print warnings instead of error when default namespace not found.
* Also update cmd help messages to include local config example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4380)
<!-- Reviewable:end -->
