### PR TITLE
Use informer / indexer to cache rolebindings

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -12,13 +12,14 @@ package kfam
 
 import (
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	istioRegister "github.com/kubeflow/kubeflow/components/access-management/pkg/apis/istiorbac/v1alpha1"
 	profileRegister "github.com/kubeflow/kubeflow/components/access-management/pkg/apis/kubeflow/v1beta1"
 	profilev1beta1 "github.com/kubeflow/kubeflow/components/profile-controller/api/v1beta1"
+	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -28,6 +29,7 @@ import (
 	"path"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"strconv"
+	"time"
 )
 
 type KfamV1Alpha1Interface interface {
@@ -64,6 +66,13 @@ func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string
 	if err != nil {
 		return nil, err
 	}
+
+	informerFactory := informers.NewSharedInformerFactory(kubeClient, time.Minute * 60)
+	roleBindingLister := informerFactory.Rbac().V1().RoleBindings().Lister()
+	stop := make(chan struct{})
+	informerFactory.Start(stop)
+	informerFactory.WaitForCacheSync(stop)
+
 	return &KfamV1Alpha1Client{
 		profileClient: &ProfileClient{
 			restClient: profileRESTClient,
@@ -71,6 +80,7 @@ func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string
 		bindingClient: &BindingClient{
 			restClient: 	istioRESTClient,
 			kubeClient: 	kubeClient,
+			roleBindingLister: roleBindingLister,
 		},
 		clusterAdmin: []string{clusterAdmin},
 		userIdHeader: userIdHeader,


### PR DESCRIPTION
To solve https://github.com/kubeflow/kubeflow/issues/5190

Found most of the issue to occur when listing the rolebindings when there are many namespaces as it does a loop. Query the shared index to list and get the rolebindings.

* Note: first commit and if there are procedures I am missing, please let me know.

