### PR TITLE
[kflogin] Support ports other than 443

### DIFF
--- a/components/kflogin/src/login.js
+++ b/components/kflogin/src/login.js
@@ -63,8 +63,8 @@ class Login extends Component {
 
   handleClick(){
     try {
-      const hostname = window.location.hostname;
-      axios.post("https://" + hostname + "/apikflogin", {"req-num": "1"}, {
+      const host = window.location.host;
+      axios.post("https://" + host + "/apikflogin", {"req-num": "1"}, {
         auth: {
           username: this.state.username,
           password: this.state.password


### PR DESCRIPTION
window.location.host includes the port, which allows hosting kflogin on ports other than 443. tested and working

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4559)
<!-- Reviewable:end -->
