### PR TITLE
Move info about IAP and TFServing to the docs website

### DIFF
--- a/docs/gke/tf_serving_iap.md
+++ b/docs/gke/tf_serving_iap.md
@@ -3,51 +3,13 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Serving with IAP enabled](#serving-with-iap-enabled)
-  - [Setup](#setup)
-  - [Send request](#send-request)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Serving with IAP enabled
 
-This document shows how to programmatically authenticate a service account to access IAP.
-To authenticate an user account, we have to follow some manual steps
-[here](https://cloud.google.com/iap/docs/authentication-howto#authenticating_a_user_account)
+To sending prediction request through ingress and IAP, read doc
+[here](https://www.kubeflow.org/docs/components/serving/tfserving_new/#sending-prediction-request-through-ingress-and-iap)
 
-## Setup
 
-Follow this [doc](https://github.com/kubeflow/kubeflow/blob/master/docs/gke/iap.md) to
-setup the cluster with IAP enabled. Save the client id as `IAP_CLIENT_ID`
-
-Deploy a [TF serving component](https://github.com/kubeflow/kubeflow/tree/master/components/k8s-model-server).
-
-Create a service account:
-```
-gcloud iam service-accounts create --project=$PROJECT $SERVICE_ACCOUNT
-```
-Grant the service account access to IAP enabled resources:
-```
-gcloud projects add-iam-policy-binding $PROJECT \
-  --role roles/iap.httpsResourceAccessor \
-  --member serviceAccount:$SERVICE_ACCOUNT
-```
-
-Download the service account key:
-```
-gcloud iam service-accounts keys create ${KEY_FILE} \
-      --iam-account ${SERVICE_ACCOUNT}@${PROJECT}.iam.gserviceaccount.com
-```
-Export the environment variable `GOOGLE_APPLICATION_CREDENTIALS` to point to the key file of the
-service account.
-
-## Send request
-Send a get request:
-```
-python iap_request.py https://YOUR_HOST/models/MODEL_NAME/ IAP_CLIENT_ID
-```
-
-Send a post request with input file:
-```
-python iap_request.py https://YOUR_HOST/models/MODEL_NAME/ IAP_CLIENT_ID --input=YOUR_INPUT_FILE
-```
 

--- a/docs/gke/tf_serving_iap.md
+++ b/docs/gke/tf_serving_iap.md
@@ -8,7 +8,7 @@
 
 # Serving with IAP enabled
 
-To sending prediction request through ingress and IAP, read doc
+To send prediction request through ingress and IAP, read doc
 [here](https://www.kubeflow.org/docs/components/serving/tfserving_new/#sending-prediction-request-through-ingress-and-iap)
 
 


### PR DESCRIPTION
This is part of fix for [website issue #240](https://github.com/kubeflow/website/issues/240).

The content in the [kubeflow repo](https://github.com/kubeflow/kubeflow/blob/430d4f7ae16af389ac570182af519f6571f160cf/docs/gke/tf_serving_iap.md) is removed and link to[ website doc](https://www.kubeflow.org/docs/components/serving/tfserving_new/#sending-prediction-request-through-ingress-and-iap) instead.

/cc @sarahmaddox

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4760)
<!-- Reviewable:end -->
