### PR TITLE
[CentralDashboard] Added a root level `healthz` api call for liveness checks.

### DIFF
--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -57,6 +57,12 @@ async function main() {
       },
     });
   });
+  app.get('/healthz', (req: Request, res: Response) => {
+    res.json({
+      codeEnvironment,
+      message: `I tick, therfore I am!`,
+    });
+  });
   app.use('/api', new Api(k8sService, metricsService).routes());
   app.use('/api/workgroup', new WorkgroupApi(profilesService, k8sService).routes());
   app.use('/api', (req: Request, res: Response) => 


### PR DESCRIPTION
#### Related to #4022 
**_update for #4718_**

## About
This PR introduces a `/healthz` route to the dashboard to allow scripts to probe Central-Dash for liveness.

### Meta
/area centraldashboard
/area front-end
/priority p0
/assign @avdaredevil
/cc @kwasi @jlewi @prodonjs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4722)
<!-- Reviewable:end -->
