### PR TITLE
Enable kfam, admission_webhook on arm64

### DIFF
--- a/components/access-management/Dockerfile
+++ b/components/access-management/Dockerfile
@@ -5,7 +5,12 @@ WORKDIR /workspace
 
 COPY . .
 RUN go mod download
-RUN go build -gcflags 'all=-N -l' -o access-management main.go
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -gcflags 'all=-N -l' -o access-management main.go; \
+    else \
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -gcflags 'all=-N -l' -o access-management main.go; \
+    fi
+
 RUN chmod a+rx access-management
 
 # Use distroless as minimal base image to package the manager binary

--- a/components/admission-webhook/Dockerfile
+++ b/components/admission-webhook/Dockerfile
@@ -4,13 +4,17 @@ FROM golang:${GOLANG_VERSION} as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/kubeflow/kubeflow/components/admission-webhook
-COPY pkg/  pkg/ 
+COPY pkg/  pkg/
 COPY . .
 
 ENV GO111MODULE=on
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux go build -o webhook -a .
+RUN if [ "$(uname -m)" = "aarch64" ]; then \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -o webhook -a . ; \
+    else \
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o webhook -a . ; \
+    fi
 
 # Copy the controller-manager into a distroless image
 FROM gcr.io/distroless/static-debian10:fd0d99e8c54d7d7b2f3dd29f5093d030d192cbbc


### PR DESCRIPTION
This commit adds container building support for ingress_setup, kfam, and admission_webhook on arm64.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>