### PR TITLE
Use project id from the default credentials for identity namesapce

### DIFF
--- a/components/profile-controller/controllers/profile_controller_test.go
+++ b/components/profile-controller/controllers/profile_controller_test.go
@@ -52,7 +52,7 @@ func TestUpdateNamespaceLabels(t *testing.T) {
 	for _, test := range tests {
 		updateNamespaceLabels(test["current"])
 		if !reflect.DeepEqual(test["expected"], test["current"]) {
-			t.Errorf("Expect:\n%v; Output:\n%v", test[current], test["expected"])
+			t.Errorf("Expect:\n%v; Output:\n%v", test["current"], test["expected"])
 		}
 	}
 }


### PR DESCRIPTION
This PR is trying to address https://github.com/kubeflow/kubeflow/issues/4749. @kunmingg 

We can use the project id from the default credentials for the identity namespace when we config the workload identity. This is more reliable than using the project id from the user sa, which can be in a different gcp project.  

Please let me know if this makes sense. I'm happy to help fix the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4754)
<!-- Reviewable:end -->
