### PR TITLE
Use replaceState instead of pushState to track iframe navigation

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -258,11 +258,11 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
     }
 
     /**
-     * Observer to reflect navigation in iframed pages and push to history.
+     * Observer to reflect navigation in iframed pages and replace history.
      * @param {string} newPage - iframe page path
      */
     _iframePageChanged(newPage) {
-        window.history.pushState(null, null,
+        window.history.replaceState(null, null,
             `/${IFRAME_LINK_PREFIX}${newPage}`);
     }
 

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -226,7 +226,7 @@ describe('Main Page', () => {
     });
 
     it('Pushes to history when iframe page changes', () => {
-        const historySpy = spyOn(window.history, 'pushState');
+        const historySpy = spyOn(window.history, 'replaceState');
         mainPage.iframePage = '/notebooks?blah=bar';
         mainPage.iframePage = '/pipelines/create/new';
         expect(historySpy).toHaveBeenCalledWith(null, null,


### PR DESCRIPTION
Fixes #4446 

Switches to using `history.replaceState` to fix the issue of back-button/in-page navigation not working properly for KFP or Katib. 

[Screencast](https://screencast.googleplex.com/cast/NjIyMjQyODM2OTg0NjI3Mnw0M2VmOWU5ZS1lYw)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4454)
<!-- Reviewable:end -->
