### PR TITLE
Use node:12 as specified in the docs

### DIFF
--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -7,7 +7,7 @@ COPY ./common/backend/ .
 RUN python3 setup.py bdist_wheel
 
 # --- Build the frontend kubeflow library ---
-FROM node:10 as frontend-kubeflow-lib
+FROM node:12 as frontend-kubeflow-lib
 
 WORKDIR /src
 
@@ -18,7 +18,7 @@ COPY ./common/frontend/kubeflow-common-lib/ .
 RUN npm run build
 
 # --- Build the frontend ---
-FROM node:10 as frontend
+FROM node:12 as frontend
 
 WORKDIR /src
 COPY ./jupyter/frontend/package*.json ./

--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -7,7 +7,7 @@ COPY ./common/backend/ .
 RUN python3 setup.py bdist_wheel
 
 # --- Build the frontend kubeflow library ---
-FROM node:12 as frontend-kubeflow-lib
+FROM node:12-buster-slim as frontend-kubeflow-lib
 
 WORKDIR /src
 
@@ -18,7 +18,7 @@ COPY ./common/frontend/kubeflow-common-lib/ .
 RUN npm run build
 
 # --- Build the frontend ---
-FROM node:12 as frontend
+FROM node:12-buster-slim as frontend
 
 WORKDIR /src
 COPY ./jupyter/frontend/package*.json ./

--- a/components/crud-web-apps/tensorboards/Dockerfile
+++ b/components/crud-web-apps/tensorboards/Dockerfile
@@ -7,7 +7,7 @@ COPY ./common/backend/ .
 RUN python3 setup.py bdist_wheel
 
 # --- Build the frontend kubeflow library ---
-FROM node:12 as frontend-kubeflow-lib
+FROM node:12-buster-slim as frontend-kubeflow-lib
 
 WORKDIR /src
 
@@ -18,7 +18,7 @@ COPY ./common/frontend/kubeflow-common-lib/ .
 RUN npm run build
 
 # --- Build the frontend ---
-FROM node:12 as frontend
+FROM node:12-buster-slim as frontend
 RUN npm install -g @angular/cli
 
 WORKDIR /src

--- a/components/crud-web-apps/tensorboards/Dockerfile
+++ b/components/crud-web-apps/tensorboards/Dockerfile
@@ -7,7 +7,7 @@ COPY ./common/backend/ .
 RUN python3 setup.py bdist_wheel
 
 # --- Build the frontend kubeflow library ---
-FROM node:10 as frontend-kubeflow-lib
+FROM node:12 as frontend-kubeflow-lib
 
 WORKDIR /src
 
@@ -18,7 +18,7 @@ COPY ./common/frontend/kubeflow-common-lib/ .
 RUN npm run build
 
 # --- Build the frontend ---
-FROM node:10 as frontend
+FROM node:12 as frontend
 RUN npm install -g @angular/cli
 
 WORKDIR /src


### PR DESCRIPTION
The docs specify that the crud-web-apps use node 12 in multiple places. However, the Dockerfiles use node 10 for the build. This PR updates the Dockerfiles to use node 12