### PR TITLE
Expose cluster domain  via a environment variable.

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -47,6 +47,7 @@ import (
 
 const DefaultContainerPort = 8888
 const DefaultServingPort = 80
+var DefaultClusterDomain = "cluster.local"
 
 // The default fsGroup of PodSecurityContext.
 // https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podsecuritycontext-v1-core
@@ -370,7 +371,11 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	prefix := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
 	rewrite := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
 	// TODO(gabrielwen): Make clusterDomain an option.
-	service := fmt.Sprintf("%s.%s.svc.cluster.local", name, namespace)
+	clusterDomain := os.Getenv("CLUSTER_DOMAIN")
+	if clusterDomain == "" {
+		clusterDomain = DefaultClusterDomain
+	}
+	service := fmt.Sprintf("%s.%s.svc.%s", name, namespace, clusterDomain)
 
 	vsvc := &unstructured.Unstructured{}
 	vsvc.SetAPIVersion("networking.istio.io/v1alpha3")


### PR DESCRIPTION
[kubeflow/kubeflow] [kubeflow-v0.6.1]Notebook cannot connect after modifying the default cluster. domain - notebook controller doesn't support custom domains (#3974)

Expose cluster domain  via a environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4595)
<!-- Reviewable:end -->
