### PR TITLE
Added gpu details to the notebook server table

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -259,10 +259,7 @@ def process_pvc(rsrc):
     return res
 
 
-def process_resource(rsrc, rsrc_events):
-    # VAR: change this function according to the main resource
-    cntr = rsrc["spec"]["template"]["spec"]["containers"][0]
-    status, reason = process_status(rsrc, rsrc_events)
+def process_gpu(cntr):
     
     # GPUs may not have been assigned to a pod 
     gpu = 0
@@ -277,6 +274,15 @@ def process_resource(rsrc, rsrc_events):
             gpu = 0
             gpuvendor = ''
 
+    return gpu, gpuvendor
+    
+
+def process_resource(rsrc, rsrc_events):
+    # VAR: change this function according to the main resource
+    cntr = rsrc["spec"]["template"]["spec"]["containers"][0]
+    status, reason = process_status(rsrc, rsrc_events)
+    gpu, gpuvendor = process_gpu(cntr)
+   
     res = {
         "name": rsrc["metadata"]["name"],
         "namespace": rsrc["metadata"]["namespace"],

--- a/components/jupyter-web-app/frontend/src/app/main-table/resource-table/resource-table.component.html
+++ b/components/jupyter-web-app/frontend/src/app/main-table/resource-table/resource-table.component.html
@@ -72,6 +72,14 @@
         <span [matTooltip]="elem.image">{{ elem.shortImage }}</span>
       </td>
     </ng-container>
+ 
+    <!-- GPU Column -->
+    <ng-container matColumnDef="gpu">
+      <th mat-header-cell *matHeaderCellDef>GPU</th>
+      <td mat-cell *matCellDef="let elem">
+        <span [matTooltip]="elem.gpuvendor">{{ elem.gpu }}</span>
+      </td>
+    </ng-container>
 
     <!-- CPU Column -->
     <ng-container matColumnDef="cpu">

--- a/components/jupyter-web-app/frontend/src/app/main-table/resource-table/resource-table.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/main-table/resource-table/resource-table.component.ts
@@ -31,6 +31,7 @@ export class ResourceTableComponent implements OnInit {
     "name",
     "age",
     "image",
+    "gpu",
     "cpu",
     "memory",
     "volumes",

--- a/components/jupyter-web-app/frontend/src/app/utils/types.ts
+++ b/components/jupyter-web-app/frontend/src/app/utils/types.ts
@@ -60,6 +60,8 @@ export interface Resource {
   age: string;
   image: string;
   volumes: string[];
+  gpu: string;
+  gpuvendor: string;
   cpu: string;
   memory: string;
   shortImage: string;

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -14,13 +14,13 @@ workflows:
   # The workflows below are related to auto building our Docker images.
   # We have separate pre/postsubmit jobs because we want to use different
   # registries
-  - app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
-    component: workflows
-    name: tf-notebook-release
-    job_types:
-      - presubmit
-    params:
-      registry: "gcr.io/kubeflow-ci"
-      step_image: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4"
-    include_dirs:
-      - components/tensorflow-notebook-image/*
+  #- app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
+  #  component: workflows
+  #  name: tf-notebook-release
+  #  job_types:
+  #    - presubmit
+  #  params:
+  #    registry: "gcr.io/kubeflow-ci"
+  #    step_image: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4"
+  #  include_dirs:
+  #    - components/tensorflow-notebook-image/*


### PR DESCRIPTION
Resolves issue #5073 
Current Notebook server dashboard displays CPU, Memory and Image name but not the GPUs used. Displaying GPUs used by notebook servers help avoid confusion with in a project team on whether the resources are still available to use. This pull request adds both GPUs as well as GPU tooltip.
Screenshot
![image](https://user-images.githubusercontent.com/8292387/84804602-df647480-afb7-11ea-90f0-babb7310920b.png)

