### PR TITLE
Include workflow for ui lib unittests

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -6,13 +6,6 @@ python_paths:
   - kubeflow/testing/py
   - kubeflow/kubeflow/py
 workflows:
-  # Run unittests
-  # TODO(jlewi): Need to add step to run go and python unittests
-  - app_dir: kubeflow/kubeflow/testing/workflows
-    component: unit_tests
-    name: unittests
-    params:
-      workflowName: unittest
   # Run unittests for the shared frontend code
   - py_func: kubeflow.kubeflow.ci.shared_ui_tests.create_workflow
     name: shared_ui_tests

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -1,6 +1,9 @@
 # This file configures the workflows to trigger in our Prow jobs.
 # see kubeflow/testing/py/run_e2e_workflow.py
 python_paths:
+  # Need to place kubeflow/testing in front of kubeflow/kubeflow so that the
+  # package can be correctly located.
+  - kubeflow/testing/py
   - kubeflow/kubeflow/py
 workflows:
   # Run unittests
@@ -10,6 +13,14 @@ workflows:
     name: unittests
     params:
       workflowName: unittest
+  # Run unittests for the shared frontend code
+  - py_func: kubeflow.kubeflow.ci.shared_ui_tests.create_workflow
+    name: shared_ui_tests
+    job_types:
+      - presubmit
+    include_dirs:
+      - components/crud-web-apps/common/frontend/kubeflow-common-lib/*
+    kwargs: {}
   # Image Auto Release workflows.
   # The workflows below are related to auto building our Docker images.
   # We have separate pre/postsubmit jobs because we want to use different


### PR DESCRIPTION
As part of setting up our CI/CD #5482 we want to extend the prow config to also run the unittests of the shared ui as a presubmit job.

/cc @PatrickXYS 