### PR TITLE
Enabled golangci-lint.

### DIFF
--- a/components/notebook-controller/.golangci.yml
+++ b/components/notebook-controller/.golangci.yml
@@ -1,0 +1,38 @@
+issues:
+  # don't skip warning about doc comments
+  # don't exclude the default set of lint
+  exclude-use-default: false
+  # restore some of the defaults
+  # (fill in the rest as needed)
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - dupl
+    - errcheck
+    - goconst
+    - gocyclo
+    - gofmt
+    - goimports
+    - golint
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - interfacer
+    - lll
+    - maligned
+    - misspell
+    - nakedret
+    - prealloc
+    - scopelint
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+
+run:
+  deadline: 5m

--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -95,3 +95,14 @@ build-gcr: test
 push-gcr: build-gcr
 	docker push $(IMG):$(TAG)
 	@echo Pushed $(IMG):$(TAG)
+
+GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
+
+golangci-lint:
+ifeq (, $(shell which golangci-lint))
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/77e211ba75b7802fe5e40b276bca0e928553fc7f/install.sh | sh -s -- -b $(shell dirname $(GOLANGCI_LINT)) v1.29.0 ;
+endif
+
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint linter
+	$(GOLANGCI_LINT) run --new-from-rev=origin/master

--- a/components/notebook-controller/controllers/notebook_controller_bdd_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_bdd_test.go
@@ -62,10 +62,7 @@ var _ = Describe("Notebook controller", func() {
 
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, notebookLookupKey, createdNotebook)
-				if err != nil {
-					return false
-				}
-				return true
+				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			/*
 				Checking for the underlying statefulset.


### PR DESCRIPTION
- The linter will report only on new issues.
- The `.golangci.yml` is based on https://github.com/kubernetes-sigs/kubebuilder/blob/master/.golangci.yml
    - The list of linters is up for discussion.

