### PR TITLE
configuring scheduler name from configmap

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -328,6 +328,10 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 			FSGroup: &fsGroup,
 		}
 	}
+	schedulerName := os.Getenv("SCHEDULER_NAME")
+	if len(schedulerName) > 0 {
+		podSpec.SchedulerName = schedulerName
+	}
 	return ss
 }
 


### PR DESCRIPTION
Set environment variable SCHEDULER_NAME in"notebook-controller-parameters" ConfigMap and it will be used as the notebook scheduler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4525)
<!-- Reviewable:end -->
