### PR TITLE
Change chown command recursively to change parent folder's ownership …

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -117,7 +117,7 @@ RUN pip3 --no-cache-dir install \
 
 COPY --chown=jovyan:users requirements.txt /tmp
 
-RUN docker-credential-gcr configure-docker && chown ${NB_USER}:users $HOME/.docker/config.json
+RUN docker-credential-gcr configure-docker && chown -R ${NB_USER}:users $HOME/.docker
 
 # Configure container startup
 EXPOSE 8888


### PR DESCRIPTION
**What this PR does / why we need it:**

Normally, kubeflow user creates notebook server with workspace volume enabled. With this configuration notebook server pod's /home/jovyan directory is backed by PV. However, if user doesn't enable workspace volume then jovyan users cannot access config.json under .docker directory since $HOME/.docker folder's ownership is set to root:root currently. 

I know that above use-case is not normal but could happen. Also, within this environment user should define DOCKER_CONFIG environment variable to avoid using default $HOME/.docker/config.json when using kubeflow-fairing appender builder.

It would be great if you guys could take a look at this PR. Thanks.