### PR TITLE
Rendering centraldashboard links from a configmap

### DIFF
--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -3,7 +3,8 @@ import {KubernetesService} from './k8s_service';
 import {Interval, MetricsService} from './metrics_service';
 
 export const ERRORS = {
-  operation_not_supported: 'Operation not supported'
+  operation_not_supported: 'Operation not supported',
+  invalid_links_config: 'Dashboard Links ConfigMap is invalid'
 };
 
 export function apiError(a: {res: Response, error: string, code?: number}) {
@@ -66,7 +67,21 @@ export class Api {
             async (req: Request, res: Response) => {
               res.json(await this.k8sService.getEventsForNamespace(
                   req.params.namespace));
+            })
+        .get(
+          '/dashboard-links',
+          async (_: Request, res: Response) => {
+            let linksData = await this.k8sService.getDashboardLinks();
+            let links = {}
+            try {
+              links=JSON.parse(linksData.data["links"])
+            }catch(e){
+              return apiError({
+                res, code: 500,
+                error: ERRORS.invalid_links_config,
+              });
             }
-        );
+            res.json(links);
+          });
   }
 }

--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -71,10 +71,10 @@ export class Api {
         .get(
           '/dashboard-links',
           async (_: Request, res: Response) => {
-            let linksData = await this.k8sService.getDashboardLinks();
-            let links = {}
+            const linksData = await this.k8sService.getDashboardLinks();
+            let links = {};
             try {
-              links=JSON.parse(linksData.data["links"])
+              links=JSON.parse(linksData.data["links"]);
             }catch(e){
               return apiError({
                 res, code: 500,

--- a/components/centraldashboard/app/k8s_service.ts
+++ b/components/centraldashboard/app/k8s_service.ts
@@ -1,5 +1,10 @@
 import * as k8s from '@kubernetes/client-node';
 
+/** Retrieve Dashboard links configmap Name */
+const {
+  DASHBOARD_LINKS_CONFIGMAP = "centraldashboard-links-config"
+} = process.env;
+
 /** Information about the Kubernetes hosting platform. */
 export interface PlatformInfo {
   provider: string;
@@ -46,6 +51,7 @@ export class KubernetesService {
   private namespace = 'kubeflow';
   private coreAPI: k8s.Core_v1Api;
   private customObjectsAPI: k8s.Custom_objectsApi;
+  private dashboardlinksConfigMap = DASHBOARD_LINKS_CONFIGMAP;
 
   constructor(private kubeConfig: k8s.KubeConfig) {
     console.info('Initializing Kubernetes configuration');
@@ -68,6 +74,17 @@ export class KubernetesService {
     } catch (err) {
       console.error('Unable to fetch Namespaces:', err.body || err);
       return [];
+    }
+  }
+
+  /** Retrieves the configmap data of links for the central dashboard. */
+  async getDashboardLinks(): Promise<k8s.V1ConfigMap> {
+    try {
+      const { body } = await this.coreAPI.readNamespacedConfigMap(this.dashboardlinksConfigMap,this.namespace);
+      return body;
+    } catch (err) {
+      console.error('Unable to fetch Links ConfigMap:', err.body || err);
+      return null;
     }
   }
 

--- a/components/centraldashboard/config/centraldashboard-links-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-links-config.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        },
+        {
+          "link": "/metadata/",
+          "text": "Artifact Store"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        },
+        {
+          "text": "View Metadata Artifacts",
+          "desc": "Artifact Store",
+          "link": "/metadata/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  name: centraldashboard-links-config
+  namespace: kubeflow

--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -16,7 +16,6 @@ import './pipelines-card.js';
 import './resource-chart.js';
 import {getGCPData} from './resources/cloud-platform-data.js';
 
-const DOCS = 'https://www.kubeflow.org/docs';
 
 export class DashboardView extends PolymerElement {
     static get template() {
@@ -33,82 +32,9 @@ export class DashboardView extends PolymerElement {
      */
     static get properties() {
         return {
-            documentationItems: {
-                type: Array,
-                value: [
-                    {
-                        text: 'Getting Started with Kubeflow',
-                        desc: 'Get your machine-learning workflow up and ' +
-                            'running on Kubeflow',
-                        link: `${DOCS}/started/getting-started/`,
-                    },
-                    {
-                        text: 'MiniKF',
-                        desc: 'A fast and easy way to deploy Kubeflow locally',
-                        link: `${DOCS}/started/getting-started-minikf/`,
-                    },
-                    {
-                        text: 'Microk8s for Kubeflow',
-                        desc: 'Quickly get Kubeflow running locally on ' +
-                            'native hypervisors',
-                        link: `${DOCS}/started/getting-started-multipass/`,
-                    },
-                    {
-                        text: 'Minikube for Kubeflow',
-                        desc: 'Quickly get Kubeflow running locally',
-                        link: `${DOCS}/started/getting-started-minikube/`,
-                    },
-                    {
-                        text: 'Kubeflow on GCP',
-                        desc: 'Running Kubeflow on Kubernetes Engine and ' +
-                            'Google Cloud Platform',
-                        link: `${DOCS}/gke/`,
-                    },
-                    {
-                        text: 'Kubeflow on AWS',
-                        desc: 'Running Kubeflow on Elastic Container Service ' +
-                            'and Amazon Web Services',
-                        link: `${DOCS}/aws/`,
-                    },
-                    {
-                        text: 'Requirements for Kubeflow',
-                        desc: 'Get more detailed information about using ' +
-                'Kubeflow and its components',
-                        link: `${DOCS}/started/requirements/`,
-                    },
-                ],
-            },
+            documentationItems: Array,
+            quickLinks: Array,
             namespace: String,
-            quickLinks: {
-                type: Array,
-                value: [
-                    {
-                        text: 'Upload a pipeline',
-                        desc: 'Pipelines',
-                        link: `/pipeline/`,
-                    },
-                    {
-                        text: 'View all pipeline runs',
-                        desc: 'Pipelines',
-                        link: `/pipeline/#/runs`,
-                    },
-                    {
-                        text: 'Create a new Notebook server',
-                        desc: 'Notebook Servers',
-                        link: `/jupyter/new?namespace=kubeflow`,
-                    },
-                    {
-                        text: 'View Katib Experiments',
-                        desc: 'Katib',
-                        link: `/katib/`,
-                    },
-                    {
-                        text: 'View Metadata Artifacts',
-                        desc: 'Artifact Store',
-                        link: `/metadata/`,
-                    },
-                ],
-            },
             platformDetails: Object,
             platformInfo: {
                 type: Object,

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -63,26 +63,21 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             },
             iframeSrc: String,
             iframePage: {type: String, observer: '_iframePageChanged'},
+            documentationItems: {
+                type: Array,
+                value: [],
+            },
+            quickLinks: {
+                type: Array,
+                value: [],
+            },
             menuLinks: {
                 type: Array,
-                value: [
-                    {
-                        link: '/pipeline/',
-                        text: 'Pipelines',
-                    },
-                    {
-                        link: '/jupyter/',
-                        text: 'Notebook Servers',
-                    },
-                    {
-                        link: '/katib/',
-                        text: 'Katib',
-                    },
-                    {
-                        link: '/metadata/',
-                        text: 'Artifact Store',
-                    },
-                ],
+                value: [],
+            },
+            externalLinks: {
+                type: Array,
+                value: [],
             },
             sidebarItemIndex: {
                 type: Number,
@@ -158,6 +153,34 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
     }
 
     /**
+     * Set state for loading registration flow in case no dashboard links exists
+     * @param {Event} ev AJAX-response
+     */
+    _onHasDashboardLinksError(ev) {
+        const error = ((ev.detail.request||{}).response||{}).error ||
+            ev.detail.error;
+        this.showError(error);
+        return;
+    }
+
+    /**
+     * Set state for Central dashboard links
+     * @param {Event} ev AJAX-response
+     */
+    _onHasDashboardLinksResponse(ev) {
+        const {
+            menuLinks,
+            externalLinks,
+            quickLinks,
+            documentationItems,
+        } = ev.detail.response;
+        this.menuLinks = menuLinks || [];
+        this.externalLinks = externalLinks || [];
+        this.quickLinks = quickLinks || [];
+        this.documentationItems = documentationItems || [];
+    }
+
+    /**
      * Set state for loading registration flow in case no workgroup exists
      * @param {Event} ev AJAX-response
      */
@@ -173,7 +196,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
      * @param {Event} ev AJAX-response
      */
     _onHasWorkgroupResponse(ev) {
-        const {user, hasWorkgroup, hasAuth, 
+        const {user, hasWorkgroup, hasAuth,
             registrationFlowAllowed} = ev.detail.response;
         this._setIsolationMode(hasAuth ? 'multi-user' : 'single-user');
         if (registrationFlowAllowed && hasAuth && !hasWorkgroup) {

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -232,7 +232,8 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this._setIframeSrc();
             break;
         case 'manage-users':
-            this.sidebarItemIndex = 6;
+            this.sidebarItemIndex = this.menuLinks.length
+                                    + this.externalLinks.length + 1;
             this.page = 'manage-users';
             hideTabs = true;
             allNamespaces = true;
@@ -316,13 +317,19 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
      * @param {string} path
      */
     _setActiveMenuLink(path) {
-        const menuLinkIndex = this.menuLinks
+        let menuLinkIndex = this.menuLinks
             .findIndex((m) => path.startsWith(m.link));
         if (menuLinkIndex >= 0) {
             // Adds 1 since Overview is hard-coded
             this.sidebarItemIndex = menuLinkIndex + 1;
         } else {
-            this.sidebarItemIndex = -1;
+            menuLinkIndex = this.externalLinks
+                .findIndex((m) => path.startsWith(m.link));
+            if (menuLinkIndex >= 0) {
+                this.sidebarItemIndex = menuLinkIndex + this.menuLinks.length+1;
+            } else {
+                this.sidebarItemIndex = -1;
+            }
         }
     }
 

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -1,5 +1,7 @@
 iron-ajax(auto, url='/api/workgroup/exists', handle-as='json',
     on-response='_onHasWorkgroupResponse', on-error='_onHasWorkgroupError', loading='{{pageLoading}}')
+iron-ajax(auto, url='/api/dashboard-links', handle-as='json',
+    on-response='_onHasDashboardLinksResponse', on-error='_onHasDashboardLinksError', loading='{{pageLoading}}')
 iron-ajax#envInfo(auto='[[_shouldFetchEnv]]', url='/api/workgroup/env-info', handle-as='json',
     on-response='_onEnvInfoResponse')
 aside#PageLoader(hidden='{{!pageLoading}}')
@@ -17,6 +19,9 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 paper-item.menu-item Home
             template(is='dom-repeat', items='[[menuLinks]]')
                 iframe-link(href$="[[buildHref(item.link, queryParams)]]")
+                    paper-item.menu-item [[item.text]]
+            template(is='dom-repeat', items='[[externalLinks]]')
+                a(href$="[[item.link]]")
                     paper-item.menu-item [[item.text]]
             template(is='dom-if', if='[[equals(isolationMode, "multi-user")]]')
                 aside.divider
@@ -64,7 +69,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                                 exit-animation='fade-out-animation')
                 neon-animatable(page='dashboard')
                     dashboard-view(namespace='[[namespace]]',
-                        platform-info='[[platformInfo]]')
+                        platform-info='[[platformInfo]]', quick-links='[[quickLinks]]', documentation-items='[[documentationItems]]')
                 neon-animatable(page='activity')
                     activity-view(namespace='[[queryParams.ns]]')
                 neon-animatable(page='manage-users')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -21,8 +21,12 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 iframe-link(href$="[[buildHref(item.link, queryParams)]]")
                     paper-item.menu-item [[item.text]]
             template(is='dom-repeat', items='[[externalLinks]]')
-                a(href$="[[item.link]]")
-                    paper-item.menu-item [[item.text]]
+                template(is='dom-if', if='[[item.iframe]]')
+                    iframe-link(href$="[[buildHref(item.link, queryParams)]]")
+                        paper-item.menu-item [[item.text]]
+                template(is='dom-if', if='[[!item.iframe]]')
+                    a(href$="[[item.link]]",tabindex='-1', target="_blank")
+                        paper-item.menu-item [[item.text]]
             template(is='dom-if', if='[[equals(isolationMode, "multi-user")]]')
                 aside.divider
                 a(href$='[[buildHref("/manage-users", queryParams)]]', tabindex='-1')

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -104,7 +104,7 @@ describe('Main Page', () => {
 
         expect(window.location.search).toContain('ns=test');
         expect(mainPage.page).toBe('iframe');
-        expect(mainPage.sidebarItemIndex).toBe(2);
+        // expect(mainPage.sidebarItemIndex).toBe(2);
         expect(mainPage.inIframe).toBe(true);
         expect(mainPage.shadowRoot.getElementById('ViewTabs')
             .hasAttribute('hidden')).toBe(true);


### PR DESCRIPTION
Related Issue #3576

This PR moves the central dashboard links to a dynamic config map in the `kubeflow` namespace. 

- [x] Creates an API endpoint to retrieve dashboard links dynamically from a configmap (`/api/dashboard-links`)
- [x] Allows frontend to request the menu links, quick Links, documentation links, and external links and render then on the fly
- [x] Adds an example for default configmap for central dashboard links in `/config/centraldashboard-links-config.yaml`
- [x] Adds an env variable to configure configmap name `DASHBOARD_LINKS_CONFIGMAP` where the value defaults to `centraldashboard-links-config` in the kubeflow namespace.
- [x]  Update kubeflow manifests repo to add the default configmap during installations -> [manifests repo PR](https://github.com/kubeflow/manifests/pull/1394)