### PR TITLE
Jupyter-Web-App: Support for selecting GPUs

### DIFF
--- a/components/jupyter-web-app/backend/Makefile
+++ b/components/jupyter-web-app/backend/Makefile
@@ -2,10 +2,10 @@ run:
 	python main.py
 
 run-dev:
-	FLASK_ENV=development python main.py --enable-cors
+	FLASK_ENV=development python main.py --dev
 
 run-rok:
 	UI=rok python main.py
 
 run-rok-dev:
-	FLASK_ENV=development UI=rok python main.py --enable-cors
+	FLASK_ENV=development UI=rok python main.py --dev

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/auth.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/auth.py
@@ -3,6 +3,7 @@ from kubernetes import client, config
 from kubernetes.config import ConfigException
 from kubernetes.client.rest import ApiException
 from . import utils
+from . import settings
 
 logger = utils.create_logger(__name__)
 
@@ -42,12 +43,18 @@ def is_authorized(user, verb, namespace, group, version, resource):
     Create a SubjectAccessReview to the K8s API to determine if the user is
     authorized to perform a specific verb on a resource.
     '''
-    return True
+    if settings.DEV_MODE:
+        logger.warning(
+            ("Running in developement mode. No authorization checks will be"
+             " issued")
+        )
+        return True
+
     if user is None:
         logger.warning(
             ("No user credentials were found! Make sure you"
              " have correctly set the USERID_HEADER in the"
-             "Jupyter Web App's deployment.")
+             " Jupyter Web App's deployment.")
         )
         return False
 

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
@@ -113,6 +113,7 @@ def get_default_storageclass():
 
         for key in keys:
             is_default = annotations.get(key, "false")
+
             if is_default == "true":
                 return jsonify({
                     "success": True,

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/settings.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/settings.py
@@ -1,0 +1,2 @@
+# Variables for configuring the Backend's behavior
+DEV_MODE = False

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -1,19 +1,20 @@
-import datetime
+import datetime as dt
+import json
 import logging
 import os
 import sys
+
 import yaml
-import json
 from collections import defaultdict
 from flask import request
 from kubernetes import client
-import datetime as dt
+
 from . import api
 
 # The backend will send the first config it will successfully load
 CONFIGS = [
     "/etc/config/spawner_ui_config.yaml",
-    "./kubeflow_jupyter/common/yaml/spawner_ui_config.yaml"
+    "./kubeflow_jupyter/common/yaml/spawner_ui_config.yaml",
 ]
 
 # The values of the headers to look for the User info
@@ -32,8 +33,11 @@ STATUS_WAITING = "waiting"
 # Logging
 def create_logger(name):
     handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(logging.Formatter(
-        "%(asctime)s | %(name)s | %(levelname)s | %(message)s"))
+    handler.setFormatter(
+        logging.Formatter(
+            "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
+        )
+    )
     logger = logging.getLogger(name)
     logger.setLevel(logging.INFO)
     logger.addHandler(handler)
@@ -51,9 +55,11 @@ def get_username_from_request():
     else:
         user = request.headers[USER_HEADER]
         username = user.replace(USER_PREFIX, "")
-        logger.debug("User: '{}' | Headers: '{}' '{}'".format(
-            username, USER_HEADER, USER_PREFIX
-        ))
+        logger.debug(
+            "User: '{}' | Headers: '{}' '{}'".format(
+                username, USER_HEADER, USER_PREFIX
+            )
+        )
 
     return username
 
@@ -86,9 +92,7 @@ def spawner_ui_config():
             with open(config, "r") as f:
                 c = f.read()
         except IOError:
-            logger.warning("Config file '{}' is not found".format(
-                config
-            ))
+            logger.warning("Config file '{}' is not found".format(config))
             continue
 
         try:
@@ -103,9 +107,9 @@ def spawner_ui_config():
             logger.error("Notebook config is not a valid yaml")
             return {}
         except AttributeError as e:
-            logger.error("Can't load the config at {}: {}".format(
-                config, str(e)
-            ))
+            logger.error(
+                "Can't load the config at {}: {}".format(config, str(e))
+            )
 
     logger.warning("Couldn't load any config")
     return {}
@@ -157,13 +161,12 @@ def handle_storage_class(vol):
 
 # Volume handling functions
 def volume_from_config(config_vol, notebook):
-    '''
+    """
     Create a Volume Dict from the config.yaml. This dict has the same fields as
     a Volume returned from the frontend
-    '''
+    """
     vol_name = config_vol["name"]["value"].replace(
-        "{notebook-name}",
-        notebook["name"]
+        "{notebook-name}", notebook["name"]
     )
     vol_class = handle_storage_class(config_vol["class"]["value"])
 
