### PR TITLE
Fix: error isn't logged before retry

### DIFF
--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -180,7 +180,7 @@ func (kustomize *kustomize) Apply(resources kftypesv3.ResourceEnum) error {
 			},
 			utils.NewDefaultBackoff(),
 			func(e error, duration time.Duration) {
-				log.Warnf("Encountered error during apply: %v", err)
+				log.Warnf("Encountered error during apply: %v", e)
 				log.Warnf("Will retry in %.0f seconds.", duration.Seconds())
 			})
 		if err != nil {


### PR DESCRIPTION
During apply failure, kustomize.Apply() retries application warning the user about currently encountered error. This error is printed as <nil> as the variable is set is incorrect.

```
WARN[0016] Encountered error during apply: <nil>         filename="kustomize/kustomize.go:183"
WARN[0016] Will retry in 13 seconds. 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4417)
<!-- Reviewable:end -->
