### PR TITLE
add hashicorp/golang-lru source code to kfam image

### DIFF
--- a/components/access-management/Dockerfile
+++ b/components/access-management/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod a+rx access-management
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:debug as serve
+FROM gcr.io/distroless/base:latest as serve
 WORKDIR /
 COPY third_party third_party
 COPY --from=builder /workspace/access-management .

--- a/components/access-management/Dockerfile
+++ b/components/access-management/Dockerfile
@@ -10,10 +10,11 @@ RUN chmod a+rx access-management
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:latest as serve
+FROM gcr.io/distroless/base:debug as serve
 WORKDIR /
 COPY third_party third_party
 COPY --from=builder /workspace/access-management .
+COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/library/
 
 EXPOSE 8081
 


### PR DESCRIPTION
`hashicorp/golang-lru` is licensed under the Mozilla Public License.
Add it's source code under kfam image `third_party/library`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4640)
<!-- Reviewable:end -->
