### PR TITLE
Add arm64 support for centraldashboard and Fix chromium@edge version cannot start bug

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -9,20 +9,31 @@ ENV CHROME_BIN=/usr/bin/chromium-browser
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # Installs latest Chromium package and configures environment for testing
-# Fall back to chromium@edge=72.0.3626.121-r0 see https://github.com/Zenika/alpine-chrome/issues/39
 RUN apk update && apk upgrade && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/community >> /etc/apk/repositories && \
     echo @edge http://nl.alpinelinux.org/alpine/edge/main >> /etc/apk/repositories && \
-    apk add --no-cache bash chromium@edge=72.0.3626.121-r0 nss@edge \
+    apk add --no-cache bash chromium@edge nss@edge \
     freetype@edge \
     harfbuzz@edge \
-    ttf-freefont@edge
+    ttf-freefont@edge \
+    libstdc++@edge
+
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        apk update && apk upgrade && \
+        apk add --no-cache python2 make g++@edge; \
+    fi
 
 COPY . /centraldashboard
 WORKDIR /centraldashboard
 
 RUN npm rebuild && \
-    npm install && \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        export CFLAGS=-Wno-error && \
+        export CXXFLAGS=-Wno-error && \
+        npm install; \
+    else \
+        npm install; \
+    fi && \
     npm test && \
     npm run build && \
     npm prune --production


### PR DESCRIPTION
Referencing [comment ](https://github.com/kubeflow/kubeflow/issues/2337#issuecomment-524690065)and issue [#2337](https://github.com/kubeflow/kubeflow/issues/2337)
 We are working on Kubeflow supporting arm64 platform. We now rebuilt some images and installed Kubeflow on arm64, and hence contribute the Dockerfile.

1. Add arm64 support for centraldashboard, tested on both arm64 and x86_64 machines.
2. Refer to [issue](https://github.com/Zenika/alpine-chrome/issues/39), fix chromium@edge version cannot start bug.

Signed-off-by: Henry Wang <<henry.wang@arm.com>>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4422)
<!-- Reviewable:end -->
