### PR TITLE
Fix dashboard wrong katib hyperlink name

### DIFF
--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -98,7 +98,7 @@ export class DashboardView extends PolymerElement {
                         link: `/jupyter/new?namespace=kubeflow`,
                     },
                     {
-                        text: 'View Katib Studies',
+                        text: 'View Katib Experiments',
                         desc: 'Katib',
                         link: `/katib/`,
                     },


### PR DESCRIPTION
In latest release Katib, Katib had renamed `StudyJob` to `Experiment`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4669)
<!-- Reviewable:end -->
