### PR TITLE
Update bootstrapper to use apps/v1 for StatefulSet

### DIFF
--- a/bootstrap/bootstrapper.yaml
+++ b/bootstrap/bootstrapper.yaml
@@ -34,7 +34,7 @@ spec:
     requests:
       storage: 5Gi
 ---
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: kubeflow-bootstrapper


### PR DESCRIPTION
Fixes #4497 

`apps/v1beta2` has been [deprecated](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/) in Kubernetes version 1.16 in favour of `apps/v1`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4498)
<!-- Reviewable:end -->
