### PR TITLE
Common code between the different python backends

### DIFF
--- a/components/crud-web-apps/common/README.md
+++ b/components/crud-web-apps/common/README.md
@@ -1,0 +1,48 @@
+# Common code for CRUD web apps
+
+Since our CRUD web apps like the Jupyter, Tensorboards and Volumes UIs are similarly build with Angular and Python/Flask we should factor the common code in to modules and libraries.
+
+This directory will contain:
+1. A Python package with a base backend. Each one of the mentioned apps are supposed to extend this backend.
+2. An Angular library that will contain the common frontend code that these apps will be sharing
+
+## Backend
+
+The backend will be exposing a base backend which will be taking care of:
+* Serving the Single Page Application
+* Adding liveness/readiness probes
+* Authentication based on the `kubeflow-userid` header
+* Authorization using SubjectAccessReviews
+* Uniform logging
+* Exceptions handling
+* Common helper functions for dates, yaml file parsing etc.
+
+### How to use
+
+In order to use this code during the development process one could use the `-e` [flag](https://pip.pypa.io/en/stable/reference/pip_install/#install-editable) with `pip install`. For example:
+
+```bash
+# I'm currently in /components/crud-web-apps/volumes/backend
+cd ../../common/backend && pip install -e .
+```
+
+This will install all the dependencies of the package and you will now be able to include code from `kubeflow.kubeflow.crud_backend` in you current Python environment.
+
+In order to build a Docker image and use this code you coud build a wheel and then install it:
+```dockerfile
+FROM python:3.7 AS backend-kubeflow-wheel
+
+WORKDIR /src
+COPY ./components/crud-web-apps/common/backend .
+
+RUN python3 setup.py bdist_wheel
+
+...
+# Web App
+FROM python:3.7
+
+WORKDIR /package
+COPY --from=backend-kubeflow-wheel /src .
+RUN pip3 install .
+...
+```

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/__init__.py
@@ -1,0 +1,35 @@
+import logging
+
+from flask import Flask
+from flask_cors import CORS
+
+from .authn import bp as authn_bp
+from .config import Config, DevConfig
+from .errors import bp as errors_bp
+from .probes import bp as probes_bp
+from .routes import bp as base_routes_bp
+from .serving import bp as serving_bp
+
+LOG_FORMAT = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
+
+
+def create_app(name, static_folder, config_class=Config):
+    config = config_class()
+    logging.basicConfig(format=LOG_FORMAT, level=config.LOG_LEVEL)
+    log = logging.getLogger(__name__)
+
+    app = Flask(name, static_folder=static_folder)
+    app.config.from_object(config)
+
+    if config_class == DevConfig:
+        log.warn("RUNNING IN DEVELOPMENT MODE")
+        CORS(app)
+
+    # Register all the blueprints
+    app.register_blueprint(authn_bp)
+    app.register_blueprint(errors_bp)
+    app.register_blueprint(probes_bp)
+    app.register_blueprint(serving_bp)
+    app.register_blueprint(base_routes_bp)
+
+    return app

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/__init__.py
@@ -1,0 +1,10 @@
+from .apis import *  # noqa F401, F403
+from .custom_resource import *  # noqa F401, F403
+from .namespace import *  # noqa F401, F403
+from .notebook import *  # noqa F401, F403
+from .pod import *  # noqa F401, F403
+from .poddefault import *  # noqa F401, F403
+from .pvc import *  # noqa F401, F403
+from .secret import *  # noqa F401, F403
+from .storageclass import *  # noqa F401, F403
+from .utils import *  # noqa F401, F403

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/apis.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/apis.py
@@ -1,0 +1,12 @@
+from kubernetes import client, config
+from kubernetes.config import ConfigException
+
+try:
+    config.load_incluster_config()
+except ConfigException:
+    config.load_kube_config()
+
+# Create the Apis
+v1_core = client.CoreV1Api()
+custom_api = client.CustomObjectsApi()
+storage_api = client.StorageV1Api()

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/custom_resource.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/custom_resource.py
@@ -1,0 +1,31 @@
+from kubernetes import client
+
+from .. import authz
+from . import custom_api
+
+
+def create_custom_rsrc(group, version, resource, data, namespace):
+    authz.ensure_authorized("create", group, version, resource, namespace)
+    return custom_api.create_namespaced_custom_object(
+        group, version, namespace, resource, data
+    )
+
+
+def delete_custom_rsrc(
+    group, version, resource, name, namespace, foreground=True
+):
+    del_policy = client.V1DeleteOptions()
+    if foreground:
+        del_policy = client.V1DeleteOptions(propagation_policy="Foreground")
+
+    authz.ensure_authorized("delete", group, version, resource, namespace)
+    return custom_api.delete_namespaced_custom_object(
+        group, version, namespace, resource, name, del_policy,
+    )
+
+
+def list_custom_rsrc(group, version, resource, namespace):
+    authz.ensure_authorized("list", group, version, resource, namespace)
+    return custom_api.list_namespaced_custom_object(
+        group, version, namespace, resource
+    )

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/namespace.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/namespace.py
@@ -1,0 +1,7 @@
+from .. import authz
+from . import v1_core
+
+
+@authz.needs_authorization("list", "", "v1", "namespaces")
+def list_namespaces():
+    return v1_core.list_namespace()

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/notebook.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/notebook.py
@@ -1,0 +1,44 @@
+from kubernetes import client
+
+from .. import authz
+from . import custom_api, v1_core
+
+
+def create_notebook(notebook, namespace):
+    authz.ensure_authorized(
+        "create", "kubeflow.org", "v1beta1", "notebooks", namespace
+    )
+    return custom_api.create_namespaced_custom_object(
+        "kubeflow.org", "v1beta1", namespace, "notebooks", notebook
+    )
+
+
+def list_notebooks(namespace):
+    authz.ensure_authorized(
+        "list", "kubeflow.org", "v1beta1", "notebooks", namespace
+    )
+    return custom_api.list_namespaced_custom_object(
+        "kubeflow.org", "v1beta1", namespace, "notebooks"
+    )
+
+
+def delete_notebook(notebook, namespace):
+    authz.ensure_authorized(
+        "delete", "kubeflow.org", "v1beta1", "notebooks", namespace
+    )
+    return custom_api.delete_namespaced_custom_object(
+        "kubeflow.org",
+        "v1beta1",
+        namespace,
+        "notebooks",
+        notebook,
+        client.V1DeleteOptions(propagation_policy="Foreground"),
+    )
+
+
+def list_notebook_events(notebook, namespace):
+    selector = "involvedObject.kind=Notebook,involvedObject.name=" + notebook
+
+    return v1_core.list_namespaced_event(
+        namespace=namespace, field_selector=selector
+    )

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
@@ -1,0 +1,7 @@
+from .. import authz
+from . import v1_core
+
+
+def list_pods(namespace):
+    authz.ensure_authorized("list", "", "v1", "pods", namespace)
+    return v1_core.list_namespaced_pod(namespace)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/poddefault.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/poddefault.py
@@ -1,0 +1,11 @@
+from .. import authz
+from . import custom_api
+
+
+def list_poddefaults(namespace):
+    authz.ensure_authorized(
+        "list", "kubeflow.org", "v1alpha1", "poddefaults", namespace
+    )
+    return custom_api.list_namespaced_custom_object(
+        "kubeflow.org", "v1alpha1", namespace, "poddefaults"
+    )

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
@@ -1,0 +1,23 @@
+from .. import authz
+from . import v1_core
+
+
+def create_pvc(pvc, namespace):
+    authz.ensure_authorized(
+        "create", "", "v1", "persistentvolumeclaims", namespace
+    )
+    return v1_core.create_namespaced_persistent_volume_claim(namespace, pvc)
+
+
+def delete_pvc(pvc, namespace):
+    authz.ensure_authorized(
+        "delete", "", "v1", "persistentvolumeclaims", namespace
+    )
+    return v1_core.delete_namespaced_persistent_volume_claim(pvc, namespace)
+
+
+def list_pvcs(namespace):
+    authz.ensure_authorized(
+        "list", "", "v1", "persistentvolumeclaims", namespace
+    )
+    return v1_core.list_namespaced_persistent_volume_claim(namespace)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/secret.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/secret.py
@@ -1,0 +1,16 @@
+from .. import authz
+from . import v1_core
+
+
+def get_secret(namespace, name, auth=True):
+    if auth:
+        authz.ensure_authorized("get", "", "v1", "secrets", namespace)
+
+    return v1_core.read_namespaced_secret(name, namespace)
+
+
+def create_secret(namespace, secret, auth=True):
+    if auth:
+        authz.ensure_authorized("create", "", "v1", "secrets", namespace)
+
+    return v1_core.create_namespaced_secret(namespace, secret)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/storageclass.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/storageclass.py
@@ -1,0 +1,10 @@
+from . import storage_api
+
+
+# @auth.needs_authorization("list", "storage.k8s.io", "v1", "storageclasses")
+# NOTE(kimwnasptd): This function is only used from the backend in order to
+# determine if a default StorageClass is set. Currently, the role aggregation
+# does not use a ClusterRoleBinding, thus we can't currently give this
+# permission to a user.
+def list_storageclasses():
+    return storage_api.list_storage_class()

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/utils.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/utils.py
@@ -1,0 +1,29 @@
+from flask import jsonify
+
+from .. import authn
+
+
+def success_response(data_field=None, data=None):
+    user = authn.get_username()
+    resp = {"status": 200, "success": True, "user": user}
+    if data_field is None and data is None:
+        return jsonify(resp)
+
+    resp[data_field] = data
+    return jsonify(resp)
+
+
+def failed_response(msg, error_code):
+    user = authn.get_username()
+    resp = {
+        "success": False,
+        "log": msg,
+        "status": error_code,
+        "user": user,
+    }
+
+    return resp, error_code
+
+
+def events_field_selector(kind, name):
+    return f"involvedObject.kind={kind},involvedObject.name={name}"

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
@@ -1,0 +1,68 @@
+import logging
+import os
+
+from flask import Blueprint, current_app, request
+from werkzeug.exceptions import Unauthorized
+
+from . import config
+
+bp = Blueprint("authn", __name__)
+log = logging.getLogger(__name__)
+
+USER_HEADER = os.getenv("USERID_HEADER", "kubeflow-userid")
+USER_PREFIX = os.getenv("USERID_PREFIX", ":")
+
+
+def get_username():
+    if USER_HEADER not in request.headers:
+        log.debug("User header not present!")
+        username = None
+    else:
+        user = request.headers[USER_HEADER]
+        username = user.replace(USER_PREFIX, "")
+        log.debug(
+            f"User: '{username}' | Headers: '{USER_HEADER}' '{USER_PREFIX}'"
+        )
+
+    return username
+
+
+def no_authentication(func):
+    """
+    This decorator will be used to disable the default authentication check
+    for the decorated endpoint.
+    """
+    func.no_authentication = True
+    return func
+
+
+@bp.before_app_request
+def check_authentication():
+    """
+    By default all the app's routes will be subject to authentication. If we
+    want a function to not have authentication check then we can decorate it
+    with the `no_authentication` decorator.
+    """
+    if current_app.config.get("ENV") == config.DEV_MODE:
+        log.debug("Skipping authentication check in development mode")
+        return
+
+    # If a function was decorated with `no_authentication` then we will skip
+    # the authn check
+    if request.endpoint and getattr(
+        current_app.view_functions[request.endpoint],
+        "no_authentication",
+        False,
+    ):
+        # when no return value is specified the designated route function will
+        # be called.
+        return
+
+    user = get_username()
+    if user is None:
+        # Return an unauthenticated response and don't call the route's
+        # assigned function.
+        raise Unauthorized("No user detected.")
+    else:
+        log.info(f"Handling request for user: {user}")
+        return

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
@@ -1,0 +1,116 @@
+import functools
+import logging
+
+from kubernetes import client
+from kubernetes import config as k8s_config
+from kubernetes.client.rest import ApiException
+from kubernetes.config import ConfigException
+from werkzeug.exceptions import Forbidden, Unauthorized
+
+from . import authn, config
+
+log = logging.getLogger(__name__)
+
+try:
+    # Load configuration inside the Pod
+    k8s_config.load_incluster_config()
+except ConfigException:
+    # Load configuration for testing
+    k8s_config.load_kube_config()
+
+# The API object for submitting SubjecAccessReviews
+authz_api = client.AuthorizationV1Api()
+
+
+def create_subject_access_review(
+    user, verb, namespace, group, version, resource
+):
+    """
+    Create the SubjecAccessReview object which we will use to determine if the
+    user is authorized.
+    """
+    return client.V1SubjectAccessReview(
+        spec=client.V1SubjectAccessReviewSpec(
+            user=user,
+            resource_attributes=client.V1ResourceAttributes(
+                group=group,
+                namespace=namespace,
+                verb=verb,
+                resource=resource,
+                version=version,
+            ),
+        )
+    )
+
+
+def is_authorized(user, verb, namespace, group, version, resource):
+    """
+    Create a SubjectAccessReview to the K8s API to determine if the user is
+    authorized to perform a specific verb on a resource.
+    """
+    # Skip authz check if in dev mode
+    if config.dev_mode_enabled():
+        log.debug("Skipping authorization check in development mode")
+        return True
+
+    if user is None:
+        log.warning(
+            (
+                "No user credentials were found! Make sure you"
+                " have correctly set the USERID_HEADER in the"
+                " Web App's deployment."
+            )
+        )
+        raise Unauthorized(description="No user credentials were found!")
+
+    sar = create_subject_access_review(
+        user, verb, namespace, group, version, resource
+    )
+    try:
+        obj = authz_api.create_subject_access_review(sar)
+    except ApiException as e:
+        log.error(f"Error submitting SubjecAccessReview: {sar}, {e}")
+        raise e
+
+    if obj.status is not None:
+        return obj.status.allowed
+    else:
+        log.error("SubjectAccessReview doesn't have status.")
+        return False
+
+
+def ensure_authorized(verb, group, version, resource, namespace=None):
+    user = authn.get_username()
+    if not is_authorized(user, verb, namespace, group, version, resource):
+        if namespace is not None:
+            msg = (
+                f"User '{user}' is not authorized to {verb}"
+                f" {group}.{version}.{resource} for namespace:"
+                f" {namespace}"
+            )
+        else:
+            msg = (
+                f"User '{user}' is not authorized to {verb}"
+                f" {group}.{version}.{resource}"
+            )
+
+        raise Forbidden(description=msg)
+
+
+def needs_authorization(verb, group, version, resource, namespace=None):
+    """
+    This function will serve as a decorator. It will be used to make sure that
+    the decorated function is authorized to perform the corresponding k8s api
+    verb on a specific resource.
+    """
+
+    def wrapper(func):
+        @functools.wraps(func)
+        def runner(*args, **kwargs):
+            # Run the decorated function only if the user is authorized
+            ensure_authorized(verb, group, version, resource, namespace)
+            return func(*args, **kwargs)
+
+        return runner
+
+    return wrapper

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/config.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/config.py
@@ -1,0 +1,40 @@
+import logging
+import os
+
+from flask import current_app
+
+DEV_MODE = "development"
+PROD_MODE = "production"
+
+
+log = logging.getLogger(__name__)
+
+
+def dev_mode_enabled():
+    return current_app.config["ENV"] == DEV_MODE
+
+
+class Config(object):
+    ENV = PROD_MODE
+    DEBUG = False
+    STATIC_DIR = "./static/"
+    JSONIFY_PRETTYPRINT_REGULAR = True
+    LOG_LEVEL = logging.INFO
+
+    def __init__(self):
+        if os.environ.get("LOG_LEVEL_DEBUG", "false") == "true":
+            self.LOG_LEVEL = logging.DEBUG
+
+
+class DevConfig(Config):
+    ENV = DEV_MODE
+    DEBUG = True
+    LOG_LEVEL = logging.DEBUG
+
+    def __init__(self):
+        super()
+        log.warn("RUNNING IN DEVELOPMENT MODE")
+
+
+class ProdConfig(Config):
+    ENV = PROD_MODE

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/decorators.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/decorators.py
@@ -1,0 +1,44 @@
+import functools
+import logging
+
+from flask import request
+from werkzeug import exceptions
+
+log = logging.getLogger(__name__)
+
+
+def request_is_json_type(func):
+    """Make sure that the current request is of type JSON"""
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        if request.content_type != "application/json":
+            raise exceptions.BadRequest("Request is not in JSON format.")
+
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def required_body_params(*params):
+    """
+    Used to decorate a route that accepts json and must contain some specific
+    fields. If a field is not present then the server will return a 400 error.
+    """
+
+    def wrapper(func):
+        @functools.wraps(func)
+        def runner(*args, **kwargs):
+            body = request.get_json()
+            for param in params:
+                if param not in body:
+                    raise exceptions.BadRequest(
+                        f"Parameter '{param}' is missing from the request's"
+                        " body."
+                    )
+
+            return func(*args, **kwargs)
+
+        return runner
+
+    return wrapper

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/errors/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/errors/__init__.py
@@ -1,0 +1,6 @@
+from flask import Blueprint
+
+bp = Blueprint("errors", __name__)
+
+from . import handlers  # noqa F401, E402
+from .utils import failed_response, parse_error_message  # noqa F401, E402

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/errors/handlers.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/errors/handlers.py
@@ -1,0 +1,41 @@
+import logging
+
+from flask import request
+from kubernetes.client.rest import ApiException
+from werkzeug import exceptions
+
+from .. import api
+from . import bp, utils
+
+log = logging.getLogger(__name__)
+
+
+@bp.app_errorhandler(ApiException)
+def api_exception_handler(e):
+    """
+    If the backend could not complete the k8s API call then the default handler
+    will catch the exception, format the error message and return an
+    appropriate response for the frontend
+    """
+    ep = request.url
+    log.error(f"An error occured talking to k8s while working on {ep}: {e}")
+
+    if e.status == 404:
+        msg = "The requested resource could not be found in the API Server"
+    else:
+        msg = utils.parse_error_message(e)
+
+    return api.failed_response(msg, e.status)
+
+
+@bp.app_errorhandler(exceptions.HTTPException)
+def handle_http_errors(e):
+    log.error(f"HTTP Exception handled: {e}")
+    return api.failed_response(e.description, e.code)
+
+
+@bp.app_errorhandler(Exception)
+def catch_all(e):
+    log.error("Caught and unhandled Exception!")
+    log.exception(e)
+    return api.failed_response("An error occured in the backend.", 500)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/errors/utils.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/errors/utils.py
@@ -1,0 +1,22 @@
+import json
+
+
+def failed_response(msg, error_code):
+    content = {
+        "success": False,
+        "log": msg,
+        "status": error_code,
+    }
+
+    return content, error_code
+
+
+def parse_error(e):
+    try:
+        return json.loads(e.body)
+    except (json.JSONDecodeError, KeyError, AttributeError):
+        return {}
+
+
+def parse_error_message(e):
+    return parse_error(e).get("message", str(e))

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/helpers.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/helpers.py
@@ -1,0 +1,103 @@
+"""
+Common helper functions for handling k8s objects information
+"""
+import datetime as dt
+import logging
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+
+def load_yaml(f):
+    """
+    f: file path
+    Load a yaml file and convert it to a python dict.
+    """
+    c = None
+    try:
+        with open(f, "r") as yaml_file:
+            c = yaml_file.read()
+    except IOError:
+        log.error(f"Error opening: {f}")
+        return None
+
+    try:
+        contents = yaml.safe_load(c)
+        if contents is None:
+            # YAML exists but is empty
+            return {}
+        else:
+            # YAML exists and is not empty
+            return contents
+    except yaml.YAMLError:
+        return None
+
+
+def load_param_yaml(f, **kwargs):
+    """
+    f: file path
+
+    Load a yaml file and convert it to a python dict. The yaml might have some
+    `{var}` values which the user will have to format. For this we first read
+    the yaml file and replace these variables and then convert the generated
+    string to a dict via the yaml module.
+    """
+    c = None
+    try:
+        with open(f, "r") as yaml_file:
+            c = yaml_file.read().format(**kwargs)
+    except IOError:
+        log.error(f"Error opening: {f}")
+        return None
+
+    try:
+        contents = yaml.safe_load(c)
+        if contents is None:
+            # YAML exists but is empty
+            return {}
+        else:
+            # YAML exists and is not empty
+            return contents
+    except yaml.YAMLError:
+        return None
+
+
+def get_uptime(then):
+    """
+    then: datetime instance | string
+
+    Return a string that informs how much time has pasted from the provided
+    timestamp.
+    """
+    if isinstance(then, str):
+        then = dt.datetime.strptime(then, "%Y-%m-%dT%H:%M:%SZ")
+
+    now = dt.datetime.now()
+    diff = now - then.replace(tzinfo=None)
+
+    days = diff.days
+    hours = int(diff.seconds / 3600)
+    mins = int((diff.seconds % 3600) / 60)
+
+    age = ""
+    if days > 0:
+        if days == 1:
+            age = str(days) + " day"
+        else:
+            age = str(days) + " days"
+    else:
+        if hours > 0:
+            if hours == 1:
+                age = str(hours) + " hour"
+            else:
+                age = str(hours) + " hours"
+        else:
+            if mins == 0:
+                return "just now"
+            if mins == 1:
+                age = str(mins) + " min"
+            else:
+                age = str(mins) + " mins"
+
+    return age + " ago"

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/probes.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/probes.py
@@ -1,0 +1,17 @@
+from flask import Blueprint, jsonify
+
+from . import authn
+
+bp = Blueprint("probes", __name__)
+
+
+@bp.route("/healthz/liveness")
+@authn.no_authentication
+def liveness():
+    return jsonify("alive"), 200
+
+
+@bp.route("/healthz/readiness")
+@authn.no_authentication
+def readiness():
+    return jsonify("ready"), 200

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/requirements.txt
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/requirements.txt
@@ -1,0 +1,6 @@
+Flask==1.1.1
+Flask-API==2.0
+kubernetes==10.0.1
+requests==2.22.0
+urllib3==1.25.7
+Werkzeug==0.16.0

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/rok/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/rok/__init__.py
@@ -1,0 +1,1 @@
+from .routes import bp  # noqa E402, F401

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/rok/routes.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/rok/routes.py
@@ -1,0 +1,13 @@
+from flask import Blueprint
+
+from .. import api
+
+bp = Blueprint("rok_base_routes", __name__)
+
+
+@bp.route("/api/rok/storageclasses")
+def get_rok_storageclasses():
+    """
+    Return a list of k8s storage classes that are provided from Rok
+    """
+    return api.success_response("storageClasses", ["rok"])

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/routes/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/routes/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("base_lib_get_routes", __name__)
+
+from . import get  # noqa E402, F401

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/routes/get.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/routes/get.py
@@ -1,0 +1,50 @@
+from .. import api
+from . import bp
+
+
+@bp.route("/info")
+def get_info():
+    return api.success_response("info", {})
+
+
+@bp.route("/api/namespaces")
+def get_namespaces():
+    namespaces = api.list_namespaces()
+    content = [ns.metadata.name for ns in namespaces.items]
+
+    return api.success_response("namespaces", content)
+
+
+@bp.route("/api/storageclasses")
+def get_storageclasses():
+    scs = api.list_storageclasses()
+    content = [sc.metadata.name for sc in scs.items]
+
+    return api.success_response("storageClasses", content)
+
+
+@bp.route("/api/storageclasses/default")
+def get_default_storageclass():
+    scs = api.list_storageclasses()
+
+    for sc in scs.items:
+        annotations = sc.metadata.annotations
+        if annotations is None:
+            continue
+
+        # List of possible annotations
+        keys = [
+            "storageclass.kubernetes.io/is-default-class",
+            "storageclass.beta.kubernetes.io/is-default-class",  # GKE
+        ]
+
+        for key in keys:
+            is_default = annotations.get(key, False)
+
+            if is_default:
+                return api.success_response(
+                    "defaultStorageClass", sc.metadata.name
+                )
+
+    # No StorageClass is default
+    return api.success_response("defaultStorageClass", "")

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/serving.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/serving.py
@@ -1,0 +1,27 @@
+import logging
+
+from flask import Blueprint, current_app, send_from_directory
+
+bp = Blueprint("serving", __name__)
+log = logging.getLogger(__name__)
+
+
+# Caching: We want the browser to always check if the index.html file it has
+# is the latest one. Also we want this check to use the ETag header and not
+# the Last-Modified since our app will be served inside a container and we
+# might want to roll-back.
+# The JS/CSS files will have a hash in their name and thus we will want to
+# cache them for as long as possible
+
+
+@bp.route("/")
+@bp.route("/index.html")
+@bp.route("/<path:path>")
+def serve_index(path="/"):
+    # Serve the index file in all other cases
+    static_dir = current_app.config["STATIC_DIR"]
+    log.info("Serving root file index.html for path %s", path)
+
+    resp = send_from_directory(static_dir, "index.html")
+    resp.headers["Cache-Control"] = "public, no-cache"
+    return resp

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/status.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/status.py
@@ -1,0 +1,21 @@
+class STATUS_PHASE:
+    """
+    Different values that the status phase should have. The frontend will be
+    expecting only these values.
+    """
+
+    READY = "ready"
+    WAITING = "waiting"
+    WARNING = "warning"
+    ERROR = "error"
+    UNINITIALIZED = "uninitialized"
+    UNAVAILABLE = "unavailable"
+    TERMINATING = "terminating"
+
+
+def create_status(phase="", message="", state=""):
+    return {
+        "phase": phase,
+        "message": message,
+        "state": state,
+    }

--- a/components/crud-web-apps/common/backend/setup.py
+++ b/components/crud-web-apps/common/backend/setup.py
@@ -1,0 +1,28 @@
+import setuptools
+
+REQUIRES = [
+    "Flask >= 1.1.1",
+    "Flask-API >= 2.0",
+    "kubernetes >= 10.0.1, < 11.0.0",
+    "requests >= 2.22.0",
+    "urllib3 >= 1.25.7",
+    "Werkzeug >= 0.16.0",
+    "Flask-Cors >= 3.0.8",
+]
+
+setuptools.setup(
+    name="kubeflow",
+    version="1.1",
+    author="kubeflow-dev-team",
+    description="A package with a base Flask CRUD backend common code",
+    packages=setuptools.find_packages(),
+    install_requires=REQUIRES,
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: Apache Software License",
+        "Topic :: Software Development",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
+    python_requires=">=3.6",
+)


### PR DESCRIPTION
Right now JWA's backend is written in Python Flask. We also have the [Tensorboards web app](https://github.com/kubeflow/kubeflow/issues/3578) whose backend will also be written in Python and Flask. Lastly, the [Volumes web app](https://github.com/kubeflow/kubeflow/issues/4758), that we'd like to contribute, will be also written with the same technologies.

I think it would be a good next step to create a common python codebase/library that all these apps could use, at some extend. This common code will include:
* How we handle exceptions in the backend
* Common routes for serving static files and their cache control policy
* Authorization checks with SubjectAccessReview
* Authentication checks on the Kubeflow headers
* Common helper functions for dates, yaml parsing etc
* health/liveness probes

I have prepared this code while working on the Volumes web app and it's the first step towards pushing the backend code upstream. It would also help our running [GSoC project with Tensorboard](https://summerofcode.withgoogle.com/projects/#4660815581413376) as the backend could use a lot of this common code. The Jupyter web app should also gradually use this code.

I'm also adding @kandrio98 to the loop since this affects his GSoC project as well as to get him more exposed to our review process.

@jlewi if you have a better candidate in mind for reviewing this PR let me know

/cc @jlewi 
/assign @kimwnasptd 