@@ -183,29 +186,24 @@ def pvc_from_dict(vol, namespace):
         return None
 
     return client.V1PersistentVolumeClaim(
-        metadata=client.V1ObjectMeta(
-            name=vol["name"],
-            namespace=namespace,
-        ),
+        metadata=client.V1ObjectMeta(name=vol["name"], namespace=namespace,),
         spec=client.V1PersistentVolumeClaimSpec(
             access_modes=[vol["mode"]],
             storage_class_name=handle_storage_class(vol),
             resources=client.V1ResourceRequirements(
-                requests={
-                    "storage": vol["size"]
-                }
-            )
-        )
+                requests={"storage": vol["size"]}
+            ),
+        ),
     )
 
 
 def get_workspace_vol(body, defaults):
-    '''
+    """
     Checks the config and the form values and returns a Volume Dict for the
     workspace. If the workspace is readOnly, then the value from the config
     will be used instead. The Volume Dict has the same format as the Volume
     interface of the frontend.
-    '''
+    """
     default_ws = volume_from_config(defaults["workspaceVolume"]["value"], body)
     form_ws = body.get("workspace", None)
 
@@ -223,14 +221,16 @@ def get_workspace_vol(body, defaults):
 
 
 def get_data_vols(body, defaults):
-    '''
+    """
     Checks the config and the form values and returns a list of Volume
     Dictionaries for the Notebook's Data Volumes. If the Data Volumes are
     readOnly, then the value from the config will be used instead. The Volume
     Dict has the same format as the Volume interface of the frontend.
-    '''
-    default_vols = [volume_from_config(vol["value"], body)
-                    for vol in defaults["dataVolumes"]["value"]]
+    """
+    default_vols = [
+        volume_from_config(vol["value"], body)
+        for vol in defaults["dataVolumes"]["value"]
+    ]
     form_vols = body.get("datavols", [])
 
     if defaults["dataVolumes"].get("readOnly", False):
@@ -280,9 +280,9 @@ def process_resource(rsrc, rsrc_events):
 
 
 def process_status(rsrc, rsrc_events):
-    '''
+    """
     Return status and reason. Status may be [running|waiting|warning|error]
-    '''
+    """
     # If the Notebook is being deleted, the status will be waiting
     if "deletionTimestamp" in rsrc["metadata"]:
         return STATUS_WAITING, "Deleting Notebook Server"
@@ -336,9 +336,9 @@ def event_timestamp(event):
 
 # Notebook YAML processing
 def set_notebook_image(notebook, body, defaults):
