### PR TITLE
JWA: Add readiness/liveness probes

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
@@ -175,3 +175,20 @@ def delete_notebook(notebook_name, namespace):
         notebook_name,
         client.V1DeleteOptions(propagation_policy="Foreground")
     )
+
+
+# Readiness Probe helper
+def can_connect_to_k8s():
+    try:
+        custom_api.list_namespaced_custom_object(
+            "kubeflow.org",
+            "v1beta1",
+            "default",
+            "notebooks",
+        )
+        return True
+
+    except ApiException:
+        return False
+
+    return True

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/base_app.py
@@ -149,5 +149,20 @@ def delete_notebook(namespace, notebook):
     return jsonify(api.delete_notebook(notebook, namespace=namespace))
 
 
+# Liveness/Readiness Probes
+@app.route("/healthz/liveness", methods=["GET"])
+def liveness_probe():
+    return jsonify("alive"), 200
+
+
+@app.route("/healthz/readiness", methods=["GET"])
+def readiness_probe():
+    # Check if the backend can communicate with the k8s API Server
+    if not api.can_connect_to_k8s():
+        return jsonify("not ready"), 503
+
+    return jsonify("ready"), 200
+
+
 if __name__ == "__main__":
     app.run(host="0.0.0.0")


### PR DESCRIPTION
closes #4069 
* For readiness the backend will need to be able to connect to the
k8s API
* For liveness the backend will only need to be able to respond to new
requests. Thus it will be only returning a 200 status code response

/cc @lluunn @jlewi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4626)
<!-- Reviewable:end -->
