### PR TITLE
Reorder katib service available check

### DIFF
--- a/testing/test_deploy.py
+++ b/testing/test_deploy.py
@@ -266,9 +266,9 @@ def test_successful_deployment(deployment_name):
 
 
 def test_katib(args):
+  test_successful_deployment('katib-db')
   test_successful_deployment('katib-manager')
   test_successful_deployment('katib-ui')
-  test_successful_deployment('katib-db')
   test_successful_deployment('katib-controller')
 
 


### PR DESCRIPTION
`katib-manager` depends on `katib-db`, so if `katib-manager` is ready, `katib-db` must be ready, too.
so we should  check`katib-db` is ready or not before `katib-manager`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4407)
<!-- Reviewable:end -->