-    '''
+    """
     If the image is set to readOnly, use only the value from the config
-    '''
+    """
     if defaults["image"].get("readOnly", False):
         image = defaults["image"]["value"]
         logger.info("Using default Image: " + image)
@@ -399,8 +399,10 @@ def set_notebook_gpus(notebook, body, defaults):
     elif "gpus" not in body:
         # Try to load the default values. If they don't exist, don't use GPUs
         if "gpus" not in defaults:
-            logger.info("No 'gpus' value in neither the form's body nor in"
-                        " the default config's values. Will not use any GPUs")
+            logger.info(
+                "No 'gpus' value in neither the form's body nor in"
+                " the default config's values. Will not use any GPUs"
+            )
             return
         else:
             gpus = gpuDefaults["value"]
@@ -435,7 +437,7 @@ def set_notebook_gpus(notebook, body, defaults):
     num = int(gpus["num"])
 
     limits = container["resources"].get("limits", {})
-    limits[f"{vendor}.com/gpu"] = num
+    limits[vendor] = num
 
     container["resources"]["limits"] = limits
 
@@ -454,8 +456,8 @@ def set_notebook_configurations(notebook, body, defaults):
         logger.info("Using default Configurations: {}".format(labels))
 
     if not isinstance(labels, list):
-        logger.warning("Labels for PodDefaults are not list: {}".format(
-            labels)
+        logger.warning(
+            "Labels for PodDefaults are not list: {}".format(labels)
         )
         return
 
@@ -502,17 +504,9 @@ def set_notebook_shm(notebook, body, defaults):
     notebook_spec = notebook["spec"]["template"]["spec"]
     notebook_cont = notebook["spec"]["template"]["spec"]["containers"][0]
 
-    shm_volume = {
-        "name": "dshm",
-        "emptyDir": {
-            "medium": "Memory"
-        }
-    }
+    shm_volume = {"name": "dshm", "emptyDir": {"medium": "Memory"}}
     notebook_spec["volumes"].append(shm_volume)
-    shm_mnt = {
-        "mountPath": "/dev/shm",
-        "name": "dshm"
-    }
+    shm_mnt = {"mountPath": "/dev/shm", "name": "dshm"}
     notebook_cont["volumeMounts"].append(shm_mnt)
 
 
@@ -520,19 +514,11 @@ def add_notebook_volume(notebook, vol_name, claim, mnt_path):
     spec = notebook["spec"]["template"]["spec"]
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
-    volume = {
-        "name": vol_name,
-        "persistentVolumeClaim": {
-            "claimName": claim
-        }
-    }
+    volume = {"name": vol_name, "persistentVolumeClaim": {"claimName": claim}}
     spec["volumes"].append(volume)
 
     # Container Mounts
-    mnt = {
-        "mountPath": mnt_path,
-        "name": vol_name
-    }
+    mnt = {"mountPath": mnt_path, "name": vol_name}
     container["volumeMounts"].append(mnt)
 
 
@@ -543,10 +529,7 @@ def add_notebook_volume_secret(nb, secret, secret_name, mnt_path, mode):
 
     volume = {
         "name": secret,
-        "secret": {
-            "defaultMode": mode,
-            "secretName": secret_name,
-        }
+        "secret": {"defaultMode": mode, "secretName": secret_name,},
     }
     spec["volumes"].append(volume)
 

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -400,7 +400,7 @@ def set_notebook_gpus(notebook, body, defaults):
         # Try to load the default values. If they don't exist, don't use GPUs
         if "gpus" not in defaults:
             logger.info(
-                "No 'gpus' value in neither the form's body nor in"
+                "No 'gpus' value in either the form's body or in"
                 " the default config's values. Will not use any GPUs"
             )
             return

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/spawner_ui_config.yaml
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/spawner_ui_config.yaml
@@ -125,7 +125,13 @@ spawnerFormDefaults:
     value:
       # values: "none", "1", "2", "4", "8"
       num: "none"
-      # values: "nvidia", "amd", ""
+      # Determines what the UI will show and send to the backend
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+        - limitsKey: "amd.com/gpu"
+          uiName: "AMD"
+      # Values: "" or a `limits-key` from the vendors list
       vendor: ""
     readOnly: false
   shm:

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/spawner_ui_config.yaml
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/spawner_ui_config.yaml
@@ -120,10 +120,13 @@ spawnerFormDefaults:
     #       class:
     #         value: {none}
     readOnly: false
-  extraResources:
-    # Extra Resource Limits for user's Notebook
-    # e.x. "{'nvidia.com/gpu': 2}"
-    value: "{}"
+  gpus:
+    # Number of GPUs to be assigned to the Notebook Container
+    value:
+      # values: "none", "1", "2", "4", "8"
+      num: "none"
+      # values: "nvidia", "amd", ""
+      vendor: ""
     readOnly: false
   shm:
     value: true

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
@@ -24,6 +24,7 @@ def post_notebook(namespace):
     utils.set_notebook_image(notebook, body, defaults)
     utils.set_notebook_cpu(notebook, body, defaults)
     utils.set_notebook_memory(notebook, body, defaults)
+    utils.set_notebook_gpus(notebook, body, defaults)
     utils.set_notebook_configurations(notebook, body, defaults)
 
     # Workspace Volume
@@ -62,11 +63,6 @@ def post_notebook(namespace):
             vol["name"],
             vol["path"]
         )
-
-    # Extra Resources
-    r = utils.set_notebook_extra_resources(notebook, body, defaults)
-    if not r["success"]:
-        return jsonify(r)
 
     # shm
     utils.set_notebook_shm(notebook, body, defaults)

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
@@ -68,6 +68,7 @@ def post_notebook(namespace):
     utils.set_notebook_image(notebook, body, defaults)
     utils.set_notebook_cpu(notebook, body, defaults)
     utils.set_notebook_memory(notebook, body, defaults)
+    utils.set_notebook_gpus(notebook, body, defaults)
     utils.set_notebook_configurations(notebook, body, defaults)
 
     # Workspace Volume
@@ -110,11 +111,6 @@ def post_notebook(namespace):
             r["pvc"].metadata.name,
             vol["path"]
         )
-
-    # Extra Resources
-    r = utils.set_notebook_extra_resources(notebook, body, defaults)
-    if not r["success"]:
-        return jsonify(r)
 
     # shm
     utils.set_notebook_shm(notebook, body, defaults)

--- a/components/jupyter-web-app/backend/main.py
+++ b/components/jupyter-web-app/backend/main.py
@@ -2,6 +2,7 @@ import os
 import sys
 import logging
 from flask_cors import CORS
+from kubeflow_jupyter.common import settings
 from kubeflow_jupyter.default.app import app as default
 from kubeflow_jupyter.rok.app import app as rok
 
@@ -17,8 +18,9 @@ apps = {
 try:
     app = apps[ui]
 
-    # Enable CORS for dev
-    if "--enable-cors" in sys.argv:
+    if "--dev" in sys.argv:
+        settings.DEV_MODE = True
+
         logger.warning("Enabling CORS")
         CORS(app)
 

--- a/components/jupyter-web-app/frontend/.prettierrc
+++ b/components/jupyter-web-app/frontend/.prettierrc
@@ -1,0 +1,11 @@
+{
+  printWidth: 80,
+  useTabs: false,
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  bracketSpacing: true,
+  arrowParens: 'avoid',
+  proseWrap: 'preserve',
+}

--- a/components/jupyter-web-app/frontend/package.json
+++ b/components/jupyter-web-app/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
+    "format": "prettier --write './**/*.{ts,html,css}'",
     "start": "ng serve --base-href /jupyter/ --deploy-url /jupyter/",
     "build": "ng build --base-href /jupyter/ --deploy-url /jupyter/",
     "test": "ng test",

--- a/components/jupyter-web-app/frontend/src/app/app.module.ts
+++ b/components/jupyter-web-app/frontend/src/app/app.module.ts
@@ -48,6 +48,8 @@ import { RokFormWorkspaceVolumeComponent } from "./uis/rok/rok-resource-form/rok
 import { RokFormDataVolumesComponent } from "./uis/rok/rok-resource-form/rok-form-data-volumes/rok-form-data-volumes.component";
 import { RokErrorMsgComponent } from "./uis/rok/rok-error-msg/rok-error-msg.component";
 import { FormConfigurationsComponent } from "./resource-form/form-configurations/form-configurations.component";
+import { FormGpusComponent } from "./resource-form/form-gpus/form-gpus.component";
+
 
 @NgModule({
   declarations: [
@@ -74,7 +76,8 @@ import { FormConfigurationsComponent } from "./resource-form/form-configurations
     RokFormWorkspaceVolumeComponent,
     RokFormDataVolumesComponent,
     RokErrorMsgComponent,
-    FormConfigurationsComponent
+    FormConfigurationsComponent,
+    FormGpusComponent,
   ],
   imports: [
     BrowserModule,

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-advanced-options/form-advanced-options.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-advanced-options/form-advanced-options.component.html
@@ -1,26 +1,13 @@
 <div class="group-wrapper" [formGroup]="parentForm">
   <h3>
     <fa-icon [icon]="['fas', 'cogs']" class="check"></fa-icon>
-    Extra Resources
+    Miscellaneous Settings
   </h3>
   <p>
-    Specify extra resoucres that might be needed in the Notebook Server.
+    Other possible settings to be applied to the Notebook Server.
   </p>
 
-  <mat-slide-toggle formControlName="shm"
-    >Enable Shared Memory</mat-slide-toggle
-  >
-
-  <mat-form-field class="wide" appearance="outline">
-    <mat-label>Extra Resources</mat-label>
-    <input
-      matInput
-      placeholder='{"nvidia.com/gpu": 2}'
-      formControlName="extra"
-      required
-    />
-    <mat-hint
-      >Extra Resources available in the cluster (ex. NVIDIA GPUs)
-    </mat-hint>
-  </mat-form-field>
+  <mat-slide-toggle formControlName="shm">
+    Enable Shared Memory
+  </mat-slide-toggle>
 </div>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.html
@@ -21,9 +21,12 @@
 
     <mat-form-field class="wide" appearance="outline">
       <mat-label>GPU Vendor</mat-label>
-      <mat-select matNativeControl formControlName="vendor">
-        <mat-option value="nvidia">NVIDIA</mat-option>
-        <mat-option value="amd">AMD</mat-option>
+      <mat-select matNativeControl formControlName="vendor" id="gpu-vendor">
+        <mat-option *ngFor="let v of vendors" [value]="v.limitsKey">
+          {{ v.uiName }}
+        </mat-option>
+        <!--<mat-option value="nvidia">NVIDIA</mat-option>-->
+        <!--<mat-option value="amd">AMD</mat-option>-->
       </mat-select>
       <mat-error>{{ getVendorError() }}</mat-error>
     </mat-form-field>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.html
@@ -1,0 +1,31 @@
+<div class="group-wrapper" [formGroup]="parentForm">
+  <h3>
+    <!--<fa-icon [icon]="['fas', 'cogs']" class="check"></fa-icon>-->
+    <mat-icon class="gpu">memory</mat-icon>
+    GPUs
+  </h3>
+  <p>
+    Specify the number and Vendor of GPUs that will be assigned to the Notebook
+    Server's Container.
+  </p>
+
+  <div class="inputs-wrapper">
+    <mat-form-field class="wide" appearance="outline">
+      <mat-label>Number of GPUs</mat-label>
+      <mat-select matNativeControl>
+        <mat-option value="none">None</mat-option>
+        <mat-option *ngFor="let v of gpusCount" [value]="v">
+          {{ v }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field class="wide" appearance="outline">
+      <mat-label>GPU Vendor</mat-label>
+      <mat-select matNativeControl>
+        <mat-option value="NVIDIA">NVIDIA</mat-option>
+        <mat-option value="AMD">AMD</mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+</div>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.html
@@ -1,6 +1,5 @@
 <div class="group-wrapper" [formGroup]="parentForm">
   <h3>
-    <!--<fa-icon [icon]="['fas', 'cogs']" class="check"></fa-icon>-->
     <mat-icon class="gpu">memory</mat-icon>
     GPUs
   </h3>
@@ -9,10 +8,10 @@
     Server's Container.
   </p>
 
-  <div class="inputs-wrapper">
+  <div class="inputs-wrapper" [formGroup]="parentForm.get('gpus')">
     <mat-form-field class="wide" appearance="outline">
       <mat-label>Number of GPUs</mat-label>
-      <mat-select matNativeControl>
+      <mat-select matNativeControl formControlName="num">
         <mat-option value="none">None</mat-option>
         <mat-option *ngFor="let v of gpusCount" [value]="v">
           {{ v }}
@@ -22,10 +21,11 @@
 
     <mat-form-field class="wide" appearance="outline">
       <mat-label>GPU Vendor</mat-label>
-      <mat-select matNativeControl>
-        <mat-option value="NVIDIA">NVIDIA</mat-option>
-        <mat-option value="AMD">AMD</mat-option>
+      <mat-select matNativeControl formControlName="vendor">
+        <mat-option value="nvidia">NVIDIA</mat-option>
+        <mat-option value="amd">AMD</mat-option>
       </mat-select>
+      <mat-error>{{ getVendorError() }}</mat-error>
     </mat-form-field>
   </div>
 </div>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.scss
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.scss
@@ -1,0 +1,9 @@
+.gpu {
+  vertical-align: middle;
+  font-size: 28px;
+  margin-left: -2px;
+}
+
+mat-slide-toggle {
+  margin-bottom: 0.6rem;
+}

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.spec.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FormGpusComponent } from './form-gpus.component';
+
+describe('FormGpusComponent', () => {
+  let component: FormGpusComponent;
+  let fixture: ComponentFixture<FormGpusComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ FormGpusComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FormGpusComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Input } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, ValidatorFn, AbstractControl } from '@angular/forms';
+import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-form-gpus',
@@ -8,11 +9,55 @@ import { FormGroup } from '@angular/forms';
 })
 export class FormGpusComponent implements OnInit {
   @Input() parentForm: FormGroup;
+  private gpuCtrl: FormGroup;
+  subscriptions = new Subscription();
 
   maxGPUs = 16;
-  gpusCount = [1, 2, 4, 8];
+  gpusCount = ['1', '2', '4', '8'];
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.gpuCtrl = this.parentForm.get('gpus') as FormGroup;
+
+    // Vendor should not be empty if the user selects GPUs num
+    this.parentForm
+      .get('gpus')
+      .get('vendor')
+      .setValidators([this.vendorWithNum()]);
+
+    this.subscriptions.add(
+      this.gpuCtrl.get('num').valueChanges.subscribe((n: string) => {
+        if (n === 'none') {
+          this.gpuCtrl.get('vendor').disable();
+        } else {
+          this.gpuCtrl.get('vendor').enable();
+        }
+      }),
+    );
+  }
+
+  // Custom Validation
+  public getVendorError() {
+    const vendorCtrl = this.parentForm.get('gpus').get('vendor');
+
+    if (vendorCtrl.hasError('vendorNullName')) {
+      return `You must also specify the GPU Vendor for the assigned GPUs`;
+    }
+  }
+
+  private vendorWithNum(): ValidatorFn {
+    // Make sure that if the user has specified a number of GPUs
+    // that they also specify the GPU vendor
+    return (control: AbstractControl): { [key: string]: any } => {
+      const num = this.parentForm.get('gpus').get('num').value;
+      const vendor = this.parentForm.get('gpus').get('vendor').value;
+
+      if (num !== 'none' && vendor === '') {
+        return { vendorNullName: true };
+      } else {
+        return null;
+      }
+    };
+  }
 }

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 import { FormGroup, ValidatorFn, AbstractControl } from '@angular/forms';
 import { Subscription } from 'rxjs';
+import { GPUVendor } from 'src/app/utils/types';
 
 @Component({
   selector: 'app-form-gpus',
@@ -9,6 +10,7 @@ import { Subscription } from 'rxjs';
 })
 export class FormGpusComponent implements OnInit {
   @Input() parentForm: FormGroup;
+  @Input() vendors: GPUVendor[];
   private gpuCtrl: FormGroup;
   subscriptions = new Subscription();
 

--- a/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/form-gpus/form-gpus.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-form-gpus',
+  templateUrl: './form-gpus.component.html',
+  styleUrls: ['./form-gpus.component.scss', '../resource-form.component.scss'],
+})
+export class FormGpusComponent implements OnInit {
+  @Input() parentForm: FormGroup;
+
+  maxGPUs = 16;
+  gpusCount = [1, 2, 4, 8];
+
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.html
@@ -32,7 +32,10 @@
         [parentForm]="formCtrl"
       ></app-form-configurations>
 
-      <app-form-gpus [parentForm]="formCtrl"></app-form-gpus>
+      <app-form-gpus
+        [parentForm]="formCtrl"
+        [vendors]="config?.gpus?.value.vendors"
+      ></app-form-gpus>
 
       <app-form-advanced-options
         [parentForm]="formCtrl"

--- a/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.html
@@ -32,6 +32,8 @@
         [parentForm]="formCtrl"
       ></app-form-configurations>
 
+      <app-form-gpus [parentForm]="formCtrl"></app-form-gpus>
+
       <app-form-advanced-options
         [parentForm]="formCtrl"
       ></app-form-advanced-options>

--- a/components/jupyter-web-app/frontend/src/app/utils/common.ts
+++ b/components/jupyter-web-app/frontend/src/app/utils/common.ts
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 import { ConfigVolume, Config } from "src/app/utils/types";
 import { Validators, FormBuilder, FormGroup, FormArray } from "@angular/forms";
+=======
+import { ConfigVolume, Config, GPU } from 'src/app/utils/types';
+import { Validators, FormBuilder, FormGroup, FormArray } from '@angular/forms';
+>>>>>>> cca6faf4... TypeScript logic and the UI mechanics
 
 const fb = new FormBuilder();
 
@@ -12,6 +17,12 @@ export function getFormDefaults(): FormGroup {
     customImageCheck: [false, []],
     cpu: ["", [Validators.required]],
     memory: ["", [Validators.required]],
+    cpu: ['', [Validators.required]],
+    memory: ['', [Validators.required]],
+    gpus: fb.group({
+      vendor: ['', []],
+      num: ['', []],
+    }),
     noWorkspace: [false, []],
     workspace: fb.group({
       type: ["", [Validators.required]],
@@ -24,7 +35,6 @@ export function getFormDefaults(): FormGroup {
       extraFields: fb.group({})
     }),
     datavols: fb.array([]),
-    extra: ["", [Validators.required]],
     shm: [true, []],
     configurations: [[], []]
   });
@@ -100,6 +110,23 @@ export function addDataVolume(
   vols.push(ctrl);
 }
 
+export function updateGPUControl(formCtrl: FormGroup, gpuConf: any) {
+  // If the backend didn't send the value, default to none
+  if (gpuConf == null) {
+    formCtrl.get('num').setValue('none');
+    return;
+  } else {
+    const gpu = gpuConf.value as GPU;
+    formCtrl.get('num').setValue(gpu.num);
+    formCtrl.get('vendor').setValue(gpu.vendor);
+  }
+
+  if (gpuConf.readOnly) {
+    formCtrl.get('num').disable();
+    formCtrl.get('vendor').disable();
+  }
+}
+
 export function initFormControls(formCtrl: FormGroup, config: Config) {
   // Sets the values from our internal dict. This is an initialization step
   // that should be only run once
@@ -134,10 +161,8 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
     addDataVolume(formCtrl, vol.value, config.dataVolumes.readOnly);
   });
 
-  formCtrl.controls.extra.setValue(config.extraResources.value);
-  if (config.extraResources.readOnly) {
-    formCtrl.controls.extra.disable();
-  }
+  // GPUs
+  updateGPUControl(formCtrl.get('gpus') as FormGroup, config.gpus);
 
   formCtrl.controls.shm.setValue(config.shm.value);
   if (config.shm.readOnly) {

--- a/components/jupyter-web-app/frontend/src/app/utils/common.ts
+++ b/components/jupyter-web-app/frontend/src/app/utils/common.ts
@@ -1,22 +1,15 @@
-<<<<<<< HEAD
-import { ConfigVolume, Config } from "src/app/utils/types";
-import { Validators, FormBuilder, FormGroup, FormArray } from "@angular/forms";
-=======
 import { ConfigVolume, Config, GPU } from 'src/app/utils/types';
 import { Validators, FormBuilder, FormGroup, FormArray } from '@angular/forms';
->>>>>>> cca6faf4... TypeScript logic and the UI mechanics
 
 const fb = new FormBuilder();
 
 export function getFormDefaults(): FormGroup {
   return fb.group({
-    name: ["", [Validators.required]],
-    namespace: ["", [Validators.required]],
-    image: ["", [Validators.required]],
-    customImage: ["", []],
+    name: ['', [Validators.required]],
+    namespace: ['', [Validators.required]],
+    image: ['', [Validators.required]],
+    customImage: ['', []],
     customImageCheck: [false, []],
-    cpu: ["", [Validators.required]],
-    memory: ["", [Validators.required]],
     cpu: ['', [Validators.required]],
     memory: ['', [Validators.required]],
     gpus: fb.group({
@@ -25,18 +18,18 @@ export function getFormDefaults(): FormGroup {
     }),
     noWorkspace: [false, []],
     workspace: fb.group({
-      type: ["", [Validators.required]],
-      name: ["", [Validators.required]],
-      templatedName: ["", []],
-      size: ["", [Validators.required]],
-      path: [{ value: "", disabled: true }, [Validators.required]],
-      mode: ["", [Validators.required]],
-      class: ["{none}", [Validators.required]],
-      extraFields: fb.group({})
+      type: ['', [Validators.required]],
+      name: ['', [Validators.required]],
+      templatedName: ['', []],
+      size: ['', [Validators.required]],
+      path: [{ value: '', disabled: true }, [Validators.required]],
+      mode: ['', [Validators.required]],
+      class: ['{none}', [Validators.required]],
+      extraFields: fb.group({}),
     }),
     datavols: fb.array([]),
     shm: [true, []],
-    configurations: [[], []]
+    configurations: [[], []],
   });
 }
 
@@ -48,8 +41,8 @@ export function createVolumeControl(vol: ConfigVolume, readonly = false) {
     size: [vol.size.value, [Validators.required]],
     path: [vol.mountPath.value, [Validators.required]],
     mode: [vol.accessModes.value, [Validators.required]],
-    class: ["{none}", []],
-    extraFields: fb.group({})
+    class: ['{none}', []],
+    extraFields: fb.group({}),
   });
 
   if (readonly) {
@@ -62,14 +55,14 @@ export function createVolumeControl(vol: ConfigVolume, readonly = false) {
 export function updateVolumeControl(
   volCtrl: FormGroup,
   vol: ConfigVolume,
-  readonly = false
+  readonly = false,
 ) {
-  volCtrl.get("name").setValue(vol.name.value);
-  volCtrl.get("type").setValue(vol.type.value);
-  volCtrl.get("size").setValue(vol.size.value);
-  volCtrl.get("mode").setValue(vol.accessModes.value);
-  volCtrl.get("path").setValue(vol.mountPath.value);
-  volCtrl.get("templatedName").setValue(vol.name.value);
+  volCtrl.get('name').setValue(vol.name.value);
+  volCtrl.get('type').setValue(vol.type.value);
+  volCtrl.get('size').setValue(vol.size.value);
+  volCtrl.get('mode').setValue(vol.accessModes.value);
+  volCtrl.get('path').setValue(vol.mountPath.value);
+  volCtrl.get('templatedName').setValue(vol.name.value);
 
   if (readonly) {
     volCtrl.disable();
@@ -79,7 +72,7 @@ export function updateVolumeControl(
 export function addDataVolume(
   formCtrl: FormGroup,
   vol: ConfigVolume = null,
-  readonly = false
+  readonly = false,
 ) {
   // If no vol is provided create one with default values
   if (vol === null) {
@@ -87,26 +80,26 @@ export function addDataVolume(
 
     vol = {
       type: {
-        value: "New"
+        value: 'New',
       },
       name: {
-        value: "{notebook-name}-vol-" + (l + 1)
+        value: '{notebook-name}-vol-' + (l + 1),
       },
       size: {
-        value: "10Gi"
+        value: '10Gi',
       },
       mountPath: {
-        value: "/home/jovyan/data-vol-" + (l + 1)
+        value: '/home/jovyan/data-vol-' + (l + 1),
       },
       accessModes: {
-        value: "ReadWriteOnce"
-      }
+        value: 'ReadWriteOnce',
+      },
     };
   }
 
   // Push it to the control
   const ctrl = createVolumeControl(vol, readonly);
-  const vols = formCtrl.get("datavols") as FormArray;
+  const vols = formCtrl.get('datavols') as FormArray;
   vols.push(ctrl);
 }
 
@@ -115,12 +108,14 @@ export function updateGPUControl(formCtrl: FormGroup, gpuConf: any) {
   if (gpuConf == null) {
     formCtrl.get('num').setValue('none');
     return;
-  } else {
-    const gpu = gpuConf.value as GPU;
-    formCtrl.get('num').setValue(gpu.num);
-    formCtrl.get('vendor').setValue(gpu.vendor);
   }
 
+  // Set the values
+  const gpu = gpuConf.value as GPU;
+  formCtrl.get('num').setValue(gpu.num);
+  formCtrl.get('vendor').setValue(gpu.vendor);
+
+  // Don't allow the user to edit them if the admin does not allow it
   if (gpuConf.readOnly) {
     formCtrl.get('num').disable();
     formCtrl.get('vendor').disable();
@@ -146,9 +141,9 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
   }
 
   updateVolumeControl(
-    formCtrl.get("workspace") as FormGroup,
+    formCtrl.get('workspace') as FormGroup,
     config.workspaceVolume.value,
-    config.workspaceVolume.readOnly
+    config.workspaceVolume.readOnly,
   );
 
   // Disable the mount path by default

--- a/components/jupyter-web-app/frontend/src/app/utils/types.ts
+++ b/components/jupyter-web-app/frontend/src/app/utils/types.ts
@@ -27,6 +27,11 @@ export interface PodDefault {
   desc: string;
 }
 
+export interface GPU {
+  vendor?: string;
+  num?: string;
+}
+
 // Backend response type
 export interface Resp {
   namespaces?: string[];
@@ -79,32 +84,39 @@ export interface Config {
     options: string[];
     readOnly?: boolean;
   };
+
   cpu?: {
     value: string;
     readOnly?: boolean;
   };
+
   memory?: {
     value: string;
     readOnly?: boolean;
   };
+
   workspaceVolume?: {
     value: ConfigVolume;
     readOnly?: boolean;
   };
+
   dataVolumes?: {
     value: {
       value: ConfigVolume;
     }[];
     readOnly?: boolean;
   };
-  extraResources?: {
-    value: any;
-    readOnly?: boolean;
-  };
+
   shm?: {
     value: boolean;
     readOnly?: boolean;
   };
+
+  gpus?: {
+    value?: GPU;
+    readOnly?: boolean;
+  };
+
   configurations?: {
     value: string[];
     readOnly?: boolean;

--- a/components/jupyter-web-app/frontend/src/app/utils/types.ts
+++ b/components/jupyter-web-app/frontend/src/app/utils/types.ts
@@ -27,9 +27,15 @@ export interface PodDefault {
   desc: string;
 }
 
+export interface GPUVendor {
+  limitsKey: string;
+  uiName: string;
+}
+
 export interface GPU {
   vendor?: string;
   num?: string;
+  vendors?: GPUVendor[];
 }
 
 // Backend response type


### PR DESCRIPTION
closes #4288 

Instead of having an `Extra Resources` field we allow the user to select the number and vendor of GPUs for a Notebook.

![gpus](https://user-images.githubusercontent.com/11134742/71671692-5d232380-2d7c-11ea-9140-92c99676946e.png)

/assign @kimwnasptd
/cc @lluunn 
/cc @avdaredevil

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4614)
<!-- Reviewable:end -->
