### PR TITLE
Centraldashbaord: Fix namespace navigation

### DIFF
--- a/components/centraldashboard/public/components/dashboard-view.js
+++ b/components/centraldashboard/public/components/dashboard-view.js
@@ -15,9 +15,10 @@ import './notebooks-card.js';
 import './pipelines-card.js';
 import './resource-chart.js';
 import {getGCPData} from './resources/cloud-platform-data.js';
+import utilitiesMixin from './utilities-mixin.js';
 
 
-export class DashboardView extends PolymerElement {
+export class DashboardView extends utilitiesMixin(PolymerElement) {
     static get template() {
         return html([`
             <style include="card-styles">
@@ -34,7 +35,10 @@ export class DashboardView extends PolymerElement {
         return {
             documentationItems: Array,
             quickLinks: Array,
-            namespace: String,
+            namespace: {
+                type: Object,
+                observer: '_namespaceChanged',
+            },
             platformDetails: Object,
             platformInfo: {
                 type: Object,
@@ -56,6 +60,20 @@ export class DashboardView extends PolymerElement {
             }
             this.platformDetails = getGCPData(gcpProject);
         }
+    }
+
+    /**
+     * Rewrites the links adding the namespace as a query parameter.
+     * @param {namespace} namespace
+     */
+    _namespaceChanged(namespace) {
+        this.quickLinks.map((quickLink) => {
+            quickLink.link = this.buildHref(quickLink.link, {ns: namespace});
+            return quickLink;
+        });
+        // We need to deep-copy and re-assign in order to trigger the
+        // re-rendering of the component
+        this.quickLinks = JSON.parse(JSON.stringify(this.quickLinks));
     }
 }
 

--- a/components/centraldashboard/public/components/dashboard-view.pug
+++ b/components/centraldashboard/public/components/dashboard-view.pug
@@ -20,8 +20,8 @@ div#grid
                 external-link-text='[[platformDetails.resourceChartsLinkText]]')
     .column
         notebooks-card(namespace='[[namespace]]')
-        pipelines-card(heading='Recent Pipelines', artifact-type='pipelines')
-        pipelines-card(heading='Recent Pipeline Runs', artifact-type='runs')
+        pipelines-card(heading='Recent Pipelines', artifact-type='pipelines', namespace='[[namespace]]')
+        pipelines-card(heading='Recent Pipeline Runs', artifact-type='runs', namespace='[[namespace]]')
     .column
         template(is='dom-if', if='[[platformDetails.links]]')
             paper-card#Platform-Links(class$='[[platformDetails.name]]',

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -269,6 +269,15 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         }
     }
 
+    _buildHref(href, queryParamsChange) {
+        // The "queryParams" value from "queryParamsChange" is not updated as
+        // expected in the "iframe-link", but it works in anchor element.
+        // A temporary workaround is  to use "this.queryParams" as an input
+        // instead of "queryParamsChange.base".
+        // const queryParams = queryParamsChange.base;
+        return this.buildHref(href, this.queryParams);
+    }
+
     /**
      * Builds the new iframeSrc string based on the subroute path, current
      * hash fragment, and the query string parameters other than ns.

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -17,7 +17,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
         figure.logo
             |!{logo}
         div.flex
-            a(href$='[[buildHref("/", queryParams)]]', tabindex='-1')
+            a(href$='[[_buildHref("/", queryParams.*)]]', tabindex='-1')
                 paper-item.menu-item#home
                     iron-icon(icon='home')
                     | Home
@@ -29,10 +29,10 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         | [[item.text]]
                     iron-collapse
                         template(is='dom-repeat', items='[[item.items]]')
-                            iframe-link(href$="[[buildHref(item.link, queryParams)]]")
+                            iframe-link(href$="[[_buildHref(item.link, queryParams.*)]]")
                                 paper-item.menu-item.inner-menu-item [[item.text]]
                 template(is='dom-if', if='[[!equals(item.type, "section")]]')
-                    iframe-link(href$="[[buildHref(item.link, queryParams)]]")
+                    iframe-link(href$="[[_buildHref(item.link, queryParams.*)]]")
                         paper-item.menu-item
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]
@@ -49,7 +49,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                             | [[item.text]]
             template(is='dom-if', if='[[equals(isolationMode, "multi-user")]]')
                 aside.divider
-                a(href$='[[buildHref("/manage-users", queryParams)]]', tabindex='-1')
+                a(href$='[[_buildHref("/manage-users", queryParams.*)]]', tabindex='-1')
                     paper-item.menu-item#contributors Manage Contributors
             aside.divider
             a(href='https://github.com/kubeflow/kubeflow',
@@ -86,9 +86,9 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
             section#ViewTabs(hidden$='[[hideTabs]]')
                 paper-tabs(selected='[[page]]', attr-for-selected='page')
                     paper-tab(page='dashboard', link)
-                        a.link(tabindex='-1', href$='[[buildHref("/", queryParams)]]') Dashboard
+                        a.link(tabindex='-1', href$='[[_buildHref("/", queryParams.*)]]') Dashboard
                     paper-tab(page='activity', link)
-                        a.link(tabindex='-1', href$='[[buildHref("/activity", queryParams)]]') Activity
+                        a.link(tabindex='-1', href$='[[_buildHref("/activity", queryParams.*)]]') Activity
             neon-animated-pages(selected='[[page]]', attr-for-selected='page',
                                 entry-animation='fade-in-animation',
                                 exit-animation='fade-out-animation')

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -93,7 +93,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                                 entry-animation='fade-in-animation',
                                 exit-animation='fade-out-animation')
                 neon-animatable(page='dashboard')
-                    dashboard-view(namespace='[[namespace]]',
+                    dashboard-view(namespace='[[queryParams.ns]]',
                         platform-info='[[platformInfo]]', quick-links='[[quickLinks]]', documentation-items='[[documentationItems]]')
                 neon-animatable(page='activity')
                     activity-view(namespace='[[queryParams.ns]]')

--- a/components/centraldashboard/public/components/pipelines-card.js
+++ b/components/centraldashboard/public/components/pipelines-card.js
@@ -68,13 +68,14 @@ export class PipelinesCard extends PolymerElement {
             },
             heading: String,
             artifactType: String,
+            namespace: String,
             message: {
                 type: String,
                 value: '',
             },
             listPipelinesUrl: {
                 type: String,
-                computed: '_getListPipelinesUrl(artifactType)',
+                computed: '_getListPipelinesUrl(artifactType, namespace)',
             },
             pipelines: {
                 type: Array,
@@ -86,12 +87,18 @@ export class PipelinesCard extends PolymerElement {
     /**
      * Returns the URL to list the available Pipeline artifacts
      * @param {string} artifactType
+     * @param {string} namespace
      * @return {string}
      */
-    _getListPipelinesUrl(artifactType) {
+    _getListPipelinesUrl(artifactType, namespace) {
         if (!VALID_ARTIFACT_TYPES.has(artifactType)) return null;
-        return `/pipeline/apis/v1beta1/${artifactType}?`
+        let link = `/pipeline/apis/v1beta1/${artifactType}?`
             + 'page_size=5&sort_by=created_at%20desc';
+        if (artifactType === RUNS) {
+            link += '&resource_reference_key.type=NAMESPACE'
+            + `&resource_reference_key.id=${namespace}`;
+        }
+        return link;
     }
 
     /**

--- a/components/centraldashboard/public/components/pipelines-card_test.js
+++ b/components/centraldashboard/public/components/pipelines-card_test.js
@@ -53,6 +53,7 @@ describe('Pipelines Card', () => {
                 'page_size=5&sort_by=created_at%20desc');
 
         pipelinesCard.artifactType = 'pipelines';
+        pipelinesCard.namespace = 'kubeflow-user';
         await requestPromise;
         flush();
 
@@ -62,7 +63,7 @@ describe('Pipelines Card', () => {
         const pipelineLinks = Array.from(pipelinesCard.shadowRoot
             .querySelectorAll('iframe-link').values());
         expect(pipelineLinks.length).toBe(5);
-        const hrefPrefix = '/pipeline/#/pipelines/details';
+        const hrefPrefix = '/pipeline/?ns=kubeflow-user#/pipelines/details';
         expect(pipelineLinks.map((l) => l.href)).toEqual([
             `${hrefPrefix}/10`,
             `${hrefPrefix}/9`,
@@ -112,7 +113,7 @@ describe('Pipelines Card', () => {
         const pipelineLinks = Array.from(pipelinesCard.shadowRoot
             .querySelectorAll('iframe-link').values());
         expect(pipelineLinks.length).toBe(5);
-        const hrefPrefix = '/pipeline/#/runs/details';
+        const hrefPrefix = '/pipeline/?ns=kubeflow-user#/runs/details';
         expect(pipelineLinks.map((l) => l.href)).toEqual([
             `${hrefPrefix}/10`,
             `${hrefPrefix}/9`,

--- a/components/centraldashboard/public/components/pipelines-card_test.js
+++ b/components/centraldashboard/public/components/pipelines-card_test.js
@@ -97,9 +97,12 @@ describe('Pipelines Card', () => {
             status: 200,
             responseText: JSON.stringify({runs}),
         }, false, '/pipeline/apis/v1beta1/runs?' +
-                'page_size=5&sort_by=created_at%20desc');
+                'page_size=5&sort_by=created_at%20desc' +
+                '&resource_reference_key.type=NAMESPACE' +
+                '&resource_reference_key.id=kubeflow-user');
 
         pipelinesCard.artifactType = 'runs';
+        pipelinesCard.namespace = 'kubeflow-user';
         await requestPromise;
         flush();
 
@@ -159,8 +162,11 @@ describe('Pipelines Card', () => {
             status: 500,
             responseText: 'Some internal error',
         }, true, '/pipeline/apis/v1beta1/runs?' +
-                'page_size=5&sort_by=created_at%20desc');
+                'page_size=5&sort_by=created_at%20desc' +
+                '&resource_reference_key.type=NAMESPACE' +
+                '&resource_reference_key.id=kubeflow-user');
         pipelinesCard.artifactType = 'runs';
+        pipelinesCard.namespace = 'kubeflow-user';
         await requestPromise;
         flush();
 


### PR DESCRIPTION
This PR improves and fixes how Centraldashabord handles namespace selection:
- Correctly track the selected namespace when it is changed in the namespace select box
- Use the tracked namespace in the homepage cards
- Call Kubeflow Pipelines API using the namespace filter

Closes #5484

/cc @kimwnasptd
/cc @StefanoFioravanzo