### PR TITLE
Add a message after kfctl apply succeeds

### DIFF
--- a/bootstrap/cmd/kfctl/cmd/apply.go
+++ b/bootstrap/cmd/kfctl/cmd/apply.go
@@ -66,7 +66,11 @@ var applyCmd = &cobra.Command{
 			if err != nil {
 				return fmt.Errorf("failed to build kfApp from URI %s: %v", configFilePath, err)
 			}
-			return kfApp.Apply(kftypes.ALL)
+			if err := kfApp.Apply(kftypes.ALL); err != nil {
+				return fmt.Errorf("failed to apply: %s", err)
+			}
+			log.Info("Applied the configuration Successfully!")
+			return nil
 		case string(kftypes.KFUPGRADE):
 			kfUpgrade, err := kfupgrade.NewKfUpgrade(configFilePath)
 			if err != nil {


### PR DESCRIPTION
Some steps in `kfctl apply` output warning messages, which confuses the user whether `apply` succeeds or not.

This PR adds a message to make it clear.

Related to: #4414 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4443)
<!-- Reviewable:end -->
