### PR TITLE
Fix bug preventing presubmits on kubeflow/manifests branches from using correct commit of kubeflow/manifests

### DIFF
--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -184,19 +184,20 @@ def get_config_spec(config_path, project, email, zone, app_path):
       if repo["name"] !=  manifests_repo_name:
         continue
 
-      version = os.getenv("PULL_NUMBER")
+      version = None
 
-      if not version:
-        # Postsubmit
-        version = os.getenv("PULL_BASE_SHA")
+      if os.getenv("PULL_PULL_SHA"):
+        # Presubmit
+        version = os.getenv("PULL_PULL_SHA")
 
       # See https://github.com/kubernetes/test-infra/blob/45246b09ed105698aa8fb928b7736d14480def29/prow/jobs.md#job-environment-variables  # pylint: disable=line-too-long
-      if version:
+      elif os.getenv("PULL_BASE_SHA"):
+        version = os.getenv("PULL_BASE_SHA")
 
-      elif os.getenv("PULL_PULL_SHA"):
-        # Postsubmit
+      if version:
         repo["uri"] = ("https://github.com/kubeflow/manifests/archive/"
                        "{0}.tar.gz").format(version)
+        logging.info("Overwriting the URI")
       else:
         # Its a periodic job so use whatever value is set in the KFDef
         logging.info("Not overwriting manifests version")

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -172,7 +172,8 @@ def get_config_spec(config_path, project, email, zone, app_path):
   config_spec["metadata"]["name"] = kfdef_name
 
   repos = config_spec["spec"]["repos"]
-  if os.getenv("REPO_NAME") == "manifests":
+  manifests_repo_name = "manifests"
+  if os.getenv("REPO_NAME") == manifests_repo_name:
     # kfctl_go_test.py was triggered on presubmit from the kubeflow/manifests
     # repository. In this case we want to use the specified PR of the
     # kubeflow/manifests repository; so we need to change the repo specification
@@ -180,10 +181,25 @@ def get_config_spec(config_path, project, email, zone, app_path):
     # TODO(jlewi): We should also point to a specific commit when triggering
     # postsubmits from the kubeflow/manifests repo
     for repo in repos:
-      for key, value in repo.items():
-        if value == "https://github.com/kubeflow/manifests/archive/master.tar.gz":
-          repo["uri"] = str("https://github.com/kubeflow/manifests/archive/pull/" + str(
-            os.getenv("PULL_NUMBER")) + "/head.tar.gz")
+      if repo["name"] !=  manifests_repo_name:
+        continue
+
+      version = os.getenv("PULL_NUMBER")
+
+      if not version:
+        # Postsubmit
+        version = os.getenv("PULL_BASE_SHA")
+
+      # See https://github.com/kubernetes/test-infra/blob/45246b09ed105698aa8fb928b7736d14480def29/prow/jobs.md#job-environment-variables  # pylint: disable=line-too-long
+      if version:
+
+      elif os.getenv("PULL_PULL_SHA"):
+        # Postsubmit
+        repo["uri"] = ("https://github.com/kubeflow/manifests/archive/"
+                       "{0}.tar.gz").format(version)
+      else:
+        # Its a periodic job so use whatever value is set in the KFDef
+        logging.info("Not overwriting manifests version")
     logging.info(str(config_spec))
   return config_spec
 
@@ -264,7 +280,7 @@ def kfctl_deploy_kubeflow(app_path, project, use_basic_auth, use_istio, config_p
   return app_path
 
 def apply_kubeflow(kfctl_path, app_path):
-  util.run([kfctl_path, "apply", "-V", "-f=" + os.path.join(app_path, "tmp.yaml")], cwd=app_path) 
+  util.run([kfctl_path, "apply", "-V", "-f=" + os.path.join(app_path, "tmp.yaml")], cwd=app_path)
   return app_path
 
 def build_and_apply_kubeflow(kfctl_path, app_path):


### PR DESCRIPTION

* When triggering tests on kubeflow/manifests we need to modify the
  KFDef spec to change the URI of the kubeflow/manifests repo in the
  KFDef spec.

* There was a bug in the code where we were checking the URI to decide
  whether to override it or not. This code assumed we were on the master
  branch so presubmits on the kubeflow/manifests v0.7-branch weren't using
  the correct commit.

* This change fixes this PR to properly set repos in the KFDef when
  triggering on kubeflow/manifests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4416)
<!-- Reviewable:end -->
