### PR TITLE
Add Notebooks WG leads as owners of components

### DIFF
--- a/components/OWNERS
+++ b/components/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - elikatsis
+  - kimwnasptd
+  - StefanoFioravanzo
+  - thesuperzapper
+  - yanniszark


### PR DESCRIPTION
In this PR I add the [tech leads](https://github.com/kubeflow/community/blob/master/wgs.yaml#L232-L245) from the Notebook WG as owners of the `components` directory since it contains the source code from artifacts owned by the Notebooks WG.

/cc @Bobgy 