### PR TITLE
Add redirection links to kubeflow app repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,30 +1,30 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Issue related to pipelines
+  - name: Issues related to Pipelines
     url: https://github.com/kubeflow/pipelines/issues/new/choose
     about: Create issue in kubeflow/pipelines repo
-  - name: Issue related to notebooks
+  - name: Issues related to Notebooks
     url: https://github.com/kubeflow/kubeflow/issues/new
     about: Creat issue in kubeflow/kubeflow repo
-  - name: Issue related to katib
+  - name: Issues related to Katib
     url: https://github.com/kubeflow/katib/issues/new/choose
     about: Create issue in kubeflow/katib repo
-  - name: Issue related to kfserving
+  - name: Issues related to Kfserving
     url: https://github.com/kubeflow/kfserving/issues/new/choose
     about: Create issue in kubeflow/kfserving repo
-  - name: Issue related to tf-operator
+  - name: Issues related to Tf-operator
     url: https://github.com/kubeflow/tf-operator/issues/new/choose
     about: Create issue in kubeflow/tf-operator repo
-  - name: Issue related to pytorch-operator
+  - name: Issues related to Pytorch-operator
     url: https://github.com/kubeflow/pytorch-operator/issues/new/choose
     about: Create issue in kubeflow/pytorch-operator repo
-  - name: Issue related to mpi-operator
+  - name: Issues related to Mpi-operator
     url: https://github.com/kubeflow/mpi-operator/issues/new/choose
     about: Create issue in kubeflow/mpi-operator repo
-  - name: Issue related to xgboost-operator
+  - name: Issues related to Xgboost-operator
     url: https://github.com/kubeflow/xgboost-operator/issues/new/choose
     about: Create issue in kubeflow/xgboost-operator repo
-  - name: Issue related to mxnet-operator
+  - name: Issues related to Mxnet-operator
     url: https://github.com/kubeflow/mxnet-operator/issues/new/choose
     about: Create issue in kubeflow/mxnet-operator repo
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,36 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Issue related to manifests
+    url: https://github.com/kubeflow/manifests/issues/new
+    about: Create issue in kubeflow/manfiests repo
+  - name: Issue related to deployment
+    url: https://github.com/kubeflow/kfctl/issues/new
+    about: Create issue in kubeflow/kfctl repo
+  - name: Issue related to pipelines
+    url: https://github.com/kubeflow/pipelines/issues/new/choose
+    about: Create issue in kubeflow/pipelines repo
+  - name: Issue related to notebooks
+    url: https://github.com/kubeflow/kubeflow/issues/new/choose
+    about: Creat issue in kubeflow/kubeflow repo
+  - name: Issue related to katib
+    url: https://github.com/kubeflow/katib/issues/new/choose
+    about: Create issue in kubeflow/katib repo
+  - name: Issue related to kfserving
+    url: https://github.com/kubeflow/kfserving/issues/new/choose
+    about: Create issue in kubeflow/kfserving repo
+  - name: Issue related to tf-operator
+    url: https://github.com/kubeflow/tf-operator/issues/new
+    about: Create issue in kubeflow/tf-operator repo
+  - name: Issue related to pytorch-operator
+    url: https://github.com/kubeflow/pytorch-operator/issues/new
+    about: Create issue in kubeflow/pytorch-operator repo
+  - name: Issue related to mpi-operator
+    url: https://github.com/kubeflow/mpi-operator/issues/new
+    about: Create issue in kubeflow/mpi-operator repo
+  - name: Issue related to xgboost-operator
+    url: https://github.com/kubeflow/xgboost-operator/issues/new
+    about: Create issue in kubeflow/xgboost-operator repo
+  - name: Issue related to mxnet-operator
+    url: https://github.com/kubeflow/mxnet-operator/issues/new
+    about: Create issue in kubeflow/mxnet-operator repo
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,16 +1,10 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Issue related to manifests
-    url: https://github.com/kubeflow/manifests/issues/new
-    about: Create issue in kubeflow/manfiests repo
-  - name: Issue related to deployment
-    url: https://github.com/kubeflow/kfctl/issues/new
-    about: Create issue in kubeflow/kfctl repo
   - name: Issue related to pipelines
     url: https://github.com/kubeflow/pipelines/issues/new/choose
     about: Create issue in kubeflow/pipelines repo
   - name: Issue related to notebooks
