### PR TITLE
Fix the GitHub action workflow to add issue triage issues

### DIFF
--- a/.github/workflows/triage_issues.yaml
+++ b/.github/workflows/triage_issues.yaml
@@ -13,4 +13,8 @@ jobs:
         with:
           # Letting input NEEDS_TRIAGE_PROJECT_CARD_ID use the default value
           ISSUE_NUMBER: ${{ github.event.issue.number }}
+<<<<<<< HEAD
           PERSONAL_ACCESS_TOKEN: ${{ secrets.triage_projects_github_token }}
+=======
+          GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.triage_projects_github_token }}
+>>>>>>> 29591dab... Fix the GitHub action workflow to add issue triage issues

--- a/.github/workflows/triage_issues.yaml
+++ b/.github/workflows/triage_issues.yaml
@@ -1,5 +1,7 @@
+# Define a GitHub action workflow to determine whether issues 
+# should be added or removed from the Needs Triage Kanban board.
 name: Check Triage Status of Issue
-on: 
+on:
   issues:
     types: [opened, closed, reopened, transferred, labeled, unlabeled]
     # Issue is created, Issue is closed, Issue added or removed from projects, Labels added/removed
@@ -13,8 +15,5 @@ jobs:
         with:
           # Letting input NEEDS_TRIAGE_PROJECT_CARD_ID use the default value
           ISSUE_NUMBER: ${{ github.event.issue.number }}
-<<<<<<< HEAD
-          PERSONAL_ACCESS_TOKEN: ${{ secrets.triage_projects_github_token }}
-=======
           GITHUB_PERSONAL_ACCESS_TOKEN: ${{ secrets.triage_projects_github_token }}
->>>>>>> 29591dab... Fix the GitHub action workflow to add issue triage issues
+


### PR DESCRIPTION
* The name of the input containing the secret is GITHUB_PERSONAL_ACCESS_TOKEN
  https://github.com/kubeflow/code-intelligence/blob/ea1e5995d7e9bc8e6326c1adf9c5149af2294ced/py/issue_triage/triage_for_action.py#L11

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4531)
<!-- Reviewable:end -->
