### PR TITLE
Fix KFCTL e2e test build path

### DIFF
--- a/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
@@ -535,6 +535,7 @@ class Builder:
         #
         "-o", "junit_suite_name=test_kfctl_go_deploy_" + self.config_name,
         "--app_path=" + self.app_dir,
+        "--kfctl_repo_path=" + self.src_dir,
     ]
 
     dependences = [checkout["name"]]

--- a/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_e2e_workflow.py
@@ -124,14 +124,15 @@ class Builder:
 
     # source directory where all repos should be checked out
     self.src_root_dir = self.test_dir + "/src"
-    # The directory containing the kubeflow/kubeflow repo
-    self.src_dir = self.src_root_dir + "/kubeflow/kubeflow"
+    # The directory containing the kubeflow/kfctl repo
+    self.src_dir = self.src_root_dir + "/kubeflow/kfctl"
+    self.kubeflow_dir = self.src_root_dir + "/kubeflow/kubeflow"
 
-    # Directory in kubeflow/kubeflow containing the pytest files for kfctl
-    self.kfctl_pytest_dir = os.path.join(self.src_dir, "testing/kfctl")
+    # Directory in kubeflow/kfctl containing the pytest files.
+    self.kfctl_pytest_dir = os.path.join(self.src_dir, "testing/e2e")
 
     # Top level directories for python code
-    self.kubeflow_py = self.src_dir
+    self.kubeflow_py = self.kubeflow_dir
 
     # The directory within the kubeflow_testing submodule containing
     # py scripts to use.
@@ -196,7 +197,7 @@ class Builder:
     self.steps_namespace = "kubeflow"
     self.test_endpoint = test_endpoint
 
-    self.kfctl_path = os.path.join(self.src_dir, "bootstrap/bin/kfctl")
+    self.kfctl_path = os.path.join(self.src_dir, "bin/kfctl")
 
     # Fetch the main repo from Prow environment.
     self.main_repo = argo_build_util.get_repo_from_prow_env()
@@ -399,7 +400,7 @@ class Builder:
                                      command, dependences)
 
     notebook_test["container"]["workingDir"] =  os.path.join(
-      self.src_dir, "kubeflow/jupyter/tests")
+      self.kubeflow_dir, "kubeflow/jupyter/tests")
 
     #***************************************************************************
     # Profiles test
@@ -420,7 +421,7 @@ class Builder:
                                      command, dependences)
 
     profiles_test["container"]["workingDir"] =  os.path.join(
-      self.src_dir, "kubeflow/profiles/tests")
+      self.kubeflow_dir, "kubeflow/profiles/tests")
 
   def _build_exit_dag(self):
     """Build the exit handler dag"""

--- a/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
+++ b/py/kubeflow/kubeflow/ci/kfctl_go_test_utils.py
@@ -18,37 +18,20 @@ from retrying import retry
 def run_with_retries(*args, **kwargs):
   util.run(*args, **kwargs)
 
-def get_kfctl_go_build_dir_binary_path():
-  """return the build directory and path to kfctl go binary.
-
-  Args:
-    None
-
-  Return:
-    build_dir (str): Path to start build will be Kubeflow/kubeflow/bootstrap/
-    kfctl_path (str): Path where kfctl go binary has been built.
-            will be Kubeflow/kubeflow/bootstrap/bin/kfctl
-  """
-  this_dir = os.path.dirname(__file__)
-  root = os.path.abspath(os.path.join(this_dir, "..", "..", "..", ".."))
-  build_dir = os.path.join(root, "bootstrap")
-  kfctl_path = os.path.join(build_dir, "bin", "kfctl")
-  return build_dir, kfctl_path
-
-def build_kfctl_go():
+def build_kfctl_go(kfctl_repo_path):
   """build the kfctl go binary and return the path for the same.
 
   Args:
-    None
+    kfctl_repo_path (str): Path to kfctl repo.
 
   Return:
     kfctl_path (str): Path where kfctl go binary has been built.
             will be Kubeflow/kubeflow/bootstrap/bin/kfctl
   """
-  build_dir, kfctl_path = get_kfctl_go_build_dir_binary_path()
+  kfctl_path = os.path.join(kfctl_repo_path, "bin", "kfctl")
   # We need to use retry builds because when building in the test cluster
   # we see intermittent failures pulling dependencies
-  run_with_retries(["make", "build-kfctl"], cwd=build_dir)
+  run_with_retries(["make", "build-kfctl"], cwd=kfctl_repo_path)
   return kfctl_path
 
 def get_or_create_app_path_and_parent_dir(app_path):


### PR DESCRIPTION
Needs to point to kfctl repo instead of using kubeflow/kubeflow/bootstrap

/assign @kunmingg

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4493)
<!-- Reviewable:end -->
