### PR TITLE
Add Tolerations to PodDefault

### DIFF
--- a/components/admission-webhook/main_test.go
+++ b/components/admission-webhook/main_test.go
@@ -126,6 +126,50 @@ func TestApplyPodDefaultsOnPod(t *testing.T) {
 					Labels: map[string]string{},
 				},
 			},
+		}, {
+			"Add tolerations",
+			&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Tolerations: []*corev1.Toleration{
+						{
+							Key: "oldToleration",
+							Operator: "Exists",
+							Effect: "NoSchedule",
+						},
+					}
+				}
+			},
+			[]*settingsapi.PodDefault{
+				{
+					Spec: settingsapi.PodDefaultSpec{
+						Tolerations: []*corev1.Toleration{
+							{
+								Key: "newToleration",
+								Operator: "Equal",
+								Value: "foo",
+								"Effect": "NoSchedule",
+							},
+						},
+					},
+				},
+			},
+			&corev1.Pod{
+				Spec: corev1.PodSpec{
+					Tolerations: []*corev1.Toleration{
+						{
+							Key: "oldToleration",
+							Operator: "Exists",
+							Effect: "NoSchedule",
+						},
+						{
+							Key: "newToleration",
+							Operator: "Equal",
+							Value: "foo",
+							"Effect": "NoSchedule",
+						},
+					}
+				}
+			},
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
+++ b/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
@@ -59,6 +59,8 @@ type PodDefaultSpec struct {
 
 	// Labels defines the labels to inject into the pod.
 	Labels map[string]string `json:"labels,omitempty"`
+
+	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
 }
 
 // PodDefaultStatus defines the observed state of PodDefault


### PR DESCRIPTION
I want to add tolerations to the pods for my Jupyter server.
I am able to inject other things like Labels and Annotations,
this would allow me to also use PodDefault to inject tolerations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4852)
<!-- Reviewable:end -->
