### PR TITLE
use buster-slim to build the frontend

### DIFF
--- a/components/jupyter-web-app/Dockerfile
+++ b/components/jupyter-web-app/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 0: UI Build Stage
-FROM node:10 as build-stage
+FROM node:10-buster-slim as build-stage
 
 WORKDIR /app
 


### PR DESCRIPTION
buster supports more architectures then stretch.
Since it's only used to build the juypter-web-app frontend,
also switch to slim version. The intermidate image size is
reduced from 1.2 GB to 550 MB.