### PR TITLE
show all existing PVCs as dropdown under volumes for a new notebook server

### DIFF
--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
@@ -1,42 +1,49 @@
 <div *ngIf="volume" [formGroup]="volume" class="volume-wrapper">
-  <mat-form-field appearance="outline" id="type">
-    <mat-label>Type</mat-label>
-    <mat-select formControlName="type">
-      <mat-option
+ 
+  <!-- Volume Type Input -->
+    <mat-form-field appearance="outline" id="type">
+      <mat-label>Type</mat-label>
+      <mat-select  (selectionChange)="selectType($event)" formControlName="type">
+        <mat-option *ngFor="let i of types"
         [disabled]="newTypeIsDisabled()"
         [matTooltip]="newTypeTooltip()"
-        value="New"
-        >New</mat-option
-      >
-      <mat-option value="Existing">Existing</mat-option>
-    </mat-select>
-  </mat-form-field>
+        value={{i}}>{{i}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+  
+    <!-- Volume Name Input -->
+    <mat-form-field *ngIf="typeSelected === 'New'" class="wide" appearance="outline" id="name">
+      <mat-label>Name</mat-label>
+      <input matInput formControlName="name"/>
+    </mat-form-field>
+    
+    <mat-form-field *ngIf="typeSelected === 'Existing'" class="wide" appearance="outline" id="name">
+      <mat-label>Name</mat-label>
+      <mat-select formControlName="name">
+        <mat-option *ngFor="let i of existingPVCs"
+          value={{i}}>{{i}}</mat-option>
+      </mat-select>
+    </mat-form-field>
 
-  <!-- Volume Name Input -->
-  <mat-form-field appearance="outline" id="name">
-    <mat-label>Name</mat-label>
-    <input matInput formControlName="name" />
-  </mat-form-field>
-
-  <!-- Size Input -->
-  <mat-form-field appearance="outline" id="size">
-    <mat-label>Size</mat-label>
-    <input matInput formControlName="size" />
-  </mat-form-field>
-
-  <!-- Mode Input -->
-  <mat-form-field appearance="outline" id="mode">
-    <mat-label>Mode</mat-label>
-    <mat-select formControlName="mode">
-      <mat-option value="ReadWriteOnce">ReadWriteOnce</mat-option>
-      <mat-option value="ReadOnlyMany">ReadOnlyMany</mat-option>
-      <mat-option value="ReadWriteMany">ReadWriteMany</mat-option>
-    </mat-select>
-  </mat-form-field>
-
-  <!-- Mount Input -->
-  <mat-form-field appearance="outline" id="path">
-    <mat-label>Mount Point</mat-label>
-    <input matInput formControlName="path" />
-  </mat-form-field>
-</div>
+    <!-- Size Input -->
+    <mat-form-field *ngIf="typeSelected === 'New'" class="wide" appearance="outline" id="size">
+      <mat-label>Size</mat-label>
+      <input matInput formControlName="size" />
+    </mat-form-field>
+  
+    <!-- Mode Input -->
+    <mat-form-field *ngIf="typeSelected === 'New'" class="wide" appearance="outline" id="mode">
+      <mat-label>Mode</mat-label>
+      <mat-select formControlName="mode">
+        <mat-option value="ReadWriteOnce">ReadWriteOnce</mat-option>
+        <mat-option value="ReadOnlyMany">ReadOnlyMany</mat-option>
+        <mat-option value="ReadWriteMany">ReadWriteMany</mat-option>
+      </mat-select>
+    </mat-form-field>
+  
+    <!-- Mount Input -->
+    <mat-form-field class="wide" appearance="outline" id="path">
+      <mat-label>Mount Point</mat-label>
+      <input matInput formControlName="path" />
+    </mat-form-field>
+  </div>

--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.html
@@ -7,7 +7,7 @@
         <mat-option *ngFor="let i of types"
         [disabled]="newTypeIsDisabled()"
         [matTooltip]="newTypeTooltip()"
-        value={{i}}>{{i}}</mat-option>
+        value="{{i}}">{{i}}</mat-option>
       </mat-select>
     </mat-form-field>
   
@@ -21,7 +21,7 @@
       <mat-label>Name</mat-label>
       <mat-select formControlName="name">
         <mat-option *ngFor="let i of existingPVCs"
-          value={{i}}>{{i}}</mat-option>
+          value="{{i}}">{{i}}</mat-option>
       </mat-select>
     </mat-form-field>
 

--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
@@ -66,9 +66,9 @@ export class VolumeComponent implements OnInit, OnDestroy {
 // ----- onChange of the New / Existing Volume -----
   selectType(event): void {
     this.typeSelected = event.value;
-    if (this.typeSelected === 'New') {
-      this.volume.controls.name.setValue(this.currentVolName);
-    }
+    if (this.typeSelected != 'New') return;
+    this.volume.controls.name.setValue(this.currentVolName);
+    
   }
 
   // ----- Get macros -----

--- a/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/resource-form/volume/volume.component.ts
@@ -3,6 +3,7 @@ import { FormGroup } from '@angular/forms';
 import { Volume } from 'src/app/utils/types';
 import { Subscription } from 'rxjs';
 
+
 @Component({
   selector: 'app-volume',
   templateUrl: './volume.component.html',
@@ -14,6 +15,10 @@ export class VolumeComponent implements OnInit, OnDestroy {
 
   currentPVC: Volume;
   existingPVCs: Set<string> = new Set();
+
+  //New - Existing dropdown
+  types: string[] = ['New', 'Existing'];
+  typeSelected = 'New';
 
   subscriptions = new Subscription();
 
@@ -55,6 +60,14 @@ export class VolumeComponent implements OnInit, OnDestroy {
 
     if (!this.volume.disabled) {
       this.updateVolInputFields();
+    }
+  }
+
+// ----- onChange of the New / Existing Volume -----
+  selectType(event): void {
+    this.typeSelected = event.value;
+    if (this.typeSelected === 'New') {
+      this.volume.controls.name.setValue(this.currentVolName);
     }
   }
 

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -14,13 +14,13 @@ workflows:
   # The workflows below are related to auto building our Docker images.
   # We have separate pre/postsubmit jobs because we want to use different
   # registries
-  - app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
-    component: workflows
-    name: tf-notebook-release
-    job_types:
-      - presubmit
-    params:
-      registry: "gcr.io/kubeflow-ci"
-      step_image: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4"
-    include_dirs:
-      - components/tensorflow-notebook-image/*
+  #- app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
+  #  component: workflows
+  #  name: tf-notebook-release
+  #  job_types:
+  #    - presubmit
+  #  params:
+  #    registry: "gcr.io/kubeflow-ci"
+  #    step_image: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4"
+  #  include_dirs:
+  #    - components/tensorflow-notebook-image/*


### PR DESCRIPTION
Resolves issue #4883 
This PR enhances two things
1. Shows all Existing PVCs in the profile as a dropdown while creating a new notebook server under both workspace / data volumes when type drop down selected as "Existing"
2. Hide Mode and Size form fields under volumes when selected existing PVCs so that its not confusing

Follow are the screenshots of before and after
**Before the fix**
![image](https://user-images.githubusercontent.com/8292387/85232257-76636f00-b3b2-11ea-971b-9959d9d6547f.png)

**After the fix**
![image](https://user-images.githubusercontent.com/8292387/85232315-e245d780-b3b2-11ea-9115-f96a432c5ea1.png)
