### PR TITLE
Bumping central dashboard node version to v12.18.3

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Builds and tests
-FROM node:10-alpine AS build
+FROM node:12.18.3-alpine AS build
 
 ARG kubeflowversion
 ARG commit
@@ -39,7 +39,7 @@ RUN npm rebuild && \
     npm prune --production
 
 # Step 2: Packages assets for serving
-FROM node:10-alpine AS serve
+FROM node:12.18.3-alpine AS serve
 
 ENV NODE_ENV=production
 WORKDIR /app


### PR DESCRIPTION
When building current master branch central dashboard on arm64, error message `Segmentation fault (core dumped)` will occur. By bumping base image node version to 10.13, this error can be fixed.

I also tested this commit on x86_64 machine to make sure this will not break current x86_64 build.

Signed-off-by: Henry Wang <Henry.Wang@arm.com>