### PR TITLE
Fix #4842 Pod resources limit

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -369,6 +369,7 @@ def set_notebook_cpu(notebook, body, defaults):
         logger.info("Using default CPU: " + cpu)
 
     container["resources"]["requests"]["cpu"] = cpu
+    container["resources"]["limits"]["cpu"] = cpu
 
 
 def set_notebook_memory(notebook, body, defaults):
@@ -385,6 +386,7 @@ def set_notebook_memory(notebook, body, defaults):
         logger.info("Using default Memory: " + memory)
 
     container["resources"]["requests"]["memory"] = memory
+    container["resources"]["limits"]["memory"] = memory
 
 
 def set_notebook_gpus(notebook, body, defaults):

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/notebook.yaml
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/notebook.yaml
@@ -18,5 +18,8 @@ spec:
             requests:
               cpu: "0.1"
               memory: "0.1Gi"
+            limits:
+              cpu: "0.1"
+              memory: "0.1Gi"
       ttlSecondsAfterFinished: 300
       volumes: []


### PR DESCRIPTION
Fix #4842 - issue was closed earlier, but not solved within Kubeflow repo by author

Sets CPU and memory limits of Notebooks equal to requests. This prevents
- out of memory problems due to over-provisioning
- users using more resources than they should