### PR TITLE
Add initial owners for testing dir

### DIFF
--- a/py/OWNERS
+++ b/py/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+- kimwnasptd
+- PatrickXYS


### PR DESCRIPTION
Create an initial OWNERS file for the `testing` dir. Adding myself and @PatrickXYS for now since we are actively working on it for now. 

/cc @Bobgy 
/assign @kimwnasptd 