### PR TITLE
twa(front): Fix the type issue with table config

### DIFF
--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
@@ -6,9 +6,10 @@ import {
   ActionButtonValue,
   TableColumn,
   TRUNCATE_TEXT_SIZE,
+  TableConfig,
 } from 'kubeflow';
 
-const tableConfig = {
+const tableConfig: TableConfig = {
   title: 'Tensorboards',
   newButtonText: 'NEW TENSORBOARD',
   columns: [


### PR DESCRIPTION
closes #5529 

This PR a sibling of #5528. The Tensorboards web app's frontend will also need this type definition in order to build.

/cc @DavidSpek 
/cc @kandrio 
/assign @kimwnasptd 