### PR TITLE
Upgrading the `go` compiler version.

### DIFF
--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -6,7 +6,7 @@
 #
 # This is necessary because the Jupyter controller now depends on
 # components/common
-ARG GOLANG_VERSION=1.12.5
+ARG GOLANG_VERSION=1.15
 FROM golang:${GOLANG_VERSION} as builder
 
 WORKDIR /workspace

--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -2,8 +2,8 @@
 # Image URL to use all building/pushing image targets
 IMG ?= gcr.io/kubeflow-images-public/notebook-controller
 TAG ?= $(eval TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6))$(TAG)
-GOLANG_VERSION ?= 1.11.2
 SHELL := /bin/bash
+GOLANG_VERSION ?= 1.15
 
 # Whether to use cached images with GCB
 USE_IMAGE_CACHE ?= true

--- a/components/notebook-controller/README.md
+++ b/components/notebook-controller/README.md
@@ -59,7 +59,7 @@ Under the hood, the controller creates a StatefulSet to run the notebook instanc
 
 To develop on `notebook-controller`, your environment must have the following:
 
-- [go](https://golang.org/dl/) version v1.12+.
+- [go](https://golang.org/dl/) version v1.15+.
 - [docker](https://docs.docker.com/install/) version 17.03+.
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.11.3+.
 - [kustomize](https://sigs.k8s.io/kustomize/docs/INSTALL.md) v3.1.0+

--- a/components/notebook-controller/go.mod
+++ b/components/notebook-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/kubeflow/components/notebook-controller
 
-go 1.12
+go 1.15
 
 require (
 	github.com/go-logr/logr v0.1.0


### PR DESCRIPTION
The `go`  compiler `1.12` and `1.11` are no more supported.  

>Each major Go release is supported until there are two newer major releases. For example, Go 1.5 was supported until the Go 1.7 release, and Go 1.6 was supported until the Go 1.8 release. We fix critical problems, including critical security problems, in supported releases as needed by issuing minor revisions (for example, Go 1.6.1, Go 1.6.2, and so on).

https://golang.org/doc/devel/release.html

Go also guarantees backward compatibility https://golang.org/doc/go1compat
