### PR TITLE
jupyter-web-app: Use SubjectAccessReviews instead of KFAM

### DIFF
--- a/components/jupyter-web-app/backend/Makefile
+++ b/components/jupyter-web-app/backend/Makefile
@@ -2,10 +2,10 @@ run:
 	python main.py
 
 run-dev:
-	python main.py --enable-cors
+	FLASK_ENV=development python main.py --enable-cors
 
 run-rok:
 	UI=rok python main.py
 
 run-rok-dev:
-	UI=rok python main.py --enable-cors
+	FLASK_ENV=development UI=rok python main.py --enable-cors

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
@@ -77,8 +77,8 @@ def wrap(fn, *args, **kwargs):
 
 # API Functions
 # GETers
-@auth.needs_authorization("get", "core", "v1", "pvcs")
-def get_pvcs(namespace):
+@auth.needs_authorization("list", "core", "v1", "pvcs")
+def list_pvcs(namespace):
     return wrap_resp(
         "pvcs",
         v1_core.list_namespaced_persistent_volume_claim,
@@ -86,17 +86,8 @@ def get_pvcs(namespace):
     )
 
 
-@auth.needs_authorization("get", "core", "v1", "pods")
-def get_pods(namespace):
-    return wrap_resp(
-        "pods",
-        v1_core.list_namespaced_pod,
-        namespace
-    )
-
-
-@auth.needs_authorization("get", "kubeflow.org", "v1beta1", "notebooks")
-def get_notebooks(namespace):
+@auth.needs_authorization("list", "kubeflow.org", "v1beta1", "notebooks")
+def list_notebooks(namespace):
     return wrap_resp(
         "notebooks",
         custom_api.list_namespaced_custom_object,
@@ -107,8 +98,8 @@ def get_notebooks(namespace):
     )
 
 
-@auth.needs_authorization("get", "kubeflow.org", "v1alpha1", "poddefaults")
-def get_poddefaults(namespace):
+@auth.needs_authorization("list", "kubeflow.org", "v1alpha1", "poddefaults")
+def list_poddefaults(namespace):
     return wrap_resp(
         "poddefaults",
         custom_api.list_namespaced_custom_object,
@@ -129,16 +120,21 @@ def get_secret(namespace, name):
     )
 
 
-@auth.needs_authorization("get", "core", "v1", "namespaces")
-def get_namespaces():
+@auth.needs_authorization("list", "core", "v1", "namespaces")
+def list_namespaces():
     return wrap_resp(
         "namespaces",
         v1_core.list_namespace
     )
 
 
