### PR TITLE
Update Central Dashboard npm packages, change Dockerfile to use Distroless

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -39,7 +39,7 @@ RUN npm rebuild && \
     npm prune --production
 
 # Step 2: Packages assets for serving
-FROM node:10-alpine AS serve
+FROM gcr.io/distroless/nodejs AS serve
 
 ENV NODE_ENV=production
 WORKDIR /app

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -2024,9 +2024,9 @@
             }
         },
         "acorn": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
-            "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+            "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
             "dev": true
         },
         "acorn-globals": {
@@ -3395,9 +3395,9 @@
             "dev": true
         },
         "compare-versions": {
-            "version": "3.5.1",
-            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.5.1.tgz",
-            "integrity": "sha512-9fGPIB7C6AyM18CJJBHt5EnCZDG3oiTJYy0NjfIAGjKpzv0tkxWko7TNQHF5ymqm7IH03tqmeuBxtvD+Izh6mg==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+            "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==",
             "dev": true
         },
         "component-bind": {
@@ -5953,7 +5953,7 @@
                 },
                 "minimist": {
                     "version": "1.2.0",
-                    "resolved": false,
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 },
                 "minipass": {
@@ -6337,26 +6337,6 @@
             "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
             "dev": true
         },
-        "handlebars": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.3.tgz",
-            "integrity": "sha512-SRGwSYuNfx8DwHD/6InAPzD6RgeruWLT+B8e8a7gGs8FWgHzlExpTFMEq2IA6QpAfOClpKHy6+8IqTjeBCu6Kg==",
-            "dev": true,
-            "requires": {
-                "neo-async": "^2.6.0",
-                "optimist": "^0.6.1",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.1.4"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                }
-            }
-        },
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -6561,6 +6541,12 @@
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
             "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+            "dev": true
+        },
+        "html-escaper": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.1.tgz",
+            "integrity": "sha512-hNX23TjWwD3q56HpWjUHOKj1+4KKlnjv9PcmBUYKVpga+2cnb9nDx/B1o0yO4n+RZXZdiNxzx6B24C9aNMTkkQ==",
             "dev": true
         },
         "html-minifier": {
@@ -7291,9 +7277,9 @@
             "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "istanbul-api": {
-            "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.6.tgz",
-            "integrity": "sha512-x0Eicp6KsShG1k1rMgBAi/1GgY7kFGEBwQpw3PXGEmu+rBcBNhqU8g2DgY9mlepAsLPzrzrbqSgCGANnki4POA==",
+            "version": "2.1.7",
+            "resolved": "https://registry.npmjs.org/istanbul-api/-/istanbul-api-2.1.7.tgz",
+            "integrity": "sha512-LYTOa2UrYFyJ/aSczZi/6lBykVMjCCvUmT64gOe+jPZFy4w6FYfPGqFT2IiQ2BxVHHDOvCD7qrIXb0EOh4uGWw==",
             "dev": true,
             "requires": {
                 "async": "^2.6.2",
@@ -7304,7 +7290,7 @@
                 "istanbul-lib-instrument": "^3.3.0",
                 "istanbul-lib-report": "^2.0.8",
                 "istanbul-lib-source-maps": "^3.0.6",
-                "istanbul-reports": "^2.2.4",
+                "istanbul-reports": "^2.2.5",
                 "js-yaml": "^3.13.1",
                 "make-dir": "^2.1.0",
                 "minimatch": "^3.0.4",
@@ -7476,12 +7462,12 @@
             }
         },
         "istanbul-reports": {
-            "version": "2.2.6",
-            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-            "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+            "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
             "dev": true,
             "requires": {
-                "handlebars": "^4.1.2"
+                "html-escaper": "^2.0.0"
             }
         },
         "jasmine": {
@@ -7869,9 +7855,9 @@
             "dev": true
         },
         "kind-of": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-            "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true
         },
         "latest-version": {
@@ -8427,9 +8413,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
             "dev": true
         },
         "mississippi": {
@@ -8805,7 +8791,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -8826,12 +8813,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -8846,17 +8835,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -8973,7 +8965,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -8985,6 +8978,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -8999,6 +8993,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -9006,12 +9001,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -9030,6 +9027,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -9110,7 +9108,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -9122,6 +9121,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -9207,7 +9207,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -9243,6 +9244,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -9262,6 +9264,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -9305,12 +9308,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
@@ -13742,9 +13747,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.3.0.tgz",
-                    "integrity": "sha512-/czfa8BwS88b9gWQVhc8eknunSA2DoJpJyTQkhheIf5E48u1N0R4q/YxxsAeqRrmK9TQ/uYfgLDfZo91UlANIA==",
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
                     "dev": true
                 },
                 "ajv": {
@@ -14091,7 +14096,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -14134,7 +14140,8 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
@@ -14145,7 +14152,8 @@
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -14262,7 +14270,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -14274,6 +14283,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -14296,12 +14306,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -14320,6 +14332,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -14400,7 +14413,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -14412,6 +14426,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -14497,7 +14512,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -14533,6 +14549,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -14552,6 +14569,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -14595,12 +14613,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },


### PR DESCRIPTION

This is part of an effort to reduce critical vulnerabilities. 

Reference issue is [Convert Container image to distroless #4590](https://github.com/kubeflow/kubeflow/issues/4590)