### PR TITLE
web-apps: Fixes to the common code

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
@@ -2,6 +2,17 @@ from .. import authz
 from . import v1_core
 
 
-def list_pods(namespace):
-    authz.ensure_authorized("list", "", "v1", "pods", namespace)
+def list_pods(namespace, auth=True):
+    if auth:
+        authz.ensure_authorized("list", "", "v1", "pods", namespace)
+
     return v1_core.list_namespaced_pod(namespace)
+
+
+def get_pod_logs(namespace, pod, container, auth=True):
+    if auth:
+        authz.ensure_authorized("read", "", "v1", "pods", namespace, "logs")
+
+    return v1_core.read_namespaced_pod_log(
+        namespace=namespace, name=pod, container=container
+    )

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/routes/get.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/routes/get.py
@@ -39,9 +39,9 @@ def get_default_storageclass():
         ]
 
         for key in keys:
-            is_default = annotations.get(key, False)
+            default_sc_annotation = annotations.get(key, "false")
 
-            if is_default:
+            if default_sc_annotation == "true":
                 return api.success_response(
                     "defaultStorageClass", sc.metadata.name
                 )

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "copyCSS": "cp ./projects/kubeflow/src/kubeflow.css ./dist/kubeflow && cp ./projects/kubeflow/src/styles.scss ./dist/kubeflow",
+    "copyCSS": "cp ./projects/kubeflow/src/kubeflow.css ./dist/kubeflow && cp ./projects/kubeflow/src/styles.scss ./dist/kubeflow && cp ./projects/kubeflow/src/lib/variables.scss ./dist/kubeflow/lib",
     "copyAssets": "cp -r ./projects/kubeflow/src/assets ./dist/kubeflow/assets"
   },
   "private": true,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list-item/details-list-item.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list-item/details-list-item.component.scss
@@ -39,7 +39,6 @@
 }
 
 .vertical-align {
-  margin-top: auto;
   margin-bottom: auto;
 }
 

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
@@ -24,6 +24,7 @@ import { PositiveNumberInputComponent } from './positive-number-input/positive-n
 import { RokUrlInputComponent } from './rok-url-input/rok-url-input.component';
 import { AdvancedOptionsComponent } from './advanced-options/advanced-options.component';
 import { PopoverModule } from '../popover/popover.module';
