### PR TITLE
Store secrets using EnvSource for basic auth

### DIFF
--- a/bootstrap/pkg/apis/apps/configconverters/testdata/kfconfig_v1beta1.yaml
+++ b/bootstrap/pkg/apis/apps/configconverters/testdata/kfconfig_v1beta1.yaml
@@ -335,6 +335,12 @@ spec:
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+  secrets:
+  - name: env_password
+    secretSource:
+      envSource:
+        name: ENV_PASSWORD_NAME
+  - name: plain_text_password
   SkipInitProject: true
   useIstio: true
 status: {}

--- a/bootstrap/pkg/apis/apps/configconverters/testdata/v1beta1.yaml
+++ b/bootstrap/pkg/apis/apps/configconverters/testdata/v1beta1.yaml
@@ -333,4 +333,13 @@ spec:
   repos:
   - name: manifests
     uri: https://github.com/kubeflow/manifests/archive/master.tar.gz
+  secrets:
+  - name: env_password
+    secretSource:
+      envSource:
+        name: ENV_PASSWORD_NAME
+  - name: plain_text_password
+    secretSource:
+      literalSource:
+        value: 12345
 status: {}

--- a/bootstrap/pkg/apis/apps/configconverters/v1beta1.go
+++ b/bootstrap/pkg/apis/apps/configconverters/v1beta1.go
@@ -137,12 +137,12 @@ func (v V1beta1) ToKfConfig(kfdefBytes []byte) (*kfconfig.KfConfig, error) {
 		s := kfconfig.Secret{
 			Name: secret.Name,
 		}
-		if secret.SecretSource == nil {
+		// We don't want to store literalSource explictly, becasue we want the config to be checked into source control and don't want secrets in source control.
+		if secret.SecretSource == nil || secret.SecretSource.LiteralSource != nil {
 			config.Spec.Secrets = append(config.Spec.Secrets, s)
 			continue
 		}
 		src := &kfconfig.SecretSource{}
-		// We don't want to store HashSource and LiteralSource explictly.
 		if secret.SecretSource.EnvSource != nil {
 			src.EnvSource = &kfconfig.EnvSource{
 				Name: secret.SecretSource.EnvSource.Name,

--- a/bootstrap/pkg/apis/apps/configconverters/v1beta1.go
+++ b/bootstrap/pkg/apis/apps/configconverters/v1beta1.go
@@ -2,6 +2,7 @@ package configconverters
 
 import (
 	"fmt"
+
 	"github.com/ghodss/yaml"
 	kfapis "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis"
 	kftypesv3 "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps"
@@ -141,11 +142,8 @@ func (v V1beta1) ToKfConfig(kfdefBytes []byte) (*kfconfig.KfConfig, error) {
 			continue
 		}
 		src := &kfconfig.SecretSource{}
-		if secret.SecretSource.LiteralSource != nil {
-			src.LiteralSource = &kfconfig.LiteralSource{
-				Value: secret.SecretSource.LiteralSource.Value,
-			}
-		} else if secret.SecretSource.EnvSource != nil {
+		// We don't want to store HashSource and LiteralSource explictly.
+		if secret.SecretSource.EnvSource != nil {
 			src.EnvSource = &kfconfig.EnvSource{
 				Name: secret.SecretSource.EnvSource.Name,
 			}

--- a/bootstrap/pkg/apis/apps/configconverters/v1beta1_test.go
+++ b/bootstrap/pkg/apis/apps/configconverters/v1beta1_test.go
@@ -1,15 +1,16 @@
 package configconverters
 
 import (
-	"github.com/ghodss/yaml"
-	"github.com/google/go-cmp/cmp"
-	kfconfig "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfconfig"
-	kfutils "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/utils"
 	"io/ioutil"
 	"os"
 	"path"
 	"reflect"
 	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/google/go-cmp/cmp"
+	kfconfig "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis/apps/kfconfig"
+	kfutils "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/utils"
 )
 
 func TestV1beta1_expectedConfig(t *testing.T) {

--- a/bootstrap/pkg/apis/apps/kfconfig/types.go
+++ b/bootstrap/pkg/apis/apps/kfconfig/types.go
@@ -13,7 +13,7 @@ import (
 	kfapis "github.com/kubeflow/kubeflow/bootstrap/v3/pkg/apis"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -533,6 +533,17 @@ func (c *KfConfig) GetSecret(name string) (string, error) {
 		return "", fmt.Errorf("No secret source provided for secret %v", name)
 	}
 	return "", NewSecretNotFound(name)
+}
+
+// GetSecretSource returns the SecretSource of the specified name or an error if the secret isn't specified.
+func (c *KfConfig) GetSecretSource(name string) (*SecretSource, error) {
+	for _, s := range c.Spec.Secrets {
+		if s.Name != name {
+			continue
+		}
+		return s.SecretSource, nil
+	}
+	return nil, NewSecretNotFound(name)
 }
 
 // GetApplicationParameter gets the desired application parameter.

--- a/bootstrap/pkg/apis/apps/kfconfig/types.go
+++ b/bootstrap/pkg/apis/apps/kfconfig/types.go
@@ -538,10 +538,9 @@ func (c *KfConfig) GetSecret(name string) (string, error) {
 // GetSecretSource returns the SecretSource of the specified name or an error if the secret isn't specified.
 func (c *KfConfig) GetSecretSource(name string) (*SecretSource, error) {
 	for _, s := range c.Spec.Secrets {
-		if s.Name != name {
-			continue
+		if s.Name == name {
+			return s.SecretSource, nil
 		}
-		return s.SecretSource, nil
 	}
 	return nil, NewSecretNotFound(name)
 }

--- a/bootstrap/pkg/apis/apps/kfdef/v1beta1/application_types.go
+++ b/bootstrap/pkg/apis/apps/kfdef/v1beta1/application_types.go
@@ -15,7 +15,7 @@
 package v1beta1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -96,7 +96,7 @@ type LiteralSource struct {
 }
 
 type EnvSource struct {
-	Name string `json:"Name,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // SecretRef is a reference to a secret

--- a/bootstrap/pkg/kfapp/gcp/gcp.go
+++ b/bootstrap/pkg/kfapp/gcp/gcp.go
@@ -1948,18 +1948,11 @@ func (gcp *Gcp) setGcpPluginDefaults() error {
 				log.Errorf("Could not configure basic auth; environment variable %s not set", kftypesv3.KUBEFLOW_PASSWORD)
 				return errors.WithStack(fmt.Errorf("Could not configure basic auth; environment variable %s not set", kftypesv3.KUBEFLOW_PASSWORD))
 			}
-			encodedPassword, err := base64EncryptPassword(password)
-
-			if err != nil {
-				log.Errorf("There was a problem encrypting the password; %v", err)
-				return errors.WithStack(err)
-			}
-
 			gcp.kfDef.SetSecret(kfconfig.Secret{
 				Name: BasicAuthPasswordSecretName,
 				SecretSource: &kfconfig.SecretSource{
-					HashedSource: &kfconfig.HashedSource{
-						HashedValue: encodedPassword,
+					EnvSource: &kfconfig.EnvSource{
+						Name: kftypesv3.KUBEFLOW_PASSWORD,
 					},
 				},
 			})


### PR DESCRIPTION
#4439 

Makes suggested changes in https://github.com/kubeflow/kubeflow/issues/4439#issuecomment-548375713

- Use EnvSource instead of HashSource for secrets
- fix Json name for env secret name 
- remove literal secret from yaml file
- Change `buildBasicAuth` encode the plain text secret to base64

Testing:
- `kfctl apply -f https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_basic_auth.0.7.0.yaml` works.
- second run `kfctl apply` with generated local yaml works too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4444)
<!-- Reviewable:end -->
