### PR TITLE
Move JWA python images to slim-buster

### DIFF
--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build the backend kubeflow-wheel ---
-FROM python:3.7 AS backend-kubeflow-wheel
+FROM python:3.7-slim-buster AS backend-kubeflow-wheel
 
 WORKDIR /src
 
@@ -31,7 +31,7 @@ RUN npm run build -- --output-path=./dist/default --configuration=production
 RUN npm run build -- --output-path=./dist/rok --configuration=rok-prod
 
 # Web App
-FROM python:3.7
+FROM python:3.7-slim-buster
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .

--- a/components/crud-web-apps/tensorboards/Dockerfile
+++ b/components/crud-web-apps/tensorboards/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build the backend kubeflow-wheel ---
-FROM python:3.8 AS backend-kubeflow-wheel
+FROM python:3.8-slim-buster AS backend-kubeflow-wheel
 
 WORKDIR /src
 
@@ -32,7 +32,7 @@ COPY ./tensorboards/frontend/ .
 RUN npm run build -- --output-path=./dist --configuration=production
 
 # Web App
-FROM python:3.8
+FROM python:3.8-slim-buster
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .


### PR DESCRIPTION
Closes: https://github.com/kubeflow/kubeflow/issues/5552

Reduced the image size of the JWA from 928 MB to 163 MB. Similarly, the TWA image is now 162 MB.