### PR TITLE
Improve language of the 'Deploy via UI on GCP' webpage

### DIFF
--- a/components/gcp-click-to-deploy/src/App.tsx
+++ b/components/gcp-click-to-deploy/src/App.tsx
@@ -115,7 +115,7 @@ class App extends React.Component<any, { signedIn: boolean }> {
                     <li> (Optional) Choose GKE zone where you want Kubeflow to be deployed </li>
                     <li> (Optional) Choose Kubeflow version </li>
                     <li> Click Create Deployment </li>
-                    <li> If your deployment include endpoint, will redirect once endpoint is ready </li>
+                    <li> If your deployment includes an endpoint, you will be redirected to the endpoint once it is ready </li>
                   </ul>
                 </div>
                 <div>


### PR DESCRIPTION
Changed a bullet point to improve grammar of the webpage at https://deploy.kubeflow.cloud/#/deploy. 