### PR TITLE
[CentralDashboard] Registration flow onError delay removed

### DIFF
--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -103,7 +103,7 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
         if (!this.validateNamespace()) return;
         API.body = {namespace: this.namespaceName};
         this.waitForRedirect = true;
-        await API.generateRequest().completes;
+        await API.generateRequest().completes.catch((e) => e);
         await this.sleep(1); // So the errors and callbacks can schedule
         if (this.error && this.error.response) {
             return this.waitForRedirect = false;


### PR DESCRIPTION
## About
There should be no delay in registration flow retry if an error comes back early. This PR fixes that

### Meta
/area centraldashboard
/area front-end
/priority p1
/assign @avdaredevil
/cc @kwasi @prodonjs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4662)
<!-- Reviewable:end -->
