### PR TITLE
ToKfConfig doesn't need to take appdir

### DIFF
--- a/bootstrap/pkg/apis/apps/configconverters/v1alpha1.go
+++ b/bootstrap/pkg/apis/apps/configconverters/v1alpha1.go
@@ -9,7 +9,6 @@ import (
 	kfconfig "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfconfig"
 	kfdeftypes "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfdef/v1alpha1"
 	kfgcp "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/kfapp/gcp"
-	log "github.com/sirupsen/logrus"
 )
 
 // Empty struct - used to implement Converter interface.
@@ -52,8 +51,7 @@ func copyGcpPluginSpec(from *kfdeftypes.KfDef, to *kfconfig.KfConfig) error {
 	return to.SetPluginSpec(kfconfig.GCP_PLUGIN_KIND, spec)
 }
 
-func (v V1alpha1) ToKfConfig(appdir string, kfdefBytes []byte) (*kfconfig.KfConfig, error) {
-	log.Infof("converting to kfconfig, appdir=%v", appdir)
+func (v V1alpha1) ToKfConfig(kfdefBytes []byte) (*kfconfig.KfConfig, error) {
 	kfdef := &kfdeftypes.KfDef{}
 	if err := yaml.Unmarshal(kfdefBytes, kfdef); err != nil {
 		return nil, &kfapis.KfError{
@@ -76,9 +74,6 @@ func (v V1alpha1) ToKfConfig(appdir string, kfdefBytes []byte) (*kfconfig.KfConf
 			Platform:        kfdef.Spec.Platform,
 			UseIstio:        true,
 		},
-	}
-	if config.Spec.AppDir == "" {
-		config.Spec.AppDir = appdir
 	}
 	config.Name = kfdef.Name
 	config.Namespace = kfdef.Namespace

--- a/bootstrap/pkg/apis/apps/configconverters/v1alpha1_test.go
+++ b/bootstrap/pkg/apis/apps/configconverters/v1alpha1_test.go
@@ -38,7 +38,7 @@ func TestV1alpha1_ConvertToKfConfigs(t *testing.T) {
 		}
 
 		v1alpha1 := V1alpha1{}
-		config, err := v1alpha1.ToKfConfig("", buf)
+		config, err := v1alpha1.ToKfConfig(buf)
 		if err != nil {
 			t.Fatalf("Error converting to KfConfig: %v", err)
 		}

--- a/bootstrap/pkg/apis/apps/configconverters/v1beta1.go
+++ b/bootstrap/pkg/apis/apps/configconverters/v1beta1.go
@@ -28,7 +28,7 @@ func maybeGetPlatform(pluginKind string) string {
 	}
 }
 
-func (v V1beta1) ToKfConfig(appdir string, kfdefBytes []byte) (*kfconfig.KfConfig, error) {
+func (v V1beta1) ToKfConfig(kfdefBytes []byte) (*kfconfig.KfConfig, error) {
 	kfdef := &kfdeftypes.KfDef{}
 	if err := yaml.Unmarshal(kfdefBytes, kfdef); err != nil {
 		return nil, &kfapis.KfError{
@@ -40,7 +40,6 @@ func (v V1beta1) ToKfConfig(appdir string, kfdefBytes []byte) (*kfconfig.KfConfi
 	// Set UseBasicAuth later.
 	config := &kfconfig.KfConfig{
 		Spec: kfconfig.KfConfigSpec{
-			AppDir:       appdir,
 			UseBasicAuth: false,
 			UseIstio:     true,
 		},

--- a/bootstrap/pkg/apis/apps/configconverters/v1beta1_test.go
+++ b/bootstrap/pkg/apis/apps/configconverters/v1beta1_test.go
@@ -35,7 +35,7 @@ func TestV1beta1_expectedConfig(t *testing.T) {
 		}
 
 		v1beta1 := V1beta1{}
-		config, err := v1beta1.ToKfConfig("", buf)
+		config, err := v1beta1.ToKfConfig(buf)
 		if err != nil {
 			t.Fatalf("Error converting to KfConfig: %v", err)
 		}

--- a/bootstrap/pkg/kfapp/coordinator/coordinator.go
+++ b/bootstrap/pkg/kfapp/coordinator/coordinator.go
@@ -249,7 +249,7 @@ func CreateKfAppCfgFileWithKfDef(d *kfdefsv3.KfDef) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	kfconfig, err := alphaConverter.ToKfConfig(d.Spec.AppDir, kfdefBytes)
+	kfconfig, err := alphaConverter.ToKfConfig(kfdefBytes)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
AppDir and ConfigFileName is set in configConverters.LoadConfigFromURI

/cc @gabrielwen @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4385)
<!-- Reviewable:end -->
