### PR TITLE
Add a check if hostname is too long for GCP endpoint

### DIFF
--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -2099,10 +2099,8 @@ func (gcp *Gcp) Generate(resources kftypesv3.ResourceEnum) error {
 		gcp.kfDef.Spec.IpName = gcp.kfDef.Name + "-ip"
 		pluginSpec.IpName = gcp.kfDef.Spec.IpName
 	}
-	if gcp.kfDef.Spec.Hostname == "" {
-		gcp.kfDef.Spec.Hostname = gcp.kfDef.Name + ".endpoints." + gcp.kfDef.Spec.Project + ".cloud.goog"
-		pluginSpec.Hostname = gcp.kfDef.Spec.Hostname
-	}
+	gcp.kfDef.Spec.Hostname = gcp.kfDef.Name + ".endpoints." + gcp.kfDef.Spec.Project + ".cloud.goog"
+	pluginSpec.Hostname = gcp.kfDef.Spec.Hostname
 
 	switch resources {
 	case kftypesv3.ALL:

--- a/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
@@ -1,6 +1,8 @@
 package gcp
 
 import (
+	"fmt"
+
 	kfdefs "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfdef/v1alpha1"
 )
 
@@ -55,7 +57,9 @@ type DeploymentManagerConfig struct {
 // IsValid returns true if the spec is a valid and complete spec.
 // If false it will also return a string providing a message about why its invalid.
 func (s *GcpPluginSpec) IsValid() (bool, string) {
-
+	if len(s.Hostname) > 63 {
+		return false, fmt.Sprintf("Invaid host name: host name %s is longer than 63 characters. Please shorten the KfApp name.", s.Hostname)
+	}
 	basicAuthSet := s.Auth.BasicAuth != nil
 	iapAuthSet := s.Auth.IAP != nil
 

--- a/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
@@ -58,7 +58,7 @@ type DeploymentManagerConfig struct {
 // If false it will also return a string providing a message about why its invalid.
 func (s *GcpPluginSpec) IsValid() (bool, string) {
 	if len(s.Hostname) > 63 {
-		return false, fmt.Sprintf("Invaid host name: host name %s is longer than 63 characters. Please shorten the metadata.name and hostname.", s.Hostname)
+		return false, fmt.Sprintf("Invaid host name: host name %s is longer than 63 characters. Please shorten the metadata.name.", s.Hostname)
 	}
 	basicAuthSet := s.Auth.BasicAuth != nil
 	iapAuthSet := s.Auth.IAP != nil

--- a/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_plugin.go
@@ -58,7 +58,7 @@ type DeploymentManagerConfig struct {
 // If false it will also return a string providing a message about why its invalid.
 func (s *GcpPluginSpec) IsValid() (bool, string) {
 	if len(s.Hostname) > 63 {
-		return false, fmt.Sprintf("Invaid host name: host name %s is longer than 63 characters. Please shorten the KfApp name.", s.Hostname)
+		return false, fmt.Sprintf("Invaid host name: host name %s is longer than 63 characters. Please shorten the metadata.name and hostname.", s.Hostname)
 	}
 	basicAuthSet := s.Auth.BasicAuth != nil
 	iapAuthSet := s.Auth.IAP != nil

--- a/bootstrap/pkg/kfapp/gcp/gcp_plugin_test.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp_plugin_test.go
@@ -1,8 +1,9 @@
 package gcp
 
 import (
-	kfdefs "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfdef/v1alpha1"
 	"testing"
+
+	kfdefs "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfdef/v1alpha1"
 )
 
 func TestGcpPluginSpec_IsValid(t *testing.T) {
@@ -112,6 +113,12 @@ func TestGcpPluginSpec_IsValid(t *testing.T) {
 						},
 					},
 				},
+			},
+			expected: false,
+		},
+		{
+			input: &GcpPluginSpec{
+				Hostname: "this-kfApp-name-is-very-long.endpoints.my-gcp-project-for-kubeflow.cloud.goog",
 			},
 			expected: false,
 		},


### PR DESCRIPTION
related to https://github.com/kubeflow/kubeflow/issues/4421

needs cherry-pick later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4436)
<!-- Reviewable:end -->
