### PR TITLE
jovyan owns /home/jovyan in tf-notebook images

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -110,7 +110,9 @@ COPY --chown=jovyan:users requirements.txt /tmp
 
 RUN docker-credential-gcr configure-docker && chown ${NB_USER}:users $HOME/.docker/config.json
 
-RUN chown -R ${NB_USER}:users $HOME
+# Following the recomendations in https://docs.openshift.com/container-platform/4.2/openshift_images/create-images.html#images-create-guide-openshift_create-images
+# tu support arbitrary user ids. When no PV is bound, notebooks are saved in the home directory
+RUN chown -R ${NB_USER}:users $HOME && chgrp -R 0 $HOME && chmod -R g=u $HOME
 
 # Configure container startup
 EXPOSE 8888

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -110,6 +110,8 @@ COPY --chown=jovyan:users requirements.txt /tmp
 
 RUN docker-credential-gcr configure-docker && chown ${NB_USER}:users $HOME/.docker/config.json
 
+RUN chown -R ${NB_USER}:users $HOME
+
 # Configure container startup
 EXPOSE 8888
 USER jovyan


### PR DESCRIPTION
Related issue: https://github.com/kubeflow/kubeflow/issues/4520

When no PV is bound, `/home/jovyan` has ownership `root:root` in tensorflow-nb images, this forbids user `jovyan` (default user) from writing to its own directory.

This PR changes the ownership of `/home/jovyan` to `jovyan:users`.

Edit: also added compatibility with Openshift following the guidelines at https://docs.openshift.com/container-platform/4.2/openshift_images/create-images.html#images-create-guide-openshift_create-images

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4537)
<!-- Reviewable:end -->
