### PR TITLE
add rate limiting to central dashboard

### DIFF
--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -44,7 +44,13 @@ async function main() {
   const metricsService = await getMetricsService(k8sService);
   console.info(`Using Profiles service at ${profilesServiceUrl}`);
   const profilesService = new DefaultApi(profilesServiceUrl);
+  const rateLimit = require("express-rate-limit");
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100 // limit each IP to 100 requests per windowMs
+  });
 
+  app.use(limiter);
   app.use(express.json());
   app.use(express.static(frontEnd));
   app.use(attachUser(USERID_HEADER, USERID_PREFIX));

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -4891,6 +4891,11 @@
                 }
             }
         },
+        "express-rate-limit": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-5.2.3.tgz",
+            "integrity": "sha512-cjQH+oDrEPXxc569XvxhHC6QXqJiuBT6BhZ70X3bdAImcnHnTNMVuMAJaT0TXPoRiEErUrVPRcOTpZpM36VbOQ=="
+        },
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -8805,7 +8810,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -8826,12 +8832,14 @@
                         "balanced-match": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "brace-expansion": {
                             "version": "1.1.11",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "balanced-match": "^1.0.0",
                                 "concat-map": "0.0.1"
@@ -8846,17 +8854,20 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -8973,7 +8984,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -8985,6 +8997,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -8999,6 +9012,7 @@
                             "version": "3.0.4",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "brace-expansion": "^1.1.7"
                             }
@@ -9006,12 +9020,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -9030,6 +9046,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -9110,7 +9127,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -9122,6 +9140,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -9207,7 +9226,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -9243,6 +9263,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -9262,6 +9283,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -9305,12 +9327,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },
@@ -14091,7 +14115,8 @@
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "aproba": {
                             "version": "1.2.0",
@@ -14134,7 +14159,8 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "concat-map": {
                             "version": "0.0.1",
@@ -14145,7 +14171,8 @@
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
@@ -14262,7 +14289,8 @@
                         "inherits": {
                             "version": "2.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "ini": {
                             "version": "1.3.5",
@@ -14274,6 +14302,7 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "number-is-nan": "^1.0.0"
                             }
@@ -14296,12 +14325,14 @@
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "minipass": {
                             "version": "2.3.5",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "safe-buffer": "^5.1.2",
                                 "yallist": "^3.0.0"
@@ -14320,6 +14351,7 @@
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -14400,7 +14432,8 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "object-assign": {
                             "version": "4.1.1",
@@ -14412,6 +14445,7 @@
                             "version": "1.4.0",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "wrappy": "1"
                             }
@@ -14497,7 +14531,8 @@
                         "safe-buffer": {
                             "version": "5.1.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "safer-buffer": {
                             "version": "2.1.2",
@@ -14533,6 +14568,7 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "code-point-at": "^1.0.0",
                                 "is-fullwidth-code-point": "^1.0.0",
@@ -14552,6 +14588,7 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
+                            "optional": true,
                             "requires": {
                                 "ansi-regex": "^2.0.0"
                             }
@@ -14595,12 +14632,14 @@
                         "wrappy": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         },
                         "yallist": {
                             "version": "3.0.3",
                             "bundled": true,
-                            "dev": true
+                            "dev": true,
+                            "optional": true
                         }
                     }
                 },

--- a/components/centraldashboard/package.json
+++ b/components/centraldashboard/package.json
@@ -70,6 +70,7 @@
         "chart.js": "^2.8.0",
         "chartjs-plugin-crosshair": "^1.1.4",
         "express": "^4.17.1",
+        "express-rate-limit": "^5.2.3",
         "node-fetch": "^2.6.0",
         "web-animations-js": "^2.3.2"
     },


### PR DESCRIPTION
closes: https://github.com/kubeflow/kubeflow/issues/5527
At the moment the central dashboard does not employ rate limiting. This PR adds rate limiting using express-rate-limit. Currently, rate limiting is enforced to 100 requests per 15 minutes per windowMs for each IP for all requests.
https://www.npmjs.com/package/express-rate-limit
