### PR TITLE
web-apps(back): Add CSRF protection mechanisms to the backends

### DIFF
--- a/components/crud-web-apps/common/README.md
+++ b/components/crud-web-apps/common/README.md
@@ -17,6 +17,14 @@ The backend will be exposing a base backend which will be taking care of:
 * Exceptions handling
 * Common helper functions for dates, yaml file parsing etc.
 
+### Supported ENV Vars
+
+The following is a list of ENV var that can be set for any web app that is using this base app.
+This is list is incomplete, we will be adding more variables in the future.
+| ENV Var | Description |
+| - | - |
+| CSRF_SAMESITE | Controls the [SameSite value](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#SameSite) of the CSRF cookie |
+
 ### How to use
 
 In order to use this code during the development process one could use the `-e` [flag](https://pip.pypa.io/en/stable/reference/pip_install/#install-editable) with `pip install`. For example:

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/__init__.py
@@ -4,6 +4,7 @@ from flask import Flask
 
 from .authn import bp as authn_bp
 from .config import BackendMode
+from .csrf import bp as csrf_bp
 from .errors import bp as errors_bp
 from .probes import bp as probes_bp
 from .routes import bp as base_routes_bp
@@ -26,6 +27,7 @@ def create_app(name, static_folder, config):
     # Register all the blueprints
     app.register_blueprint(authn_bp)
     app.register_blueprint(errors_bp)
+    app.register_blueprint(csrf_bp)
     app.register_blueprint(probes_bp)
     app.register_blueprint(serving_bp)
     app.register_blueprint(base_routes_bp)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/csrf.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/csrf.py
@@ -1,0 +1,112 @@
+"""
+Cross Site Request Forgery Blueprint.
+
+This module provides a Flask blueprint that implements protection against
+request forgeries from other sites. Currently, it is only meant to be used with
+an AJAX frontend, not with server-side rendered forms.
+
+The module implements the following protecting measures against CSRF:
+- Double Submit Cookie.
+- Custom HTTP Headers.
+- SameSite cookie attribute.
+
+To elaborate, the `Double Submit Cookie` procedure looks like the following:
+1. Browser requests `index.html`, which contains the compiled Javascript.
+2. Backend sets the `CSRF_COOKIE` by calling `set_cookie`. If the cookie
+   already exists, `set_cookie` overrides it with a new one. The cookie
+   contains a random value.
+3. Frontend (`index.html`) is loaded and starts making requests to the backend.
+   For every request, the frontend reads the `CSRF_COOKIE` value and adds a
+   `CSRF_HEADER` with the same value.
+4. Backend checks that the value of `CSRF_COOKIE` matches the value of
+   `CSRF_HEADER`. All endpoints are checked, except the index endpoint and
+   endpoints with safe methods (GET, HEAD, OPTIONS, TRACE).
+
+Custom Headers (`CSRF_HEADER`) provide an extra layer of protection, as
+cross-origin requests cannot include custom headers (assuming CORS is not
+misconfigured) because of the Same-Origin policy.
+
+The SameSite cookie attribute provides another layer of protection, but may
+impede usability so it is configurable. This attribute controls whether a
+cookie is sent by the browser when a cross-site request is made. It defaults to
+"Strict".
+
+References:
+-  OWASP CSRF Mitigation: https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html
+"""
+
+import logging
+import os
+import secrets
+
+from flask import Blueprint, current_app, request
+from werkzeug.exceptions import Forbidden
+
+from . import config
+
+bp = Blueprint("csrf", __name__)
+log = logging.getLogger(__name__)
+
+# NOTE: We can't make these configurable until we have a way to pass settings
+# to the frontend in Kubeflow Web Apps (e.g., a `/settings` endpoint).
+CSRF_COOKIE = "XSRF-TOKEN"
+CSRF_HEADER = "X-" + CSRF_COOKIE
+SAMESITE_VALUES = ["Strict", "Lax", "None"]
+
+
+def set_cookie(resp):
+    """
+    Sets a new CSRF protection cookie to the response. The backend should call
+    this function every time it serves the index endpoint (`index.html`), in
+    order to refresh the cookie.
+    - The frontend should be able to read this cookie: HttpOnly=False
+    - The cookie should only be sent with HTTPS: Secure=True
+    - The cookie should only live in the app's path and not in the entire
+      domain. Path={app.prefix}
+
+    Finally, disable caching for the endpoint that calls this function, which
+    should be the index endpoint.
+    """
+    cookie = secrets.token_urlsafe(32)
+
+    secure = True
+    if config.dev_mode_enabled():
+        log.info("Allowing the cookie to be sent through http for dev mode")
+        secure = False
+
+    samesite = os.getenv("CSRF_SAMESITE", "Strict")
+    if samesite not in SAMESITE_VALUES:
+        samesite = "Strict"
+
+    resp.set_cookie(key=CSRF_COOKIE, value=cookie, samesite=samesite,
+                    httponly=False, secure=secure,
+                    path=current_app.config["PREFIX"])
+
+    # Don't cache a response that sets a CSRF cookie
+    no_cache = "no-cache, no-store, must-revalidate, max-age=0"
+    resp.headers["Cache-Control"] = no_cache
+
+
+@bp.before_app_request
+def check_endpoint():
+    safe_methods = ["GET", "HEAD", "OPTIONS", "TRACE"]
+    if request.method in safe_methods:
+        log.info("Skipping CSRF check for safe method: %s", request.method)
+        return
+
+    log.debug("Ensuring endpoint is CSRF protected: %s", request.path)
+    if CSRF_HEADER not in request.headers:
+        raise Forbidden("Could not detect CSRF protection header %s."
+                        % CSRF_HEADER)
+
+    if CSRF_COOKIE not in request.cookies:
+        raise Forbidden("Could not find CSRF cookie %s in the request."
+                        % CSRF_COOKIE)
+
+    header_token = request.headers[CSRF_HEADER]
+    cookie_token = request.cookies[CSRF_COOKIE]
+    if header_token != cookie_token:
+        raise Forbidden("CSRF check failed. Token in cookie %s doesn't match "
+                        "token in header %s." % (CSRF_COOKIE, CSRF_HEADER))
+
+    return


### PR DESCRIPTION
closes #5461
This is the backend PR. In order to fully close the issue we also need to merge #5463 

I also added some small changes wrt:
* parsing strings. We should gradually move away from `f"strings"` 
* allow the backend to skip the Subject Access Review check in some cases

/cc @elikatsis 
/assign @kimwnasptd 