### PR TITLE
Fix annotation/label injection in admission hook

### DIFF
--- a/components/admission-webhook/main.go
+++ b/components/admission-webhook/main.go
@@ -114,8 +114,8 @@ func safeToApplyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.Pod
 		defaultLabels      = make([]*map[string]string, len(podDefaults))
 	)
 	for i, pd := range podDefaults {
-		defaultAnnotations[i] = &pd.Annotations
-		defaultLabels[i] = &pd.Labels
+		defaultAnnotations[i] = &pd.Spec.Annotations
+		defaultLabels[i] = &pd.Spec.Labels
 	}
 	if _, err := mergeMap(pod.Annotations, defaultAnnotations); err != nil {
 		errs = append(errs, err)
@@ -336,8 +336,8 @@ func applyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.PodDefaul
 		defaultLabels      = make([]*map[string]string, len(podDefaults))
 	)
 	for i, pd := range podDefaults {
-		defaultAnnotations[i] = &pd.Annotations
-		defaultLabels[i] = &pd.Labels
+		defaultAnnotations[i] = &pd.Spec.Annotations
+		defaultLabels[i] = &pd.Spec.Labels
 	}
 	annotations, err := mergeMap(pod.Annotations, defaultAnnotations)
 	if err != nil {

--- a/components/admission-webhook/main_test.go
+++ b/components/admission-webhook/main_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
+
+	settingsapi "github.com/kubeflow/kubeflow/components/admission-webhook/pkg/apis/settings/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestMergeMapBad(t *testing.T) {
@@ -57,7 +60,7 @@ func TestMergeMapGood(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(fmt.Sprintf(test.name), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			out, err := mergeMap(test.existing, []*map[string]string{&test.defaults})
 			if err != nil {
 				t.Fatal(err)
@@ -67,4 +70,73 @@ func TestMergeMapGood(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestApplyPodDefaultsOnPod(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		in          *corev1.Pod
+		podDefaults []*settingsapi.PodDefault
+		out         *corev1.Pod
+	}{
+		{
+			"Add Annotations",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			[]*settingsapi.PodDefault{
+				{
+					Spec: settingsapi.PodDefaultSpec{
+						Annotations: map[string]string{"baz": "bux"},
+					},
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+						"baz": "bux",
+						"poddefault.admission.kubeflow.org/poddefault-": "",
+					},
+					Labels: map[string]string{},
+				},
+			},
+		}, {
+			"Same k/v",
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"foo": "bar"},
+				},
+			},
+			[]*settingsapi.PodDefault{
+				{
+					Spec: settingsapi.PodDefaultSpec{
+						Annotations: map[string]string{"foo": "bar"},
+					},
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+						"poddefault.admission.kubeflow.org/poddefault-": "",
+					},
+					Labels: map[string]string{},
+				},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if err := safeToApplyPodDefaultsOnPod(test.in, test.podDefaults); err != nil {
+				t.Fatal(err)
+			}
+			applyPodDefaultsOnPod(test.in, test.podDefaults)
+			if !reflect.DeepEqual(test.in, test.out) {
+				t.Fatalf("%#v\n  Not Equals:\n%#v", test.in.ObjectMeta, test.out.ObjectMeta)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
Fix for my broken implementation in #4539 /cc @jlewi 

Before we used the annotations/labels from PodDefaults's embedded
ObjectMeta instead of the correct Annotations/Labels field of the
PodDefaultSpec.

This also adds tests for the (SafeTo)ApplyPodDefaultsOnPod function to
that uncovered the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4544)
<!-- Reviewable:end -->
