### PR TITLE
Fix entrypoint of crud-jwa

### DIFF
--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -47,4 +47,4 @@ COPY ./jupyter/backend/entrypoint.py .
 COPY --from=frontend /src/dist/default/ /src/apps/default/static/
 COPY --from=frontend /src/dist/rok/ /src/apps/rok/static/
 
-ENTRYPOINT ["/bin/bash","-c","APP_PREFIX=/jupyter gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app"]
+ENTRYPOINT ["/bin/bash","-c","gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app"]

--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -43,9 +43,8 @@ RUN pip3 install -r requirements.txt
 
 COPY ./jupyter/backend/apps/ ./apps
 COPY ./jupyter/backend/entrypoint.py .
-COPY ./jupyter/backend/Makefile .
 
 COPY --from=frontend /src/dist/default/ /src/apps/default/static/
 COPY --from=frontend /src/dist/rok/ /src/apps/rok/static/
 
-ENTRYPOINT make run
+ENTRYPOINT ["/bin/bash","-c","APP_PREFIX=/jupyter gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app"]


### PR DESCRIPTION
Closes: https://github.com/kubeflow/kubeflow/issues/5552

More specifically, this addresses the absence of `make` in the buster-slim version of the images. As described [here](https://github.com/kubeflow/kubeflow/issues/5552#issuecomment-769792232). 

/cc @kimwnasptd 