### PR TITLE
Add dash (a shell) the profile-controller docker image.

### DIFF
--- a/components/profile-controller/Dockerfile
+++ b/components/profile-controller/Dockerfile
@@ -14,6 +14,7 @@ RUN go mod download
 COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
+RUN cp /bin/dash /workspace/dash
 
 # Build
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
@@ -26,6 +27,8 @@ RUN if [ "$(uname -m)" = "aarch64" ]; then \
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/base:latest as serve
 WORKDIR /
+COPY --from=builder /workspace/dash /bin/dash
+
 COPY third_party third_party
 COPY --from=builder /workspace/manager .
 COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/library/

--- a/components/profile-controller/skaffold.yaml
+++ b/components/profile-controller/skaffold.yaml
@@ -1,0 +1,48 @@
+# Reference: https://skaffold.dev/docs/references/yaml/
+apiVersion: skaffold/v2alpha1
+kind: Config
+metadata:
+  name: profile-controller
+build:
+  artifacts:
+  - image: gcr.io/kubeflow-releasing/profile-controller
+    # Set the context to the root directory. 
+    # All paths in the Dockerfile should be relative to this one.
+    context: . 
+    kaniko:
+      dockerfile: ./Dockerfile
+      buildContext:
+        gcsBucket: kubeflow-releasing_skaffold
+      env: 
+        # TODO(GoogleContainerTools/skaffold#3468) skaffold doesn't
+        # appear to work with workload identity
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /secret/user-gcp-sa.json
+      cache: {}
+  cluster:    
+    pullSecretName: user-gcp-sa
+    resources:
+      requests:
+        cpu: 8
+        memory: 16Gi
+profiles:
+  # TODO(jlewi): What is a good pattern for people setting up personal
+  # skaffold configs?
+  - name: jlewi
+    patches:
+      - op: replace
+        path: /build/artifacts/0/image
+        value: gcr.io/jlewi-dev/profile-controller
+      - op: replace
+        path: /build/artifacts/0/kaniko/buildContext/gcsBucket
+        value: jlewi-dev_skaffold
+    build:
+      cluster:    
+        # Build in a namespace with ISTIO sidecar injection disabled
+        # see  GoogleContainerTools/skaffold#3442
+        namespace: kubeflow
+        pullSecretName: user-gcp-sa
+        resources:
+          requests:
+            cpu: 8
+            memory: 16Gi


### PR DESCRIPTION
* The profile kustomize deployments rely on a brittle pattern for
  substitution in parameters into the command line.
  https://github.com/kubeflow/manifests/blob/9e6ef8681003c195560fb7b3b75211830c19b7a0/profiles/base/deployment.yaml#L16

* The current pattern is to define kustomize vars and a custom
  configuration (https://github.com/kubeflow/manifests/blob/master/profiles/base/params.yaml) that does substitution of specific containers and their arguments
  based on position.

* A much better pattern is to

  * Define environment variables based on a configmap
  * Run the command via a shell that can evaluate the environment variables.

* To do that we need to put a shell into the container since the distroless
  images don't have one.

* We pick the dash shell. It is a little lighter weight then bash and is
  available in the golang builder image so we can just copy it to the
  distroless image.

* Add a skaffold config to help future developers build the container using skaffold + kaniko.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kubeflow/4880)
<!-- Reviewable:end -->
