### PR TITLE
Add missing `login` command for gcloud authentication

### DIFF
--- a/docs_dev/releasing.md
+++ b/docs_dev/releasing.md
@@ -38,7 +38,7 @@ If you're new to using GKE or are new to the release team, you'll need to authen
 
 ```
 gcloud config set account your-account@yourdomain.org
-gcloud auth
+gcloud auth login
 ```
 
 This will open your browser to authenticate you.  Then you can proceed as follows:


### PR DESCRIPTION
This needs to be `gcloud auth login` to open the browser automatically for authentication as mentioned in the instruction.