### PR TITLE
Add a check for not allowing deploying v1alpha1 config

### DIFF
--- a/bootstrap/cmd/kfctl/cmd/build.go
+++ b/bootstrap/cmd/kfctl/cmd/build.go
@@ -47,6 +47,9 @@ var buildCmd = &cobra.Command{
 
 		if kind == string(kftypes.KFDEF) {
 			_, err = coordinator.NewLoadKfAppFromURI(configFilePath)
+			if err != nil {
+				return fmt.Errorf("failed to build kfApp from URI %s: %v", configFilePath, err)
+			}
 		} else if kind == string(kftypes.KFUPGRADE) {
 			kfUpgrade, kfUpgradeErr := kfupgrade.NewKfUpgrade(configFilePath)
 			if kfUpgradeErr != nil {


### PR DESCRIPTION
Fixes https://github.com/kubeflow/kubeflow/issues/4371

As a temporary fix, we don't allow deploying Kubeflow 0.6 using latest kfctl + 0.6 configs

Tested it locally:

```
INFO[0000] Downloading https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml to /var/folders/1k/m148sdcd2szf5j5zdnbzq0c4006c2s/T/773576815/tmp_app.yaml  filename="configconverters/converters.go:71"
Error: failed to build kfApp from URI https://raw.githubusercontent.com/kubeflow/kubeflow/v0.6-branch/bootstrap/config/kfctl_gcp_basic_auth.0.6.2.yaml:  (kubeflow.error): Code 400 with message: Error creating KfApp from config file:  (kubeflow.error): Code 400 with message: KfDef version v1alpha1 is not supported by this binary. Please use configs at https://github.com/kubeflow/manifests/tree/v0.7-branch/kfdef for to deploy Kubeflow 0.7 or use old kfctl at https://github.com/kubeflow/kubeflow/releases/tag/v0.6.2 to deploy Kubeflow 0.6
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4394)
<!-- Reviewable:end -->
