### PR TITLE
Centraldashboard: Clean up OWNERS file

### DIFF
--- a/components/centraldashboard/OWNERS
+++ b/components/centraldashboard/OWNERS
@@ -1,10 +1,9 @@
 approvers:
-  - avdaredevil
   - elikatsis
   - kimwnasptd
-  - prodonjs
   - StefanoFioravanzo
-  - swiftdiaries
   - thesuperzapper
+  - yanniszark
 reviewers:
+  - avdaredevil
   - SachinVarghese


### PR DESCRIPTION
Add @yanniszark and remove @avdaredevil , @prodonjs, and @swiftdiaries from the approvers list of the OWNERS file to reflect the recent formation of the Notebooks Working Group, and the fact that Centraldashboard is part of the Notebooks WG going forward.
https://github.com/kubeflow/community/blob/master/wg-notebooks/

For reference, the above is stated in the [charter](https://github.com/kubeflow/community/blob/master/wg-notebooks/charter.md#in-scope) of the WG.