### PR TITLE
Add experimental VS-Code image

### DIFF
--- a/components/vs-code-experimental/Dockerfile
+++ b/components/vs-code-experimental/Dockerfile
@@ -1,0 +1,105 @@
+FROM ubuntu:20.04
+
+# ARG OVERLAY_VERSION=2.1.0.2
+# ARG OVERLAY_ARCH="amd64"
+# ARG S6_OVERLAY_MD5HASH=7e81e28fcb4d882d2fbc6c7f671758e2
+
+ENV NB_PREFIX /
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y wget tzdata locales curl sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+    # cd /tmp && \
+    # wget https://github.com/just-containers/s6-overlay/releases/download/v$S6_OVERLAY_VERSION/s6-overlay-amd64.tar.gz && \
+    # echo "$S6_OVERLAY_MD5HASH *s6-overlay-amd64.tar.gz" | md5sum -c - && \
+    # tar xzf s6-overlay-amd64.tar.gz -C / --exclude='./bin' && \
+    # tar xzf s6-overlay-amd64.tar.gz -C /usr ./bin && \
+    # rm s6-overlay-amd64.tar.gz
+
+# set version for s6 overlay
+ARG OVERLAY_VERSION="v2.2.0.1"
+ARG OVERLAY_ARCH="amd64"
+
+# add s6 overlay
+ADD https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
+RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && rm /tmp/s6-overlay-${OVERLAY_ARCH}-installer
+
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen \
+	&& locale-gen en_US.utf8 \
+	&& /usr/sbin/update-locale LANG=en_US.UTF-8
+
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+
+RUN adduser --gecos '' --disabled-password jovyan && \
+    echo "jovyan ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/nopasswd && \
+    addgroup jovyan staff
+
+RUN echo "**** install node repo ****" && \
+    apt-get update && \
+    apt-get install -y \
+	gnupg && \
+    curl -s https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo 'deb https://deb.nodesource.com/node_14.x focal main' \
+    > /etc/apt/sources.list.d/nodesource.list && \
+    curl -s https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
+    echo 'deb https://dl.yarnpkg.com/debian/ stable main' \
+    > /etc/apt/sources.list.d/yarn.list && \
+    echo "**** install build dependencies ****" && \
+    apt-get update && \
+    apt-get install -y \
+    build-essential \
+    libx11-dev \
+    libxkbfile-dev \
+    libsecret-1-dev \
+    pkg-config && \
+    echo "**** install runtime dependencies ****" && \
+    apt-get install -y \
+    git \
+    jq \
+    nano \
+    net-tools \
+    nodejs \
+    sudo \
+    yarn \
+    python3-pip \
+    apache2 && \
+    echo "**** install code-server ****" && \
+    if [ -z ${CODE_RELEASE+x} ]; then \
+        CODE_RELEASE=$(curl -sX GET "https://api.github.com/repos/cdr/code-server/releases/latest" \
+        | awk '/tag_name/{print $4;exit}' FS='[""]'); \
+    fi && \
+    CODE_VERSION=$(echo "$CODE_RELEASE" | awk '{print substr($1,2); }') && \
+    yarn config set network-timeout 600000 -g && \
+    yarn --production --verbose --frozen-lockfile global add code-server@"$CODE_VERSION" && \
+    yarn cache clean && \
+    echo "**** clean up ****" && \
+    apt-get purge --auto-remove -y \
+    build-essential \
+    libx11-dev \
+    libxkbfile-dev \
+    libsecret-1-dev \
+    pkg-config && \
+    apt-get clean && \
+    rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+COPY requirements.txt .
+RUN pip3 install -r requirements.txt
+
+COPY root/ /
+
+COPY vs-code-proxy.conf /etc/apache2/sites-enabled/vs-code-proxy.conf
+
+RUN echo 'Listen 8888' > /etc/apache2/ports.conf
+
+RUN a2enmod proxy proxy_ajp proxy_http rewrite deflate headers proxy_balancer proxy_connect proxy_html proxy_wstunnel
+
+EXPOSE 8888
+
+ENV HOME="/home/jovyan"
+
+ENTRYPOINT ["/init"]

