### PR TITLE
Adding env var to suppress automatic additon of fsGroup in notebook pod

### DIFF
--- a/components/notebook-controller/README.md
+++ b/components/notebook-controller/README.md
@@ -33,6 +33,12 @@ That is, the user should specify what and how to run.
 
 All other fields will be filled in with default value if not specified.
 
+## Environment parameters
+
+ADD_FSGROUP:  If the value is true or unset, fsGroup: 100 will be included
+in the pod's security context. If this value is present and set to false, it will suppress the
+automatic addition of fsGroup: 100 to the security context of the pod.  
+
 ## Implementation detail
 
 This part is WIP as we are still developing.


### PR DESCRIPTION
Adding env var to suppress automatic additon of fsGroup in notebook pod (#4713)

* Allowing for an env var ADD_FSGROUP to be set to false to suppress the automatic addition of fsGroup: 100 in the pod's security context.
This addresses issue #4617.

* Adding note in README regarding ADD_FSGROUP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4782)
<!-- Reviewable:end -->
