### PR TITLE
Adding env var to suppress automatic additon of fsGroup in notebook pod

### DIFF
--- a/components/notebook-controller/README.md
+++ b/components/notebook-controller/README.md
@@ -33,6 +33,12 @@ That is, the user should specify what and how to run.
 
 All other fields will be filled in with default value if not specified.
 
+## Environment parameters
+
+ADD_FSGROUP:  If the value is true or unset, fsGroup: 100 will be included
+in the pod's security context. If this value is present and set to false, it will suppress the
+automatic addition of fsGroup: 100 to the security context of the pod.  
+
 ## Implementation detail
 
 This part is WIP as we are still developing.

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -299,10 +299,17 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 		Name:  "NB_PREFIX",
 		Value: "/notebook/" + instance.Namespace + "/" + instance.Name,
 	})
-	if podSpec.SecurityContext == nil {
-		fsGroup := DefaultFSGroup
-		podSpec.SecurityContext = &corev1.PodSecurityContext{
-			FSGroup: &fsGroup,
+
+	// For some platforms (like OpenShift), adding fsGroup: 100 is troublesome.
+	// This allows for those platforms to bypass the automatic addition of the fsGroup
+	// and will allow for the Pod Security Policy controller to make an appropriate choice
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/4617
+	if value, exists := os.LookupEnv("ADD_FSGROUP"); !exists || value == "true" {
+		if podSpec.SecurityContext == nil {
+			fsGroup := DefaultFSGroup
+			podSpec.SecurityContext = &corev1.PodSecurityContext{
+				FSGroup: &fsGroup,
+			}
 		}
 	}
 	return ss


### PR DESCRIPTION
Allowing for an env var ADD_FSGROUP to be set to false to suppress the automatic addition of fsGroup: 100 in the pod's security context.
If the env var is not specified or set to true, the current behaviour will be unchanged.
This addresses issue #4617.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4713)
<!-- Reviewable:end -->
