### PR TITLE
Revert "Fix #4842 Pod resources limit (#5118)"

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/utils.py
@@ -390,7 +390,6 @@ def set_notebook_cpu(notebook, body, defaults):
         logger.info("Using default CPU: " + cpu)
 
     container["resources"]["requests"]["cpu"] = cpu
-    container["resources"]["limits"]["cpu"] = cpu
 
 
 def set_notebook_memory(notebook, body, defaults):
@@ -407,7 +406,6 @@ def set_notebook_memory(notebook, body, defaults):
         logger.info("Using default Memory: " + memory)
 
     container["resources"]["requests"]["memory"] = memory
-    container["resources"]["limits"]["memory"] = memory
 
 
 def set_notebook_gpus(notebook, body, defaults):

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/notebook.yaml
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/notebook.yaml
@@ -18,8 +18,5 @@ spec:
             requests:
               cpu: "0.1"
               memory: "0.1Gi"
-            limits:
-              cpu: "0.1"
-              memory: "0.1Gi"
       ttlSecondsAfterFinished: 300
       volumes: []


### PR DESCRIPTION
This reverts commit 4b06248b

Setting a limit is an extremely bad idea, as it can result in an unexpected shutdown of notebook instance (and losing anything currently in memory on the pod).

There is also an important distinction to make about what a "request" actually means. Let's not forget that in the end we are just spawning Pods on Docker, which has access to all of the host's resources, meaning the code running in the pod has no idea that it will be suddenly killed if it uses more than some arbitrary number.