### PR TITLE
Add yanniszark to access-management, profile-controller

### DIFF
--- a/components/access-management/OWNERS
+++ b/components/access-management/OWNERS
@@ -1,4 +1,3 @@
 approvers:
-  - kunmingg
   - yanniszark
 reviewers:


### PR DESCRIPTION
Adding `yanniszark` to access-management, profile-controller components.
I am familiar with the codebase and they are also directly related with the multi-user cuj, which I'm very familiar with.
This way, I can be of help to people contributing fixes to these components.

/cc @jlewi 

Signed-off-by: Yannis Zarkadas <yanniszark@arrikto.com>