### PR TITLE
Add new profile namespace label for user namespaces

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -65,6 +65,7 @@ const (
 var kubeflowNamespaceLabels = map[string]string{
 	"katib-metricscollector-injection":      "enabled",
 	"serving.kubeflow.org/inferenceservice": "enabled",
+	"app.kubernetes.io/part-of":             "kubeflow-profile",
 }
 
 const DEFAULT_EDITOR = "default-editor"

--- a/components/profile-controller/controllers/profile_controller_test.go
+++ b/components/profile-controller/controllers/profile_controller_test.go
@@ -22,6 +22,7 @@ func TestUpdateNamespaceLabels(t *testing.T) {
 					Labels: map[string]string{
 						"katib-metricscollector-injection":      "enabled",
 						"serving.kubeflow.org/inferenceservice": "enabled",
+						"app.kubernetes.io/part-of":             "kubeflow-profile",
 					},
 					Name: name,
 				},
@@ -43,6 +44,7 @@ func TestUpdateNamespaceLabels(t *testing.T) {
 						"user-name":                             "Jim",
 						"katib-metricscollector-injection":      "enabled",
 						"serving.kubeflow.org/inferenceservice": "disabled",
+						"app.kubernetes.io/part-of":             "kubeflow-profile",
 					},
 					Name: name,
 				},


### PR DESCRIPTION
Related https://github.com/kubeflow/kubeflow/issues/4808

This is one of the PR for adding a new label to indicate the Kubeflow-owned namespaces. We will be using this new `app.kubernetes.io/part-of: kubeflow-profile` as the namespace selector for the Admission Webhook. Once this PR is patched into the latest profile controller release, then we can update the Admission Webhook base manifest to the following so that it only watches namespaces with the kubeflow-profile label.
 
```yaml
apiVersion: admissionregistration.k8s.io/v1beta1
kind: MutatingWebhookConfiguration
metadata:
  name: mutating-webhook-configuration
webhooks:
- clientConfig:
    caBundle: ""
    service:
      name: $(podDefaultsServiceName)
      namespace: $(podDefaultsNamespace)
      path: /apply-poddefault
  name: $(podDefaultsDeploymentName).kubeflow.org
  namespaceSelector:
    matchLabels:
      app.kubernetes.io/part-of: kubeflow-profile
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - v1
    operations:
    - CREATE
    resources:
    - pods
```

cc @animeshsingh 