### PR TITLE
Pr/email escape (issue 4970)

### DIFF
--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 
 	istiorbac "github.com/kubeflow/kubeflow/components/profile-controller/api/istiorbac/v1alpha1"
-
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -57,7 +56,7 @@ type BindingClient struct {
 
 //getBindingName returns bindingName, which is combination of user kind, username, RoleRef kind, RoleRef name.
 func getBindingName(binding *Binding) (string, error) {
-	// Only keep lower case letters, replace other with -
+	// Only keep lower case letters and numbers, replace other with -
 	reg, err := regexp.Compile("[^a-z0-9]+")
 	if err != nil {
 		return "", err
@@ -167,7 +166,6 @@ func (c *BindingClient) Delete(binding *Binding) error {
 }
 
 func (c *BindingClient) List(user string, namespaces []string, role string) (*BindingEntries, error) {
-
 	bindings := []Binding{}
 	for _, ns := range namespaces {
 		roleBindingList, err := c.kubeClient.RbacV1().RoleBindings(ns).List(metav1.ListOptions{})

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -57,7 +57,6 @@ type BindingClient struct {
 
 //getBindingName returns bindingName, which is combination of user kind, username, RoleRef kind, RoleRef name.
 func getBindingName(binding *Binding) (string, error) {
-	//Lalith Change
 	// Only keep lower case letters, replace other with -
 	reg, err := regexp.Compile("[^a-z0-9]+")
 	if err != nil {

--- a/components/access-management/kfam/bindings_test.go
+++ b/components/access-management/kfam/bindings_test.go
@@ -23,43 +23,39 @@ func getBindingObject(binding string) *Binding {
 }
 
 func TestGetBindingName(t *testing.T) {
-
-	/* Read the test data from a file if needed
-
-	// create a testdata folder under this package and add files as needed
-	file, err := os.Open("./testdata/file.go")
-	if err != nil {
-		log.Fatal(err)
-	}
-	*/
-
 	//Table driven tests
 	var tests = []struct {
+		name     string
 		in       *Binding
 		out      string
 		hasError bool
 	}{
-		{getBindingObject("lalith.vaka@zq.msds.kp.org"), "user-lalith-vaka-zq-msds-kp-org-clusterrole-edit", false},
-		{getBindingObject("397401@zq.msds.kp.org"), "user-397401-zq-msds-kp-org-clusterrole-edit", false},
-		{getBindingObject("lalith.397401@zq.msds.kp.org"), "user-lalith-397401-zq-msds-kp-org-clusterrole-edit", false},
-		{getBindingObject("397401.vaka@zq.msds.kp.org"), "user-397401-vaka-zq-msds-kp-org-clusterrole-edit", false},
-		{getBindingObject("i397401@zq.msds.kp.org"), "user-i397401-zq-msds-kp-org-clusterrole-edit", false},
+		{"letters", getBindingObject("lalith.vaka@zq.msds.kp.org"), "user-lalith-vaka-zq-msds-kp-org-clusterrole-edit", false},
+		{"numbers", getBindingObject("397401@zq.msds.kp.org"), "user-397401-zq-msds-kp-org-clusterrole-edit", false},
+		{"letters-numbers", getBindingObject("lalith.397401@zq.msds.kp.org"), "user-lalith-397401-zq-msds-kp-org-clusterrole-edit", false},
+		{"numbers-letters", getBindingObject("397401.vaka@zq.msds.kp.org"), "user-397401-vaka-zq-msds-kp-org-clusterrole-edit", false},
+		{"lettersnumbers", getBindingObject("i397401@zq.msds.kp.org"), "user-i397401-zq-msds-kp-org-clusterrole-edit", false},
 	}
 
 	//format := "--- %s: %s (%s)\n"
 	for _, tt := range tests {
-		s, errorReturned := getBindingName(tt.in)
-		if tt.hasError {
-			// expected an error
-			if errorReturned == nil {
-				t.Errorf("got %q, want %q", tt.in, s)
+		t.Run(tt.name, func(t *testing.T) {
+			s, errorReturned := getBindingName(tt.in)
+			if tt.hasError {
+				// expected an error
+				if errorReturned == nil {
+					t.Fatalf("Expected error but got none:  input: %q", tt.in)
+				}
+			} else {
+				//expected a value
+				if errorReturned != nil {
+					t.Fatalf("unExpected occured:  input: %q, errorReturned: %q", tt.in, errorReturned)
+				}
+				if s != tt.out {
+					t.Fatalf("Value different than expected: input: %q, output: %q", s, tt.out)
+				}
 			}
-		} else {
-			//expected a value
-			if s != tt.out {
-				t.Errorf("got %q, want %q", s, tt.out)
-			}
-		}
+		})
 	}
 
 }

--- a/components/access-management/kfam/bindings_test.go
+++ b/components/access-management/kfam/bindings_test.go
@@ -11,7 +11,7 @@ func getBindingObject(binding string) *Binding {
 
 	return &Binding{
 		User: &rbacv1.Subject{
-			Kind: "user",
+			Kind: rbacv1.UserKind,
 			Name: binding,
 		},
 		RoleRef: &rbacv1.RoleRef{
@@ -20,19 +20,6 @@ func getBindingObject(binding string) *Binding {
 		},
 	}
 
-}
-
-//Table driven tests
-var tests = []struct {
-	in       *Binding
-	out      string
-	hasError bool
-}{
-	{getBindingObject("lalith.vaka@zq.msds.kp.org"), "user-lalith-vaka-zq-msds-kp-org-clusterrole-edit", false},
-	{getBindingObject("397401@zq.msds.kp.org"), "user-397401-zq-msds-kp-org-clusterrole-edit", false},
-	{getBindingObject("lalith.397401@zq.msds.kp.org"), "user-lalith-397401-zq-msds-kp-org-clusterrole-edit", false},
-	{getBindingObject("397401.vaka@zq.msds.kp.org"), "user-397401-vaka-zq-msds-kp-org-clusterrole-edit", false},
-	{getBindingObject("i397401@zq.msds.kp.org"), "user-i397401-zq-msds-kp-org-clusterrole-edit", false},
 }
 
 func TestGetBindingName(t *testing.T) {
@@ -44,27 +31,33 @@ func TestGetBindingName(t *testing.T) {
 	if err != nil {
 		log.Fatal(err)
 	}
-
 	*/
+
+	//Table driven tests
+	var tests = []struct {
+		in       *Binding
+		out      string
+		hasError bool
+	}{
+		{getBindingObject("lalith.vaka@zq.msds.kp.org"), "user-lalith-vaka-zq-msds-kp-org-clusterrole-edit", false},
+		{getBindingObject("397401@zq.msds.kp.org"), "user-397401-zq-msds-kp-org-clusterrole-edit", false},
+		{getBindingObject("lalith.397401@zq.msds.kp.org"), "user-lalith-397401-zq-msds-kp-org-clusterrole-edit", false},
+		{getBindingObject("397401.vaka@zq.msds.kp.org"), "user-397401-vaka-zq-msds-kp-org-clusterrole-edit", false},
+		{getBindingObject("i397401@zq.msds.kp.org"), "user-i397401-zq-msds-kp-org-clusterrole-edit", false},
+	}
+
 	//format := "--- %s: %s (%s)\n"
 	for _, tt := range tests {
-
-		s, error := getBindingName(tt.in)
-
+		s, errorReturned := getBindingName(tt.in)
 		if tt.hasError {
 			// expected an error
-			if error == nil {
+			if errorReturned == nil {
 				t.Errorf("got %q, want %q", tt.in, s)
-			} else {
-				//t.Logf("getBindingName() with args %v PASSED and got value '%v'", tt.in, error)
 			}
-
 		} else {
 			//expected a value
 			if s != tt.out {
 				t.Errorf("got %q, want %q", s, tt.out)
-			} else {
-				//t.Logf("getBindingName() with args %v PASSED and got value '%v'", tt.in, s)
 			}
 		}
 	}

--- a/components/access-management/kfam/bindings_test.go
+++ b/components/access-management/kfam/bindings_test.go
@@ -1,0 +1,72 @@
+package kfam
+
+import (
+	"testing"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+// Building Binding Object from k8s.io/api/rbac/v1
+func getBindingObject(binding string) *Binding {
+
+	return &Binding{
+		User: &rbacv1.Subject{
+			Kind: "user",
+			Name: binding,
+		},
+		RoleRef: &rbacv1.RoleRef{
+			Kind: "clusterrole",
+			Name: "edit",
+		},
+	}
+
+}
+
+//Table driven tests
+var tests = []struct {
+	in       *Binding
+	out      string
+	hasError bool
+}{
+	{getBindingObject("lalith.vaka@zq.msds.kp.org"), "user-lalith-vaka-zq-msds-kp-org-clusterrole-edit", false},
+	{getBindingObject("397401@zq.msds.kp.org"), "user-397401-zq-msds-kp-org-clusterrole-edit", false},
+	{getBindingObject("lalith.397401@zq.msds.kp.org"), "user-lalith-397401-zq-msds-kp-org-clusterrole-edit", false},
+	{getBindingObject("397401.vaka@zq.msds.kp.org"), "user-397401-vaka-zq-msds-kp-org-clusterrole-edit", false},
+	{getBindingObject("i397401@zq.msds.kp.org"), "user-i397401-zq-msds-kp-org-clusterrole-edit", false},
+}
+
+func TestGetBindingName(t *testing.T) {
+
+	/* Read the test data from a file if needed
+
+	// create a testdata folder under this package and add files as needed
+	file, err := os.Open("./testdata/file.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	*/
+	//format := "--- %s: %s (%s)\n"
+	for _, tt := range tests {
+
+		s, error := getBindingName(tt.in)
+
+		if tt.hasError {
+			// expected an error
+			if error == nil {
+				t.Errorf("got %q, want %q", tt.in, s)
+			} else {
+				//t.Logf("getBindingName() with args %v PASSED and got value '%v'", tt.in, error)
+			}
+
+		} else {
+			//expected a value
+			if s != tt.out {
+				t.Errorf("got %q, want %q", s, tt.out)
+			} else {
+				//t.Logf("getBindingName() with args %v PASSED and got value '%v'", tt.in, s)
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
Updating the getBindingName to not ignore the digits in the email while creating a binding name. This is my first ever pull request. Apologies for lot of spaces with no real changes in the file.

```go
//getBindingName returns bindingName, which is combination of user kind, username, RoleRef kind, RoleRef name.
func getBindingName(binding *Binding) (string, error) {
	// Only keep lower case letters, replace other with -
	reg, err := regexp.Compile("[^a-z0-9]+")
	if err != nil {
		return "", err
	}
	nameRaw := strings.ToLower(
		strings.Join([]string{
			binding.User.Kind,
			url.QueryEscape(reg.ReplaceAllString(binding.User.Name, "-")),
			binding.RoleRef.Kind,
			binding.RoleRef.Name,
		}, "-"),
	)

	return reg.ReplaceAllString(nameRaw, "-"), nil
}
```
