### PR TITLE
Fix the kubeflow git link for clone.

### DIFF
--- a/bootstrap/developer_guide.md
+++ b/bootstrap/developer_guide.md
@@ -75,7 +75,7 @@ git clone git@github.com:kubeflow/kubeflow.git
 or
 
 ```sh
-git clone https://github.com:kubeflow/kubeflow .
+git clone https://github.com/kubeflow/kubeflow .
 ```
 
 Create a symbolic link inside your GOPATH to the location you checked out the code


### PR DESCRIPTION
New to kubeflow but I hope I will help in improving and contributing whenever I can.

The fix in this PR is to rectify the `https` git clone link, with `:` in url it will fail the clone with message like this: `'https://github.com:kubeflow/kubeflow/': URL using bad/illegal format or missing URL` 

* Fix is to rectify the https url to this; `https://github.com/kubeflow/kubeflow`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4814)
<!-- Reviewable:end -->
