### PR TITLE
Support set enviroment and command in notebook backend

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -471,3 +471,19 @@ def add_notebook_volume_secret(nb, secret, secret_name, mnt_path, mode):
         "name": secret,
     }
     container["volumeMounts"].append(mnt)
+
+
+def set_notebook_command(notebook, body, defaults):
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+    if body.get("command", []) is not None:
+        command = body.get("command", [])
+        logger.info("Using form's command: {}".format(command))
+        container["command"] = command
+
+
+def set_notebook_env(notebook, body, defaults):
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+    if body.get("env", []) is not None:
+        env = body.get("env", [])
+        logger.info("Using form's env: {}".format(env))
+        container["env"] = env

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
@@ -26,6 +26,8 @@ def post_notebook(namespace):
     utils.set_notebook_cpu(notebook, body, defaults)
     utils.set_notebook_memory(notebook, body, defaults)
     utils.set_notebook_configurations(notebook, body, defaults)
+    utils.set_notebook_command(notebook, body, defaults)
+    utils.set_notebook_env(notebook, body, defaults)
 
     # Workspace Volume
     workspace_vol = utils.get_workspace_vol(body, defaults)

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
@@ -71,6 +71,8 @@ def post_notebook(namespace):
     utils.set_notebook_cpu(notebook, body, defaults)
     utils.set_notebook_memory(notebook, body, defaults)
     utils.set_notebook_configurations(notebook, body, defaults)
+    utils.set_notebook_command(notebook, body, defaults)
+    utils.set_notebook_env(notebook, body, defaults)
 
     # Workspace Volume
     workspace_vol = utils.get_workspace_vol(body, defaults)


### PR DESCRIPTION
Add enviroment and command field in create notebook request in kubeflow components of jupter-web-app.
New fileds example:
```json
{
    "env":[
        {
            "name":"Key1",
            "value":"Value1"
        },
        {
            "name":"Key2",
            "value":"Value2"
        }
    ],
    "command":[
        "tini",
        "--"
    ]
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4408)
<!-- Reviewable:end -->
