### PR TITLE
Use valid commit for kubeflow/components/common module.

### DIFF
--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/go-logr/logr v0.1.0
-	github.com/kubeflow/kubeflow/components/common v0.0.0-00010101000000-000000000000
+	github.com/kubeflow/kubeflow/components/common v0.0.0-20200908101143-7f5e242f4671
 	github.com/prometheus/client_golang v0.9.0
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b
 	k8s.io/apimachinery v0.0.0-20190404173353-6a84e37a896d
@@ -13,4 +13,7 @@ require (
 	sigs.k8s.io/controller-tools v0.2.0 // indirect
 )
 
+// Ensure we build the notebook-controller with the latest `common`
+// module. However, because this module's `replace` will be ignored by
+// other modules, we still specify a commit in the `require` directive.
 replace github.com/kubeflow/kubeflow/components/common => ../common


### PR DESCRIPTION
Makes the notebook controller API importable for 3rd party applications. 

See #5308 