### PR TITLE
Update the documentation for how to publish/release the website.

### DIFF
--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -30,7 +30,6 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-
 # Releasing Prerequisities
 
 ## Authenticate to GCP
@@ -193,10 +192,10 @@ version of the website we want users to see.
 
 * Most of the time this will correspond to the **master** branch of the `kubeflow/website` repo
 
-* However, leading up to the release of vY.0.0 [www.kubeflow.org](www.kubeflow.org) 
-  will point at a branch containing a stable version of the docs corresponding to vX.0.0
+* However, leading up to a minor release (0.Y) [www.kubeflow.org](www.kubeflow.org) 
+  will point at a branch containing a stable version of the docs corresponding to v0.X
 
-For each minor (X.Y) release, we also publish a corresponding version of the 
+For each minor (0.Y) release, we also publish a corresponding version of the 
 website. Each version of the website is generated from a separate 
 [branch](https://github.com/kubeflow/website/branches)
 of the `kubeflow/website` repository. 
@@ -207,27 +206,23 @@ For example, the [documentation for v0.6](https://v0-6.kubeflow.org) is
 maintained in the
 [v0.6-branch](https://github.com/kubeflow/website/tree/v0.6-branch).
 
-* Per [kubeflow/website#1581](https://github.com/kubeflow/kubeflow/pull/4717) the naming
-  convention might change when we switch to using Netlify's deploy branch feature
-  rather than creating multiple Netlify sites.
+## Lifecycle
 
-## Lifcycle
+Our typical process when getting ready to do a minor release 0.Y 
+(i.e. going from 0.X to 0.Y); this process doesn't apply for patch releases.
 
-Our typical process when getting ready to release vY.0.0 is
-
-1. Follow the [instructions below](#create-website-branch) to create a release branch for vX.0.0
+1. Follow the [instructions below](#create-website-branch) to create a release branch for v0.X
 1. Update `www.kubeflow.org` to point at the vX.0.0 branch ([see below](#update-kubeflow-org))
-1. Develop vY.0.0 docs on the master branch
+1. Develop v0.X docs on the master branch
  
-   * Follow the [instructions](#prepare-docs) below to update version numbers etc. on master for the upcoming vY.0.0 release
+   * Follow the [instructions](#prepare-docs) below to update version numbers etc. on master for the upcoming v0.Y release
 
    * Docs for the master branch should be available on [https://master.kubeflow.org](https://master.kubeflow.org)
-     * There is currently an SSL certificate error see [kubeflow/website#1586](https://github.com/kubeflow/website/issues/1586)
-     * Docs for master can also be accessed at [https://master--competent-brattain-de2d6d.netlify.com/](https://master--competent-brattain-de2d6d.netlify.com/)
-1. When we are ready to publish docs for vY.0.0, follow the [instructions](#update-kubeflow-org) below to
+  
+1. When we are ready to publish docs for v0.Y, follow the [instructions](#update-kubeflow-org) below to
    point [www.kubeflow.org](https://www.kubeflow.org)  at the master branch 
 
-1. Follow the [instructions](#archive) to mark the docs on the vX.0.0 branch as archived
+1. Follow the [instructions](#archive) to mark the docs on the v0.Y branch as archived
 
 <a id="prepare-docs"></a>
 ##  Updating version numbers etc for the upcoming release (major, minor, or patch)

--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -109,7 +109,7 @@ If you aren't already working on a release branch (of the form `v${MAJOR}.${MINO
 
 1. Add a `version` for the new release to [applications.yaml](https://github.com/kubeflow/testing/blob/master/apps-cd/applications.yaml)
 
-1. Set the `version` for each repository to point to the release branch e.g. v0.x.y for kubeflow/kubeflow
+1. Set the `version` for each repository to point to the release branch e.g. vX.Y for kubeflow/kubeflow
 
 1. Set the tag associated with this version
 
@@ -192,10 +192,10 @@ version of the website we want users to see.
 
 * Most of the time this will correspond to the **master** branch of the `kubeflow/website` repo
 
-* However, leading up to a minor release (0.Y) [www.kubeflow.org](www.kubeflow.org) 
-  will point at a branch containing a stable version of the docs corresponding to v0.X
+* However, leading up to a minor release (vX.Y) [www.kubeflow.org](www.kubeflow.org) 
+  will point at a branch containing a stable version of the docs corresponding to vX.Y
 
-For each minor (0.Y) release, we also publish a corresponding version of the 
+For each minor (vX.Y) release, we also publish a corresponding version of the 
 website. Each version of the website is generated from a separate 
 [branch](https://github.com/kubeflow/website/branches)
 of the `kubeflow/website` repository. 
@@ -208,8 +208,8 @@ maintained in the
 
 ## Lifecycle
 
-Our typical process when getting ready to do a minor release X.Y 
-(i.e. going from X.Y to X.Z); this process doesn't apply for patch releases.
+Our typical process when getting ready to do a minor release vX.Y 
+(i.e. going from vX.Y to vX.Z); this process doesn't apply for patch releases.
 
 1. Follow the [instructions below](#create-website-branch) to create a release branch for vX.Y
 1. Update `www.kubeflow.org` to point at the vX.Y branch ([see below](#update-kubeflow-org))
@@ -286,14 +286,26 @@ getting the correct installation instructions etc. Here are the steps to follow:
 1. Update the matrix of Kubernetes versions on 
   [the Kubernetes overview](https://www.kubeflow.org/docs/started/k8s/overview/).
 
-1. Update the application version matrix on the version policy. (This is a 
-  placeholder for the task, as the page does
-  not yet exist. We'll have the page for version 1.0 onwards. See 
-  [PR #1308](https://github.com/kubeflow/website/pull/1308).)
+1. Update the application version matrix on the [version policy page](https://github.com/kubeflow/website/edit/master/content/docs/reference/version-policy.md)
 
+   * There are a number of different ways to get the application versions
+
+     1. You can look at the [kustomization.yaml](https://github.com/kubeflow/manifests/blob/30b666f2b8a0d1b5217a095cfe18f6a03f22231f/metadata/overlays/application/kustomization.yaml#L10)
+        file at the label `app.kubernetes.io/version`
+
+        * TODO(https://github.com/kubeflow/testing/issues/600): Create a script to get all application
+          version 
+   
+     1. You can get the application versions in a running Kubeflow deployment by doing
+
+        ```
+        kubectl -n kubeflow get applications 
+        ```
+ 
+        * You can use one of the [auto-deployed clusters](https://kf-ci-v1.endpoints.kubeflow-ci.cloud.goog/auto_deploy/)
 
 <a id="create-website-branch"></a> 
-## Creating and publishing a website branch for v.X.Y
+## Creating and publishing a website branch for vX.Y
 
 1. Create a new version branch under the 
   [website repository](https://github.com/kubeflow/website). The branch name
@@ -351,9 +363,9 @@ getting the correct installation instructions etc. Here are the steps to follow:
 <a id="archive"></a>
 ##  Archiving docs
 
-At some point we will to mark the docs for vX.0.0 as being archived and point users at the docs for v1.0
+When the website branch exists for the previous version of the docs (vX.X) and www.kubeflow.org is pointing to the new version (vX.Y), we must mark the docs for vX.X as being archived and point users at the docs for vX.Y.
 
-1. On the branch corresponding to vX.0.0
+1. On the branch corresponding to vX.X
 1. In the `config.toml` for the **version branch**,
   set the `archived_version` parameter to `true`:
 

--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -208,21 +208,21 @@ maintained in the
 
 ## Lifecycle
 
-Our typical process when getting ready to do a minor release 0.Y 
-(i.e. going from 0.X to 0.Y); this process doesn't apply for patch releases.
+Our typical process when getting ready to do a minor release X.Y 
+(i.e. going from X.Y to X.Z); this process doesn't apply for patch releases.
 
-1. Follow the [instructions below](#create-website-branch) to create a release branch for v0.X
-1. Update `www.kubeflow.org` to point at the vX.0.0 branch ([see below](#update-kubeflow-org))
-1. Develop v0.X docs on the master branch
+1. Follow the [instructions below](#create-website-branch) to create a release branch for vX.Y
+1. Update `www.kubeflow.org` to point at the vX.Y branch ([see below](#update-kubeflow-org))
+1. Develop vX.Z docs on the master branch
  
-   * Follow the [instructions](#prepare-docs) below to update version numbers etc. on master for the upcoming v0.Y release
+   * Follow the [instructions](#prepare-docs) below to update version numbers etc. on master for the upcoming vX.Z release
 
    * Docs for the master branch should be available on [https://master.kubeflow.org](https://master.kubeflow.org)
   
-1. When we are ready to publish docs for v0.Y, follow the [instructions](#update-kubeflow-org) below to
+1. When we are ready to publish docs for vX.Z, follow the [instructions](#update-kubeflow-org) below to
    point [www.kubeflow.org](https://www.kubeflow.org)  at the master branch 
 
-1. Follow the [instructions](#archive) to mark the docs on the v0.Y branch as archived
+1. Follow the [instructions](#archive) to mark the docs on the vX.Y branch as archived
 
 <a id="prepare-docs"></a>
 ##  Updating version numbers etc for the upcoming release (major, minor, or patch)


### PR DESCRIPTION
* The big change is that we instead of creating new Netlify sites
  for each version of the website we will take advantage of Netlify's
  ability to automatically deploy branches.

* Using branch deploys has two many advantages

1. Managing multiple Netlify sites is an administrative challenge.

   * In particular, when the new site is created the creator needs to
     ensure they create it under the kubeflow-team otherwise it will
     be private to them.

   * This has not been happening. Only the v0.5 and www.kubeflow.org sites
     are currently under the kubeflow-team in Netlify.

   * We have no easy way to track down the owner of the individual sites
     or gain access if they are unavailable

2. Using branch deploys should be much simpler than setting up a new
   Netlify site.

* In addition we can take advantage of Netlify to use a different branch
  from master for the production website (i.e. www.kubeflow.org)

* This allows us to start preparing the docs on master for an upcoming release
  while still showing stable docs corresponding to the current release to users.

* Using the branch deploy feature the docs on master should be available at
  htts://master.kubeflow.org.

Related to kubeflow/website#1581

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4717)
<!-- Reviewable:end -->
