### PR TITLE
JWA: Fix UI handling of default StorageClass

### DIFF
--- a/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/resource-form.component.ts
@@ -1,21 +1,21 @@
-import { Component, OnInit, OnDestroy } from "@angular/core";
-import { FormGroup } from "@angular/forms";
-import { NamespaceService } from "../services/namespace.service";
-import { KubernetesService } from "../services/kubernetes.service";
-import { Router } from "@angular/router";
-import { catchError } from "rxjs/operators";
-import { Subscription, of } from "rxjs";
-import { Volume, Config, SnackType } from "../utils/types";
-import { SnackBarService } from "../services/snack-bar.service";
-import { getFormDefaults, initFormControls } from "../utils/common";
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { NamespaceService } from '../services/namespace.service';
+import { KubernetesService } from '../services/kubernetes.service';
+import { Router } from '@angular/router';
+import { catchError } from 'rxjs/operators';
+import { Subscription, of } from 'rxjs';
+import { Volume, Config, SnackType } from '../utils/types';
+import { SnackBarService } from '../services/snack-bar.service';
+import { getFormDefaults, initFormControls } from '../utils/common';
 
 @Component({
-  selector: "app-resource-form",
-  templateUrl: "./resource-form.component.html",
-  styleUrls: ["./resource-form.component.scss"]
+  selector: 'app-resource-form',
+  templateUrl: './resource-form.component.html',
+  styleUrls: ['./resource-form.component.scss'],
 })
 export class ResourceFormComponent implements OnInit, OnDestroy {
-  currNamespace = "";
+  currNamespace = '';
   formCtrl: FormGroup;
   config: Config;
 
@@ -30,7 +30,7 @@ export class ResourceFormComponent implements OnInit, OnDestroy {
     private namespaceService: NamespaceService,
     private k8s: KubernetesService,
     private router: Router,
-    private popup: SnackBarService
+    private popup: SnackBarService,
   ) {}
 
   ngOnInit() {
@@ -58,19 +58,13 @@ export class ResourceFormComponent implements OnInit, OnDestroy {
         this.k8s.getVolumes(namespace).subscribe(pvcs => {
           this.pvcs = pvcs;
         });
-      })
+      }),
     );
 
     // Check if a default StorageClass is set
     this.k8s.getDefaultStorageClass().subscribe(defaultClass => {
       if (defaultClass.length === 0) {
         this.defaultStorageclass = false;
-        this.popup.show(
-          "No default Storage Class is set. Can't create new Disks for the " +
-            "new Notebook. Please use an Existing Disk.",
-          SnackType.Warning,
-          0
-        );
       } else {
         this.defaultStorageclass = true;
       }
@@ -85,11 +79,11 @@ export class ResourceFormComponent implements OnInit, OnDestroy {
   public onSubmit() {
     this.k8s
       .postResource(this.formCtrl.value)
-      .pipe(catchError(_ => of("failed")))
+      .pipe(catchError(_ => of('failed')))
       .subscribe(resp => {
-        if (resp === "posted") {
-          this.router.navigate(["/"]);
-        } else if (resp === "failed") {
+        if (resp === 'posted') {
+          this.router.navigate(['/']);
+        } else if (resp === 'failed') {
           // The Notebook wasn't created, but its volumes might have been created
           this.k8s.getVolumes(this.currNamespace).subscribe(pvcs => {
             this.pvcs = pvcs;

--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
@@ -2,7 +2,12 @@
   <mat-form-field appearance="outline" id="type">
     <mat-label>Type</mat-label>
     <mat-select formControlName="type">
-      <mat-option *ngIf="defaultStorageClass" value="New">New</mat-option>
+      <mat-option
+        [disabled]="newTypeIsDisabled()"
+        [matTooltip]="newTypeTooltip()"
+        value="New"
+        >New</mat-option
+      >
       <mat-option value="Existing">Existing</mat-option>
     </mat-select>
   </mat-form-field>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
@@ -1,15 +1,15 @@
-import { Component, OnInit, Input, OnDestroy } from "@angular/core";
-import { FormGroup } from "@angular/forms";
-import { Volume } from "src/app/utils/types";
-import { Subscription } from "rxjs";
+import { Component, OnInit, Input, OnDestroy } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+import { Volume } from 'src/app/utils/types';
+import { Subscription } from 'rxjs';
 
 @Component({
-  selector: "app-volume",
-  templateUrl: "./volume.component.html",
-  styleUrls: ["./volume.component.scss"]
+  selector: 'app-volume',
+  templateUrl: './volume.component.html',
+  styleUrls: ['./volume.component.scss'],
 })
 export class VolumeComponent implements OnInit, OnDestroy {
-  private _notebookName = "";
+  private _notebookName = '';
   private _defaultStorageClass: boolean;
 
   currentPVC: Volume;
@@ -60,22 +60,59 @@ export class VolumeComponent implements OnInit, OnDestroy {
 
   // ----- Get macros -----
   get selectedVolIsExistingType(): boolean {
-    return (
-      this.existingPVCs.has(this.volume.value.name) || !this.defaultStorageClass
-    );
+    if (this.existingPVCs.has(this.volume.value.name)) {
+      return true;
+    }
+
+    if (
+      this.volume.get('class').value === '{none}' &&
+      !this.defaultStorageClass
+    ) {
+      return true;
+    }
+
+    return false;
   }
 
   get currentVolName(): string {
-    return this.renderVolName(this.volume.get("templatedName").value);
+    return this.renderVolName(this.volume.get('templatedName').value);
+  }
+
+  // ----- Functions for handling the New volume type -----
+  newTypeIsDisabled(): boolean {
+    // This option should only be disabled if the class value is set to
+    // use the default StorageClass, but none is set in the cluster
+    if (this.volume.get('class').value !== '{none}') {
+      return false;
+    }
+
+    if (!this.defaultStorageClass) {
+      return true;
+    }
+
+    return false;
+  }
+
+  newTypeTooltip(): string {
+    const volClass = this.volume.get('class').value;
+    if (volClass !== '{none}') {
+      return '';
+    }
+
+    if (!this.defaultStorageClass) {
+      return `No default StorageClass is detected in the cluster`;
+    }
+
+    return '';
   }
 
   // ----- utility functions -----
   renderVolName(name: string): string {
-    return name.replace("{notebook-name}", this.notebookName);
+    return name.replace('{notebook-name}', this.notebookName);
   }
 
   setVolumeType(type: string) {
-    if (type === "Existing") {
+    if (type === 'Existing') {
       this.volume.controls.size.disable();
       this.volume.controls.mode.disable();
     } else {
@@ -90,11 +127,11 @@ export class VolumeComponent implements OnInit, OnDestroy {
       // Disable all fields
       this.volume.controls.size.disable();
       this.volume.controls.mode.disable();
-      this.volume.controls.type.setValue("Existing");
+      this.volume.controls.type.setValue('Existing');
     } else {
       this.volume.controls.size.enable();
       this.volume.controls.mode.enable();
-      this.volume.controls.type.setValue("New");
+      this.volume.controls.type.setValue('New');
     }
   }
 
@@ -104,18 +141,18 @@ export class VolumeComponent implements OnInit, OnDestroy {
   ngOnInit() {
     // type
     this.subscriptions.add(
-      this.volume.get("type").valueChanges.subscribe((type: string) => {
+      this.volume.get('type').valueChanges.subscribe((type: string) => {
         this.setVolumeType(type);
-      })
+      }),
     );
 
     // name
     this.subscriptions.add(
-      this.volume.get("name").valueChanges.subscribe((name: string) => {
+      this.volume.get('name').valueChanges.subscribe((name: string) => {
         // Update the fields if the volume is an existing one
-        this.volume.get("name").setValue(name, { emitEvent: false });
+        this.volume.get('name').setValue(name, { emitEvent: false });
         this.updateVolInputFields();
-      })
+      }),
     );
   }
 

--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
@@ -64,14 +64,9 @@ export class VolumeComponent implements OnInit, OnDestroy {
       return true;
     }
 
-    if (
-      this.volume.get('class').value === '{none}' &&
-      !this.defaultStorageClass
-    ) {
-      return true;
-    }
-
-    return false;
+    return (
+      this.volume.get('class').value === '{none}' && !this.defaultStorageClass
+    );
   }
 
   get currentVolName(): string {
@@ -86,11 +81,7 @@ export class VolumeComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    if (!this.defaultStorageClass) {
-      return true;
-    }
-
-    return false;
+    return !this.defaultStorageClass;
   }
 
   newTypeTooltip(): string {

--- a/components/jupyter-web-app/frontend/src/app/uis/rok/utils/common.ts
+++ b/components/jupyter-web-app/frontend/src/app/uis/rok/utils/common.ts
@@ -1,20 +1,20 @@
-import { createVolumeControl } from "src/app/utils/common";
-import { ConfigVolume } from "src/app/utils/types";
-import { FormGroup, FormControl, FormArray } from "@angular/forms";
+import { createVolumeControl } from 'src/app/utils/common';
+import { ConfigVolume } from 'src/app/utils/types';
+import { FormGroup, FormControl, FormArray } from '@angular/forms';
 
 export function createRokVolumeControl(vol: ConfigVolume) {
   const volCtrl = createVolumeControl(vol);
 
   // Set the rokUrl in extraFields
-  const extraFields: FormGroup = volCtrl.get("extraFields") as FormGroup;
-  extraFields.addControl("rokUrl", new FormControl("", []));
+  const extraFields: FormGroup = volCtrl.get('extraFields') as FormGroup;
+  extraFields.addControl('rokUrl', new FormControl('', []));
 
   return volCtrl;
 }
 
 export function addRokDataVolume(
   formCtrl: FormGroup,
-  vol: ConfigVolume = null
+  vol: ConfigVolume = null,
 ) {
   // If no vol is provided create one with default values
   if (vol === null) {
@@ -22,24 +22,27 @@ export function addRokDataVolume(
 
     vol = {
       type: {
-        value: "New"
+        value: 'New',
       },
       name: {
-        value: "{notebook-name}-vol-" + (l + 1)
+        value: '{notebook-name}-vol-' + (l + 1),
       },
       size: {
-        value: "10Gi"
+        value: '10Gi',
       },
       mountPath: {
-        value: "/home/jovyan/data-vol-" + (l + 1)
+        value: '/home/jovyan/data-vol-' + (l + 1),
       },
       accessModes: {
-        value: "ReadWriteOnce"
-      }
+        value: 'ReadWriteOnce',
+      },
+      class: {
+        value: 'rok',
+      },
     };
   }
 
   // Push it to the control
-  const vols = formCtrl.get("datavols") as FormArray;
+  const vols = formCtrl.get('datavols') as FormArray;
   vols.push(createRokVolumeControl(vol));
 }

--- a/components/jupyter-web-app/frontend/src/app/utils/common.ts
+++ b/components/jupyter-web-app/frontend/src/app/utils/common.ts
@@ -62,6 +62,7 @@ export function updateVolumeControl(
   volCtrl.get('size').setValue(vol.size.value);
   volCtrl.get('mode').setValue(vol.accessModes.value);
   volCtrl.get('path').setValue(vol.mountPath.value);
+  volCtrl.get('class').setValue(vol.class.value);
   volCtrl.get('templatedName').setValue(vol.name.value);
 
   if (readonly) {
@@ -93,6 +94,9 @@ export function addDataVolume(
       },
       accessModes: {
         value: 'ReadWriteOnce',
+      },
+      class: {
+        value: '{none}',
       },
     };
   }

--- a/components/jupyter-web-app/frontend/src/app/utils/types.ts
+++ b/components/jupyter-web-app/frontend/src/app/utils/types.ts
@@ -12,13 +12,13 @@ export interface Volume {
 
 export function emptyVolume(): Volume {
   return {
-    type: "",
-    name: "",
-    size: "",
-    path: "",
-    mode: "",
+    type: '',
+    name: '',
+    size: '',
+    path: '',
+    mode: '',
     extraFields: {},
-    templatedName: ""
+    templatedName: '',
   };
 }
 
@@ -82,6 +82,9 @@ export interface ConfigVolume {
   accessModes: {
     value: string;
   };
+  class: {
+    value: string;
+  };
 }
 
 export interface Config {
@@ -134,5 +137,5 @@ export enum SnackType {
   Success,
   Error,
   Warning,
-  Info
+  Info,
 }


### PR DESCRIPTION
closes #4906 

Right now the UI will completely ignore the `class` field of a volume in
the config received from the backend.

We want the UI to:
* Respect that field from the config
* Disable the `New` option in the volume type if
  a. The volume class is `{none}` (default SC) and
  b. No default storage class is set in the cluster

Else the UI should allow the user to create a new volume and the UI will
use the storage class received from the config.

/cc @avdaredevil 
/cc @kunmingg 
/assign @kimwnasptd 