### PR TITLE
remove xfail for endpoint_is_ready test

### DIFF
--- a/testing/kfctl/endpoint_ready_test.py
+++ b/testing/kfctl/endpoint_ready_test.py
@@ -13,9 +13,6 @@ from kubeflow.testing import util
 from testing import deploy_utils
 from testing import gcp_util
 
-# TODO(https://github.com/kubeflow/kfctl/issues/42):
-# Test is failing pretty consistently.
-@pytest.mark.xfail
 # There's really no good reason to run test_endpoint during presubmits.
 # We shouldn't need it to feel confident that kfctl is working.
 @pytest.mark.skipif(os.getenv("JOB_TYPE") == "presubmit",


### PR DESCRIPTION
* We are already skipping the test in presubmits
* using xfail prevents the results from showing up in test grid and we'd like to see results in test grid.

Related: kubeflow/kfctl#42

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4458)
<!-- Reviewable:end -->
