### PR TITLE
web-apps(front): Make the library tests run in CI

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -6,6 +6,7 @@
     "start": "ng serve",
     "build": "ng build && npm run copyCSS && npm run copyAssets",
     "test": "ng test",
+    "test-ci": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "copyCSS": "cp ./projects/kubeflow/src/kubeflow.css ./dist/kubeflow && cp ./projects/kubeflow/src/styles.scss ./dist/kubeflow",

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/karma.conf.js
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/karma.conf.js
@@ -26,6 +26,12 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['Chrome'],
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox'],
+      },
+    },
     singleRun: false,
     restartOnFileChange: true,
   });


### PR DESCRIPTION
A first stop for adding a presubmit #5482 job for running unit tests in the common front end code.

The presubmit tests will run inside a container, as an Argo task/step. In order to run the tests inside a container, without any interactions, we will need to make the following changes:
1. Run a headless version of Chrome, to run the tests
2. Don't run the testing process, `ng test`, in watch mode. By default watch mode is on, in order for the process to track changes and run the tests while code is modified.

With the above changes we can run the tests of the common frontend code by navigating to the frontent code, where the `package.json` lives, and running:
```bash
docker run --rm -t \
  -v $(pwd):/mnt/project \
  --user 1000:1000 \
  --workdir /mnt/project \
  -e NG_CLI_ANALYTICS='false' \
  node:12.20.1-stretch-slim \
  npm ci && npm run test-ci
```

/cc @StefanoFioravanzo 
/cc @elikatsis 
/assign @kimwnasptd 