### PR TITLE
Expand the email regex to allow more TLDs

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -9,7 +9,7 @@ import {
 } from './api';
 
 // From: https://www.w3resource.com/javascript/form/email-validation.php
-const EMAIL_RGX = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/;
+const EMAIL_RGX = /^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,7})+$/;
 
 // Valid actions for handling a contributor
 type ContributorActions = 'create' | 'remove';


### PR DESCRIPTION
Fixes https://github.com/kubeflow/kubeflow/issues/5004 by allowing top level domains up to 7 characters in length