### PR TITLE
Refactor the JWA backend to utilize common code

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/__init__.py
@@ -1,10 +1,9 @@
 import logging
 
 from flask import Flask
-from flask_cors import CORS
 
 from .authn import bp as authn_bp
-from .config import Config, DevConfig
+from .config import BackendMode
 from .errors import bp as errors_bp
 from .probes import bp as probes_bp
 from .routes import bp as base_routes_bp
@@ -13,17 +12,16 @@ from .serving import bp as serving_bp
 LOG_FORMAT = "%(asctime)s | %(name)s | %(levelname)s | %(message)s"
 
 
-def create_app(name, static_folder, config_class=Config):
-    config = config_class()
+def create_app(name, static_folder, config):
     logging.basicConfig(format=LOG_FORMAT, level=config.LOG_LEVEL)
     log = logging.getLogger(__name__)
 
     app = Flask(name, static_folder=static_folder)
     app.config.from_object(config)
 
-    if config_class == DevConfig:
+    if (config.ENV == BackendMode.DEVELOPMENT.value
+            or config.ENV == BackendMode.DEVELOPMENT_FULL.value):
         log.warn("RUNNING IN DEVELOPMENT MODE")
-        CORS(app)
 
     # Register all the blueprints
     app.register_blueprint(authn_bp)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/namespace.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/namespace.py
@@ -2,6 +2,6 @@ from .. import authz
 from . import v1_core
 
 
-@authz.needs_authorization("list", "", "v1", "namespaces")
+@authz.needs_authorization("list", "core", "v1", "namespaces")
 def list_namespaces():
     return v1_core.list_namespace()

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/notebook.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/notebook.py
@@ -4,6 +4,15 @@ from .. import authz
 from . import custom_api, v1_core
 
 
+def get_notebook(notebook, namespace):
+    authz.ensure_authorized(
+        "get", "kubeflow.org", "v1beta1", "notebooks", namespace
+    )
+    return custom_api.get_namespaced_custom_object(
+        "kubeflow.org", "v1beta1", namespace, "notebooks", notebook
+    )
+
+
 def create_notebook(notebook, namespace):
     authz.ensure_authorized(
         "create", "kubeflow.org", "v1beta1", "notebooks", namespace
@@ -33,6 +42,16 @@ def delete_notebook(notebook, namespace):
         "notebooks",
         notebook,
         client.V1DeleteOptions(propagation_policy="Foreground"),
+    )
+
+
+def patch_notebook(notebook, namespace, body):
+    authz.ensure_authorized(
+        "patch", "kubeflow.org", "v1beta1", "notebooks", namespace
+    )
+
+    return custom_api.patch_namespaced_custom_object(
+        "kubeflow.org", "v1beta1", namespace, "notebooks", notebook, body
     )
 
 

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/storageclass.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/storageclass.py
@@ -5,6 +5,7 @@ from . import storage_api
 # NOTE(kimwnasptd): This function is only used from the backend in order to
 # determine if a default StorageClass is set. Currently, the role aggregation
 # does not use a ClusterRoleBinding, thus we can't currently give this
-# permission to a user.
+# permission to a user. The backend does not expose any endpoint that would
+# allow an unauthorized user to list the storage classes using this function.
 def list_storageclasses():
     return storage_api.list_storage_class()

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
@@ -43,7 +43,7 @@ def check_authentication():
     want a function to not have authentication check then we can decorate it
     with the `no_authentication` decorator.
     """
-    if current_app.config.get("ENV") == config.DEV_MODE:
+    if config.dev_mode_enabled():
         log.debug("Skipping authentication check in development mode")
         return
 

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
@@ -108,7 +108,7 @@ def needs_authorization(verb, group, version, resource, namespace=None):
         @functools.wraps(func)
         def runner(*args, **kwargs):
             # Run the decorated function only if the user is authorized
-            ensure_authorized(verb, group, version, resource, namespace)
+            ensure_authorized(verb, namespace, group, version, resource)
             return func(*args, **kwargs)
 
         return runner

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/config.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/config.py
@@ -1,25 +1,32 @@
-import logging
 import os
+import enum
+import logging
 
 from flask import current_app
-
-DEV_MODE = "development"
-PROD_MODE = "production"
 
 
 log = logging.getLogger(__name__)
 
 
+class BackendMode(enum.Enum):
+    DEVELOPMENT = "dev"
+    DEVELOPMENT_FULL = "development"
+    PRODUCTION = "prod"
+    PRODUCTION_FULL = "production"
+
+
 def dev_mode_enabled():
-    return current_app.config["ENV"] == DEV_MODE
+    return (current_app.config.get("ENV") == BackendMode.DEVELOPMENT_FULL.value
+            or current_app.config.get("ENV") == BackendMode.DEVELOPMENT.value)
 
 
 class Config(object):
-    ENV = PROD_MODE
+    ENV = "generic"
     DEBUG = False
     STATIC_DIR = "./static/"
     JSONIFY_PRETTYPRINT_REGULAR = True
     LOG_LEVEL = logging.INFO
+    PREFIX = "/"
 
     def __init__(self):
         if os.environ.get("LOG_LEVEL_DEBUG", "false") == "true":
@@ -27,7 +34,7 @@ class Config(object):
 
 
 class DevConfig(Config):
-    ENV = DEV_MODE
+    ENV = BackendMode.DEVELOPMENT_FULL.value
     DEBUG = True
     LOG_LEVEL = logging.DEBUG
 
@@ -37,4 +44,4 @@ class DevConfig(Config):
 
 
 class ProdConfig(Config):
-    ENV = PROD_MODE
+    ENV = BackendMode.PRODUCTION_FULL.value

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/helpers.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/helpers.py
@@ -3,10 +3,31 @@ Common helper functions for handling k8s objects information
 """
 import datetime as dt
 import logging
+import os
+import re
 
 import yaml
+from flask import current_app
 
 log = logging.getLogger(__name__)
+
+
+def get_prefixed_index_html():
+    """
+    The backend should modify the <base> element of the index.html file to
+    align with the configured prefix the backend is listening
+    """
+    prefix = os.path.join("/", current_app.config["PREFIX"], "")
+    static_dir = current_app.config["STATIC_DIR"]
+
+    log.info("Setting the <base> to reflect the prefix: %s", prefix)
+    with open(os.path.join(static_dir, "index.html"), "r") as f:
+        index_html = f.read()
+        index_prefixed = re.sub(
+            r"\<base href=\".*\"\>", '<base href="%s">' % prefix, index_html,
+        )
+
+        return index_prefixed
 
 
 def load_yaml(f):
