### PR TITLE
Add a github action to add/remove issues from the needs triage Kanban board

### DIFF
--- a/.github/workflows/triage_issues.yaml
+++ b/.github/workflows/triage_issues.yaml
@@ -1,0 +1,16 @@
+name: Check Triage Status of Issue
+on: 
+  issues:
+    types: [opened, closed, reopened, transferred, labeled, unlabeled]
+    # Issue is created, Issue is closed, Issue added or removed from projects, Labels added/removed
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Kanban
+        uses: kubeflow/code-intelligence/Issue_Triage/action@master
+        with:
+          # Letting input NEEDS_TRIAGE_PROJECT_CARD_ID use the default value
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.triage_projects_github_token }}


### PR DESCRIPTION
Related to kubeflow/community#27

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4526)
<!-- Reviewable:end -->
