### PR TITLE
cluster admin support multiple user split by comma

### DIFF
--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -11,6 +11,7 @@
 package kfam
 
 import (
+	"strings"
 	"encoding/json"
 	log "github.com/sirupsen/logrus"
 	istioRegister "github.com/kubeflow/kubeflow/components/access-management/pkg/apis/istiorbac/v1alpha1"
@@ -72,7 +73,7 @@ func NewKfamClient(userIdHeader string, userIdPrefix string, clusterAdmin string
 			restClient: 	istioRESTClient,
 			kubeClient: 	kubeClient,
 		},
-		clusterAdmin: []string{clusterAdmin},
+		clusterAdmin: strings.Split(clusterAdmin, ","),
 		userIdHeader: userIdHeader,
 		userIdPrefix: userIdPrefix,
 	}, nil


### PR DESCRIPTION
now kfam can only accept a single cluster admin in command line
we should support pass multiple cluster admins  into kfam ,and then we can update profiles-profiles-config after kubeflow is deployed 