+import { StepInfoComponent } from './step-info/step-info.component';
 
 @NgModule({
   declarations: [
@@ -33,6 +34,8 @@ import { PopoverModule } from '../popover/popover.module';
     PositiveNumberInputComponent,
     RokUrlInputComponent,
     AdvancedOptionsComponent,
+    SubmitBarComponent,
+    StepInfoComponent,
   ],
   imports: [
     CommonModule,
@@ -54,6 +57,7 @@ import { PopoverModule } from '../popover/popover.module';
     PositiveNumberInputComponent,
     RokUrlInputComponent,
     AdvancedOptionsComponent,
+    StepInfoComponent,
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
@@ -24,6 +24,7 @@ import { PositiveNumberInputComponent } from './positive-number-input/positive-n
 import { RokUrlInputComponent } from './rok-url-input/rok-url-input.component';
 import { AdvancedOptionsComponent } from './advanced-options/advanced-options.component';
 import { PopoverModule } from '../popover/popover.module';
+import { SubmitBarComponent } from './submit-bar/submit-bar.component';
 import { StepInfoComponent } from './step-info/step-info.component';
 
 @NgModule({
@@ -57,6 +58,7 @@ import { StepInfoComponent } from './step-info/step-info.component';
     PositiveNumberInputComponent,
     RokUrlInputComponent,
     AdvancedOptionsComponent,
+    SubmitBarComponent,
     StepInfoComponent,
     MatFormFieldModule,
     MatInputModule,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
@@ -11,6 +11,8 @@ import {
   MatProgressSpinnerModule,
   MatDialogModule,
   MatTooltipModule,
+  MatDividerModule,
+  MatIconModule,
 } from '@angular/material';
 
 import { FormSectionComponent } from './section/section.component';
@@ -38,9 +40,11 @@ import { PopoverModule } from '../popover/popover.module';
     MatCardModule,
     MatButtonModule,
     MatFormFieldModule,
+    MatDividerModule,
     MatInputModule,
     MatTooltipModule,
     IconModule,
+    MatProgressSpinnerModule,
     PopoverModule,
   ],
   exports: [
@@ -58,6 +62,8 @@ import { PopoverModule } from '../popover/popover.module';
     MatProgressSpinnerModule,
     MatDialogModule,
     MatTooltipModule,
+    MatIconModule,
+    MatDividerModule,
   ],
 })
 export class FormModule {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.html
@@ -1,0 +1,10 @@
+<div class="flex">
+  <div class="separator"></div>
+
+  <div class="lib-flex-layout-column">
+    <span class="mat-hint bold small-text">{{ header }}</span>
+    <span class="mat-hint small-text">
+      <ng-content></ng-content>
+    </span>
+  </div>
+</div>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.scss
@@ -1,0 +1,14 @@
+:host {
+  display: block;
+  margin-bottom: 8px;
+  width: 300px;
+}
+
+.separator {
+  border-left: 2px solid #edeff1;
+  margin-right: 12px;
+}
+
+.small-text {
+  font-size: 12px;
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StepInfoComponent } from './step-info.component';
+
+describe('StepInfoComponent', () => {
+  let component: StepInfoComponent;
+  let fixture: ComponentFixture<StepInfoComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ StepInfoComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StepInfoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit, Input, HostBinding } from '@angular/core';
+
+@Component({
+  selector: 'lib-step-info',
+  templateUrl: './step-info.component.html',
+  styleUrls: ['./step-info.component.scss'],
+})
+export class StepInfoComponent implements OnInit {
+  @Input() header: string;
+  @HostBinding('class.lib-step-info') selfClass = true;
+
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.html
@@ -1,0 +1,27 @@
+<mat-divider></mat-divider>
+
+<div class="flex bar">
+  <button
+    *ngIf="!isApplying"
+    mat-raised-button
+    color="primary"
+    (click)="create.emit(true)"
+    [disabled]="createDisabled"
+  >
+    CREATE
+  </button>
+
+  <button *ngIf="isApplying" mat-raised-button disabled>
+    <div class="waiting-button-wrapper">
+      <mat-spinner diameter="16"></mat-spinner>
+      <div>CREATING</div>
+    </div>
+  </button>
+
+  <button mat-raised-button (click)="cancel.emit(true)">CANCEL</button>
+
+  <div class="flex text-area" *ngIf="allowYAMLEditing">
+    <span class="link" (click)="yaml.emit(true)">Edit</span>
+    <span> and submit YAML</span>
+  </div>
+</div>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.html
@@ -21,7 +21,7 @@
   <button mat-raised-button (click)="cancel.emit(true)">CANCEL</button>
 
   <div class="flex text-area" *ngIf="allowYAMLEditing">
-    <span class="link" (click)="yaml.emit(true)">Edit</span>
+    <button class="btn-link" (click)="yaml.emit(true)">Edit</button>
     <span> and submit YAML</span>
   </div>
 </div>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.scss
@@ -1,0 +1,45 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.link {
+  color: blue;
+  text-decoration: underline;
+}
+
+.link {
+  color: blue;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.bar {
+  padding: 0.5rem 0;
+}
+
+.bar > * {
+  margin-top: auto;
+  margin-bottom: auto;
+}
+
+.bar > button:first-child {
+  margin-left: 35%;
+}
+
+.bar > button:nth-child(2) {
+  margin-left: 1rem;
+  margin-right: 1rem;
+}
+
+.text-area > * {
+  white-space: break-spaces;
+}
+
+.waiting-button-wrapper {
+  display: flex;
+}
+
+.waiting-button-wrapper .mat-spinner {
+  margin: auto 0.2rem;
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.scss
@@ -3,10 +3,16 @@
   width: 100%;
 }
 
-.link {
+.btn-link {
   color: blue;
   text-decoration: underline;
   cursor: pointer;
+  display: inline-block;
+  background-color: transparent;
+  border: 0;
+  padding: 0;
+  font-family: inherit;
+  font-size: inherit;
 }
 
 .bar {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.scss
@@ -6,11 +6,6 @@
 .link {
   color: blue;
   text-decoration: underline;
-}
-
-.link {
-  color: blue;
-  text-decoration: underline;
   cursor: pointer;
 }
 

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SubmitBarComponent } from './submit-bar.component';
+import { FormModule } from '../form.module';
+
+describe('SubmitBarComponent', () => {
+  let component: SubmitBarComponent;
+  let fixture: ComponentFixture<SubmitBarComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [FormModule],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SubmitBarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.ts
@@ -1,0 +1,19 @@
+import { Component, OnInit, Output, EventEmitter, Input } from '@angular/core';
+
+@Component({
+  selector: 'lib-submit-bar',
+  templateUrl: './submit-bar.component.html',
+  styleUrls: ['./submit-bar.component.scss'],
+})
+export class SubmitBarComponent implements OnInit {
+  @Input() createDisabled = false;
+  @Input() allowYAMLEditing = true;
+  @Input() isApplying = false;
+  @Output() create = new EventEmitter<boolean>();
+  @Output() cancel = new EventEmitter<boolean>();
+  @Output() yaml = new EventEmitter<boolean>();
+
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/kubeflow.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/kubeflow.module.ts
@@ -18,6 +18,7 @@ import { DetailsListModule } from './details-list/details-list.module';
 import { DateTimeModule } from './date-time/date-time.module';
 import { PanelModule } from './panel/panel.module';
 import { LoadingSpinnerModule } from './loading-spinner/loading-spinner.module';
+import { ConfirmDialogModule } from './confirm-dialog/confirm-dialog.module';
 
 @NgModule({
   declarations: [],
@@ -27,6 +28,7 @@ import { LoadingSpinnerModule } from './loading-spinner/loading-spinner.module';
     SnackBarModule,
     FormModule,
     PopoverModule,
+    ConfirmDialogModule,
     HttpClientModule,
     HttpClientXsrfModule,
     TitleActionsToolbarModule,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.html
@@ -1,11 +1,11 @@
-<div class="flex wide margin-top-title">
+<div class="flex">
   <div class="page-padding-left"></div>
 
   <button
     *ngIf="backButton"
     mat-icon-button
     color="primary"
-    class="margin-top-bottom-auto"
+    class="back-button"
     (click)="emitBack()"
   >
     <mat-icon>keyboard_backspace</mat-icon>
@@ -15,23 +15,44 @@
     {{ title }}
   </div>
 
-  <div class="margin-top-bottom-auto">
-    <button
-      *ngFor="let button of buttons"
-      mat-button
-      [color]="button.color"
-      [disabled]="button.disabled"
-      (click)="emitButtonClicked(button.eventName)"
-    >
-      <mat-icon *ngIf="button.icon" class="button-icon">
-        {{ button.icon }}
-      </mat-icon>
-      {{ button.text }}
-    </button>
-  </div>
-
   <div class="margin-content">
     <ng-content></ng-content>
+  </div>
+
+  <div class="toolbar-buttons">
+    <ng-container *ngFor="let button of buttons">
+      <!--raised button-->
+      <ng-container *ngIf="button.raised">
+        <button
+          mat-button
+          [color]="button.color"
+          [disabled]="button.disabled"
+          (click)="button.fn()"
+          class="toolbar-button"
+        >
+          <mat-icon *ngIf="button.icon" class="button-icon">
+            {{ button.icon }}
+          </mat-icon>
+          {{ button.text }}
+        </button>
+      </ng-container>
+
+      <!--stroked button-->
+      <ng-container *ngIf="button.stroked">
+        <button
+          mat-stroked-button
+          [color]="button.color"
+          [disabled]="button.disabled"
+          (click)="button.fn()"
+          class="toolbar-button"
+        >
+          <mat-icon *ngIf="button.icon" class="button-icon">
+            {{ button.icon }}
+          </mat-icon>
+          {{ button.text }}
+        </button>
+      </ng-container>
+    </ng-container>
   </div>
 </div>
 

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
@@ -1,5 +1,9 @@
+@import '../variables.scss';
+
 :host {
   display: block;
+  width: 100%;
+  padding-top: 8px;
 }
 
 .title {
@@ -7,12 +11,16 @@
   font-size: 20px;
 }
 
+.back-button {
+  margin: auto 0;
+}
+
 .actions-wrapper {
   margin-top: 0.22rem;
 }
 
 .title-margin {
-  margin: auto 4rem auto 0.5rem;
+  margin: auto 0;
 }
 
 .button-icon {
@@ -29,17 +37,17 @@
 }
 
 .margin-content {
-  margin: auto 1rem auto auto;
+  margin: auto;
 }
 
-.margin-top-bottom-auto {
+.toolbar-buttons {
   margin: auto 0px;
 }
 
-.flex {
-  display: flex;
+.toolbar-button {
+  margin-left: 0.2rem;
 }
 
-.margin-top-title {
-  margin-top: 8px;
+.toolbar-buttons .toolbar-button:last-child {
+  margin-right: $page-space-right;
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.ts
@@ -14,16 +14,12 @@ import { ToolbarButton } from './types';
 })
 export class TitleActionsToolbarComponent {
   @Input() buttons: ToolbarButton[] = [];
-  @Input() backButton = true;
+  @Input() backButton = false;
   @Input() title: string;
-  @Output() buttonClicked = new EventEmitter<string>();
+  @Output() back = new EventEmitter();
   @HostBinding('class.lib-title-actions-toolbar') selfClass = true;
 
-  emitButtonClicked(button: string) {
-    this.buttonClicked.emit(button);
-  }
-
   emitBack() {
-    this.buttonClicked.emit('backButton');
+    this.back.emit('backButton');
   }
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/types.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/types.ts
@@ -1,36 +1,47 @@
 export interface ToolbarButtonConfig {
   icon?: string;
   text: string;
-  eventName: string;
   disabled?: boolean;
   color?: string;
+  raised?: boolean;
+  stroked?: boolean;
+  fn: () => any;
 }
 
 export class ToolbarButton {
   icon: string;
   text: string;
-  eventName: string;
   disabled: boolean;
   color: string;
+  raised: boolean;
+  stroked: boolean;
+  fn: () => {};
 
   private defaults: ToolbarButtonConfig = {
     icon: '',
     text: '',
-    eventName: '',
     disabled: false,
     color: 'primary',
+    raised: true,
+    fn: () => {},
   };
 
   constructor(config: ToolbarButtonConfig) {
-    const { icon, text, eventName, disabled, color } = {
+    const { icon, text, disabled, color, stroked, raised, fn } = {
       ...this.defaults,
       ...config,
     };
 
     this.icon = icon;
     this.text = text;
-    this.eventName = eventName;
     this.disabled = disabled;
     this.color = color;
+    this.raised = raised;
+    this.fn = fn;
+
+    if (stroked) {
+      this.raised = false;
+      this.stroked = true;
+    }
   }
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/utils/kubernetes.model.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/utils/kubernetes.model.ts
@@ -1,8 +1,8 @@
 import { V1ObjectMeta } from '@kubernetes/client-node';
 export interface K8sObject {
-  apiVersion: string;
-  kind: string;
-  metadata: V1ObjectMeta;
-  spec: any;
-  status: any;
+  apiVersion?: string;
+  kind?: string;
+  metadata?: V1ObjectMeta;
+  spec?: any;
+  status?: any;
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables.scss
@@ -1,0 +1,2 @@
+$page-space-left: 20px;
+$page-space-right: 20px;

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -75,6 +75,7 @@ body {
 
 .fit-content {
   width: fit-content;
+  width: -moz-fit-content;
 }
 
 .bold {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -73,6 +73,10 @@ body {
   flex-direction: column;
 }
 
+.fit-content {
+  width: fit-content;
+}
+
 .bold {
   font-weight: 500;
 }
@@ -178,4 +182,33 @@ body {
 
 .page-padding-left {
   padding-left: $page-space-left;
+}
+
+/*
+ * Classes for showing a Toolbar, footer and scrollable content
+ */
+.lib-content-wrapper {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.lib-flex-layout-column {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.lib-flex-grow {
+  flex-grow: 1;
+}
+
+.lib-overflow-auto {
+  overflow: auto;
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -55,6 +55,28 @@ body {
   display: flex;
 }
 
+.flex-column {
+  display: flex;
+  flex-direction: column;
+}
+
+.lib-step-wrapper {
+  display: flex;
+  justify-content: space-between;
+}
+
+.lib-step-info-wrapper {
+  width: fit-content;
+  flex-grow: 0;
+  margin-right: 10%;
+  display: flex;
+  flex-direction: column;
+}
+
+.bold {
+  font-weight: 500;
+}
+
 .wide {
   width: 100%;
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -47,6 +47,8 @@ mat-form-field .mat-form-field {
 html,
 body {
   font-family: Roboto, Sans-Serif;
+  margin: 0;
+  background-color: white;
 }
 
 .flex {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -1,5 +1,6 @@
 @import './kubeflow.css';
 @import '~@angular/material/theming';
+@import './lib/variables.scss';
 
 // always include only once per project
 @include mat-core();
@@ -142,9 +143,6 @@ body {
 /*
  * padding for the page
  */
-$page-space-left: 20px;
-$page-space-right: 20px;
-
 .page-padding {
   padding-left: $page-space-left;
   padding-right: $page-space-right;

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -67,6 +67,7 @@ body {
 
 .lib-step-info-wrapper {
   width: fit-content;
+  width: -moz-fit-content;
   flex-grow: 0;
   margin-right: 10%;
   display: flex;


### PR DESCRIPTION
This PR introduces various fixes into both the common frontend and backend code. 
Since there are a lot of small ones I didn't create separate issues for each one of them, but here's a list of what's included:

Backend:
* Allow backend to skip authz checks when listing Pods
* Add ability to fetch pod logs
* Correctly calculate the default storage class

Frontend:
* Global SCSS classes for common types
* Export common modules to be used from the apps without requiring explicit imports
* Make the backgrounds of the apps white, and not grey due to CentralDashboard
* Move the toolbar buttons to the right, like the Pipelines UI
* Create a component for showing explanatory text. This will be useful for forms
* Create a component for a bottom bar for submitting CRs in forms

The bulk of the code is the two new components, but they are only view components [without any specialized logic].
I also included some basic tests for the new components and `ng test` passes as expected.

/cc @StefanoFioravanzo 
/cc @elikatsis 
/assigh kimwnasptd