### PR TITLE
Add support for tf 2.2.0 for kubeflow jupyter image

### DIFF
--- a/components/tensorflow-notebook-image/Dockerfile
+++ b/components/tensorflow-notebook-image/Dockerfile
@@ -113,7 +113,7 @@ RUN pip3 --no-cache-dir install \
     jupyter-console==6.0.0 \
     jupyterlab \
     xgboost \
-    kubeflow-fairing==0.7.1
+    kubeflow-fairing==0.7.2
 
 COPY --chown=jovyan:users requirements.txt /tmp
 

--- a/components/tensorflow-notebook-image/versions/2.2.0gpu/version-config.json
+++ b/components/tensorflow-notebook-image/versions/2.2.0gpu/version-config.json
@@ -1,0 +1,4 @@
+{
+  "BASE_IMAGE": "tensorflow/tensorflow:2.2.0-gpu-jupyter",
+  "INSTALL_TFMA": "yes"
+}

--- a/components/tensorflow-notebook-image/versions/2.3.0gpu/version_config.json
+++ b/components/tensorflow-notebook-image/versions/2.3.0gpu/version_config.json
@@ -1,0 +1,4 @@
+{
+  "BASE_IMAGE": "tensorflow/tensorflow:2.3.0-gpu-jupyter",
+  "INSTALL_TFMA": "yes"
+}


### PR DESCRIPTION
add tf 2.2.0 script metadata
upgrade `Kubeflow-fairing` because 0.7.1 does not support tf 2.2