### PR TITLE
centraldashboard: redirect non-iframed apps

### DIFF
--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -4,7 +4,7 @@ import {Interval, MetricsService} from './metrics_service';
 
 export const ERRORS = {
   operation_not_supported: 'Operation not supported',
-  invalid_links_config: 'Dashboard Links ConfigMap is invalid'
+  invalid_links_config: 'Cannot load dashboard menu link'
 };
 
 export function apiError(a: {res: Response, error: string, code?: number}) {
@@ -71,10 +71,10 @@ export class Api {
         .get(
           '/dashboard-links',
           async (_: Request, res: Response) => {
-            const linksData = await this.k8sService.getDashboardLinks();
+            const cm = await this.k8sService.getConfigMap();
             let links = {};
             try {
-              links=JSON.parse(linksData.data["links"]);
+              links=JSON.parse(cm.data["links"]);
             }catch(e){
               return apiError({
                 res, code: 500,

--- a/components/centraldashboard/app/api.ts
+++ b/components/centraldashboard/app/api.ts
@@ -4,7 +4,8 @@ import {Interval, MetricsService} from './metrics_service';
 
 export const ERRORS = {
   operation_not_supported: 'Operation not supported',
-  invalid_links_config: 'Cannot load dashboard menu link'
+  invalid_links_config: 'Cannot load dashboard menu link',
+  invalid_settings: 'Cannot load dashboard settings'
 };
 
 export function apiError(a: {res: Response, error: string, code?: number}) {
@@ -82,6 +83,21 @@ export class Api {
               });
             }
             res.json(links);
+          })
+        .get(
+          '/dashboard-settings',
+          async (_: Request, res: Response) => {
+            const cm = await this.k8sService.getConfigMap();
+            let settings = {};
+            try {
+              settings=JSON.parse(cm.data["settings"]);
+            }catch(e){
+              return apiError({
+                res, code: 500,
+                error: ERRORS.invalid_settings,
+              });
+            }
+            res.json(settings);
           });
   }
 }

--- a/components/centraldashboard/app/k8s_service.ts
+++ b/components/centraldashboard/app/k8s_service.ts
@@ -1,8 +1,8 @@
 import * as k8s from '@kubernetes/client-node';
 
-/** Retrieve Dashboard links configmap Name */
+/** Retrieve Dashboard configmap Name */
 const {
-  DASHBOARD_LINKS_CONFIGMAP = "centraldashboard-links-config"
+  DASHBOARD_CONFIGMAP = "centraldashboard-config"
 } = process.env;
 
 /** Information about the Kubernetes hosting platform. */
@@ -51,7 +51,7 @@ export class KubernetesService {
   private namespace = 'kubeflow';
   private coreAPI: k8s.Core_v1Api;
   private customObjectsAPI: k8s.Custom_objectsApi;
-  private dashboardlinksConfigMap = DASHBOARD_LINKS_CONFIGMAP;
+  private dashboardConfigMap = DASHBOARD_CONFIGMAP;
 
   constructor(private kubeConfig: k8s.KubeConfig) {
     console.info('Initializing Kubernetes configuration');
@@ -77,13 +77,13 @@ export class KubernetesService {
     }
   }
 
-  /** Retrieves the configmap data of links for the central dashboard. */
-  async getDashboardLinks(): Promise<k8s.V1ConfigMap> {
+  /** Retrieves the configmap data for the central dashboard. */
+  async getConfigMap(): Promise<k8s.V1ConfigMap> {
     try {
-      const { body } = await this.coreAPI.readNamespacedConfigMap(this.dashboardlinksConfigMap,this.namespace);
+      const { body } = await this.coreAPI.readNamespacedConfigMap(this.dashboardConfigMap,this.namespace);
       return body;
     } catch (err) {
-      console.error('Unable to fetch Links ConfigMap:', err.body || err);
+      console.error('Unable to fetch ConfigMap:', err.body || err);
       return null;
     }
   }

--- a/components/centraldashboard/config/centraldashboard-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-config.yaml
@@ -79,5 +79,5 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: centraldashboard-links-config
+  name: centraldashboard-config
   namespace: kubeflow

--- a/components/centraldashboard/config/centraldashboard-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-config.yaml
@@ -1,5 +1,9 @@
 apiVersion: v1
 data:
+  settings: |-
+    {
+      DASHBOARD_FORCE_IFRAME: true
+    }
   links: |-
     {
       "menuLinks": [


### PR DESCRIPTION
**Problem statement**:

Centraldashboard provides a shared JS library that Kubeflow apps can use
to get the selected namespace. This PR extends this shared lib by allowing
apps to redirect themselves under a Centraldashboard iFrame, if they are
not iFramed. This is particularly useful when one open a KF app link in a
new tab, thus losing the `/_/` iFrame prefix and consequently not seeing
anymore the Centraldashboard sidebar.

**Solution**:

* Implement a new `dashboard-settings` API which returns the `settings`
  field of the Centraldashboard ConfigMap.
* Extend the shared lib to call the settings endpoint if the app
  is not iFramed. If `DASHBOARD_FORCE_IFRAME` in the settings is set to
  `true`, then redirect the app under the `/_/` prefix.
* An app can opt out from the global config by setting the 
  `disableForceIframe` flag in the `init` function.

/cc @kimwnasptd
/cc @elikatsis