### PR TITLE
Remove metadata link from centraldashboard

### DIFF
--- a/components/centraldashboard/config/centraldashboard-links-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-links-config.yaml
@@ -14,10 +14,6 @@ data:
         {
           "link": "/katib/",
           "text": "Katib"
-        },
-        {
-          "link": "/metadata/",
-          "text": "Artifact Store"
         }
       ],
       "externalLinks": [],
@@ -41,11 +37,6 @@ data:
           "text": "View Katib Experiments",
           "desc": "Katib",
           "link": "/katib/"
-        },
-        {
-          "text": "View Metadata Artifacts",
-          "desc": "Artifact Store",
-          "link": "/metadata/"
         }
       ],
       "documentationItems": [


### PR DESCRIPTION
There's a discussion that metadata HTTP deployment and UI will be deprecated. Instead, KFP team will enhance inside KFP page and we don't need two UIs.

/cc @Bobgy @PatrickXYS @jlewi 

https://github.com/kubeflow/metadata/issues/250
https://github.com/kubeflow/manifests/pull/1638