### PR TITLE
C2D UI: add option for v0.7 and deprecate v0.5

### DIFF
--- a/components/gcp-click-to-deploy/src/DeployForm.tsx
+++ b/components/gcp-click-to-deploy/src/DeployForm.tsx
@@ -842,9 +842,11 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
      * @throws Error on any invalid condition
      */
     private _validateInputFields(): void {
+        const {clientId, clientSecret, deploymentName, project,
+            password, password2, username, zone} = this.state;
         const err = new Error('Invalid inputs');
-        for (const prop of ['project', 'zone', 'deploymentName']) {
-            if (this.state[prop] === '') {
+        for (const prop of [project, zone, deploymentName]) {
+            if (prop === '') {
                 this.setState({
                     dialogAsCode: false,
                     dialogBody: 'Some required fields (project, zone, deploymentName) are missing',
@@ -854,8 +856,8 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
             }
         }
         if (this.state.ingress === IngressType.Iap) {
-            for (const prop of ['clientId', 'clientSecret']) {
-                if (this.state[prop] === '') {
+            for (const prop of [clientId, clientSecret]) {
+                if (prop === '') {
                     this.setState({
                         dialogAsCode: false,
                         dialogBody: 'Some required fields (IAP Oauth Client ID, IAP Oauth Client Secret) are missing',
@@ -866,8 +868,8 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
             }
         }
         if (this.state.ingress === IngressType.BasicAuth) {
-            for (const prop of ['username', 'password', 'password2']) {
-                if (this.state[prop] === '') {
+            for (const prop of [username, password, password2]) {
+                if (prop === '') {
                     this.setState({
                         dialogAsCode: false,
                         dialogBody: 'Some required fields (username, password) are missing',
@@ -876,7 +878,7 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
                     throw err;
                 }
             }
-            if (this.state.password !== this.state.password2) {
+            if (password !== password2) {
                 this.setState({
                     dialogAsCode: false,
                     dialogBody: 'Two passwords does not match',
@@ -885,10 +887,8 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
                 throw err;
             }
         }
-        const deploymentNameKey = 'deploymentName';
-        const projectKey = 'project';
-        const maxNameLen = 41 - this.state[projectKey].length;
-        if (this.state[deploymentNameKey].length < 4 || this.state[deploymentNameKey].length > maxNameLen) {
+        const maxNameLen = 41 - project.length;
+        if (deploymentName.length < 4 || deploymentName.length > maxNameLen) {
             this.setState({
                 dialogAsCode: false,
                 dialogBody: 'For current project id, deployment name length need to be between 4 and ' + maxNameLen,
@@ -896,8 +896,8 @@ export default class DeployForm extends React.Component<any, DeployFormState> {
             });
             throw err;
         }
-        const filtered = this.state[deploymentNameKey].match(NAME_FORMAT);
-        if (!(filtered && this.state[deploymentNameKey] === filtered[0])) {
+        const filtered = deploymentName.match(NAME_FORMAT);
+        if (!(filtered && deploymentName === filtered[0])) {
             this.setState({
                 dialogAsCode: false,
                 dialogBody: 'Deployment name: the first character must be a lowercase letter, and all following ' +

--- a/components/gcp-click-to-deploy/src/Gapi.ts
+++ b/components/gcp-click-to-deploy/src/Gapi.ts
@@ -116,6 +116,22 @@ export default class Gapi {
     }
 
   };
+  public static servicemanagement = class {
+    public static async enable(project: string, serviceName: string) {
+      await Gapi.load();
+      const consumerId = `project:${project}`;
+      return gapi.client.request({
+        body: {
+          consumerId
+        },
+        method: 'POST',
+        path: `https://content-servicemanagement.googleapis.com/v1/services/${serviceName}:enable`,
+      }).then(response => response.result as EnableServiceRequest,
+        badResult => {
+          throw new Error('Errors enabling service: ' + flattenDeploymentOperationError(badResult.result));
+        });
+    }
+  };
 
   public static cloudresourcemanager = class {
 


### PR DESCRIPTION
* C2D v0.7: build kfdef obejct on backend side, frontend use new light-weighted request body: `C2Drequest` Related: https://github.com/kubeflow/kubeflow/pull/4399
* Add name length check for cert domain name length restriction
* Automate API enabling for `cloudresourcemanager.googleapis.com` and `iam.googleapis.com`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4487)
<!-- Reviewable:end -->
