### PR TITLE
Allow intra namespace traffic by default

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -389,6 +389,9 @@ func (r *ProfileReconciler) updateIstioRbac(profileIns *profilev1.Profile) error
 				{
 					Properties: map[string]string{fmt.Sprintf("request.headers[%v]", r.UserIdHeader): r.UserIdPrefix + profileIns.Spec.Owner.Name},
 				},
+				{
+					Properties: map[string]string{"source.namespace": istioServiceRole.Namespace},
+				},
 			},
 			RoleRef: &istiorbac.RoleRef{
 				Kind: "ServiceRole",


### PR DESCRIPTION
We have strict RBAC authorization enabled by default for all user traffic. This gives problems when a user deploys an app or database in their namespace. Connections will be terminated due to missing authorization (in our case a valid JWT).

We would like to make an exception for traffic in the user's own namespace, which the following property takes care of.