### PR TITLE
Use v1alpha1 for poddefaults instead of v1beta1

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
@@ -173,7 +173,7 @@ def get_poddefaults(ns, user=None):
         "poddefaults",
         custom_api.list_namespaced_custom_object,
         "kubeflow.org",
-        "v1beta1",
+        "v1alpha1",
         ns,
         "poddefaults"
     )


### PR DESCRIPTION
Closes #4547 

/cc @lluunn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4548)
<!-- Reviewable:end -->
