### PR TITLE
Add initial python files for CI

### DIFF
--- a/py/kubeflow/kubeflow/ci/Makefile
+++ b/py/kubeflow/kubeflow/ci/Makefile
@@ -7,12 +7,10 @@ KUBEFLOW_KUBEFLOW_REPO ?= /tmp/kubeflow/kubeflow
 PYTHONPATH ?= "${KUBEFLOW_KUBEFLOW_REPO}/py:${KUBEFLOW_TESTING_REPO}/py"
 
 check-local-shared-ui-tests:
-	KUBEFLOW_TESTING_REPO=${KUBEFLOW_TESTING_REPO} \
 	PYTHONPATH=${PYTHONPATH} \
 	LOCAL_TESTING=True \
 	python shared_ui_tests_runner.py
 
 check-prod-shared-ui-tests:
-	KUBEFLOW_TESTING_REPO=${KUBEFLOW_TESTING_REPO} \
 	PYTHONPATH=${PYTHONPATH} \
 	python shared_ui_tests_runner.py

--- a/py/kubeflow/kubeflow/ci/Makefile
+++ b/py/kubeflow/kubeflow/ci/Makefile
@@ -1,0 +1,18 @@
+# This file is only intended for development purposes
+
+# change this env var based on where kubeflow/testing repo lives
+# in your local machine
+KUBEFLOW_TESTING_REPO ?= /tmp/kubeflow/testing
+KUBEFLOW_KUBEFLOW_REPO ?= /tmp/kubeflow/kubeflow
+PYTHONPATH ?= "${KUBEFLOW_KUBEFLOW_REPO}/py:${KUBEFLOW_TESTING_REPO}/py"
+
+check-local-shared-ui-tests:
+	KUBEFLOW_TESTING_REPO=${KUBEFLOW_TESTING_REPO} \
+	PYTHONPATH=${PYTHONPATH} \
+	LOCAL_TESTING=True \
+	python shared_ui_tests_runner.py
+
+check-prod-shared-ui-tests:
+	KUBEFLOW_TESTING_REPO=${KUBEFLOW_TESTING_REPO} \
+	PYTHONPATH=${PYTHONPATH} \
+	python shared_ui_tests_runner.py

