### PR TITLE
(JWA and notebook controller): Allow setting Istio rewrite rule for Code-Server and R-Studio support

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -135,12 +135,11 @@ def set_notebook_image_pull_policy(notebook, body, defaults):
     )
 
 
-def set_notebook_root_url_rewrite(notebook, body, defaults):
+def set_notebook_base_uri(notebook, body, defaults):
     notebook_annotations = notebook["metadata"]["annotations"]
-    if get_form_value(body, defaults, "useRootURL"):
-        notebook_annotations["use-root-url"] = "true"
-    else:
-        notebook_annotations["use-root-url"] = "false"
+    base_uri = get_form_value(body, defaults, "baseURI")
+    if base_uri:
+        notebook_annotations["base-uri"] = base_uri
 
 
 def set_notebook_cpu(notebook, body, defaults):

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -135,6 +135,14 @@ def set_notebook_image_pull_policy(notebook, body, defaults):
     )
 
 
+def set_notebook_root_url_rewrite(notebook, body, defaults):
+    notebook_annotations = notebook["metadata"]["annotations"]
+    if get_form_value(body, defaults, "useRootURL"):
+        notebook_annotations["use-root-url"] = "true"
+    else:
+        notebook_annotations["use-root-url"] = "false"
+
+
 def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {name}
   annotations:
-    use-root-url: 
+    base-uri: 
 spec:
   template:
     spec:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {namespace}
   labels:
     app: {name}
+  annotations:
+    use-root-url: 
 spec:
   template:
     spec:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -56,6 +56,10 @@ spawnerFormDefaults:
     # Memory for user's Notebook
     value: 1.0Gi
     readOnly: false
+  useRootURL:
+    # Use root URL during Istio rewrite
+    value: false
+    readOnly: false
   environment:
     value: {}
     readOnly: false

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -56,9 +56,9 @@ spawnerFormDefaults:
     # Memory for user's Notebook
     value: 1.0Gi
     readOnly: false
-  useRootURL:
+  baseURI:
     # Use root URL during Istio rewrite
-    value: false
+    value: ''
     readOnly: false
   environment:
     value: {}

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -27,7 +27,7 @@ def post_pvc(namespace):
 
     form.set_notebook_image(notebook, body, defaults)
     form.set_notebook_image_pull_policy(notebook, body, defaults)
-    form.set_notebook_root_url_rewrite(notebook, body, defaults)
+    form.set_notebook_base_uri(notebook, body, defaults)
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -27,6 +27,7 @@ def post_pvc(namespace):
 
     form.set_notebook_image(notebook, body, defaults)
     form.set_notebook_image_pull_policy(notebook, body, defaults)
+    form.set_notebook_root_url_rewrite(notebook, body, defaults)
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -45,13 +45,21 @@
   </mat-form-field>
 
   <lib-advanced-options>
-    <mat-form-field class="wide" appearance="outline">
-      <mat-label>Image pull policy</mat-label>
-      <mat-select [formControl]="parentForm.get('imagePullPolicy')">
-        <mat-option value="Always">Always</mat-option>
-        <mat-option value="IfNotPresent">IfNotPresent</mat-option>
-        <mat-option value="Never">Never</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <div class="row">
+      <mat-form-field class="column" appearance="outline">
+        <mat-label>Image pull policy</mat-label>
+        <mat-select [formControl]="parentForm.get('imagePullPolicy')">
+          <mat-option value="Always">Always</mat-option>
+          <mat-option value="IfNotPresent">IfNotPresent</mat-option>
+          <mat-option value="Never">Never</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-checkbox class="column" appearance="outline"
+        *ngIf="!readonly"
+        [formControl]="parentForm.get('useRootURL')"
+      >
+        Use root URL
+      </mat-checkbox>
+    </div>
   </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -54,12 +54,15 @@
           <mat-option value="Never">Never</mat-option>
         </mat-select>
       </mat-form-field>
-      <mat-checkbox class="column" appearance="outline"
-        *ngIf="!readonly"
-        [formControl]="parentForm.get('useRootURL')"
-      >
-        Use root URL
-      </mat-checkbox>
+      <mat-form-field class="column" appearance="outline">
+        <mat-label>Base URI that the server is exposed on</mat-label>
+        <input
+          matInput
+          placeholder="Base URI that the server is exposed on"
+          [formControl]="parentForm.get('baseURI')"
+          #cstmimg
+        />
+      </mat-form-field>
     </div>
   </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -30,7 +30,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
         this.parentForm.get('customImage').updateValueAndValidity();
         this.parentForm.get('image').updateValueAndValidity();
