### PR TITLE
[CentralDashboard] Namespace defaulting and validation

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -328,8 +328,6 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this._setRegistrationFlow(true);
         }
         this.ownedNamespace = namespaces.find((n) => n.role == 'owner');
-        this.$.NamespaceSelector.validate();
-
         this.platformInfo = platform;
         const kVer = this.platformInfo.kubeflowVersion;
         if (kVer && kVer != 'unknown') {

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -316,8 +316,9 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
      * @param {Event} responseEvent AJAX-response
      */
     _onEnvInfoResponse(responseEvent) {
-        const {platform, user,
-            namespaces, isClusterAdmin} = responseEvent.detail.response;
+        const {
+            platform, user, namespaces, isClusterAdmin,
+        } = responseEvent.detail.response;
         Object.assign(this, {user, isClusterAdmin});
         this.namespaces = namespaces;
         if (this.namespaces.length) {
@@ -327,6 +328,8 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this._setRegistrationFlow(true);
         }
         this.ownedNamespace = namespaces.find((n) => n.role == 'owner');
+        this.$.NamespaceSelector.validate();
+
         this.platformInfo = platform;
         const kVer = this.platformInfo.kubeflowVersion;
         if (kVer && kVer != 'unknown') {

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -161,12 +161,9 @@ export class NamespaceSelector extends PolymerElement {
         const {namespaces} = this;
         if (!namespaces) return;
         const nsSet = new Set(namespaces.map((i) => i.namespace));
-        const owned = namespaces.find((n) => n.role == 'owner');
-
         if (nsSet.has(this.selected)) return;
 
-        // eslint-disable-next-line
-        console.log({own: (owned||[]).namespace, namespaces, ns: this.selected, yeah: namespaces.includes('kubeflow')});
+        const owned = namespaces.find((n) => n.role == 'owner');
         this.selected = (owned && owned.namespace)
             || (nsSet.has('kubeflow')
                 ? 'kubeflow'

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -141,7 +141,8 @@ export class NamespaceSelector extends PolymerElement {
     }
 
     /**
-     * Check if role is owner
+     * Convert the current state of this component to the visual text seen in
+     * the selector
      * @param {string} selected
      * @param {boolean} allNamespaces
      * @param {[object]} namespaces
@@ -155,7 +156,8 @@ export class NamespaceSelector extends PolymerElement {
     }
 
     /**
-     * Check if role is owner
+     * Validate internal state of the selector, and change selected state
+     * if needed
      */
     validate() {
         const {namespaces} = this;

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -164,8 +164,6 @@ export class NamespaceSelector extends PolymerElement {
         if (nsSet.has(this.selected)) return;
 
         const owned = namespaces.find((n) => n.role == 'owner');
-        // eslint-disable-next-line
-        console.log({own: (owned||[]).namespace, namespaces, ns: this.selected, yeah: namespaces.includes('kubeflow')});
         this.selected = (owned && owned.namespace)
             || (nsSet.has('kubeflow')
                 ? 'kubeflow'

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -164,6 +164,8 @@ export class NamespaceSelector extends PolymerElement {
         if (nsSet.has(this.selected)) return;
 
         const owned = namespaces.find((n) => n.role == 'owner');
+        // eslint-disable-next-line
+        console.log({own: (owned||[]).namespace, namespaces, ns: this.selected, yeah: namespaces.includes('kubeflow')});
         this.selected = (owned && owned.namespace)
             || (nsSet.has('kubeflow')
                 ? 'kubeflow'

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -127,6 +127,7 @@ export class NamespaceSelector extends PolymerElement {
         return [
             '_queryParamChanged(queryParams.ns)',
             '_ownedContextChanged(namespaces, selected)',
+            'validate(selected, namespaces)',
         ];
     }
 
@@ -151,6 +152,25 @@ export class NamespaceSelector extends PolymerElement {
         if (!namespaces || !namespaces.length) return 'No Namespaces';
         if (!selected) return 'Select namespace';
         return selected;
+    }
+
+    /**
+     * Check if role is owner
+     */
+    validate() {
+        const {namespaces} = this;
+        if (!namespaces) return;
+        const nsSet = new Set(namespaces.map((i) => i.namespace));
+        const owned = namespaces.find((n) => n.role == 'owner');
+
+        if (nsSet.has(this.selected)) return;
+
+        // eslint-disable-next-line
+        console.log({own: (owned||[]).namespace, namespaces, ns: this.selected, yeah: namespaces.includes('kubeflow')});
+        this.selected = (owned && owned.namespace)
+            || (nsSet.has('kubeflow')
+                ? 'kubeflow'
+                : '');
     }
 
     /**

--- a/components/centraldashboard/public/components/namespace-selector_test.js
+++ b/components/centraldashboard/public/components/namespace-selector_test.js
@@ -16,22 +16,14 @@ const TEMPLATE = `
 describe('Namespace Selector', () => {
     const namespaces = [
         {
-            user: {kind: 'user', name: 'testuser'},
-            referredNamespace: 'default',
-            roleRef: {
-                apiGroup: '',
-                kind: 'ClusterRole',
-                name: 'editor',
-            },
+            user: 'testuser',
+            namespace: 'default',
+            role: 'contributor',
         },
         {
-            user: {kind: 'user', name: 'testuser'},
-            referredNamespace: 'other-namespace',
-            roleRef: {
-                apiGroup: '',
-                kind: 'ClusterRole',
-                name: 'editor',
-            },
+            user: 'testuser',
+            namespace: 'other-namespace',
+            role: 'contributor',
         },
     ];
     let namespaceSelector;


### PR DESCRIPTION
#### fixes #3863 

## About
This PR introduces a validation layer into the namespace selector (anytime namespaces or selected is changed):
- Defaulting logic added for Namespace selector:
  - If namespace selected is valid, keep
  - If there is an owned namespace, use that
  - If not, go for `kubeflow` if available
  - If not, leave unselected
- Invalidate a namespace that's not part of `namespaces` and use the logic defined above

### Meta
/area centraldashboard
/area front-end
/priority p1
/assign @avdaredevil
/cc @kwasi @prodonjs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4659)
<!-- Reviewable:end -->
