### PR TITLE
add prometheus metrics for profile controller

### DIFF
--- a/components/profile-controller/Dockerfile
+++ b/components/profile-controller/Dockerfile
@@ -30,4 +30,6 @@ COPY third_party third_party
 COPY --from=builder /workspace/manager .
 COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/library/
 
+EXPOSE 8080
+
 ENTRYPOINT ["/manager"]

--- a/components/profile-controller/controllers/moniotring.go
+++ b/components/profile-controller/controllers/moniotring.go
@@ -1,0 +1,75 @@
+package controllers
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+)
+
+const PROFILE = "profile_controller"
+const COMPONENT = "component"
+const KIND = "kind"
+// User that make the request
+const REQUSER = "user"
+const ACTION = "action"
+const PATH = "path"
+const SEVERITY  = "severity"
+const SEVERITY_MINOR = "minor"
+const SEVERITY_MAJOR = "major"
+const SEVERITY_CRITICAL = "critical"
+const MAX_TAG_LEN = 30
+
+var (
+	// Counter metrics
+	// num of requests counter vec
+	requestCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "request_kf",
+			Help: "Number of request_counter",
+		},
+		[]string{COMPONENT, KIND, REQUSER, ACTION, PATH},
+	)
+	// Counter metrics for failed requests
+	requestErrorCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "request_kf_failure",
+		Help: "Number of request_failure_counter",
+	}, []string{COMPONENT, KIND, REQUSER, ACTION, PATH, SEVERITY})
+
+	serviceHeartbeat = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "service_heartbeat",
+		Help: "Heartbeat signal every 10 seconds indicating pods are alive.",
+	}, []string{COMPONENT, SEVERITY})
+)
+
+func init() {
+	// Register prometheus counters
+	prometheus.MustRegister(requestCounter)
+	prometheus.MustRegister(requestErrorCounter)
+	prometheus.MustRegister(serviceHeartbeat)
+	// Count heartbeat
+	go func() {
+		labels := prometheus.Labels{COMPONENT: PROFILE, SEVERITY: SEVERITY_CRITICAL}
+		for {
+			time.Sleep(10 * time.Second)
+			serviceHeartbeat.With(labels).Inc()
+		}
+	}()
+}
+
+func IncRequestCounter(kind string) {
+	if len(kind) > MAX_TAG_LEN{
+		kind = kind[0:MAX_TAG_LEN]
+	}
+	labels := prometheus.Labels{COMPONENT: PROFILE, KIND: kind}
+	requestCounter.With(labels).Inc()
+}
+
+func IncRequestErrorCounter(kind string, severity string) {
+	if len(kind) > MAX_TAG_LEN{
+		kind = kind[0:MAX_TAG_LEN]
+	}
+	labels := prometheus.Labels{COMPONENT: PROFILE, KIND: kind, SEVERITY: severity}
+	log.Errorf("Failed request with kind: %v", kind)
+	requestErrorCounter.With(labels).Inc()
+}


### PR DESCRIPTION
requestCounter:
normal reconcile count with tags: `COMPONENT, KIND`
requestErrorCounter:
failed reconcile count with tags: `COMPONENT, KIND, SEVERITY`

serviceHeartbeat:
counter that increase value by 1 every 10 seconds, indicating controller is alive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4676)
<!-- Reviewable:end -->