-        this.parentForm.get('useRootURL').updateValueAndValidity();
+        this.parentForm.get('baseURI').updateValueAndValidity();
       }),
     );
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -19,7 +19,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.subs.add(
       this.parentForm.get('customImageCheck').valueChanges.subscribe(check => {
-        // Make sure that the use will insert and Image value
+        // Make sure that the user inserts an Image value
         if (check) {
           this.parentForm.get('customImage').setValidators(Validators.required);
           this.parentForm.get('image').setValidators([]);
@@ -30,6 +30,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
         this.parentForm.get('customImage').updateValueAndValidity();
         this.parentForm.get('image').updateValueAndValidity();
+        this.parentForm.get('useRootURL').updateValueAndValidity();
       }),
     );
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -12,6 +12,7 @@ export function getFormDefaults(): FormGroup {
     imagePullPolicy: ['IfNotPresent', [Validators.required]],
     customImage: ['', []],
     customImageCheck: [false, []],
+    useRootURL: [false, []],
     cpu: [1, [Validators.required]],
     memory: [1, [Validators.required]],
     gpus: fb.group({

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -12,7 +12,7 @@ export function getFormDefaults(): FormGroup {
     imagePullPolicy: ['IfNotPresent', [Validators.required]],
     customImage: ['', []],
     customImageCheck: [false, []],
-    useRootURL: [false, []],
+    baseURI: ['', []],
     cpu: [1, [Validators.required]],
     memory: [1, [Validators.required]],
     gpus: fb.group({

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -39,6 +39,7 @@ export interface NotebookFormObject {
   imagePullPolicy: string;
   customImage?: string;
   customImageCheck: boolean;
+  useRootURL: boolean;
   cpu: number | string;
   memory: number | string;
   gpus: GPU;
@@ -138,6 +139,11 @@ export interface Config {
 
   imagePullPolicy?: {
     value: string;
+    readOnly?: boolean;
+  };
+
+  useRootURL?: {
+    value: boolean;
     readOnly?: boolean;
   };
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -39,7 +39,7 @@ export interface NotebookFormObject {
   imagePullPolicy: string;
   customImage?: string;
   customImageCheck: boolean;
-  useRootURL: boolean;
+  baseURI: string;
   cpu: number | string;
   memory: number | string;
   gpus: GPU;
@@ -142,8 +142,8 @@ export interface Config {
     readOnly?: boolean;
   };
 
-  useRootURL?: {
-    value: boolean;
+  baseURI?: {
+    value: string;
     readOnly?: boolean;
   };
 

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -400,13 +400,13 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	namespace := instance.Namespace
 	clusterDomain := "cluster.local"
 	prefix := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
-	labels := make(map[string]string)
-	for k, v := range instance.ObjectMeta.Labels {
-		labels[k] = v
+	annotations := make(map[string]string)
+	for k, v := range instance.ObjectMeta.Annotations {
+		annotations[k] = v
 	}
 
 	var rewrite string
-	if _, ok := labels["use-root-url"]; ok {
+	if annotations["use-root-url"] == "true" {
 		rewrite = fmt.Sprintf("/")
 	} else {
 		rewrite = fmt.Sprintf("/notebook/%s/%s/", namespace, name)

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -406,8 +406,8 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	}
 
 	var rewrite string
-	if annotations["use-root-url"] == "true" {
-		rewrite = fmt.Sprintf("/")
+	if _, ok := annotations["base-uri"]; ok {
+		rewrite = fmt.Sprintf(annotations["base-uri"])
 	} else {
 		rewrite = fmt.Sprintf("/notebook/%s/%s/", namespace, name)
 	}

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -400,7 +400,17 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	namespace := instance.Namespace
 	clusterDomain := "cluster.local"
 	prefix := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
-	rewrite := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
+	labels := make(map[string]string)
+	for k, v := range instance.ObjectMeta.Labels {
+		labels[k] = v
+	}
+
+	var rewrite string
+	if _, ok := labels["use-root-url"]; ok {
+		rewrite = fmt.Sprintf("/")
+	} else {
+		rewrite = fmt.Sprintf("/notebook/%s/%s/", namespace, name)
+	}
 	if clusterDomainFromEnv, ok := os.LookupEnv("CLUSTER_DOMAIN"); ok {
 		clusterDomain = clusterDomainFromEnv
 	}


### PR DESCRIPTION
Partially solves: https://github.com/kubeflow/kubeflow/issues/2208
More specifically, implements the functionality described in https://github.com/kubeflow/kubeflow/issues/2208#issuecomment-698044771

To enable support for more types of Notebook servers, Web-IDEs, or really any other web application, this PR adds the ability to set the rewrite URI of the Istio virtual service to `/` when the annotation `use-root-url` is `true` on a Notebook resource. This implementation removes the need for an apache or similar container in the pod as described in https://github.com/kubeflow/kubeflow/issues/2208#issuecomment-698044771. 

With this implementation, the code-server (VS-Code) image from https://github.com/kubeflow/kubeflow/pull/5582 will not require apache to be present in the container, greatly simplifying it.
This will work for the R-Studio image, however, this image will also require the injection of a config file so that the script that sets the `www-root-path` and `www-port` in `/etc/rstudio/rserver.conf` is also no longer needed. If this PR along with the config injection are implemented for R-Studio, I believe the notebook controller will be compatible with most (if not all) R-Studio images. 

A new checkbox under the Advanved options for an image allows a user to set annotation.
![image](https://user-images.githubusercontent.com/28541758/107967212-1fe41a00-6fad-11eb-8c86-b8ea70c2a2f5.png)


For those that would like to test the functionality, the notebook controller image is `davidspek/notebook-controller-nonroot:0.4-test-rewrite` and the JWA image is `davidspek/jupyter-web-app:0.4-root-url`.
Code-server image without apache installation: `davidspek/kubeflow-ubuntu-code-server-experimental:0.6-no-apache`
Don't forget to also apply the above PodDefault spec to the container, and change the namespace for the PodDefault spec to reflect your namespace.

/cc @kimwnasptd 