### PR TITLE
Show namespace selector when choosing pipelines

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -203,7 +203,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         case IFRAME_LINK_PREFIX:
             this.page = 'iframe';
             isIframe = true;
-            hideNamespaces = this.subRouteData.path.startsWith('/pipeline');
+            hideNamespaces = false;
             this._setActiveMenuLink(this.subRouteData.path);
             this._setIframeSrc();
             break;

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -149,22 +149,6 @@ describe('Main Page', () => {
         hrefs.forEach((h) => expect(h).toContain('?ns=another-namespace'));
     });
 
-    it('Hides namespace selector when showing Pipelines dashboard', () => {
-        expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
-            .hasAttribute('hidden')).toBe(false);
-
-        mainPage.subRouteData.path = '/pipeline/';
-        mainPage._routePageChanged('_');
-        flush();
-        expect(mainPage.shadowRoot.querySelector('#NamespaceSelector')
-            .hasAttribute('hidden')).toBe(true);
-        expect(mainPage.page).toBe('iframe');
-        expect(mainPage.sidebarItemIndex).toBe(1);
-        expect(mainPage.inIframe).toBe(true);
-        expect(mainPage.shadowRoot.getElementById('ViewTabs')
-            .hasAttribute('hidden')).toBe(true);
-    });
-
     it('Sets information when platform info is received', async () => {
         const namespaces = [
             {


### PR DESCRIPTION
We are working on supporting multi user mode for pipelines in Kubeflow.
Show the selector so it becomes visible.

I would also want to add a "pipelines multi user" feature flag that can turn this on/off. Can someone point me to the right direction?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4518)
<!-- Reviewable:end -->
