### PR TITLE
Updates to install Fairing from PyPI

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -104,7 +104,7 @@ RUN pip3 --no-cache-dir install \
     jupyter-console==6.0.0 \
     jupyterlab \
     xgboost \
-    git+https://github.com/kubeflow/fairing@a9bb9d5cc1c9f1d75efa31198ddbdccfe176b7bf
+    kubeflow-fairing
 
 COPY --chown=jovyan:users requirements.txt /tmp
 

--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -104,7 +104,7 @@ RUN pip3 --no-cache-dir install \
     jupyter-console==6.0.0 \
     jupyterlab \
     xgboost \
-    kubeflow-fairing
+    kubeflow-fairing==0.7.1
 
 COPY --chown=jovyan:users requirements.txt /tmp
 


### PR DESCRIPTION
Updates the Dockerfile for the TF notebook images to install Fairing from PyPI, instead of installing Fairing v0.5 from a GitHub commit.

This change fixes [Kubeflow/Kubeflow #4551](https://github.com/kubeflow/kubeflow/issues/4551).

This change should help fix:
-  [Kubeflow/Website #1428](https://github.com/kubeflow/website/issues/1428)
-  [Kubeflow/Fairing #381](https://github.com/kubeflow/fairing/issues/381): This issue describes that they couldn't run the Kubeflow Notebook example because the notebook was running an old release of Fairing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4645)
<!-- Reviewable:end -->