-@auth.needs_authorization("get", "storage.k8s.io", "v1", "storageclasses")
-def get_storageclasses():
+# @auth.needs_authorization("list", "storage.k8s.io", "v1", "storageclasses")
+# NOTE: This function is only used from the backend in order to determine if a
+# default StorageClass is set. Currently, the role aggregation does not use a
+# ClusterRoleBinding, thus we can't currently give this permission to a user.
+# The backend does not expose any endpoint that would allow an unauthorized
+# user to list the storage classes using this function.
+def list_storageclasses():
     return wrap_resp(
         "storageclasses",
         storage_api.list_storage_class
@@ -146,8 +142,8 @@ def get_storageclasses():
 
 
 # POSTers
-@auth.needs_authorization("post", "kubeflow.org", "v1beta1", "notebooks")
-def post_notebook(namespace, notebook):
+@auth.needs_authorization("create", "kubeflow.org", "v1beta1", "notebooks")
+def create_notebook(namespace, notebook):
     return wrap(
         custom_api.create_namespaced_custom_object,
         "kubeflow.org",
@@ -158,8 +154,8 @@ def post_notebook(namespace, notebook):
     )
 
 
-@auth.needs_authorization("post", "core", "v1", "pvcs")
-def post_pvc(namespace, pvc):
+@auth.needs_authorization("create", "core", "v1", "pvcs")
+def create_pvc(namespace, pvc):
     return wrap_resp(
         "pvc",
         v1_core.create_namespaced_persistent_volume_claim,

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
@@ -77,7 +77,7 @@ def wrap(fn, *args, **kwargs):
 
 # API Functions
 # GETers
-@auth.needs_authorization("list", "core", "v1", "pvcs")
+@auth.needs_authorization("list", "", "v1", "persistentvolumeclaims")
 def list_pvcs(namespace):
     return wrap_resp(
         "pvcs",
@@ -111,7 +111,7 @@ def list_poddefaults(namespace):
 
 
 @auth.needs_authorization("get", "core", "v1", "secrets")
-def get_secret(namespace, name):
+def get_secret(name, namespace):
     return wrap_resp(
         "secret",
         v1_core.read_namespaced_secret,
@@ -143,7 +143,7 @@ def list_storageclasses():
 
 # POSTers
 @auth.needs_authorization("create", "kubeflow.org", "v1beta1", "notebooks")
-def create_notebook(namespace, notebook):
+def create_notebook(notebook, namespace):
     return wrap(
         custom_api.create_namespaced_custom_object,
         "kubeflow.org",
@@ -154,8 +154,8 @@ def create_notebook(namespace, notebook):
     )
 
 
-@auth.needs_authorization("create", "core", "v1", "pvcs")
-def create_pvc(namespace, pvc):
+@auth.needs_authorization("create", "", "v1", "persistentvolumeclaims")
+def create_pvc(pvc, namespace):
     return wrap_resp(
         "pvc",
         v1_core.create_namespaced_persistent_volume_claim,
@@ -163,10 +163,9 @@ def create_pvc(namespace, pvc):
         pvc
     )
 
-
 # DELETErs
 @auth.needs_authorization("delete", "kubeflow.org", "v1beta1", "notebooks")
-def delete_notebook(namespace, notebook_name):
+def delete_notebook(notebook_name, namespace):
     return wrap(
         custom_api.delete_namespaced_custom_object,
         "kubeflow.org",

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
@@ -77,7 +77,7 @@ def wrap(fn, *args, **kwargs):
 
 # API Functions
 # GETers
-@auth.needs_authorization("get", "pvcs")
+@auth.needs_authorization("get", "core", "v1", "pvcs")
 def get_pvcs(namespace):
     return wrap_resp(
         "pvcs",
@@ -86,7 +86,7 @@ def get_pvcs(namespace):
     )
 
 
-@auth.needs_authorization("get", "pods")
+@auth.needs_authorization("get", "core", "v1", "pods")
 def get_pods(namespace):
     return wrap_resp(
         "pods",
@@ -95,7 +95,7 @@ def get_pods(namespace):
     )
 
 
-@auth.needs_authorization("get", "notebooks")
+@auth.needs_authorization("get", "kubeflow.org", "v1beta1", "notebooks")
 def get_notebooks(namespace):
     return wrap_resp(
         "notebooks",
@@ -107,7 +107,7 @@ def get_notebooks(namespace):
     )
 
 
-@auth.needs_authorization("get", "poddefaults")
+@auth.needs_authorization("get", "kubeflow.org", "v1alpha1", "poddefaults")
 def get_poddefaults(namespace):
     return wrap_resp(
         "poddefaults",
@@ -119,7 +119,7 @@ def get_poddefaults(namespace):
     )
 
 
-@auth.needs_authorization("get", "secrets")
+@auth.needs_authorization("get", "core", "v1", "secrets")
 def get_secret(namespace, name):
     return wrap_resp(
         "secret",
@@ -129,7 +129,7 @@ def get_secret(namespace, name):
     )
 
 
-@auth.needs_authorization("get", "namespaces")
+@auth.needs_authorization("get", "core", "v1", "namespaces")
 def get_namespaces():
     return wrap_resp(
         "namespaces",
@@ -137,7 +137,7 @@ def get_namespaces():
     )
 
 
-@auth.needs_authorization("get", "storageclasses")
+@auth.needs_authorization("get", "storage.k8s.io", "v1", "storageclasses")
 def get_storageclasses():
     return wrap_resp(
         "storageclasses",
@@ -146,7 +146,7 @@ def get_storageclasses():
 
 
 # POSTers
-@auth.needs_authorization("post", "notebooks")
+@auth.needs_authorization("post", "kubeflow.org", "v1beta1", "notebooks")
 def post_notebook(namespace, notebook):
     return wrap(
         custom_api.create_namespaced_custom_object,
@@ -158,7 +158,7 @@ def post_notebook(namespace, notebook):
     )
 
 
-@auth.needs_authorization("post", "pvcs")
+@auth.needs_authorization("post", "core", "v1", "pvcs")
 def post_pvc(namespace, pvc):
     return wrap_resp(
         "pvc",
@@ -168,8 +168,8 @@ def post_pvc(namespace, pvc):
     )
 
 
-# DELETEers
-@auth.needs_authorization("delete", "notebooks")
+# DELETErs
+@auth.needs_authorization("delete", "kubeflow.org", "v1beta1", "notebooks")
 def delete_notebook(namespace, notebook_name):
     return wrap(
         custom_api.delete_namespaced_custom_object,

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/auth.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/auth.py
@@ -1,0 +1,69 @@
+import os
+import requests
+import functools
+from . import utils
+
+logger = utils.create_logger(__name__)
+
+KFAM = os.getenv("KFAM", "profiles-kfam.kubeflow.svc.cluster.local:8081")
+
+
+def is_authorized(user, namespace):
+    '''
+    Queries KFAM for whether the provided user has access
+    to the specific namespace
+    '''
+    if user is None:
+        # In case a user is not present, preserve the behavior from 0.5
+        # Pass the authorization check and make the calls with the webapp's SA
+        return True
+
+    try:
+        resp = requests.get("http://{}/kfam/v1/bindings?namespace={}".format(
+            KFAM, namespace)
+        )
+    except Exception as e:
+        logger.warning(
+            "Error talking to KFAM: {}".format(utils.parse_error(e))
+        )
+        return False
+
+    if resp.status_code == 200:
+        # Iterate through the namespace's bindings and check for the user
+        for binding in resp.json().get("bindings", []):
+            if binding["user"]["name"] == user:
+                return True
+
+        return False
+    else:
+        logger.warning("{}: Error talking to KFAM!".format(resp.status_code))
+        return False
+
+
+def needs_authorization(verb, rsrc):
+    '''
+    This function will serve as a decorator. It will be used to make sure that
+    the decorated function is authorized to perform the corresponding k8s api
+    verb on a specific resource.
+    '''
+    def wrapper(func):
+        @functools.wraps(func)
+        def runner(*args, **kwargs):
+            user = utils.get_username_from_request()
+            ns = kwargs.get("namespace", None)
+
+            if is_authorized(user, ns):
+                # If the user is authorized, then perform the func
+                return func(*args, **kwargs)
+            else:
+                # If the user is not authorized, then we don't perform the
+                # func and return an unauthorized message
+                msg = f"User '{user}' is not authorized for namespace '{ns}'"
+                return {
+                    "success": False,
+                    "log": msg,
+                }
+
+        return runner
+
+    return wrapper

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
@@ -139,7 +139,7 @@ def post_pvc(namespace):
         )
     )
 
-    return jsonify(api.post_pvc(pvc, namespace=namespace))
+    return jsonify(api.create_pvc(pvc, namespace=namespace))
 
 
 # DELETErs

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
@@ -19,7 +19,7 @@ def prefix():
 # REST Routes
 @app.route("/api/namespaces/<namespace>/notebooks")
 def get_notebooks(namespace):
-    data = api.get_notebooks(namespace=namespace)
+    data = api.list_notebooks(namespace=namespace)
 
     if not data["success"]:
         return jsonify(data)
@@ -31,7 +31,7 @@ def get_notebooks(namespace):
 
 @app.route("/api/namespaces/<namespace>/poddefaults")
 def get_poddefaults(namespace):
-    data = api.get_poddefaults(namespace=namespace)
+    data = api.list_poddefaults(namespace=namespace)
 
     if not data["success"]:
         return jsonify(data)
@@ -54,7 +54,7 @@ def get_poddefaults(namespace):
 
 @app.route("/api/namespaces/<namespace>/pvcs")
 def get_pvcs(namespace):
-    data = api.get_pvcs(namespace=namespace)
+    data = api.list_pvcs(namespace=namespace)
     if not data["success"]:
         return jsonify(data)
 
@@ -65,7 +65,7 @@ def get_pvcs(namespace):
 
 @app.route("/api/namespaces")
 def get_namespaces():
-    data = api.get_namespaces()
+    data = api.list_namespaces()
 
     # Result must be jsonify-able
     if data["success"]:
@@ -75,21 +75,9 @@ def get_namespaces():
     return jsonify(data)
 
 
-@app.route("/api/storageclasses")
-def get_storageclasses():
-    data = api.get_storageclasses()
-
-    # Result must be jsonify-able
-    if data["success"]:
-        scs = data["storageclasses"]
-        data["storageclasses"] = [sc.metadata.name for sc in scs.items]
-
-    return jsonify(data)
-
-
 @app.route("/api/storageclasses/default")
 def get_default_storageclass():
-    data = api.get_storageclasses()
+    data = api.list_storageclasses()
     if not data["success"]:
         return jsonify({
             "success": False,

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
@@ -19,8 +19,7 @@ def prefix():
 # REST Routes
 @app.route("/api/namespaces/<namespace>/notebooks")
 def get_notebooks(namespace):
-    user = utils.get_username_from_request()
-    data = api.get_notebooks(namespace, user)
+    data = api.get_notebooks(namespace=namespace)
 
     if not data["success"]:
         return jsonify(data)
@@ -32,8 +31,7 @@ def get_notebooks(namespace):
 
 @app.route("/api/namespaces/<namespace>/poddefaults")
 def get_poddefaults(namespace):
-    user = utils.get_username_from_request()
-    data = api.get_poddefaults(namespace, user)
+    data = api.get_poddefaults(namespace=namespace)
 
     if not data["success"]:
         return jsonify(data)
@@ -56,8 +54,7 @@ def get_poddefaults(namespace):
 
 @app.route("/api/namespaces/<namespace>/pvcs")
 def get_pvcs(namespace):
-    user = utils.get_username_from_request()
-    data = api.get_pvcs(namespace, user)
+    data = api.get_pvcs(namespace=namespace)
     if not data["success"]:
         return jsonify(data)
 
@@ -68,8 +65,7 @@ def get_pvcs(namespace):
 
 @app.route("/api/namespaces")
 def get_namespaces():
-    user = utils.get_username_from_request()
-    data = api.get_namespaces(user)
+    data = api.get_namespaces()
 
     # Result must be jsonify-able
     if data["success"]:
@@ -81,8 +77,7 @@ def get_namespaces():
 
 @app.route("/api/storageclasses")
 def get_storageclasses():
-    user = utils.get_username_from_request()
-    data = api.get_storageclasses(user)
+    data = api.get_storageclasses()
 
     # Result must be jsonify-able
     if data["success"]:
@@ -94,8 +89,7 @@ def get_storageclasses():
 
 @app.route("/api/storageclasses/default")
 def get_default_storageclass():
-    user = utils.get_username_from_request()
-    data = api.get_storageclasses(user)
+    data = api.get_storageclasses()
     if not data["success"]:
         return jsonify({
             "success": False,
@@ -116,7 +110,6 @@ def get_default_storageclass():
 
         for key in keys:
             is_default = annotations.get(key, "false")
-            
             if is_default == "true":
                 return jsonify({
                     "success": True,
@@ -141,7 +134,6 @@ def get_config():
 # POSTers
 @app.route("/api/namespaces/<namespace>/pvcs", methods=["POST"])
 def post_pvc(namespace):
-    user = utils.get_username_from_request()
     body = request.get_json()
 
     pvc = client.V1PersistentVolumeClaim(
@@ -159,15 +151,14 @@ def post_pvc(namespace):
         )
     )
 
-    return jsonify(api.post_pvc(pvc, user))
+    return jsonify(api.post_pvc(pvc, namespace=namespace))
 
 
 # DELETErs
 @app.route("/api/namespaces/<namespace>/notebooks/<notebook>",
            methods=["DELETE"])
 def delete_notebook(namespace, notebook):
-    user = utils.get_username_from_request()
-    return jsonify(api.delete_notebook(namespace, notebook, user))
+    return jsonify(api.delete_notebook(notebook, namespace=namespace))
 
 
 if __name__ == "__main__":

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -36,12 +36,12 @@ logger = create_logger(__name__)
 # Utils
 def get_username_from_request():
     if USER_HEADER not in request.headers:
-        logger.warning("User header not present!")
+        logger.debug("User header not present!")
         username = None
     else:
         user = request.headers[USER_HEADER]
         username = user.replace(USER_PREFIX, "")
-        logger.info("User: '{}' | Headers: '{}' '{}'".format(
+        logger.debug("User: '{}' | Headers: '{}' '{}'".format(
             username, USER_HEADER, USER_PREFIX
         ))
 

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
@@ -33,7 +33,7 @@ def post_notebook(namespace):
         ws_pvc = utils.pvc_from_dict(workspace_vol, namespace)
 
         logger.info("Creating Workspace Volume: {}".format(ws_pvc.to_dict()))
-        r = api.post_pvc(ws_pvc, namespace=namespace)
+        r = api.create_pvc(ws_pvc, namespace=namespace)
         if not r["success"]:
             return jsonify(r)
 
@@ -52,7 +52,7 @@ def post_notebook(namespace):
             dtvol_pvc = utils.pvc_from_dict(vol, namespace)
 
             logger.info("Creating Data Volume {}:".format(dtvol_pvc))
-            r = api.post_pvc(dtvol_pvc, namespace=namespace)
+            r = api.create_pvc(dtvol_pvc, namespace=namespace)
             if not r["success"]:
                 return jsonify(r)
 
@@ -72,7 +72,7 @@ def post_notebook(namespace):
     utils.set_notebook_shm(notebook, body, defaults)
 
     logger.info("Creating Notebook: {}".format(notebook))
-    return jsonify(api.post_notebook(notebook, namespace=namespace))
+    return jsonify(api.create_notebook(notebook, namespace=namespace))
 
 
 # Since Angular is a SPA, we serve index.html every time

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
@@ -12,7 +12,6 @@ NOTEBOOK = "./kubeflow_jupyter/common/yaml/notebook.yaml"
 # POSTers
 @app.route("/api/namespaces/<namespace>/notebooks", methods=["POST"])
 def post_notebook(namespace):
-    user = utils.get_username_from_request()
     body = request.get_json()
     defaults = utils.spawner_ui_config()
     logger.info("Got Notebook: {}".format(body))
@@ -34,7 +33,7 @@ def post_notebook(namespace):
         ws_pvc = utils.pvc_from_dict(workspace_vol, namespace)
 
         logger.info("Creating Workspace Volume: {}".format(ws_pvc.to_dict()))
-        r = api.post_pvc(ws_pvc, user)
+        r = api.post_pvc(ws_pvc, namespace=namespace)
         if not r["success"]:
             return jsonify(r)
 
@@ -53,7 +52,7 @@ def post_notebook(namespace):
             dtvol_pvc = utils.pvc_from_dict(vol, namespace)
 
             logger.info("Creating Data Volume {}:".format(dtvol_pvc))
-            r = api.post_pvc(dtvol_pvc, user)
+            r = api.post_pvc(dtvol_pvc, namespace=namespace)
             if not r["success"]:
                 return jsonify(r)
 
@@ -73,7 +72,7 @@ def post_notebook(namespace):
     utils.set_notebook_shm(notebook, body, defaults)
 
     logger.info("Creating Notebook: {}".format(notebook))
-    return jsonify(api.post_notebook(notebook, user))
+    return jsonify(api.post_notebook(notebook, namespace=namespace))
 
 
 # Since Angular is a SPA, we serve index.html every time

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
@@ -80,7 +80,7 @@ def post_notebook(namespace):
             rok.add_workspace_volume_annotations(ws_pvc, workspace_vol)
 
         logger.info("Creating Workspace Volume: {}".format(ws_pvc.to_dict()))
-        r = api.post_pvc(ws_pvc, namespace=namespace)
+        r = api.create_pvc(ws_pvc, namespace=namespace)
         if not r["success"]:
             return jsonify(r)
 
@@ -100,7 +100,7 @@ def post_notebook(namespace):
             rok.add_data_volume_annotations(dtvol_pvc, vol)
 
         logger.info("Creating Data Volume {}:".format(dtvol_pvc))
-        r = api.post_pvc(dtvol_pvc, namespace=namespace)
+        r = api.create_pvc(dtvol_pvc, namespace=namespace)
         if not r["success"]:
             return jsonify(r)
 
@@ -120,7 +120,7 @@ def post_notebook(namespace):
     utils.set_notebook_shm(notebook, body, defaults)
 
     logger.info("Creating Notebook: {}".format(notebook))
-    return jsonify(api.post_notebook(notebook, namespace=namespace))
+    return jsonify(api.create_notebook(notebook, namespace=namespace))
 
 
 # Since Angular is a SPA, we serve index.html every time

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
@@ -23,8 +23,7 @@ def get_token(namespace):
         "value": "",
     }
 
-    user = utils.get_username_from_request()
-    data = api.get_secret(namespace, name, user)
+    data = api.get_secret(name, namespace=namespace)
     if not data["success"]:
         logger.warning("Couldn't load ROK token in namespace '{}': {}".format(
             namespace, data["log"]
@@ -56,7 +55,6 @@ def get_token(namespace):
 # POSTers
 @app.route("/api/namespaces/<namespace>/notebooks", methods=["POST"])
 def post_notebook(namespace):
-    user = utils.get_username_from_request()
     body = request.get_json()
     defaults = utils.spawner_ui_config()
     logger.info("Got Notebook: {}".format(body))
@@ -82,7 +80,7 @@ def post_notebook(namespace):
             rok.add_workspace_volume_annotations(ws_pvc, workspace_vol)
 
         logger.info("Creating Workspace Volume: {}".format(ws_pvc.to_dict()))
-        r = api.post_pvc(ws_pvc, user)
+        r = api.post_pvc(ws_pvc, namespace=namespace)
         if not r["success"]:
             return jsonify(r)
 
@@ -102,7 +100,7 @@ def post_notebook(namespace):
             rok.add_data_volume_annotations(dtvol_pvc, vol)
 
         logger.info("Creating Data Volume {}:".format(dtvol_pvc))
-        r = api.post_pvc(dtvol_pvc, user)
+        r = api.post_pvc(dtvol_pvc, namespace=namespace)
         if not r["success"]:
             return jsonify(r)
 
@@ -122,7 +120,7 @@ def post_notebook(namespace):
     utils.set_notebook_shm(notebook, body, defaults)
 
     logger.info("Creating Notebook: {}".format(notebook))
-    return jsonify(api.post_notebook(notebook, user))
+    return jsonify(api.post_notebook(notebook, namespace=namespace))
 
 
 # Since Angular is a SPA, we serve index.html every time
@@ -140,4 +138,3 @@ def static_proxy(path):
 def page_not_found(e):
     logger.info("Sending file 'index.html'")
     return send_from_directory("./static/", "index.html")
-


### PR DESCRIPTION
closes #2981 

With this PR Jupyter Web App will use k8s `SubjectAccessReviews` to check whether a user is authorized to perform an action on the k8s api server.

This PR should be merged after [manifests/655](https://github.com/kubeflow/manifests/pull/655) is merged, which gives permissions to JWA's ServiceAccount to use SubjectAccessReviews.

/cc @yanniszark 
/cc @kunmingg 
/cc @jlewi 
/assign @kimwnasptd

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4556)
<!-- Reviewable:end -->
