### PR TITLE
Add a `hasWorkgroup` condition for `/api/workgroup/exists` when in Non-Identity Clusters

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -261,6 +261,9 @@ export class WorkgroupApi {
                         );
                         response.hasWorkgroup = !!(workgroup.namespaces || [])
                             .find((w) => w.role === 'owner');
+                    } else {
+                        // Basic auth workgroup condition
+                        response.hasWorkgroup = !!(await this.getAllWorkgroups(req.user.username)).length;
                     }
                     res.json(response);
                 } catch (err) {

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -216,12 +216,19 @@ describe('Workgroup API', () => {
         });
 
         it('Should return for a non-identity aware cluster', async () => {
+            mockProfilesService.readBindings.withArgs()
+                .and.returnValue(Promise.resolve({
+                    response: null,
+                    body: {
+                        bindings: []
+                    },
+                }));
             const expectedResponse = {hasAuth: false, hasWorkgroup: false, user: 'anonymous'};
 
             const response = await sendTestRequest(url);
             expect(response).toEqual(expectedResponse);
             expect(mockProfilesService.v1RoleClusteradminGet).not.toHaveBeenCalled();
-            expect(mockProfilesService.readBindings).not.toHaveBeenCalled();
+            expect(mockProfilesService.readBindings).toHaveBeenCalledWith();
         });
 
         it('Should return for an identity aware cluster with a Workgroup',


### PR DESCRIPTION
#### Related to: #4415 

## About
- Fixes issue by giving /exists a hasWorkgroup condition for non-identity cluster

### Meta
/area centraldashboard
/area front-end
/priority p0
/assign @avdaredevil
/cc @prodonjs @jlewi @krishnadurai

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4425)
<!-- Reviewable:end -->