@@ -112,7 +133,6 @@ def get_age(k8s_object):
     (uptime).
     """
     return {
-        "uptime": get_uptime(
-            k8s_object["metadata"]["creationTimestamp"]),
+        "uptime": get_uptime(k8s_object["metadata"]["creationTimestamp"]),
         "timestamp": k8s_object["metadata"]["creationTimestamp"],
     }

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/rok/routes.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/rok/routes.py
@@ -10,4 +10,5 @@ def get_rok_storageclasses():
     """
     Return a list of k8s storage classes that are provided from Rok
     """
+    # TODO(kimwnasptd): Should use annotations on storage classes instead
     return api.success_response("storageClasses", ["rok"])

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/serving.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/serving.py
@@ -1,6 +1,8 @@
 import logging
 
-from flask import Blueprint, current_app, send_from_directory
+from flask import Blueprint, Response, request
+
+from . import helpers
 
 bp = Blueprint("serving", __name__)
 log = logging.getLogger(__name__)
@@ -14,14 +16,16 @@ log = logging.getLogger(__name__)
 # cache them for as long as possible
 
 
-@bp.route("/")
 @bp.route("/index.html")
-@bp.route("/<path:path>")
-def serve_index(path="/"):
+@bp.route("/")
+@bp.route("/new")
+@bp.route("/form")
+def serve_index():
     # Serve the index file in all other cases
-    static_dir = current_app.config["STATIC_DIR"]
-    log.info("Serving root file index.html for path %s", path)
+    log.info("Serving index.html for path: %s", request.path)
 
-    resp = send_from_directory(static_dir, "index.html")
-    resp.headers["Cache-Control"] = "public, no-cache"
-    return resp
+    return Response(
+        helpers.get_prefixed_index_html(),
+        mimetype="text/html",
+        headers={"Cache-Control": "public, no-cache"},
+    )

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/status.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/status.py
@@ -11,6 +11,7 @@ class STATUS_PHASE:
     UNINITIALIZED = "uninitialized"
     UNAVAILABLE = "unavailable"
     TERMINATING = "terminating"
+    STOPPED = "stopped"
 
 
 def create_status(phase="", message="", state=""):

--- a/components/crud-web-apps/jupyter/.gitignore
+++ b/components/crud-web-apps/jupyter/.gitignore
@@ -1,0 +1,3 @@
+**/__pycache__/
+**/.vscode/
+**/static/*

--- a/components/crud-web-apps/jupyter/backend/Makefile
+++ b/components/crud-web-apps/jupyter/backend/Makefile
@@ -1,0 +1,29 @@
+SHELL=bash
+
+install-deps:
+	pushd ../../../py && \
+	pip install -e . && \
+	popd
+	pip install -r requirements.txt
+
+run:
+	APP_PREFIX=/jupyter \
+	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+
+run-rok:
+	UI_FLAVOR=rok \
+	APP_PREFIX=/jupyter \
+	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+
+run-dev:
+	UI_FLAVOR=default \
+	BACKEND_MODE=dev \
+	APP_PREFIX=/ \
+	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+
+run-dev-rok:
+	UI_FLAVOR=rok \
+	BACKEND_MODE=dev \
+	ROK_URL=http://10.10.10.10:8080/rok \
+	APP_PREFIX=/ \
+	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app

--- a/components/crud-web-apps/jupyter/backend/apps/common/__init__.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/__init__.py
@@ -1,0 +1,18 @@
+import kubeflow.kubeflow.flask_rest_backend as base
+from kubeflow.kubeflow.flask_rest_backend import config, logging
+
+from .routes import bp as routes_bp
+
+log = logging.getLogger(__name__)
+
+
+def create_app(name=__name__, static_folder="static",
+               cfg: config.Config = None):
+    cfg = config.Config() if cfg is None else cfg
+
+    app = base.create_app(name, static_folder, cfg)
+
+    # Register the app's blueprints
+    app.register_blueprint(routes_bp)
+
+    return app

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -151,6 +151,54 @@ def set_notebook_memory(notebook, body, defaults):
     container["resources"]["requests"]["memory"] = memory
 
 
+def set_notebook_tolerations(notebook, body, defaults):
+    tolerations_group_key = get_form_value(body, defaults, "tolerationGroup")
+
+    if tolerations_group_key == "none":
+        return
+
+    notebook_tolerations = notebook["spec"]["template"]["spec"]["tolerations"]
+    config = utils.load_spawner_ui_config()
+    toleration_groups = config.get("tolerationGroup", {}).get("options", [])
+
+    for group in toleration_groups:
+        if group["groupKey"] != tolerations_group_key:
+            continue
+
+        log.info("Appending Notebook tolerations: %s", group["tolerations"])
+        notebook_tolerations.extend(group["tolerations"])
+        return
+
+    log.warning(
+        "Didn't find any Toleration Group with key '%s' in the config",
+        tolerations_group_key,
+    )
+
+
+def set_notebook_affinity(notebook, body, defaults):
+    affinity_config_key = get_form_value(body, defaults, "affinityConfig")
+
+    if affinity_config_key == "none":
+        return
+
+    notebook_spec = notebook["spec"]["template"]["spec"]
+    config = utils.load_spawner_ui_config()
+    affinity_configs = config.get("affinityConfig", {}).get("options", [])
+
+    for affinity_config in affinity_configs:
+        if affinity_config["configKey"] != affinity_config_key:
+            continue
+
+        log.info("Setting Notebook affinity: %s", affinity_config["affinity"])
+        notebook_spec["affinity"] = affinity_config["affinity"]
+        return
+
+    log.warning(
+        "Didn't find any Affinity Config with key '%s' in the config",
+        affinity_config_key,
+    )
+
+
 def set_notebook_gpus(notebook, body, defaults):
     gpus = get_form_value(body, defaults, "gpus")
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -1,0 +1,227 @@
+import json
+
+from werkzeug.exceptions import BadRequest
+
+from kubeflow.kubeflow.flask_rest_backend import logging
+
+from . import utils
+
+log = logging.getLogger(__name__)
+
+
+def get_form_value(body, defaults, body_field, defaults_field=None):
+    """
+    Get the value to set by respecting the readOnly configuration for
+    the field.
+    If the field does not exist in the configuration then just use the form
+    value.
+    """
+    if defaults_field is None:
+        defaults_field = body_field
+
+    user_value = body.get(body_field, None)
+    if defaults_field not in defaults:
+        return user_value
+
+    readonly = defaults[defaults_field].get("readOnly", False)
+    default_value = defaults[defaults_field]["value"]
+
+    if readonly:
+        if body_field in body:
+            raise BadRequest(
+                "'%s' is readonly but a value was provided: %s"
+                % (body_field, user_value),
+            )
+
+        log.info("Using default value for '%s': %s", body_field, default_value)
+        return default_value
+
+    # field is not readonly
+    if user_value is None:
+        raise BadRequest("No value provided for: %s" % body_field)
+
+    log.info("Using provided value for '%s': %s", body_field, user_value)
+    return user_value
+
+
+# Volume handling functions
+def is_config_volume(vol):
+    if "name" not in vol:
+        return False
+
+    if not isinstance(vol["name"], dict):
+        return False
+
+    return True
+
+
+def volume_from_config(config_vol, notebook):
+    """
+    Create a Volume Dict from the config.yaml. This dict has the same fields as
+    a Volume returned from the frontend
+    """
+    vol_name = config_vol["name"]["value"].replace(
+        "{notebook-name}", notebook["name"]
+    )
+    vol_class = utils.get_storage_class(config_vol["class"]["value"])
+
+    return {
+        "name": vol_name,
+        "type": config_vol["type"]["value"],
+        "size": config_vol["size"]["value"],
+        "mode": config_vol["accessModes"]["value"],
+        "path": config_vol["mountPath"]["value"],
+        "class": vol_class,
+        "extraFields": config_vol.get("extra", {}),
+    }
+
+
+def get_workspace_vol(body, defaults):
+    """
+    Checks the config and the form values and returns a Volume Dict for the
+    workspace.
+    """
+    if body.get("noWorkspace", False):
+        log.info("Requested to NOT use persistent storage for home dir")
+        return {}
+
+    workspace_vol = get_form_value(
+        body, defaults, "workspace", "workspaceVolume"
+    )
+
+    # check if it is a value from the config
+    if is_config_volume(workspace_vol):
+        workspace_vol = volume_from_config(workspace_vol, body)
+
+    return workspace_vol
+
+
+def get_data_vols(body, defaults):
+    """
+    Checks the config and the form values and returns a list of Volume
+    Dictionaries for the Notebook's Data Volumes.
+    """
+    vols = get_form_value(body, defaults, "datavols", "dataVolumes")
+    data_vols = []
+
+    for vol in vols:
+        if is_config_volume(vol):
+            vol = volume_from_config(vol, body)
+
+        data_vols.append(vol)
+
+    return data_vols
+
+
+# Notebook YAML processing
+def set_notebook_image(notebook, body, defaults):
+    """
+    If the image is set to readOnly, use only the value from the config
+    """
+    image_body_field = "image"
+    is_custom_image = body.get("customImage", False)
+    if is_custom_image:
+        image_body_field = "customImage"
+
+    image = get_form_value(body, defaults, image_body_field, "image")
+    notebook["spec"]["template"]["spec"]["containers"][0]["image"] = image
+
+
+def set_notebook_image_pull_policy(notebook, body, defaults):
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+
+    container["imagePullPolicy"] = get_form_value(
+        body, defaults, "imagePullPolicy"
+    )
+
+
+def set_notebook_cpu(notebook, body, defaults):
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+
+    cpu = get_form_value(body, defaults, "cpu")
+
+    container["resources"]["requests"]["cpu"] = cpu
+
+
+def set_notebook_memory(notebook, body, defaults):
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+
+    memory = get_form_value(body, defaults, "memory")
+
+    container["resources"]["requests"]["memory"] = memory
+
+
+def set_notebook_gpus(notebook, body, defaults):
+    gpus = get_form_value(body, defaults, "gpus")
+
+    # Make sure the GPUs value is properly formatted
+    if "num" not in gpus:
+        raise BadRequest("'gpus' must have a 'num' field")
+
+    if gpus["num"] == "none":
+        return
+
+    if "vendor" not in gpus:
+        raise BadRequest("'gpus' must have a 'vendor' field")
+
+    # set the gpus annotation
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+    vendor = gpus["vendor"]
+    try:
+        num = int(gpus["num"])
+    except ValueError:
+        raise BadRequest("gpus.num is not a valid number: %s" % gpus["num"])
+
+    limits = container["resources"].get("limits", {})
+    limits[vendor] = num
+
+    container["resources"]["limits"] = limits
+
+
+def set_notebook_configurations(notebook, body, defaults):
+    notebook_labels = notebook["metadata"]["labels"]
+    labels = get_form_value(body, defaults, "configurations")
+
+    if not isinstance(labels, list):
+        raise BadRequest("Labels for PodDefaults are not list: %s" % labels)
+
+    for label in labels:
+        notebook_labels[label] = "true"
+
+
+def set_notebook_shm(notebook, body, defaults):
+    shm = get_form_value(body, defaults, "shm")
+    if not shm:
+        return
+
+    notebook_spec = notebook["spec"]["template"]["spec"]
+    notebook_cont = notebook["spec"]["template"]["spec"]["containers"][0]
+
+    shm_volume = {"name": "dshm", "emptyDir": {"medium": "Memory"}}
+    notebook_spec["volumes"].append(shm_volume)
+
+    shm_mnt = {"mountPath": "/dev/shm", "name": "dshm"}
+    notebook_cont["volumeMounts"].append(shm_mnt)
+
+
+def set_notebook_environment(notebook, body, defaults):
+    env = get_form_value(body, defaults, "environment")
+
+    # FIXME: Validate the environment?
+    env = json.loads(env) if env else {}
+
+    env = [{"name": name, "value": str(value)} for name, value in env.items()]
+    notebook["spec"]["template"]["spec"]["containers"][0]["env"] += env
+
+
+# Volume add functions
+def add_notebook_volume(notebook, vol_name, claim, mnt_path):
+    spec = notebook["spec"]["template"]["spec"]
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+
+    volume = {"name": vol_name, "persistentVolumeClaim": {"claimName": claim}}
+    spec["volumes"].append(volume)
+
+    # Container Mounts
+    mnt = {"mountPath": mnt_path, "name": vol_name}
+    container["volumeMounts"].append(mnt)

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/__init__.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("base_routes", __name__)
+
+from . import get, delete, patch  # noqa: F401

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/delete.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/delete.py
@@ -1,0 +1,17 @@
+from kubeflow.kubeflow.flask_rest_backend import api, logging
+
+from . import bp
+
+log = logging.getLogger(__name__)
+
+
+@bp.route(
+    "/api/namespaces/<namespace>/notebooks/<notebook>", methods=["DELETE"]
+)
+def delete_notebook(notebook, namespace):
+    log.info(f"Deleting Notebook '{namespace}/{notebook}'")
+    api.delete_notebook(notebook, namespace)
+
+    return api.success_response(
+        "message", f"Notebook {notebook} successfully deleted."
+    )

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -1,0 +1,47 @@
+from kubeflow.kubeflow.flask_rest_backend import api, logging
+
+from .. import utils
+from . import bp
+
+log = logging.getLogger(__name__)
+
+
+@bp.route("/api/config")
+def get_config():
+    config = utils.load_spawner_ui_config()
+    return api.success_response("config", config)
+
+
+@bp.route("/api/namespaces/<namespace>/pvcs")
+def get_pvcs(namespace):
+    pvcs = api.list_pvcs(namespace).items
+    contents = [utils.pvc_dict_from_k8s_obj(pvc) for pvc in pvcs]
+
+    return api.success_response("pvcs", contents)
+
+
+@bp.route("/api/namespaces/<namespace>/poddefaults")
+def get_poddefaults(namespace):
+    pod_defaults = api.list_poddefaults(namespace)
+
+    # Return a list of (label, desc) with the pod defaults
+    contents = []
+    for pd in pod_defaults["items"]:
+        label = list(pd["spec"]["selector"]["matchLabels"].keys())[0]
+        if "desc" in pd["spec"]:
+            desc = pd["spec"]["desc"]
+        else:
+            desc = pd["metadata"]["name"]
+
+        contents.append({"label": label, "desc": desc})
+
+    log.info("Found poddefaults: %s", contents)
+    return api.success_response("poddefaults", contents)
+
+
+@bp.route("/api/namespaces/<namespace>/notebooks")
+def get_notebooks(namespace):
+    notebooks = api.list_notebooks(namespace)["items"]
+    contents = [utils.notebook_dict_from_k8s_obj(nb) for nb in notebooks]
+
+    return api.success_response("notebooks", contents)

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/patch.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/patch.py
@@ -1,0 +1,80 @@
+import datetime as dt
+
+from flask import request
+from werkzeug import exceptions
+
+from kubeflow.kubeflow.flask_rest_backend import api, decorators, logging
+
+from .. import status
+from . import bp
+
+log = logging.getLogger(__name__)
+
+STOP_ATTR = "stopped"
+ATTRIBUTES = set([STOP_ATTR])
+
+
+# Routes
+@bp.route(
+    "/api/namespaces/<namespace>/notebooks/<notebook>", methods=["PATCH"]
+)
+@decorators.request_is_json_type
+def patch_notebook(namespace, notebook):
+    request_body = request.get_json()
+    log.info("Got body: %s", request_body)
+
+    if request_body is None:
+        raise exceptions.BadRequest("Request doesn't have a body.")
+
+    # Ensure request has at least one valid command
+    if not any(attr in ATTRIBUTES for attr in request_body.keys()):
+        raise exceptions.BadRequest(
+            "Request body must include at least one supported key: %s"
+            % list(ATTRIBUTES)
+        )
+
+    # start/stop a notebook
+    if STOP_ATTR in request_body:
+        start_stop_notebook(namespace, notebook, request_body)
+
+    return api.success_response()
+
+
+# helper functions
+def start_stop_notebook(namespace, notebook, request_body):
+    stop = request_body[STOP_ATTR]
+
+    patch_body = {}
+    if stop:
+        if notebook_is_stopped(namespace, notebook):
+            raise exceptions.Conflict(
+                "Notebook %s/%s is already stopped." % (namespace, notebook)
+            )
+
+        log.info("Stopping Notebook Server '%s/%s'", namespace, notebook)
+        now = dt.datetime.now(dt.timezone.utc)
+        timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        patch_body = {
+            "metadata": {"annotations": {status.STOP_ANNOTATION: timestamp}}
+        }
+    else:
+        log.info("Starting Notebook Server '%s/%s'", namespace, notebook)
+        patch_body = {
+            "metadata": {"annotations": {status.STOP_ANNOTATION: None}}
+        }
+
+    log.info(
+        "Sending PATCH to Notebook %s/%s: %s", namespace, notebook, patch_body
+    )
+    api.patch_notebook(notebook, namespace, patch_body)
+
+
+def notebook_is_stopped(namespace, notebook):
+    log.info(
+        "Checking if Notebook %s/%s is already stopped", namespace, notebook,
+    )
+    notebook = api.get_notebook(notebook, namespace)
+    annotations = notebook.get("metadata", {}).get("annotations", {})
+
+    return status.STOP_ANNOTATION in annotations

--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -1,0 +1,99 @@
+import datetime as dt
+
+from kubeflow.kubeflow.flask_rest_backend import api, status
+
+EVENT_TYPE_WARNING = "Warning"
+STOP_ANNOTATION = "kubeflow-resource-stopped"
+
+
+def process_status(notebook):
+    """
+    Return status and reason. Status may be [running|waiting|warning|error]
+    """
+    # Check if the Notebook is stopped
+    readyReplicas = notebook.get("status", {}).get("readyReplicas", 0)
+    metadata = notebook.get("metadata", {})
+    annotations = metadata.get("annotations", {})
+
+    if STOP_ANNOTATION in annotations:
+        if readyReplicas == 0:
+            return status.create_status(
+                status.STATUS_PHASE.STOPPED,
+                "No Pods are currently running for this Notebook Server.",
+            )
+        else:
+            return status.create_status(
+                status.STATUS_PHASE.TERMINATING, "Notebook Server is stopping."
+            )
+
+    # If the Notebook is being deleted, the status will be waiting
+    if "deletionTimestamp" in metadata:
+        return status.create_status(
+            status.STATUS_PHASE.TERMINATING, "Deleting Notebook Server"
+        )
+
+    # Check the status
+    state = notebook.get("status", {}).get("containerState", "")
+
+    # Use conditions on the Jupyter notebook (i.e., s) to determine overall
+    # status. If no container state is available, we try to extract information
+    # about why the notebook is not starting from the notebook's events
+    # (see find_error_event)
+    if readyReplicas == 1:
+        return status.create_status(status.STATUS_PHASE.READY, "Running")
+
+    if "waiting" in state:
+        return status.create_status(
+            status.STATUS_PHASE.WAITING, state["waiting"]["reason"]
+        )
+
+    # Provide the user with detailed information (if any) about
+    # why the notebook is not starting
+    notebook_events = get_notebook_events(notebook)
+    status_val, reason = status.STATUS_PHASE.WAITING, "Scheduling the Pod"
+    status_event, reason_event = find_error_event(notebook_events)
+    if status_event is not None:
+        status_val, reason = status_event, reason_event
+
+    return status.create_status(status_val, reason)
+
+
+def get_notebook_events(notebook):
+    name = notebook["metadata"]["name"]
+    namespace = notebook["metadata"]["namespace"]
+
+    nb_creation_time = dt.datetime.strptime(
+        notebook["metadata"]["creationTimestamp"], "%Y-%m-%dT%H:%M:%SZ"
+    )
+
+    nb_events = api.list_notebook_events(name, namespace).items
+    # User can delete and then create a nb server with the same name
+    # Make sure previous events are not taken into account
+    nb_events = filter(
+        lambda e: event_timestamp(e) >= nb_creation_time, nb_events,
+    )
+
+    return nb_events
+
+
+def find_error_event(notebook_events):
+    """
+    Returns status and reason from the latest event that surfaces the cause
+    of why the resource could not be created. For a Notebook, it can be due to:
+
+          EVENT_TYPE      EVENT_REASON      DESCRIPTION
+          Warning         FailedCreate      pods "x" is forbidden: error
+            looking up service account ... (originated in statefulset)
+          Warning         FailedScheduling  0/1 nodes are available: 1
+            Insufficient cpu (originated in pod)
+
+    """
+    for e in sorted(notebook_events, key=event_timestamp, reverse=True):
+        if e.type == EVENT_TYPE_WARNING:
+            return status.STATUS_PHASE.WAITING, e.message
+
+    return None, None
+
+
+def event_timestamp(event):
+    return event.metadata.creation_timestamp.replace(tzinfo=None)

--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -1,0 +1,99 @@
+import os
+
+from kubernetes import client
+from werkzeug import exceptions
+
+from kubeflow.kubeflow.flask_rest_backend import helpers, logging
+
+from . import status
+
+log = logging.getLogger(__name__)
+
+FILE_ABS_PATH = os.path.abspath(os.path.dirname(__file__))
+
+NOTEBOOK_TEMPLATE_YAML = os.path.join(
+    FILE_ABS_PATH, "yaml/notebook_template.yaml"
+)
+
+# The production configuration is mounted on the app's pod via a configmap
+DEV_CONFIG = os.path.join(FILE_ABS_PATH, "yaml/spawner_ui_config.yaml")
+CONFIGS = [
+    "/etc/config/spawner_ui_config.yaml",
+    DEV_CONFIG,
+]
+
+
+def load_notebook_template(**kwargs):
+    """
+    kwargs: the parameters to be replaced in the yaml
+
+    Reads the yaml for the web app's custom resource, replaces the variables
+    and returns it as a python dict.
+    """
+    return helpers.load_param_yaml(NOTEBOOK_TEMPLATE_YAML, **kwargs)
+
+
+def load_spawner_ui_config():
+    for config in CONFIGS:
+        config_dict = helpers.load_yaml(config)
+
+        if config_dict is not None:
+            return config_dict["spawnerFormDefaults"]
+
+    log.error("Couldn't find any config file.")
+    raise exceptions.NotFound("Couldn't find any config file.")
+
+
+def pvc_from_dict(vol, namespace):
+    if vol is None:
+        return None
+
+    return client.V1PersistentVolumeClaim(
+        metadata=client.V1ObjectMeta(name=vol["name"], namespace=namespace,),
+        spec=client.V1PersistentVolumeClaimSpec(
+            access_modes=[vol["mode"]],
+            storage_class_name=get_storage_class(vol),
+            resources=client.V1ResourceRequirements(
+                requests={"storage": vol["size"]}
+            ),
+        ),
+    )
+
+
+def get_storage_class(vol):
+    # handle the StorageClass
+    if "class" not in vol:
+        return None
+    if vol["class"] == "{empty}":
+        return ""
+    if vol["class"] == "{none}":
+        return None
+    else:
+        return vol["class"]
+
+
+# Functions for transforming the data from k8s api
+def pvc_dict_from_k8s_obj(pvc):
+    return {
+        "name": pvc.metadata.name,
+        "namespace": pvc.metadata.namespace,
+        "size": pvc.spec.resources.requests["storage"],
+        "mode": pvc.spec.access_modes,
+        "class": pvc.spec.storage_class_name,
+    }
+
+
+def notebook_dict_from_k8s_obj(notebook):
+    cntr = notebook["spec"]["template"]["spec"]["containers"][0]
+
+    return {
+        "name": notebook["metadata"]["name"],
+        "namespace": notebook["metadata"]["namespace"],
+        "age": helpers.get_uptime(notebook["metadata"]["creationTimestamp"]),
+        "image": cntr["image"],
+        "shortImage": cntr["image"].split("/")[-1],
+        "cpu": cntr["resources"]["requests"]["cpu"],
+        "memory": cntr["resources"]["requests"]["memory"],
+        "volumes": [v["name"] for v in cntr["volumeMounts"]],
+        "status": status.process_status(notebook),
+    }

--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -38,6 +38,7 @@ def load_spawner_ui_config():
         config_dict = helpers.load_yaml(config)
 
         if config_dict is not None:
+            log.info("Using config file: %s", config)
             return config_dict["spawnerFormDefaults"]
 
     log.error("Couldn't find any config file.")

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -1,0 +1,21 @@
+apiVersion: kubeflow.org/v1beta1
+kind: Notebook
+metadata:
+  name: {name}
+  namespace: {namespace}
+  labels:
+    app: {name}
+spec:
+  template:
+    spec:
+      serviceAccountName: {serviceAccount}
+      containers:
+        - name: {name}
+          image: ""
+          volumeMounts: []
+          env: []
+          resources:
+            requests:
+              cpu: "0.1"
+              memory: "0.1Gi"
+      volumes: []

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -19,3 +19,4 @@ spec:
               cpu: "0.1"
               memory: "0.1Gi"
       volumes: []
+      tolerations: []

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -141,6 +141,54 @@ spawnerFormDefaults:
       # Values: "" or a `limits-key` from the vendors list
       vendor: ""
     readOnly: false
+  affinityConfig:
+    # If readonly, the default value will be the only option
+    # value is a list of `configKey`s that we want to be selected by default
+    value: ""
+    # The list of available affinity configs
+    options: []
+    #options:
+    #  - configKey: "exclusive__n1-standard-2"
+    #    displayName: "Exclusive: n1-standard-2"
+    #    affinity:
+    #      # (Require) Node having label: `node_pool=notebook-n1-standard-2`
+    #      nodeAffinity:
+    #        requiredDuringSchedulingIgnoredDuringExecution:
+    #          nodeSelectorTerms:
+    #            - matchExpressions:
+    #                - key: "node_pool"
+    #                  operator: "In"
+    #                  values:
+    #                   - "notebook-n1-standard-2"
+    #      # (Require) Node WITHOUT existing Pod having label: `notebook-name`
+    #      podAntiAffinity:
+    #        requiredDuringSchedulingIgnoredDuringExecution:
+    #          - labelSelector:
+    #              matchExpressions:
+    #                - key: "notebook-name"
+    #                  operator: "Exists"
+    #            namespaces: []
+    #            topologyKey: "kubernetes.io/hostname"
+    #readOnly: false
+  tolerationGroup:
+    # The default `groupKey` from the options list
+    # If readonly, the default value will be the only option
+    value: ""
+    # The list of available tolerationGroup configs
+    options: []
+    #options:
+    #  - groupKey: "group_1"
+    #    displayName: "Group 1: description"
+    #    tolerations:
+    #      - key: "key1"
+    #        operator: "Equal"
+    #        value: "value1"
+    #        effect: "NoSchedule"
+    #      - key: "key2"
+    #        operator: "Equal"
+    #        value: "value2"
+    #        effect: "NoSchedule"
+    readOnly: false
   shm:
     value: true
     readOnly: false

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -1,0 +1,153 @@
+# Configuration file for the Jupyter UI.
+#
+# Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
+# - The 'value' key contains the default value
+# - The 'readOnly' key determines if the option will be available to users
+#
+# If the 'readOnly' key is present and set to 'true', the respective option
+# will be disabled for users and only set by the admin. Also when a
+# Notebook is POSTED to the API if a necessary field is not present then
+# the value from the config will be used.
+#
+# If the 'readOnly' key is missing (defaults to 'false'), the respective option
+# will be available for users to edit.
+#
+# Note that some values can be templated. Such values are the names of the
+# Volumes as well as their StorageClass
+spawnerFormDefaults:
+  image:
+    # The container Image for the user's Jupyter Notebook
+    # If readonly, this value must be a member of the list below
+    value: gcr.io/kubeflow-images-public/tensorflow-1.13.1-notebook-cpu:v0.5.0
+    # The list of available standard container Images
+    options:
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.6.0-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.9.0-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.10.1-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.11.0-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.12.0-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.13.1-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.13.1-notebook-gpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.0.0a-notebook-cpu:v0.5.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.0.0a-notebook-gpu:v0.5.0
+    # By default, custom container Images are allowed
+    # Uncomment the following line to only enable standard container Images
+    readOnly: false
+  imagePullPolicy:
+    # Supported values: Always, IfNotPresent, Never
+    value: IfNotPresent
+    readOnly: false
+  cpu:
+    # CPU for user's Notebook
+    value: '0.5'
+    readOnly: false
+  memory:
+    # Memory for user's Notebook
+    value: 1.0Gi
+    readOnly: false
+  environment:
+    value: {}
+    readOnly: false
+  workspaceVolume:
+    # Workspace Volume to be attached to user's Notebook
+    # Each Workspace Volume is declared with the following attributes:
+    # Type, Name, Size, MountPath and Access Mode
+    value:
+      type:
+        # The Type of the Workspace Volume
+        # Supported values: 'New', 'Existing'
+        value: New
+      name:
+        # The Name of the Workspace Volume
+        # Note that this is a templated value. Special values:
+        # {notebook-name}: Replaced with the name of the Notebook. The frontend
+        #                  will replace this value as the user types the name
+        value: 'workspace-{notebook-name}'
+      size:
+        # The Size of the Workspace Volume (in Gi)
+        value: '5Gi'
+      mountPath:
+        # The Path that the Workspace Volume will be mounted
+        value: /home/jovyan
+      accessModes:
+        # The Access Mode of the Workspace Volume
+        # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
+        value: ReadWriteOnce
+      class:
+        # The StrageClass the PVC will use if type is New. Special values are:
+        # {none}: default StorageClass
+        # {empty}: empty string ""
+        value: '{none}'
+    readOnly: false
+  dataVolumes:
+    # List of additional Data Volumes to be attached to the user's Notebook
+    value: []
+    # Each Data Volume is declared with the following attributes:
+    # Type, Name, Size, MountPath and Access Mode
+    #
+    # For example, a list with 2 Data Volumes:
+    # value:
+    #   - value:
+    #       type:
+    #         value: New
+    #       name:
+    #         value: '{notebook-name}-vol-1'
+    #       size:
+    #         value: '10Gi'
+    #       class:
+    #         value: standard
+    #       mountPath:
+    #         value: /home/jovyan/vol-1
+    #       accessModes:
+    #         value: ReadWriteOnce
+    #       class:
+    #         value: {none}
+    #   - value:
+    #       type:
+    #         value: New
+    #       name:
+    #         value: '{notebook-name}-vol-2'
+    #       size:
+    #         value: '10Gi'
+    #       mountPath:
+    #         value: /home/jovyan/vol-2
+    #       accessModes:
+    #         value: ReadWriteMany
+    #       class:
+    #         value: {none}
+    readOnly: false
+  gpus:
+    # Number of GPUs to be assigned to the Notebook Container
+    value:
+      # values: "none", "1", "2", "4", "8"
+      num: "none"
+      # Determines what the UI will show and send to the backend
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+        - limitsKey: "amd.com/gpu"
+          uiName: "AMD"
+      # Values: "" or a `limits-key` from the vendors list
+      vendor: ""
+    readOnly: false
+  shm:
+    value: true
+    readOnly: false
+  configurations:
+    # List of labels to be selected, these are the labels from PodDefaults
+    # value:
+    #   - add-gcp-secret
+    #   - default-editor
+    value: []
+    readOnly: false

--- a/components/crud-web-apps/jupyter/backend/apps/default/__init__.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/__init__.py
@@ -1,0 +1,27 @@
+import os
+
+from kubeflow.kubeflow.flask_rest_backend import config, logging
+
+from ..common import create_app as create_default_app
+from .routes import bp as routes_bp
+
+log = logging.getLogger(__name__)
+
+
+def create_app(name=__name__, cfg: config.Config = None):
+    cfg = config.Config() if cfg is None else cfg
+
+    # Properly set the static serving directory
+    static_dir = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "static"
+    )
+
+    app = create_default_app(name, static_dir, cfg)
+
+    log.info("Setting STATIC_DIR to: " + static_dir)
+    app.config["STATIC_DIR"] = static_dir
+
+    # Register the app's blueprints
+    app.register_blueprint(routes_bp)
+
+    return app

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/__init__.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("default_routes", __name__)
+
+from . import post  # noqa: F401

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -30,6 +30,8 @@ def post_pvc(namespace):
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)
+    form.set_notebook_tolerations(notebook, body, defaults)
+    form.set_notebook_affinity(notebook, body, defaults)
     form.set_notebook_configurations(notebook, body, defaults)
 
     # Workspace Volume

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -1,0 +1,71 @@
+from flask import request
+
+from kubeflow.kubeflow.flask_rest_backend import (api, decorators, helpers,
+                                                  logging)
+
+from ...common import form, utils
+from . import bp
+
+log = logging.getLogger(__name__)
+
+
+@bp.route("/api/namespaces/<namespace>/notebooks", methods=["POST"])
+@decorators.request_is_json_type
+@decorators.required_body_params("name")
+def post_pvc(namespace):
+    body = request.get_json()
+    log.info(f"Got body: {body}")
+
+    notebook = helpers.load_param_yaml(
+        utils.NOTEBOOK_TEMPLATE_YAML,
+        name=body["name"],
+        namespace=namespace,
+        serviceAccount="default-editor",
+    )
+
+    defaults = utils.load_spawner_ui_config()
+
+    form.set_notebook_image(notebook, body, defaults)
+    form.set_notebook_image_pull_policy(notebook, body, defaults)
+    form.set_notebook_cpu(notebook, body, defaults)
+    form.set_notebook_memory(notebook, body, defaults)
+    form.set_notebook_gpus(notebook, body, defaults)
+    form.set_notebook_configurations(notebook, body, defaults)
+
+    # Workspace Volume
+    workspace_vol = form.get_workspace_vol(body, defaults)
+    if not body.get("noWorkspace", False) and workspace_vol["type"] == "New":
+        # Create the PVC
+        ws_pvc = utils.pvc_from_dict(workspace_vol, namespace)
+
+        log.info("Creating Workspace Volume: %s", ws_pvc.to_dict())
+        api.create_pvc(ws_pvc, namespace)
+
+    if not body.get("noWorkspace", False) and workspace_vol["type"] != "None":
+        form.add_notebook_volume(
+            notebook,
+            workspace_vol["name"],
+            workspace_vol["name"],
+            "/home/jovyan",
+        )
+
+    # Add the Data Volumes
+    for vol in form.get_data_vols(body, defaults):
+        if vol["type"] == "New":
+            # Create the PVC
+            dtvol_pvc = utils.pvc_from_dict(vol, namespace)
+
+            log.info("Creating Data Volume: %s", dtvol_pvc)
+            api.create_pvc(dtvol_pvc, namespace=namespace)
+
+        form.add_notebook_volume(
+            notebook, vol["name"], vol["name"], vol["path"]
+        )
+
+    # shm
+    form.set_notebook_shm(notebook, body, defaults)
+
+    log.info("Creating Notebook: %s", notebook)
+    api.create_notebook(notebook, namespace)
+
+    return api.success_response("message", "Notebook created successfully.")

--- a/components/crud-web-apps/jupyter/backend/apps/rok/__init__.py
+++ b/components/crud-web-apps/jupyter/backend/apps/rok/__init__.py
@@ -1,0 +1,28 @@
+import os
+
+from kubeflow.kubeflow.flask_rest_backend import config, logging, rok
+
+from ..common import create_app as create_default_app
+from .routes import bp as routes_bp
+
+log = logging.getLogger(__name__)
+
+
+def create_app(name=__name__, cfg: config.Config = None):
+    cfg = config.Config() if cfg is None else cfg
+
+    # Properly set the static serving directory
+    static_dir = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "static"
+    )
+
+    app = create_default_app(name, static_dir, cfg)
+
+    log.info("Setting STATIC_DIR to: " + static_dir)
+    app.config["STATIC_DIR"] = static_dir
+
+    # Register the app's blueprints
+    app.register_blueprint(rok.bp)
+    app.register_blueprint(routes_bp)
+
+    return app

--- a/components/crud-web-apps/jupyter/backend/apps/rok/routes/__init__.py
+++ b/components/crud-web-apps/jupyter/backend/apps/rok/routes/__init__.py
@@ -1,0 +1,5 @@
+from flask import Blueprint
+
+bp = Blueprint("rok_routes", __name__)
+
+from . import post  # noqa: F401, E402

--- a/components/crud-web-apps/jupyter/backend/apps/rok/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/rok/routes/post.py
@@ -31,6 +31,8 @@ def post_notebook(namespace):
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)
+    form.set_notebook_tolerations(notebook, body, defaults)
+    form.set_notebook_affinity(notebook, body, defaults)
     form.set_notebook_configurations(notebook, body, defaults)
     form.set_notebook_environment(notebook, body, defaults)
 

--- a/components/crud-web-apps/jupyter/backend/apps/rok/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/rok/routes/post.py
@@ -1,0 +1,85 @@
+from flask import request
+
+from kubeflow.kubeflow.flask_rest_backend import (api, decorators, helpers,
+                                                  logging)
+
+from ...common import form, utils
+from ..utils import common as rok_common
+from . import bp
+
+log = logging.getLogger(__name__)
+
+
+@bp.route("/api/namespaces/<namespace>/notebooks", methods=["POST"])
+@decorators.request_is_json_type
+@decorators.required_body_params("name")
+def post_notebook(namespace):
+    body = request.get_json()
+    log.info(f"Got body: {body}")
+
+    notebook = helpers.load_param_yaml(
+        utils.NOTEBOOK_TEMPLATE_YAML,
+        name=body["name"],
+        namespace=namespace,
+        serviceAccount="default-editor",
+    )
+
+    defaults = utils.load_spawner_ui_config()
+
+    form.set_notebook_image(notebook, body, defaults)
+    form.set_notebook_image_pull_policy(notebook, body, defaults)
+    form.set_notebook_cpu(notebook, body, defaults)
+    form.set_notebook_memory(notebook, body, defaults)
+    form.set_notebook_gpus(notebook, body, defaults)
+    form.set_notebook_configurations(notebook, body, defaults)
+    form.set_notebook_environment(notebook, body, defaults)
+
+    # Workspace Volume
+    ws_pvc = None
+    workspace_vol = form.get_workspace_vol(body, defaults)
+    if not body.get("noWorkspace", False) and workspace_vol["type"] != "None":
+        ws_pvc = rok_common.rok_pvc_from_dict(workspace_vol, namespace)
+
+        rok_common.add_workspace_volume_annotations(ws_pvc, workspace_vol)
+
+        form.add_notebook_volume(
+            notebook,
+            ws_pvc.metadata.name,
+            ws_pvc.metadata.name,
+            "/home/jovyan",
+        )
+
+    # Add the Data Volumes
+    dtvol_pvcs = []
+    for vol in form.get_data_vols(body, defaults):
+        dtvol_pvc = rok_common.rok_pvc_from_dict(vol, namespace)
+        dtvol_pvcs.append(dtvol_pvc)
+
+        rok_common.add_data_volume_annotations(dtvol_pvc, vol)
+
+        form.add_notebook_volume(
+            notebook,
+            dtvol_pvc.metadata.name,
+            dtvol_pvc.metadata.name,
+            vol["path"],
+        )
+
+    # shm
+    form.set_notebook_shm(notebook, body, defaults)
+
+    # Create the Notebook before creating the PVCs
+    log.info("Creating Notebook: %s", notebook)
+    notebook = api.create_notebook(notebook, namespace)
+
+    # Create the PVCs with owner references to the Notebook
+    if ws_pvc is not None:
+        rok_common.add_owner_reference(ws_pvc, notebook)
+        log.info("Creating Workspace Volume: %s", ws_pvc.to_dict())
+        api.create_pvc(ws_pvc, namespace)
+
+    for dtvol_pvc in dtvol_pvcs:
+        rok_common.add_owner_reference(dtvol_pvc, notebook)
+        log.info("Creating Data Volume %s:", dtvol_pvc)
+        api.create_pvc(dtvol_pvc, namespace=namespace)
+
+    return api.success_response("message", "Notebook created successfully.")

--- a/components/crud-web-apps/jupyter/backend/apps/rok/utils/common.py
+++ b/components/crud-web-apps/jupyter/backend/apps/rok/utils/common.py
@@ -1,0 +1,58 @@
+import random
+import string
+
+from kubernetes import client
+
+
+from ...common import utils
+
+
+def random_string(size=9, chars=string.ascii_lowercase + string.digits):
+    """Create a random string."""
+    return "".join(random.choice(chars) for _ in range(size))
+
+
+def rok_pvc_from_dict(vol, namespace):
+    pvc = utils.pvc_from_dict(vol, namespace)
+    pvc.metadata.name = "%s-%s" % (vol["name"], random_string())
+    return pvc
+
+
+def add_workspace_volume_annotations(pvc, vol):
+    """
+    Attach the needed annotation to the PVC k8s object
+    """
+    annotations = {"jupyter-workspace": vol["name"]}
+
+    if vol["type"] == "Existing":
+        annotations["rok/origin"] = vol["extraFields"].get("rokUrl", "")
+
+    labels = {"component": "singleuser-storage"}
+
+    pvc.metadata.annotations = annotations
+    pvc.metadata.labels = labels
+
+
+def add_data_volume_annotations(pvc, vol):
+    annotations = {"jupyter-dataset": vol["name"]}
+
+    if vol["type"] == "Existing":
+        annotations["rok/origin"] = vol["extraFields"].get("rokUrl", "")
+
+    labels = {"component": "singleuser-storage"}
+
+    pvc.metadata.annotations = annotations
+    pvc.metadata.labels = labels
+
+
+def add_owner_reference(obj, nb):
+    owner_reference = client.V1ObjectReference(
+        api_version=nb["apiVersion"],
+        kind=nb["kind"],
+        name=nb["metadata"]["name"],
+        uid=nb["metadata"]["uid"],
+    )
+
+    if not obj.metadata.owner_references:
+        obj.metadata.owner_references = []
+    obj.metadata.owner_references.append(owner_reference)

--- a/components/crud-web-apps/jupyter/backend/entrypoint.py
+++ b/components/crud-web-apps/jupyter/backend/entrypoint.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+from apps import default, rok
+from kubeflow.kubeflow.flask_rest_backend import config, logging
+
+log = logging.getLogger(__name__)
+
+
+def get_config(mode):
+    """Return a config based on the selected mode."""
+    config_classes = {
+        config.BackendMode.DEVELOPMENT.value: config.DevConfig,
+        config.BackendMode.DEVELOPMENT_FULL.value: config.DevConfig,
+        config.BackendMode.PRODUCTION.value: config.ProdConfig,
+        config.BackendMode.PRODUCTION_FULL.value: config.ProdConfig,
+    }
+    cfg_class = config_classes.get(mode)
+    if not cfg_class:
+        raise RuntimeError("Backend mode '%s' is not implemented. Choose one"
+                            " of %s" % (mode, list(config_classes.keys())))
+    return cfg_class()
+
+
+APP_NAME = os.environ.get("APP_NAME", "Jupyter Web App")
+BACKEND_MODE = os.environ.get("BACKEND_MODE",
+                              config.BackendMode.PRODUCTION.value)
+PREFIX = os.environ.get("APP_PREFIX", "/")
+
+# Check both values for determining what flavor to load
+UI_FLAVOR = os.environ.get("UI_FLAVOR", None)
+if UI_FLAVOR is None:
+    UI_FLAVOR = os.environ.get("UI", "default")
+
+cfg = get_config(BACKEND_MODE)
+cfg.PREFIX = PREFIX
+
+# Load the app based on UI_FLAVOR env var
+if UI_FLAVOR == "default":
+    app = default.create_app(APP_NAME, cfg)
+elif UI_FLAVOR == "rok":
+    app = rok.create_app(APP_NAME, cfg)
+else:
+    log.error(f"No UI flavor for '{UI_FLAVOR}'")
+    sys.exit(1)
+
+if __name__ == "__main__":
+    app.run()

--- a/components/crud-web-apps/jupyter/backend/requirements.txt
+++ b/components/crud-web-apps/jupyter/backend/requirements.txt
@@ -1,0 +1,1 @@
+gunicorn


### PR DESCRIPTION
first step for #5310 

Will move the backend under `/components/crud-web-apps/jupyter/backend`.

All the backend requests will have the following structure:
```json
{
  "some-field": "some-value",

  "status": 200,
  "success": true,
  "user": "kimwnasptd",
  "log": "this field will be present only when the success is false",
}
```

Need to append a commit for tolerations and affinity.

We (Arrikto) are deploying this jupyter web app on MiniKF and have extensively tested it. So @elikatsis @yanniszark and @StefanoFioravanzo will most probably not have something big to propose in the review.

cc @thesuperzapper