### PR TITLE
Fix notebook controller rbac gen

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -78,6 +78,7 @@ type NotebookReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=services/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=kubeflow.org,resources=notebooks/status,verbs=get;update;patch
+
 func (r *NotebookReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log.WithValues("notebook", req.NamespacedName)


### PR DESCRIPTION
[make manifest](https://github.com/kubeflow/kubeflow/blob/master/components/notebook-controller/Makefile#L48) for `notebook-controller` doesn't seem to generate the rbac files as described [here](https://github.com/kubeflow/kubeflow/blob/master/components/notebook-controller/controllers/notebook_controller.go#L75). Adding a new line after the gen markers seems to solve this problem! 