--- a/components/vs-code-experimental/Dockerfile
+++ b/components/vs-code-experimental/Dockerfile
@@ -87,6 +87,13 @@ RUN echo "**** install node repo ****" && \
     /var/lib/apt/lists/* \
     /var/tmp/*
 
+RUN apt-get update && sudo apt-get install -y apt-transport-https gnupg2 curl && \
+    curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add - && \
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get update && \
+    apt-get install -y kubectl && \
+    rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 

--- a/components/vs-code-experimental/requirements.txt
+++ b/components/vs-code-experimental/requirements.txt
@@ -1,0 +1,2 @@
+kfp==1.3.0
+kfp-server-api==1.3.0

--- a/components/vs-code-experimental/root/etc/cont-init.d/01-proxy_setup
+++ b/components/vs-code-experimental/root/etc/cont-init.d/01-proxy_setup
@@ -1,0 +1,5 @@
+#!/usr/bin/with-contenv bash
+## allow apache2 to use the NB_PREFIX provided by kubeflow
+## note: we strip off any trailing / for consistency
+shopt -s extglob;
+echo "export NB_PREFIX_NO_SLASH=${NB_PREFIX%%+(/)}" >> /etc/apache2/envvars

--- a/components/vs-code-experimental/root/etc/cont-init.d/02-apache2_start
+++ b/components/vs-code-experimental/root/etc/cont-init.d/02-apache2_start
@@ -1,0 +1,2 @@
+#!/usr/bin/with-contenv bash
+service apache2 start

--- a/components/vs-code-experimental/root/etc/services.d/code-server/run
+++ b/components/vs-code-experimental/root/etc/services.d/code-server/run
@@ -1,0 +1,8 @@
+#!/usr/bin/with-contenv bash
+
+exec \
+	s6-setuidgid jovyan \
+		/usr/local/bin/code-server \
+			--bind-addr 0.0.0.0:8080 \
+			--disable-telemetry \
+			--auth none

--- a/components/vs-code-experimental/vs-code-proxy.conf
+++ b/components/vs-code-experimental/vs-code-proxy.conf
@@ -1,0 +1,17 @@
+<VirtualHost *:8888>
+  ProxyPreserveHost On
+  ProxyPassInterpolateEnv On
+
+  RewriteEngine on
+  RewriteCond %{HTTP:Upgrade} =websocket
+  RewriteRule ${NB_PREFIX_NO_SLASH}/(.*)     ws://127.0.0.1:8080/$1  [P,L]
+  RewriteCond %{HTTP:Upgrade} !=websocket
+  RewriteRule ${NB_PREFIX_NO_SLASH}/(.*)     http://127.0.0.1:8080/$1 [P,L]
+
+  ProxyRequests Off
+  ProxyPass ${NB_PREFIX_NO_SLASH}/ http://127.0.0.1:8080/
+  ProxyPassReverse ${NB_PREFIX_NO_SLASH}/ http://127.0.0.1:8080/
+
+  Redirect 404 /
+
+</VirtualHost>


### PR DESCRIPTION
Closes: https://github.com/kubeflow/kubeflow/issues/3362

This PR adds an experimental VS Code image which makes use of the [code server](https://github.com/cdr/code-server) package. The way this image works is by having an embedded instance of Apache2 rewrite the url base from the NB_PREFIX environment variable, similar to the experimental R-Studio images. To make the image more easy to customize, a custom image was created which makes use of the [s6 overlay](https://github.com/just-containers/s6-overlay), again similar to the R-Studio images. With this overlay, scripts placed in `/etc/cont-init.d` or `/etc/services.d/` are executed at container start and support the use of environment variables. The image in its current state is only 753 MB and has the KFP SDK installed. 

There are some things that are non-optimal, and thus why I think the image should be seen as experimental.
1. I have not yet found a way to have the s6 overlay start as user `jovyan`. While passing the environment variable `USER` during `docker run` did seem to work, having it in the Dockerfile did not. However, code-server itself is run as user `jovyan`. This is accomplished by the line `exec s6-setuidgid jovyan /usr/local/bin/code-server ...`. 
2. <s>Sadly `kubectl` does not seem to work, neither in the browser based terminal nor from inside the pod. </s> This seems to have been due to the method of installation, when installed from apt it works in the web UI, as well as from the pod directly.
3. While the KFP SDK is installed, I have not yet tested it. 
4. Further customization of the image will be necessary, such as deciding on a default set of extensions to install (adding the `--install-extension` flag to code-server) and other tools such as tensorflow or pytorch
5. Consider the creation of a GPU image that includes the necessary drivers

As always, any feedback to improve the image or overcome the above mentioned points (mainly point 1) are much appreciated.

For those that would like to test this image, it is available as `davidspek/vs-code-kubeflow-custom:0.31`
Kubectl was added in 0.31

/cc @kubeflow/wg-notebooks-leads