### PR TITLE
[CentralDashboard] Fix #4819

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Builds and tests
-FROM node:10-alpine AS build
+FROM node:12-alpine AS build
 
 ARG kubeflowversion
 ARG commit
@@ -39,7 +39,7 @@ RUN npm rebuild && \
     npm prune --production
 
 # Step 2: Packages assets for serving
-FROM node:10-alpine AS serve
+FROM node:12-alpine AS serve
 
 ENV NODE_ENV=production
 WORKDIR /app


### PR DESCRIPTION
Bump nodeJS base image from 10 to 12 on centraldashboard

This fixes https://github.com/kubeflow/kubeflow/issues/4819

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4877)
<!-- Reviewable:end -->
