### PR TITLE
env variable driven registrationFlow

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -27,6 +27,7 @@ interface HasWorkgroupResponse {
     user: string;
     hasAuth: boolean;
     hasWorkgroup: boolean;
+    registrationFlowAllowed: boolean;
 }
 
 interface EnvironmentInfo {
@@ -116,7 +117,8 @@ export class WorkgroupApi {
     private platformInfo: PlatformInfo;
     constructor(
         private profilesService: DefaultApi,
-        private k8sService: KubernetesService) {}
+        private k8sService: KubernetesService,
+        private registrationFlowAllowed: boolean) {}
     /** Retrieves and memoizes the PlatformInfo. */
     private async getPlatformInfo(): Promise<PlatformInfo> {
         if (!this.platformInfo) {
@@ -250,6 +252,7 @@ export class WorkgroupApi {
                     hasAuth: req.user.hasAuth,
                     user: req.user.username,
                     hasWorkgroup: false,
+                    registrationFlowAllowed: this.registrationFlowAllowed,
                 };
                 if (req.user.hasAuth) {
                     const workgroup = await this.getWorkgroupInfo(

--- a/components/centraldashboard/app/api_workgroup_test.ts
+++ b/components/centraldashboard/app/api_workgroup_test.ts
@@ -20,6 +20,7 @@ describe('Workgroup API', () => {
     };
     const attachUserGCPMiddleware = attachUser(header.goog, prefix.goog);
     const attachUserOtherIAPMiddleware = attachUser(header.other, prefix.other);
+    const registrationFlowAllowed = true;
     let mockK8sService: jasmine.SpyObj<KubernetesService>;
     let mockProfilesService: jasmine.SpyObj<DefaultApi>;
     let testApp: express.Application;
@@ -27,6 +28,7 @@ describe('Workgroup API', () => {
     const newAPI = () => new WorkgroupApi(
         mockProfilesService,
         mockK8sService,
+        registrationFlowAllowed,
     );
 
     describe('Environment Information', () => {
@@ -223,7 +225,8 @@ describe('Workgroup API', () => {
                         bindings: []
                     },
                 }));
-            const expectedResponse = {hasAuth: false, hasWorkgroup: false, user: 'anonymous'};
+            const expectedResponse = {hasAuth: false, hasWorkgroup: false, 
+                user: 'anonymous', registrationFlowAllowed: true};
 
             const response = await sendTestRequest(url);
             expect(response).toEqual(expectedResponse);
@@ -248,7 +251,8 @@ describe('Workgroup API', () => {
                         },
                     }));
 
-                const expectedResponse = {hasAuth: true, hasWorkgroup: true, user: 'test'};
+                const expectedResponse = {hasAuth: true, hasWorkgroup: true, 
+                    user: 'test', registrationFlowAllowed: true};
 
                 const headers = {
                     [header.goog]: `${prefix.goog}test@testdomain.com`,
@@ -271,7 +275,8 @@ describe('Workgroup API', () => {
                     body: {bindings: []},
                 }));
 
-            const expectedResponse = {hasAuth: true, hasWorkgroup: false, user: 'test'};
+            const expectedResponse = {hasAuth: true, hasWorkgroup: false, 
+                user: 'test', registrationFlowAllowed: true};
 
             const headers = {
                 [header.goog]: `${prefix.goog}test@testdomain.com`,

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -28,12 +28,14 @@ const {
   PROFILES_KFAM_SERVICE_PORT = '8081',
   USERID_HEADER = 'X-Goog-Authenticated-User-Email',
   USERID_PREFIX = 'accounts.google.com:',
+  REGISTRATION_FLOW = "true",
 } = process.env;
 
 
 async function main() {
   const port: number = Number(PORT_1);
   const frontEnd: string = resolve(__dirname, 'public');
+  const registrationFlowAllowed = (REGISTRATION_FLOW.toLowerCase() === "true");
   const profilesServiceUrl =
       `http://${PROFILES_KFAM_SERVICE_HOST}:${PROFILES_KFAM_SERVICE_PORT}/kfam`;
 
@@ -51,6 +53,7 @@ async function main() {
       user: req.user,
       profilesServiceUrl,
       codeEnvironment,
+      registrationFlowAllowed,
       headersForIdentity: {
         USERID_HEADER,
         USERID_PREFIX,
@@ -64,7 +67,7 @@ async function main() {
     });
   });
   app.use('/api', new Api(k8sService, metricsService).routes());
-  app.use('/api/workgroup', new WorkgroupApi(profilesService, k8sService).routes());
+  app.use('/api/workgroup', new WorkgroupApi(profilesService, k8sService, registrationFlowAllowed).routes());
   app.use('/api', (req: Request, res: Response) => 
     apiError({
       res,

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -173,9 +173,10 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
      * @param {Event} ev AJAX-response
      */
     _onHasWorkgroupResponse(ev) {
-        const {user, hasWorkgroup, hasAuth} = ev.detail.response;
+        const {user, hasWorkgroup, hasAuth, 
+            registrationFlowAllowed} = ev.detail.response;
         this._setIsolationMode(hasAuth ? 'multi-user' : 'single-user');
-        if (hasAuth && !hasWorkgroup) {
+        if (registrationFlowAllowed && hasAuth && !hasWorkgroup) {
             this.user = user;
             this._setRegistrationFlow(true);
         }

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -182,6 +182,7 @@ describe('Main Page', () => {
             user,
             hasWorkgroup: false,
             hasAuth: false,
+            registrationFlowAllowed: true,
         };
         const getHasWorkgroup = mockRequest(mainPage, {
             status: 200,


### PR DESCRIPTION
This PR will address issue: https://github.com/kubeflow/kubeflow/issues/4889

**Description:**

The modification of this PR only take effect when we set REGISTRATION_FLOW = "false", which will disable the namespace creation when a new user is authenticated. 

**Internal Tests:**

I've tested this on our dev cluster with Istio + Dex 1.0.2, on the following scenarios: 
- REGISTRATION_FLOW = "false" - New users are not given a registration flow
- REGISTRATION_FLOW = "falser" - New users are  not given a registration flow
- REGISTRATION_FLOW = "true" - New users are given a registration flow
- REGISTRATION_FLOWS = "false" - New users are given a registration flow

**How this is intended to be used:**

- Admins that disable the registration flow will need to manage the registration and contributors assignments via ```kubectl```, CI/CD or third party services.
- It's expected that Admins create a "team" profile with and assign users as contributors to that "team". 
- This enabled Admins to better manage resources and control who has access to datasets. 

@yanniszark @avdaredevil @bmorphism Could one of you you review this PR? Thank you in advance.

FYI: @marcjimz 