### PR TITLE
Remove authorization check for events (kubeflow/kubeflow#4699)

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/api.py
@@ -98,7 +98,10 @@ def list_notebooks(namespace):
     )
 
 
-@auth.needs_authorization("list", "", "v1", "events")
+# We don't do a subject access review on notebook events because
+# notebook events are cluster scoped resources. Users however are only
+# granted access to particular namespacs. We rely on the notebook webserver
+# to filter out information a user shouldn't see.
 def list_notebook_events(namespace, nb_name):
     '''
     V1EventList with events whose source the Notebook with 'nb_name' from namespace 'namespace'


### PR DESCRIPTION
* Events are cluster scoped resources. Users are only granted access
  to specific namespaces though.

* So we can't do a subject access review check for events.

* Should fix kubeflow/kubeflow#4699

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4710)
<!-- Reviewable:end -->
