### PR TITLE
Fixes the leader election ID

### DIFF
--- a/components/profile-controller/main.go
+++ b/components/profile-controller/main.go
@@ -48,7 +48,7 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
+	var metricsAddr, leaderElectionNamespace string
 	var enableLeaderElection bool
 	var userIdHeader string
 	var userIdPrefix string
@@ -56,17 +56,22 @@ func main() {
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.StringVar(&leaderElectionNamespace, "leader-election-namespace", "",
+		"Determines the namespace in which the leader election configmap will be created.")
 	flag.StringVar(&userIdHeader, USERIDHEADER, "x-goog-authenticated-user-email", "Key of request header containing user id")
 	flag.StringVar(&userIdPrefix, USERIDPREFIX, "accounts.google.com:", "Request header user id common prefix")
 	flag.StringVar(&workloadIdentity, WORKLOADIDENTITY, "", "Default identity (GCP service account) for workload_identity plugin")
+
 	flag.Parse()
 
 	ctrl.SetLogger(zap.Logger(true))
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:             scheme,
-		MetricsBindAddress: metricsAddr,
-		LeaderElection:     enableLeaderElection,
+		Scheme:                  scheme,
+		MetricsBindAddress:      metricsAddr,
+		LeaderElection:          enableLeaderElection,
+		LeaderElectionNamespace: leaderElectionNamespace,
+		LeaderElectionID:        "kubeflow-profile-controller",
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
The default leader election ID is `controller-leader-election-helper` which could conflict when multiple controllers run within the same namespace. This is a required field in later versions of controller-runtime.

More details on this kubernetes-sigs/controller-runtime#446

Similar to https://github.com/kubeflow/kubeflow/pull/5374