### PR TITLE
Fix #5111: Trim whitespace from custom images

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -319,7 +319,7 @@ def find_error_event(rsrc_events):
     Returns status and reason from the latest event that surfaces the cause
     of why the resource could not be created. For a Notebook, it can be due to:
 
-          EVENT_TYPE      EVENT_REASON      DESCRIPTION   
+          EVENT_TYPE      EVENT_REASON      DESCRIPTION
           Warning         FailedCreate      pods "x" is forbidden: error looking up service account ... (originated in statefulset)
           Warning         FailedScheduling  0/1 nodes are available: 1 Insufficient cpu (originated in pod)
 
@@ -343,7 +343,7 @@ def set_notebook_image(notebook, body, defaults):
         image = defaults["image"]["value"]
         logger.info("Using default Image: " + image)
     elif body.get("customImageCheck", False):
-        image = body["customImage"]
+        image = body["customImage"].strip()
         logger.info("Using form's custom Image: " + image)
     elif "image" in body:
         image = body["image"]

--- a/components/jupyter-web-app/frontend/src/app/uis/rok/rok-resource-form/rok-jupyter-lab-selector/rok-jupyter-lab-selector.component.ts
+++ b/components/jupyter-web-app/frontend/src/app/uis/rok/rok-resource-form/rok-jupyter-lab-selector/rok-jupyter-lab-selector.component.ts
@@ -47,7 +47,7 @@ export class RokJupyterLabSelectorComponent implements OnInit {
   }
 
   setLabValues(lab: JupyterLab) {
-    this.parentForm.get("customImage").setValue(lab.image);
+    this.parentForm.get("customImage").setValue(lab.image.trim());
     this.parentForm.get("customImageCheck").setValue(true);
     this.parentForm.get("cpu").setValue(lab.cpu);
     this.parentForm.get("memory").setValue(lab.memory);


### PR DESCRIPTION
See: #5111 

It trims the whitespace around custom images to avoid pod creation failures. It does so in the backend and Rok template, where `customImage` is explicitly set.

---

Note: I tried running both the frontend and backend on my own machine but could not make it work. Perhaps the instructions for npm and Flask are outdated. I ran Flask in a fresh virtual environment.

NPM:

```
../src/create_string.cpp:17:25: error: no matching constructor for initialization of 'v8::String::Utf8Value'
  v8::String::Utf8Value string(value);
                        ^      ~~~~~
```

Flask:

```
2020-07-07 13:43:47,944 | kubeflow_jupyter.default.app | INFO | Sending file 'index.html'
127.0.0.1 - - [07/Jul/2020 13:43:47] "GET / HTTP/1.1" 500 -
Traceback (most recent call last):
  File "/Users/ian/Python/backend/lib/python3.7/site-packages/flask/app.py", line 1813, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/ian/Python/backend/lib/python3.7/site-packages/flask/app.py", line 1799, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/ian/Code/oss/kubeflow/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py", line 77, in serve_root
    return send_from_directory("./static/", "index.html")
  File "/Users/ian/Python/backend/lib/python3.7/site-packages/flask/helpers.py", line 709, in send_from_directory
    raise NotFound()
werkzeug.exceptions.NotFound: 404 Not Found: The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.
```
