### PR TITLE
Correct ContainerStatus of Notebook CR

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -213,30 +213,35 @@ func (r *NotebookReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		if len(pod.Status.ContainerStatuses) > 0 {
 			notebookContainerFound := false
 			for i := range pod.Status.ContainerStatuses {
-				if pod.Status.ContainerStatuses[i].Name == instance.Name &&
-					pod.Status.ContainerStatuses[i].State != instance.Status.ContainerState {
-					log.Info("Updating Notebook CR state: ", "namespace", instance.Namespace, "name", instance.Name)
-					cs := pod.Status.ContainerStatuses[i].State
-					instance.Status.ContainerState = cs
-					oldConditions := instance.Status.Conditions
-					newCondition := getNextCondition(cs)
-					// Append new condition
-					if len(oldConditions) == 0 || oldConditions[0].Type != newCondition.Type ||
-						oldConditions[0].Reason != newCondition.Reason ||
-						oldConditions[0].Message != newCondition.Message {
-						log.Info("Appending to conditions: ", "namespace", instance.Namespace, "name", instance.Name, "type", newCondition.Type, "reason", newCondition.Reason, "message", newCondition.Message)
-						instance.Status.Conditions = append([]v1beta1.NotebookCondition{newCondition}, oldConditions...)
-					}
-					err = r.Status().Update(ctx, instance)
-					if err != nil {
-						return ctrl.Result{}, err
-					}
-					notebookContainerFound = true
-					break
+				if pod.Status.ContainerStatuses[i].Name != instance.Name {
+					continue
 				}
+				if pod.Status.ContainerStatuses[i].State == instance.Status.ContainerState {
+					continue
+				}
+
+				log.Info("Updating Notebook CR state: ", "namespace", instance.Namespace, "name", instance.Name)
+				cs := pod.Status.ContainerStatuses[i].State
+				instance.Status.ContainerState = cs
+				oldConditions := instance.Status.Conditions
+				newCondition := getNextCondition(cs)
+				// Append new condition
+				if len(oldConditions) == 0 || oldConditions[0].Type != newCondition.Type ||
+					oldConditions[0].Reason != newCondition.Reason ||
+					oldConditions[0].Message != newCondition.Message {
+					log.Info("Appending to conditions: ", "namespace", instance.Namespace, "name", instance.Name, "type", newCondition.Type, "reason", newCondition.Reason, "message", newCondition.Message)
+					instance.Status.Conditions = append([]v1beta1.NotebookCondition{newCondition}, oldConditions...)
+				}
+				err = r.Status().Update(ctx, instance)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+				notebookContainerFound = true
+				break
+
 			}
 			if !notebookContainerFound {
-				log.Error(nil, "Could not found the Notebook container, will not update the status of the CR. No container has the same name as the CR.", "CR name:", instance.Name)
+				log.Error(nil, "Could not find the Notebook container, will not update the status of the CR. No container has the same name as the CR.", "CR name:", instance.Name)
 			}
 		}
 	}

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -207,6 +207,9 @@ func (r *NotebookReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		// Got the pod
 		podFound = true
 
+		// Update status of the CR using the ContainerState of
+		// the container that has the same name as the CR.
+		// If no container of same name is found, the state of the CR is not updated.
 		if len(pod.Status.ContainerStatuses) > 0 {
 			notebookContainerFound := false
 			for i := range pod.Status.ContainerStatuses {
@@ -233,7 +236,7 @@ func (r *NotebookReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				}
 			}
 			if !notebookContainerFound {
-				log.Info("WARNING: Notebook container is not found, so could not update State of Notebook CR")
+				log.Error(nil, "Could not found the Notebook container, will not update the status of the CR. No container has the same name as the CR.", "CR name:", instance.Name)
 			}
 		}
 	}

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -206,23 +206,34 @@ func (r *NotebookReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	} else {
 		// Got the pod
 		podFound = true
-		if len(pod.Status.ContainerStatuses) > 0 &&
-			pod.Status.ContainerStatuses[0].State != instance.Status.ContainerState {
-			log.Info("Updating container state: ", "namespace", instance.Namespace, "name", instance.Name)
-			cs := pod.Status.ContainerStatuses[0].State
-			instance.Status.ContainerState = cs
-			oldConditions := instance.Status.Conditions
-			newCondition := getNextCondition(cs)
-			// Append new condition
-			if len(oldConditions) == 0 || oldConditions[0].Type != newCondition.Type ||
-				oldConditions[0].Reason != newCondition.Reason ||
-				oldConditions[0].Message != newCondition.Message {
-				log.Info("Appending to conditions: ", "namespace", instance.Namespace, "name", instance.Name, "type", newCondition.Type, "reason", newCondition.Reason, "message", newCondition.Message)
-				instance.Status.Conditions = append([]v1beta1.NotebookCondition{newCondition}, oldConditions...)
+
+		if len(pod.Status.ContainerStatuses) > 0 {
+			notebookContainerFound := false
+			for i := range pod.Status.ContainerStatuses {
+				if pod.Status.ContainerStatuses[i].Name == instance.Name &&
+					pod.Status.ContainerStatuses[i].State != instance.Status.ContainerState {
+					log.Info("Updating Notebook CR state: ", "namespace", instance.Namespace, "name", instance.Name)
+					cs := pod.Status.ContainerStatuses[i].State
+					instance.Status.ContainerState = cs
+					oldConditions := instance.Status.Conditions
+					newCondition := getNextCondition(cs)
+					// Append new condition
+					if len(oldConditions) == 0 || oldConditions[0].Type != newCondition.Type ||
+						oldConditions[0].Reason != newCondition.Reason ||
+						oldConditions[0].Message != newCondition.Message {
+						log.Info("Appending to conditions: ", "namespace", instance.Namespace, "name", instance.Name, "type", newCondition.Type, "reason", newCondition.Reason, "message", newCondition.Message)
+						instance.Status.Conditions = append([]v1beta1.NotebookCondition{newCondition}, oldConditions...)
+					}
+					err = r.Status().Update(ctx, instance)
+					if err != nil {
+						return ctrl.Result{}, err
+					}
+					notebookContainerFound = true
+					break
+				}
 			}
-			err = r.Status().Update(ctx, instance)
-			if err != nil {
-				return ctrl.Result{}, err
+			if !notebookContainerFound {
+				log.Info("WARNING: Notebook container is not found, so could not update State of Notebook CR")
 			}
 		}
 	}
@@ -489,7 +500,7 @@ func nbNameFromInvolvedObject(c client.Client, object *corev1.ObjectReference) (
 		pod := &corev1.Pod{}
 		err := c.Get(
 			context.TODO(),
-			types.NamespacedName {
+			types.NamespacedName{
 				Namespace: namespace,
 				Name:      name,
 			},


### PR DESCRIPTION
The Notebook Controller doesn't set the `ContainerState` of the CR correctly. In some cases the first container is the istio-sidecar which results in an incorrect state being shown to the Notebook CR. This is fixed now by showing the `ContainerState` of Notebook container to the Notebook CR `ContainerState`. 

The Notebook container is selected by matching with [the name of the notebook](https://github.com/kubeflow/kubeflow/blob/7f5e242f4671f453eaee72e4319a5f7f190f7725/components/jupyter-web-app/backend/kubeflow_jupyter/common/yaml/notebook.yaml#L14). A warning is logged in case no container is found.

This PR fixes #5282.