### PR TITLE
Automated cherry pick of #4417: Fix: error isn't logged before retry Cherry pick of #4417 on v0.7-branch. #4417: Fix: error isn't logged before retry

### DIFF
--- a/bootstrap/pkg/kfapp/kustomize/kustomize.go
+++ b/bootstrap/pkg/kfapp/kustomize/kustomize.go
@@ -180,7 +180,7 @@ func (kustomize *kustomize) Apply(resources kftypesv3.ResourceEnum) error {
 			},
 			utils.NewDefaultBackoff(),
 			func(e error, duration time.Duration) {
-				log.Warnf("Encountered error during apply: %v", err)
+				log.Warnf("Encountered error during apply: %v", e)
 				log.Warnf("Will retry in %.0f seconds.", duration.Seconds())
 			})
 		if err != nil {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4452)
<!-- Reviewable:end -->
