### PR TITLE
[CentralDashboard v2] Polling for profile state (for 20 seconds) to allow a transition to dashboard

### DIFF
--- a/components/centraldashboard/public/ajax_test_helper.js
+++ b/components/centraldashboard/public/ajax_test_helper.js
@@ -76,7 +76,7 @@ export function mockIronAjax(component, response, respondWithError = false) {
 
         // So that code can await when using this dynamically
         resp.completes = new Promise((res, rej) =>
-            (respondWithError?rej:res)(resp)
+            (respondWithError ? rej : res)(resp)
         );
         return resp;
     };

--- a/components/centraldashboard/public/ajax_test_helper.js
+++ b/components/centraldashboard/public/ajax_test_helper.js
@@ -59,7 +59,7 @@ export function mockIronAjax(component, response, respondWithError = false) {
     );
     // eslint-disable-next-line no-console
     const finalEvent = `${respondWithError?'error':'response'}`;
-    component.generateRequest = async () => {
+    component.generateRequest = () => {
         const eventPayload = createRespPayload(
             response,
             respondWithError,
@@ -75,10 +75,10 @@ export function mockIronAjax(component, response, respondWithError = false) {
         const resp = component.lastResponse || component.lastError;
 
         // So that code can await when using this dynamically
-        resp.completes = new Promise((res, rej) =>
+        const completes = new Promise((res, rej) =>
             (respondWithError ? rej : res)(resp)
         );
-        return resp;
+        return {response: resp, completes};
     };
 }
 

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -142,7 +142,6 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
      */
     async resyncApp() {
         await this.$.envInfo.generateRequest().completes;
-        await this.sleep(100);
         this.$.welcomeUser.show();
     }
 

--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -87,12 +87,12 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
         );
     }
 
-    async pollProfile(times = 10, delay = 500) {
+    async pollProfile(times, delay) {
         const profileAPI = this.$.GetMyNamespace;
         if (times < 1) throw Error('Cannot poll profile < 1 times!');
         for (let i = 0; i < times; i++) {
             const req = profileAPI.generateRequest();
-            await req.completes;
+            await req.completes.catch(() => 0);
             if (req.response && req.response.hasWorkgroup) return true;
             await this.sleep(delay);
         }

--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -87,6 +87,17 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
         );
     }
 
+    async pollProfile(times = 10, delay = 500) {
+        const profileAPI = this.$.getMyNamespace;
+        if (times < 1) throw Error('Cannot poll profile < 1 times!');
+        for (let i = 0; i < times; i++) {
+            const req = profileAPI.generateRequest();
+            await req.completes;
+            if (req.response && req.response.hasWorkgroup) return true;
+            await this.sleep(delay);
+        }
+    }
+
     async finishSetup() {
         const API = this.$.MakeNamespace;
         if (!this.validateNamespace()) return;
@@ -97,9 +108,9 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
         if (this.error && this.error.response) {
             return this.waitForRedirect = false;
         }
-        // If request completed and 6 seconds pass, probably let
-        // the user click next again!
-        await this.sleep(6000);
+        // Poll for profile over a span of 6 seconds
+        // if still not there, let the user click next again!
+        await this.pollProfile(20, 300);
         this.waitForRedirect = false;
     }
 

--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -104,13 +104,13 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
         API.body = {namespace: this.namespaceName};
         this.waitForRedirect = true;
         await API.generateRequest().completes;
-        await this.sleep(500);
+        await this.sleep(1); // So the errors and callbacks can schedule
         if (this.error && this.error.response) {
             return this.waitForRedirect = false;
         }
-        // Poll for profile over a span of 20 seconds (every 500ms)
+        // Poll for profile over a span of 20 seconds (every 300ms)
         // if still not there, let the user click next again!
-        const success = await this.pollProfile(40, 500);
+        const success = await this.pollProfile(66, 300);
         if (success) this._successSetup();
         this.waitForRedirect = false;
     }

