### PR TITLE
Refactor kfctl_go_test_utils codes

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -13,7 +13,7 @@ workflows:
     include_dirs:
       - bootstrap/*
       - testing/*
-      - py/kubeflow/kubeflow/ci/* 
+      - py/kubeflow/kubeflow/ci/*
     kwargs:
       use_basic_auth: false
       # Run build and then apply rather than just apply
@@ -22,7 +22,7 @@ workflows:
       # presubmit.
       test_endpoint: true
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_iap.yaml  
-  # Run basic auth test as part of every periodic and postsubmit run. 
+  # Run basic auth test as part of every periodic and postsubmit run.
   - py_func: kubeflow.kubeflow.ci.kfctl_e2e_workflow.create_workflow
     name: kfctl-go-basic-auth
     job_types:
@@ -33,18 +33,19 @@ workflows:
       - deployment/*
       - kubeflow/*
       - testing/*
+      - py/kubeflow/kubeflow/ci/*
     kwargs:
       use_basic_auth: true
       test_endpoint: true
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/master/kfdef/kfctl_gcp_basic_auth.yaml
-  # E2E tests for kfctl_existing_arrikto 
+  # E2E tests for kfctl_existing_arrikto
   - app_dir: kubeflow/kubeflow/testing/workflows
     component: kfctl_go_test
     name: kfctl-go-existing
     job_types:
       # Enable once we have confirmed the stability of the test
       # - presubmit
-      # TODO(jlewi): I don't think we want to enable on presubmit. 
+      # TODO(jlewi): I don't think we want to enable on presubmit.
       # see https://github.com/kubeflow/kfctl/issues/57
       - postsubmit
       - periodic
@@ -184,7 +185,7 @@ workflows:
     include_dirs:
       - bootstrap/*
       - testing/*
-      - py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py 
+      - py/kubeflow/kubeflow/ci/*
     kwargs:
       use_basic_auth: false
       # Run build and then apply rather than just apply
@@ -204,6 +205,7 @@ workflows:
       - deployment/*
       - kubeflow/*
       - testing/*
+      - py/kubeflow/kubeflow/ci/*
     kwargs:
       use_basic_auth: true
       config_path: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_gcp_basic_auth.0.7.0.yaml
@@ -233,4 +235,4 @@ workflows:
       configPath: https://raw.githubusercontent.com/kubeflow/manifests/v0.7-branch/kfdef/kfctl_existing_arrikto.yaml
       cluster_creation_script: create_existing_cluster.sh
       cluster_deletion_script: delete_existing_cluster.py
-      nameSuffix: existing_arrikto    
+      nameSuffix: existing_arrikto

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -91,7 +91,14 @@ def load_config(config_path):
       config_spec = yaml.load(f)
       return config_spec
 
-def set_env_init_args(use_basic_auth, use_istio, app_path):
+def set_env_init_args(config_spec):
+  gcp_plugin = {}
+  for plugin in config_spec["spec"]["plugins"]:
+    if plugin["kind"] == "KfGcpPlugin":
+      gcp_plugin = plugin
+      break
+  use_basic_auth = gcp_plugin.get("spec", {}).get("useBasicAuth", False)
+  logging.info("use_basic_auth=%s", use_basic_auth)
   # Is it really needed?
   init_args = []
   # Set ENV for basic auth username/password.
@@ -100,12 +107,6 @@ def set_env_init_args(use_basic_auth, use_istio, app_path):
     # logging.info("Setting environment variables KUBEFLOW_USERNAME and KUBEFLOW_PASSWORD")
     os.environ["KUBEFLOW_USERNAME"] = "kf-test-user"
     os.environ["KUBEFLOW_PASSWORD"] = str(uuid.uuid4().hex)
-    with open(os.path.join(app_path, "login.json"), "w") as f:
-      login = {
-          "KUBEFLOW_USERNAME": os.environ["KUBEFLOW_USERNAME"],
-          "KUBEFLOW_PASSWORD": os.environ["KUBEFLOW_PASSWORD"],
-      }
-      json.dump(login, f)
     init_args = ["--use_basic_auth"]
   else:
     # Owned by project kubeflow-ci-deployment.
@@ -114,11 +115,7 @@ def set_env_init_args(use_basic_auth, use_istio, app_path):
     os.environ["CLIENT_ID"] = (
       "29647740582-7meo6c7a9a76jvg54j0g2lv8lrsb4l8g"
       ".apps.googleusercontent.com")
-
-  if use_istio:
-    init_args.append("--use_istio")
-  else:
-    init_args.append("--use_istio=false")
+  init_args.append("--use_istio")
 
 def filter_spartakus(spec):
   """Filter our Spartakus from KfDef spec.
@@ -261,19 +258,6 @@ def kfctl_deploy_kubeflow(app_path, project, use_basic_auth, use_istio, config_p
   config_spec = get_config_spec(config_path, project, email, zone, app_path)
   with open(os.path.join(app_path, "tmp.yaml"), "w") as f:
     yaml.dump(config_spec, f)
-
-  # TODO(jlewi): When we switch to KfDef v1beta1 this logic will need to change because
-  # use_base_auth will move into the plugin spec
-  gcp_plugin = {}
-  for plugin in config_spec["spec"]["plugins"]:
-    if plugin["kind"] == "KfGcpPlugin":
-      gcp_plugin = plugin
-      break
-  use_basic_auth = gcp_plugin.get("spec", {}).get("useBasicAuth", False)
-  logging.info("use_basic_auth=%s", use_basic_auth)
-
-  use_istio = gcp_plugin.get("spec", {}).get("useIstio", True)
-  logging.info("use_istio=%s", use_istio)
 
   # Set ENV for basic auth username/password.
   set_env_init_args(use_basic_auth, use_istio, app_path)

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -282,7 +282,7 @@ def kfctl_deploy_kubeflow(app_path, project, use_basic_auth, use_istio, config_p
     yaml.dump(config_spec, f)
 
   # Set ENV for credentials IAP/basic auth needs.
-  set_env_init_args(use_basic_auth, use_istio, app_path)
+  set_env_init_args(config_spec)
 
   # Write basic auth login username/password to a file for later tests.
   # If the ENVs are not set, this function call will be noop.

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -119,6 +119,9 @@ def set_env_init_args(config_spec):
   # TODO(gabrielwen): We should be able to remove this flag.
   init_args.append("--use_istio")
 
+def write_basic_auth_login(app_path):
+  pass
+
 def filter_spartakus(spec):
   """Filter our Spartakus from KfDef spec.
 
@@ -261,7 +264,7 @@ def kfctl_deploy_kubeflow(app_path, project, use_basic_auth, use_istio, config_p
   with open(os.path.join(app_path, "tmp.yaml"), "w") as f:
     yaml.dump(config_spec, f)
 
-  # Set ENV for basic auth username/password.
+  # Set ENV for credentials IAP/basic auth needs.
   set_env_init_args(use_basic_auth, use_istio, app_path)
 
   # build_and_apply

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -115,6 +115,8 @@ def set_env_init_args(config_spec):
     os.environ["CLIENT_ID"] = (
       "29647740582-7meo6c7a9a76jvg54j0g2lv8lrsb4l8g"
       ".apps.googleusercontent.com")
+  # Always use ISTIO.
+  # TODO(gabrielwen): We should be able to remove this flag.
   init_args.append("--use_istio")
 
 def filter_spartakus(spec):

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -93,8 +93,8 @@ def load_config(config_path):
 
 def set_env_init_args(config_spec):
   gcp_plugin = {}
-  for plugin in config_spec["spec"]["plugins"]:
-    if plugin["kind"] == "KfGcpPlugin":
+  for plugin in config_spec.get("spec", {}).get("plugins", []):
+    if plugin.get("kind", "") == "KfGcpPlugin":
       gcp_plugin = plugin
       break
   use_basic_auth = gcp_plugin.get("spec", {}).get("useBasicAuth", False)


### PR DESCRIPTION
Related: kubeflow/kfctl#71

- Use config_spec to access config info.
- Include `py/kubeflow/kubeflow/ci/*` to all E2E tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4459)
<!-- Reviewable:end -->
