### PR TITLE
Add the Azure CLI to Tensorflow Jupyter Image

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -68,6 +68,13 @@ RUN curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "/tmp/awscli-bu
     unzip /tmp/awscli-bundle.zip && ./awscli-bundle/install -i /usr/local/aws -b /usr/local/bin/aws && \
     rm -rf ./awscli-bundle
 
+# Install Azure CLI
+RUN curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.asc.gpg > /dev/null && \
+    AZ_REPO=$(lsb_release -cs) && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && \
+    apt-get update && \
+    apt-get install azure-cli
+
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
     locale-gen
 


### PR DESCRIPTION
This pull requests adds the Azure CLI to the Tensorflow Jupyter Image per the official instructions at:
https://docs.microsoft.com/cli/azure/install-azure-cli-linux?view=azure-cli-latest

The Tensorflow Jupyter Image currently contains the GCP, AWS CLIs. Just like the AWS CLI the Azure CLI is not a precompiled standalone binary and therefore needs to be installed in the Docker image itself.

For some context why this CLI is needed see my MNIST Azure E2E example. Currently to complete this tutorial one has to switch back and forth between local terminal and Kubeflow environment, manually copying values back and forth. I would like to reduce friction for Kubeflow users on Azure.
https://github.com/kubeflow/examples/tree/master/mnist#azure

See also this discussion: https://github.com/kubeflow/examples/pull/759#issuecomment-592717666

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4816)
<!-- Reviewable:end -->