-    url: https://github.com/kubeflow/kubeflow/issues/new/choose
+    url: https://github.com/kubeflow/kubeflow/issues/new
     about: Creat issue in kubeflow/kubeflow repo
   - name: Issue related to katib
     url: https://github.com/kubeflow/katib/issues/new/choose
@@ -19,18 +13,18 @@ contact_links:
     url: https://github.com/kubeflow/kfserving/issues/new/choose
     about: Create issue in kubeflow/kfserving repo
   - name: Issue related to tf-operator
-    url: https://github.com/kubeflow/tf-operator/issues/new
+    url: https://github.com/kubeflow/tf-operator/issues/new/choose
     about: Create issue in kubeflow/tf-operator repo
   - name: Issue related to pytorch-operator
-    url: https://github.com/kubeflow/pytorch-operator/issues/new
+    url: https://github.com/kubeflow/pytorch-operator/issues/new/choose
     about: Create issue in kubeflow/pytorch-operator repo
   - name: Issue related to mpi-operator
-    url: https://github.com/kubeflow/mpi-operator/issues/new
+    url: https://github.com/kubeflow/mpi-operator/issues/new/choose
     about: Create issue in kubeflow/mpi-operator repo
   - name: Issue related to xgboost-operator
-    url: https://github.com/kubeflow/xgboost-operator/issues/new
+    url: https://github.com/kubeflow/xgboost-operator/issues/new/choose
     about: Create issue in kubeflow/xgboost-operator repo
   - name: Issue related to mxnet-operator
-    url: https://github.com/kubeflow/mxnet-operator/issues/new
+    url: https://github.com/kubeflow/mxnet-operator/issues/new/choose
     about: Create issue in kubeflow/mxnet-operator repo
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,30 +1,30 @@
 blank_issues_enabled: true
 contact_links:
-  - name: Issues related to Pipelines
+  - name: Issues related to Kubeflow Pipelines
     url: https://github.com/kubeflow/pipelines/issues/new/choose
     about: Create issue in kubeflow/pipelines repo
-  - name: Issues related to Notebooks
+  - name: Issues related to Kubeflow Notebooks
     url: https://github.com/kubeflow/kubeflow/issues/new
     about: Creat issue in kubeflow/kubeflow repo
-  - name: Issues related to Katib
+  - name: Issues related to Kubeflow Katib
     url: https://github.com/kubeflow/katib/issues/new/choose
     about: Create issue in kubeflow/katib repo
-  - name: Issues related to Kfserving
+  - name: Issues related to Kubeflow Kfserving
     url: https://github.com/kubeflow/kfserving/issues/new/choose
     about: Create issue in kubeflow/kfserving repo
-  - name: Issues related to Tf-operator
+  - name: Issues related to Kubeflow Tf-operator
     url: https://github.com/kubeflow/tf-operator/issues/new/choose
     about: Create issue in kubeflow/tf-operator repo
-  - name: Issues related to Pytorch-operator
+  - name: Issues related to Kubeflow Pytorch-operator
     url: https://github.com/kubeflow/pytorch-operator/issues/new/choose
     about: Create issue in kubeflow/pytorch-operator repo
-  - name: Issues related to Mpi-operator
+  - name: Issues related to Kubeflow Mpi-operator
     url: https://github.com/kubeflow/mpi-operator/issues/new/choose
     about: Create issue in kubeflow/mpi-operator repo
-  - name: Issues related to Xgboost-operator
+  - name: Issues related to Kubeflow Xgboost-operator
     url: https://github.com/kubeflow/xgboost-operator/issues/new/choose
     about: Create issue in kubeflow/xgboost-operator repo
-  - name: Issues related to Mxnet-operator
+  - name: Issues related to Kubeflow Mxnet-operator
     url: https://github.com/kubeflow/mxnet-operator/issues/new/choose
     about: Create issue in kubeflow/mxnet-operator repo
 


### PR DESCRIPTION
**What issue it solves**
Help https://github.com/kubeflow/community/issues/476

**What change it makes**
Add redirection links to kubeflow application repos which are sponsored by WG. 

When users create an issue in kubeflow/kubeflow, they will be able to be redirected to disired repo and create issue there.

/cc @Bobgy @kubeflow/wg-notebooks-leads 