--- a/py/kubeflow/kubeflow/ci/shared_ui_tests.py
+++ b/py/kubeflow/kubeflow/ci/shared_ui_tests.py
@@ -1,0 +1,93 @@
+""""Argo Workflow for running frontend unit tests"""
+from kubeflow.kubeflow.ci import workflow_utils
+from kubeflow.testing import argo_build_util
+
+
+class Builder(workflow_utils.ArgoTestBuilder):
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None, **kwargs):
+        super().__init__(name=name, namespace=namespace, bucket=bucket,
+                         test_target_name=test_target_name, **kwargs)
+
+    def _create_install_modules_task(self, task_template):
+        install = argo_build_util.deep_copy(task_template)
+
+        install["name"] = "npm-modules-install"
+        install["container"]["image"] = "node:12.20.1-stretch-slim"
+        install["container"]["command"] = ["npm"]
+        install["container"]["args"] = ["ci"]
+
+        ui_dir = ("%s/components/crud-web-apps/common/"
+                  "frontend/kubeflow-common-lib/") % self.src_dir
+        install["container"]["workingDir"] = ui_dir
+
+        return install
+
+    def _create_ui_tests_task(self, task_template):
+        ui_tests = argo_build_util.deep_copy(task_template)
+
+        ui_tests["name"] = "shared-ui-tests"
+        ui_tests["container"]["image"] = "node:12.20.1-stretch-slim"
+        ui_tests["container"]["command"] = ["npm"]
+        ui_tests["container"]["args"] = ["run", "test-ci"]
+
+        ui_dir = ("%s/components/crud-web-apps/common/"
+                  "frontend/kubeflow-common-lib/") % self.src_dir
+        ui_tests["container"]["workingDir"] = ui_dir
+
+        return ui_tests
+
+    def _create_ui_build_task(self, task_template):
+        ui_build = argo_build_util.deep_copy(task_template)
+
+        ui_build["name"] = "build-shared-ui-library"
+        ui_build["container"]["image"] = "node:12.20.1-stretch-slim"
+        ui_build["container"]["command"] = ["npm"]
+        ui_build["container"]["args"] = ["run", "build"]
+
+        ui_dir = ("%s/components/crud-web-apps/common/"
+                  "frontend/kubeflow-common-lib/") % self.src_dir
+        ui_build["container"]["workingDir"] = ui_dir
+
+        return ui_build
+
+    def build(self):
+        """Build the Argo workflow graph"""
+        workflow = self.build_init_workflow()
+        task_template = self.build_task_template()
+
+        # install npm modules
+        modules_install_task = self._create_install_modules_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        modules_install_task,
+                                        [self.mkdir_task_name])
+
+        # run common ui frontend tests
+        ui_tests_task = self._create_ui_tests_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        ui_tests_task,
+                                        [modules_install_task["name"]])
+
+        # run common ui frontend tests
+        build_step = self._create_ui_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        build_step,
+                                        [modules_install_task["name"]])
+
+        # Set the labels on all templates
+        workflow = argo_build_util.set_task_template_labels(workflow)
+
+        return workflow
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """Create workflow returns an Argo workflow to test kfctl upgrades.
+
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+
+    builder = Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build()

--- a/py/kubeflow/kubeflow/ci/shared_ui_tests_runner.py
+++ b/py/kubeflow/kubeflow/ci/shared_ui_tests_runner.py
@@ -1,0 +1,13 @@
+# This file is only intended for development purposes
+import os
+
+import yaml
+
+from kubeflow.kubeflow.ci import shared_ui_tests
+
+WORKFLOW_NAME = os.getenv("WORKFLOW_NAME", "shared-ui-tests")
+WORKFLOW_NAMESPACE = os.getenv("WORKFLOW_NAMESPACE", "kubeflow-user")
+
+if __name__ == "__main__":
+    print(yaml.dump(shared_ui_tests.create_workflow(WORKFLOW_NAME,
+                                                    WORKFLOW_NAMESPACE)))

--- a/py/kubeflow/kubeflow/ci/workflow_utils.py
+++ b/py/kubeflow/kubeflow/ci/workflow_utils.py
@@ -1,0 +1,249 @@
+import logging
+import os
+
+from kubeflow.testing import argo_build_util
+
+# The name of the NFS volume claim to use for test files.
+NFS_VOLUME_CLAIM = "nfs-external"
+# The name to use for the volume to use to contain test data
+DATA_VOLUME = "kubeflow-test-volume"
+
+E2E_DAG_NAME = "e2e"
+EXIT_DAG_NAME = "exit-handler"
+
+
+LOCAL_TESTING = os.getenv("LOCAL_TESTING", "False")
+CREDENTIALS_VOLUME = {"name": "aws-secret",
+                      "secret": {"secretName": "aws-secret"}}
+CREDENTIALS_MOUNT = {"mountPath": "/root/.aws/",
+                     "name": "aws-secret"}
+
+AWS_WORKER_IMAGE = ("527798164940.dkr.ecr.us-west-2.amazonaws.com/"
+                    "aws-kubeflow-ci/test-worker:latest")
+PUBLIC_WORKER_IMAGE = "gcr.io/kubeflow-ci/test-worker:latest"
+
+
+class ArgoTestBuilder:
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None,
+                 **kwargs):
+        self.name = name
+        self.namespace = namespace
+        self.bucket = bucket
+        self.template_label = "argo_test"
+        self.test_target_name = test_target_name
+        self.mkdir_task_name = "make-artifacts-dir"
+
+        # *********************************************************************
+        #
+        # Define directory locations
+        #
+        # *********************************************************************
+
+        # mount_path is the directory where the volume to store the test data
+        # should be mounted.
+        self.mount_path = "/mnt/" + "test-data-volume"
+        # test_dir is the root directory for all data for a particular test
+        # run.
+        self.test_dir = self.mount_path + "/" + self.name
+        # output_dir is the directory to sync to GCS to contain the output for
+        # this job.
+        self.output_dir = self.test_dir + "/output"
+
+        self.artifacts_dir = "%s/artifacts/junit_%s" % (self.output_dir, name)
+
+        # source directory where all repos should be checked out
+        self.src_root_dir = "%s/src" % self.test_dir
+        # The directory containing the kubeflow/kubeflow repo
+        self.src_dir = "%s/kubeflow/kubeflow" % self.src_root_dir
+
+        # Root of testing repo.
+        self.testing_src_dir = os.path.join(self.src_root_dir,
+                                            "kubeflow/testing")
+
+        # Top level directories for python code
+        self.kubeflow_py = self.src_dir
+
+        # The directory within the kubeflow_testing submodule containing
+        # py scripts to use.
+        self.kubeflow_testing_py = "%s/kubeflow/testing/py" % self.src_root_dir
+
+        self.go_path = self.test_dir
+
+    def _build_workflow(self):
+        """Create a scaffolding CR for the Argo workflow"""
+        volumes = [{
+            "name": DATA_VOLUME,
+            "persistentVolumeClaim": {
+                "claimName": NFS_VOLUME_CLAIM
+            },
+        }]
+        if LOCAL_TESTING == "False":
+            volumes.append(CREDENTIALS_VOLUME)
+
+        workflow = {
+            "apiVersion": "argoproj.io/v1alpha1",
+            "kind": "Workflow",
+            "metadata": {
+                "name": self.name,
+                "namespace": self.namespace,
+                "labels": argo_build_util.add_dicts([
+                    {
+                        "workflow": self.name,
+                        "workflow_template": self.template_label,
+                    },
+                    argo_build_util.get_prow_labels()
+                ]),
+            },
+            "spec": {
+                "entrypoint": E2E_DAG_NAME,
+                # Have argo garbage collect old workflows otherwise we overload
+                # the API server.
+                "ttlSecondsAfterFinished": 7 * 24 * 60 * 60,
+                "volumes": volumes,
+                "onExit": EXIT_DAG_NAME,
+                "templates": [
+                    {
+                        "dag": {
+                            "tasks": []
+                        },
+                        "name": E2E_DAG_NAME
+                    },
+                    {
+                        "dag": {
+                            "tasks": []
+                        },
+                        "name":EXIT_DAG_NAME
+                    },
+                ],
+            },  # spec
+        }  # workflow
+
+        return workflow
+
+    def build_task_template(self):
+        """Return a template for all the tasks"""
+        volume_mounts = [{
+            "mountPath": "/mnt/test-data-volume",
+            "name": DATA_VOLUME
+        }]
+        if LOCAL_TESTING == "False":
+            volume_mounts.append(CREDENTIALS_MOUNT)
+
+        image = PUBLIC_WORKER_IMAGE
+        if LOCAL_TESTING == "False":
+            image = AWS_WORKER_IMAGE
+
+        task_template = {
+            "activeDeadlineSeconds": 3000,
+            "container": {
+                "command": [],
+                "env": [],
+                "image": image,
+                "imagePullPolicy": "Always",
+                "name": "",
+                "resources": {
+                    "limits": {
+                        "cpu": "4",
+                        "memory": "4Gi"
+                    },
+                    "requests": {
+                        "cpu": "1",
+                        "memory": "1536Mi"
+                    },
+                },
+                "volumeMounts": volume_mounts,
+            },
+            "metadata": {
+                "labels": {
+                    "workflow_template": self.template_label,
+                }
+            },
+            "outputs": {},
+        }
+
+        # Define common environment variables to be added to all steps
+        common_env = [
+            {
+                "name": "PYTHONPATH",
+                "value": ":".join([self.kubeflow_py, self.kubeflow_testing_py])
+            },
+            {
+                "name": "GOPATH",
+                "value": self.go_path
+            },
+        ]
+
+        task_template["container"]["env"].extend(common_env)
+
+        if self.test_target_name:
+            task_template["container"]["env"].append(
+                {
+                    "name": "TEST_TARGET_NAME",
+                    "value": self.test_target_name
+                }
+            )
+
+        task_template = argo_build_util.add_prow_env(task_template)
+
+        return task_template
+
+    def _create_checkout_task(self, task_template):
+        """Checkout the kubeflow/testing and kubeflow/kubeflow code"""
+        main_repo = argo_build_util.get_repo_from_prow_env()
+        if not main_repo:
+            logging.info("Prow environment variables for repo not set")
+            main_repo = "kubeflow/testing@HEAD"
+        logging.info("Main repository: %s", main_repo)
+        repos = [main_repo]
+
+        checkout = argo_build_util.deep_copy(task_template)
+
+        checkout["name"] = "checkout"
+        checkout["container"]["command"] = [
+            "/usr/local/bin/checkout_repos.sh",
+            "--repos=" + ",".join(repos),
+            "--src_dir=" + self.src_root_dir,
+        ]
+
+        return checkout
+
+    def _create_make_dir_task(self, task_template):
+        """Create the directory to store the artifacts of each task"""
+        # (jlewi)
+        # pytest was failing trying to call makedirs. My suspicion is its
+        # because the two steps ended up trying to create the directory at the
+        # same time and classing. So we create a separate step to do it.
+        mkdir_step = argo_build_util.deep_copy(task_template)
+
+        mkdir_step["name"] = self.mkdir_task_name
+        mkdir_step["container"]["command"] = ["mkdir", "-p",
+                                              self.artifacts_dir]
+
+        return mkdir_step
+
+    def build_init_workflow(self):
+        """Build the Argo workflow graph"""
+        workflow = self._build_workflow()
+        task_template = self.build_task_template()
+
+        # checkout the code
+        checkout_task = self._create_checkout_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, E2E_DAG_NAME, checkout_task,
+                                        [])
+
+        # create the artifacts directory
+        mkdir_task = self._create_make_dir_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, E2E_DAG_NAME, mkdir_task,
+                                        [checkout_task["name"]])
+
+        return workflow
+
+    # the following methods should be implemented from the test cases
+    def build(self):
+        """Build the Argo Worfklow for this test"""
+        raise NotImplementedError("Subclasses should implement this!")
+
+    def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+        """Return the final dict with the Argo Workflow to be submitted"""
+        raise NotImplementedError("Subclasses should implement this!")

--- a/py/kubeflow/kubeflow/ci/workflow_utils.py
+++ b/py/kubeflow/kubeflow/ci/workflow_utils.py
@@ -18,9 +18,7 @@ CREDENTIALS_VOLUME = {"name": "aws-secret",
 CREDENTIALS_MOUNT = {"mountPath": "/root/.aws/",
                      "name": "aws-secret"}
 
-AWS_WORKER_IMAGE = ("527798164940.dkr.ecr.us-west-2.amazonaws.com/"
-                    "aws-kubeflow-ci/test-worker:latest")
-PUBLIC_WORKER_IMAGE = "gcr.io/kubeflow-ci/test-worker:latest"
+AWS_WORKER_IMAGE = "public.ecr.aws/j1r0q0g6/kubeflow-testing:latest"
 
 
 class ArgoTestBuilder:
@@ -99,7 +97,6 @@ class ArgoTestBuilder:
                 "entrypoint": E2E_DAG_NAME,
                 # Have argo garbage collect old workflows otherwise we overload
                 # the API server.
-                "ttlSecondsAfterFinished": 7 * 24 * 60 * 60,
                 "volumes": volumes,
                 "onExit": EXIT_DAG_NAME,
                 "templates": [
@@ -130,9 +127,7 @@ class ArgoTestBuilder:
         if LOCAL_TESTING == "False":
             volume_mounts.append(CREDENTIALS_MOUNT)
 
-        image = PUBLIC_WORKER_IMAGE
-        if LOCAL_TESTING == "False":
-            image = AWS_WORKER_IMAGE
+        image = AWS_WORKER_IMAGE
 
         task_template = {
             "activeDeadlineSeconds": 3000,


### PR DESCRIPTION
A first Argo Worflow generator script which can be used as a Prow presubmit Job. This is a first step for #5482.
This workflow runs two basic tests on the common frontend code:
1. it runs it's unittests #5564 
2. checks if the npm module, from the common code, can be build

@PatrickXYS since the [run_e2e_workflow.py](https://github.com/kubeflow/testing/blob/master/py/kubeflow/testing/run_e2e_workflow.py#L232) imports the pythonpaths from the workflow jobs, defined in the `prow_config.yaml`, I made all the imports in my code to use packages like `kubeflow.testing` and `kubeflow.kubeflow.ci` [and no relative imports].

I also defined a file with common code, since some of this logic will be needed for future workflows. Again I think we shouldn't have a problem with imports but please take a look to be sure.

I've created two helper files, a Makefile and a `_runner.py` for checking the generated Argo Workflow. The code is also conditional and can completely omit any secrets in the Argo Workflow. This is useful for testing the produced workflow in a local cluster with argo.

Lastly, please also take a look at the credentials-secrets mounts/volumes as well as to the name of the NFS volume. I'm expecting this NFS volume will also be in the Optional-test infra. If not let's discuss what changes we'll need to make

/cc @PatrickXYS 
/assign @kimwnasptd 

note that we will need to wait for #5574 to be merged first, but we can run the review process in parallel