### PR TITLE
Deduplicate contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,40 +1,13 @@
-<!-- START doctoc generated TOC please keep comment here to allow auto update -->
-<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+# Kubeflow Contributor Guide
 
-- [How to Contribute](#how-to-contribute)
-  - [Contributor License Agreement](#contributor-license-agreement)
-  - [Code reviews](#code-reviews)
-  - [Get involved](#get-involved)
+Welcome to the Kubeflow project! We'd love to accept your patches and 
+contributions to this project. Please read the 
+[contributor's guide in our docs](https://www.kubeflow.org/docs/about/contributing/).
 
-<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+The contributor's guide
 
-# How to Contribute
-
-We'd love to accept your patches and contributions to this project. There are
-just a few small guidelines you need to follow.
-
-## Contributor License Agreement
-
-Contributions to this project must be accompanied by a Contributor License
-Agreement. You (or your employer) retain the copyright to your contribution,
-this simply gives us permission to use and redistribute your contributions as
-part of the project. Head over to <https://cla.developers.google.com/> to see
-your current agreements on file or to sign a new one.
-
-You generally only need to submit a CLA once, so if you've already submitted one
-(even if it was for a different project), you probably don't need to do it
-again.
-
-## Code reviews
-
-All submissions, including submissions by project members, require review. We
-use GitHub pull requests for this purpose. Consult
-[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
-information on using pull requests.
-
-## Get involved
-
-* [Slack](http://kubeflow.slack.com/)
-* [Twitter](http://twitter.com/kubeflow)
-* [Mailing List](https://groups.google.com/forum/#!forum/kubeflow-discuss)
+* shows you where to find the Contributor License Agreement (CLA) that you need 
+  to sign,
+* helps you get started with your first contribution to Kubeflow,
+* and describes the pull request and review workflow in detail, including the
+  OWNERS files and automated workflow tool.


### PR DESCRIPTION
Similar vain as: https://github.com/kubeflow/community/pull/185

Following the link from the `k8s-ci-robot` suggesting to join the community links (see https://github.com/kubeflow/pipelines/pull/4228#issuecomment-659685533) to this page but this page doesn't actually have any instructions on how to join the community!