### PR TITLE
Jupyter displays Warn event message when hover over the spinner

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -320,13 +320,13 @@ def find_error_event(rsrc_events):
     of why the resource could not be created. For a Notebook, it can be due to:
 
           EVENT_TYPE      EVENT_REASON      DESCRIPTION   
-          Warning         FailedCreate      serviceaccount not found (originated in statefulset)
-          Warning         FailedScheduling  Insufficient CPU (originated in pod)
+          Warning         FailedCreate      pods "x" is forbidden: error looking up service account ... (originated in statefulset)
+          Warning         FailedScheduling  0/1 nodes are available: 1 Insufficient cpu (originated in pod)
 
     '''
     for e in sorted(rsrc_events, key=event_timestamp, reverse=True):
-        if e.type == EVENT_TYPE_WARNING and e.reason in ["FailedCreate", "FailedScheduling"]:
-            return STATUS_ERROR, e.message
+        if e.type == EVENT_TYPE_WARNING:
+            return STATUS_WAITING, e.message
     return None, None
 
 
@@ -529,7 +529,7 @@ def add_notebook_volume_secret(nb, secret, secret_name, mnt_path, mode):
 
     volume = {
         "name": secret,
-        "secret": {"defaultMode": mode, "secretName": secret_name,},
+        "secret": {"defaultMode": mode, "secretName": secret_name, },
     }
     spec["volumes"].append(volume)
 


### PR DESCRIPTION
Jupyter UI should show the event's message for any `WARNING` event. The UI should not display an error ❌ next to the affected notebook since it is difficult to distinguish which of these errors are temporary.

Related to: #4705

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4729)
<!-- Reviewable:end -->
