### PR TITLE
Add dashboard link to Azure documentation

### DIFF
--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -71,6 +71,12 @@ export class DashboardView extends PolymerElement {
                         link: `${DOCS}/aws/`,
                     },
                     {
+                        text: 'Kubeflow on Azure',
+                        desc: 'Running Kubeflow on Azure Kubernetes Service ' +
+                            'and Microsoft Azure',
+                        link: `${DOCS}/azure/`,
+                    },
+                    {
                         text: 'Requirements for Kubeflow',
                         desc: 'Get more detailed information about using ' +
                 'Kubeflow and its components',


### PR DESCRIPTION
The main Kubernetes Dashboard has links to the GCP and AWS sections of the docs. This adds a link for the Azure section.