### PR TITLE
Add $HOME/.local/bin into PATH

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -19,6 +19,7 @@ ENV NB_USER $NB_USER
 ENV NB_UID 1000
 ENV HOME /home/$NB_USER
 ENV NB_PREFIX /
+ENV PATH $HOME/.local/bin:$PATH
 
 
 # Use bash instead of sh


### PR DESCRIPTION
## Issue to fix
Issue #4878 mentions that we want to add `$HOME/.local/bin` into `PATH`. Thus, we don't have to explicitly use `$HOME/.local/bin/cmd` to invoke the cmd located in the `$HOME/.local/bin`.

## Change to make
I add a `ENV` layer in the `DockerFile` of `tensorflow-notebook-image` for this functionality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4879)
<!-- Reviewable:end -->