--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -88,7 +88,7 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
     }
 
     async pollProfile(times = 10, delay = 500) {
-        const profileAPI = this.$.getMyNamespace;
+        const profileAPI = this.$.GetMyNamespace;
         if (times < 1) throw Error('Cannot poll profile < 1 times!');
         for (let i = 0; i < times; i++) {
             const req = profileAPI.generateRequest();
@@ -108,9 +108,10 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
         if (this.error && this.error.response) {
             return this.waitForRedirect = false;
         }
-        // Poll for profile over a span of 6 seconds
+        // Poll for profile over a span of 20 seconds (every 500ms)
         // if still not there, let the user click next again!
-        await this.pollProfile(20, 300);
+        const success = await this.pollProfile(40, 500);
+        if (success) this._successSetup();
         this.waitForRedirect = false;
     }
 

--- a/components/centraldashboard/public/components/registration-page.pug
+++ b/components/centraldashboard/public/components/registration-page.pug
@@ -1,5 +1,6 @@
 iron-ajax#MakeNamespace(method='POST', url='/api/workgroup/create', handle-as='json', last-error='{{error}}', last-response='{{resp}}',
-    on-response='_successSetup', content-type='application/json', loading='{{submittingWorkgroup}}', on-input='clearInvalidation')
+    content-type='application/json', loading='{{submittingWorkgroup}}', on-input='clearInvalidation')
+iron-ajax#GetMyNamespace(url='/api/workgroup/exists', handle-as='json')
 paper-card#MainCard
     figure#Logo !{logo}
     neon-animated-pages.Main-Content(selected='[[page]]',

--- a/components/centraldashboard/public/components/registration-page_test.js
+++ b/components/centraldashboard/public/components/registration-page_test.js
@@ -16,27 +16,36 @@ const TEMPLATE = `
   </template>
 </test-fixture>
 `;
+const jasmineWait = async (t = 1) => {
+    const pr = sleep(t);
+    jasmine.clock().tick(t+3);
+    await pr;
+};
 
 describe('Registration Page', () => {
     let registrationPage;
     let flowcomplete;
+    let clockInstalled;
 
     beforeAll(() => {
         jasmine.Ajax.install();
         const div = document.createElement('div');
         div.innerHTML = TEMPLATE;
         document.body.appendChild(div);
+        clockInstalled = 0;
     });
 
     beforeEach(() => {
         document.getElementById(FIXTURE_ID).create();
         registrationPage = document.getElementById(MU_VIEW_SELECTOR_ID);
+        // eslint-disable-next-line no-console
         flowcomplete = jasmine.createSpy('Flow Completion Event');
         registrationPage.addEventListener('flowcomplete', flowcomplete);
     });
 
     afterEach(() => {
         document.getElementById(FIXTURE_ID).restore();
+        clockInstalled && jasmine.clock().uninstall();
     });
 
     afterAll(() => {
@@ -69,6 +78,9 @@ describe('Registration Page', () => {
     });
 
     it('Should work when API DB is not consistent (use polling)', async () => {
+        jasmine.clock().install();
+        clockInstalled = 1;
+
         mockIronAjax(
             registrationPage.$.GetMyNamespace,
             {hasWorkgroup: false, hasAuth: true, user: 'test'},
@@ -80,7 +92,7 @@ describe('Registration Page', () => {
 
         const $e = (selector) => registrationPage.shadowRoot.querySelector(selector);
         flush();
-        await yieldForAsync(); // So the view can render
+        await jasmineWait(); // So the view can render
 
         $e('.Main-Content .iron-selected .actions > paper-button').click();
         const input = registrationPage.$.Namespace;
@@ -89,7 +101,7 @@ describe('Registration Page', () => {
 
         $e('.Main-Content .iron-selected .actions > paper-button:nth-of-type(1)').click();
 
-        await sleep(5);
+        await jasmineWait(2);
         expect(flowcomplete).not.toHaveBeenCalled();
 
         mockIronAjax(
@@ -97,8 +109,48 @@ describe('Registration Page', () => {
             {hasWorkgroup: true, hasAuth: true, user: 'test'},
         );
 
-        await sleep(300);
+        for (const _ of Array(~~(600/300)).fill()) {
+            await jasmineWait(300);
+        }
         expect(flowcomplete).toHaveBeenCalled();
+    });
+
+    it('Should Fail when API DB is not consistent for more than 20s (use polling)', async () => {
+        jasmine.clock().install();
+        clockInstalled = 1;
+        mockIronAjax(
+            registrationPage.$.GetMyNamespace,
+            {hasWorkgroup: false, hasAuth: true, user: 'test'},
+        );
+        mockIronAjax(
+            registrationPage.$.MakeNamespace,
+            {message: 'Success!'},
+        );
+
+        const $e = (selector) => registrationPage.shadowRoot.querySelector(selector);
+        flush();
+        await jasmineWait(); // So the view can render
+
+        $e('.Main-Content .iron-selected .actions > paper-button').click();
+        const input = registrationPage.$.Namespace;
+        input.value = 'kubeflow';
+        input.fireEnter();
+
+        $e('.Main-Content .iron-selected .actions > paper-button:nth-of-type(1)').click();
+
+        for (const _ of Array(~~(20e3/300)).fill()) {
+            await jasmineWait(300);
+        }
+
+        expect(flowcomplete).not.toHaveBeenCalled();
+
+        mockIronAjax(
+            registrationPage.$.GetMyNamespace,
+            {hasWorkgroup: true, hasAuth: true, user: 'test'},
+        );
+
+        await jasmineWait(1e3);
+        expect(flowcomplete).not.toHaveBeenCalled();
     });
 
     it('Should show errors correctly', async () => {


### PR DESCRIPTION
#### enhancements to: #4364 and #4283

## About
- Registration polling added to check for a profile before running env-info
- Nits tackled
- Removed an unnecessary wait

### Meta
/area centraldashboard
/area front-end
/priority p1
/assign @avdaredevil
/cc @prodonjs @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4384)
<!-- Reviewable:end -->
