### PR TITLE
Notebook Controller: Move manifests development upstream

### DIFF
--- a/components/notebook-controller/config/base/cluster-role-binding.yaml
+++ b/components/notebook-controller/config/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: role
+subjects:
+- kind: ServiceAccount
+  name: service-account

--- a/components/notebook-controller/config/base/cluster-role.yaml
+++ b/components/notebook-controller/config/base/cluster-role.yaml
@@ -1,0 +1,107 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: role
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - deployments
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  - notebooks/finalizers
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  verbs:
+  - '*'
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-notebooks-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-notebooks-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-notebooks-admin: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-notebooks-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/status
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/notebook-controller/config/base/crd.yaml
+++ b/components/notebook-controller/config/base/crd.yaml
@@ -1,0 +1,91 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: notebooks.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: Notebook
+    plural: notebooks
+    singular: notebook
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: false
+  - name: v1beta1
+    served: true
+    storage: true
+  - name: v1
+    served: true
+    storage: false
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            template:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "make" to regenerate code after modifying this file'
+              properties:
+                spec:
+                  properties:
+                    containers:
+                      items:
+                        properties:
+                          resources:
+                            properties:
+                              limits:
+                                properties:
+                                  memory:
+                                    type: string
+                                    pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                                  cpu:
+                                    type: string
+                                    pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                                type: object
+                              requests:
+                                properties:
+                                  memory:
+                                    type: string
+                                    pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                                  cpu:
+                                    type: string
+                                    pattern: '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
+                                type: object
+                            type: object
+                        type: object
+                      type: array
+                  type: object
+              type: object
+          type: object
+        status:
+          properties:
+            conditions:
+              description: Conditions is an array of current conditions
+              items:
+                properties:
+                  type:
+                    description: Type of the confition/
+                    type: string
+                required:
+                - type
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object

--- a/components/notebook-controller/config/base/deployment.yaml
+++ b/components/notebook-controller/config/base/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: manager
+        image: gcr.io/kubeflow-images-public/notebook-controller:v20190614-v0-160-g386f2749-e3b0c4
+        command:
+          - /manager
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+      serviceAccountName: service-account

--- a/components/notebook-controller/config/base/deployment_patch.yaml
+++ b/components/notebook-controller/config/base/deployment_patch.yaml
@@ -1,0 +1,15 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager        
+        env:
+          # We use a patch to set the USE_ISTIO because in other patches
+          # we want to set it to a configMapRef and so if we include the value
+          # in the base when we do the merge we end up with 2 fields setting the value.
+          - name: USE_ISTIO
+            value: "false"        

--- a/components/notebook-controller/config/base/kustomization.yaml
+++ b/components/notebook-controller/config/base/kustomization.yaml
@@ -1,0 +1,43 @@
+# TODO(https://github.com/kubeflow/manifests/issues/1052): Cleanup this up
+# once kustomize_v3 migration is done.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- crd.yaml
+- deployment.yaml
+- service-account.yaml
+- service.yaml
+namePrefix: notebook-controller-
+namespace: kubeflow
+patchesStrategicMerge:
+- deployment_patch.yaml
+commonLabels:
+  app: notebook-controller
+  kustomize.component: notebook-controller
+images:
+- name: gcr.io/kubeflow-images-public/notebook-controller
+  newName: gcr.io/kubeflow-images-public/notebook-controller
+  newTag: vmaster-g6eb007d0
+configMapGenerator:
+- envs:
+  - params.env
+  name: parameters
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- fieldref:
+    fieldPath: data.USE_ISTIO
+  name: USE_ISTIO
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.ISTIO_GATEWAY
+  name: ISTIO_GATEWAY
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters

--- a/components/notebook-controller/config/base/params.env
+++ b/components/notebook-controller/config/base/params.env
@@ -1,0 +1,3 @@
+POD_LABELS=gcp-cred-secret=user-gcp-sa,gcp-cred-secret-filename=user-gcp-sa.json
+USE_ISTIO=false
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway

--- a/components/notebook-controller/config/base/service-account.yaml
+++ b/components/notebook-controller/config/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account

--- a/components/notebook-controller/config/base/service.yaml
+++ b/components/notebook-controller/config/base/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  ports:
+  - port: 443

--- a/components/notebook-controller/config/base_v3/deployment_patch.yaml
+++ b/components/notebook-controller/config/base_v3/deployment_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: USE_ISTIO
+            valueFrom:
+              configMapKeyRef:
+                name: notebook-controller-config
+                key: USE_ISTIO
+          - name: ISTIO_GATEWAY
+            valueFrom:
+              configMapKeyRef:
+                name: notebook-controller-config
+                key: ISTIO_GATEWAY
+        

--- a/components/notebook-controller/config/base_v3/kustomization.yaml
+++ b/components/notebook-controller/config/base_v3/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app: notebook-controller
+  kustomize.component: notebook-controller
+configMapGenerator:
+- literals:
+  - USE_ISTIO=true
+  - ISTIO_GATEWAY=kubeflow/kubeflow-gateway
+  name: notebook-controller-config
+images:
+- name: gcr.io/kubeflow-images-public/notebook-controller
+  newName: gcr.io/kubeflow-images-public/notebook-controller
+  newTag: vmaster-g6eb007d0
+kind: Kustomization
+namePrefix: notebook-controller-
+namespace: kubeflow
+patchesStrategicMerge:
+- deployment_patch.yaml
+resources:
+- ../base/cluster-role-binding.yaml
+- ../base/cluster-role.yaml
+- ../base/crd.yaml
+- ../base/deployment.yaml
+- ../base/service-account.yaml
+- ../base/service.yaml
+- ../overlays/application/application.yaml

--- a/components/notebook-controller/config/overlays/application/application.yaml
+++ b/components/notebook-controller/config/overlays/application/application.yaml
@@ -1,0 +1,37 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: notebook-controller
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: notebook-controller
+      app.kubernetes.io/name: notebook-controller
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  descriptor:
+    type: notebook-controller
+    version: v1beta1
+    description: Notebooks controller allows users to create a custom resource \"Notebook\" (jupyter notebook).
+    maintainers:
+    - name: Lun-kai Hsu
+      email: lunkai@google.com
+    owners:
+    - name: Lun-kai Hsu
+      email: lunkai@gogle.com
+    keywords:
+     - jupyter
+     - notebook
+     - notebook-controller
+     - jupyterhub
+    links:
+    - description: About
+      url: "https://github.com/kubeflow/kubeflow/tree/master/components/notebook-controller"
+  addOwnerRef: true

--- a/components/notebook-controller/config/overlays/application/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/application/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+commonLabels:
+  app.kubernetes.io/component: notebook-controller
+  app.kubernetes.io/name: notebook-controller
+kind: Kustomization
+resources:
+- application.yaml

--- a/components/notebook-controller/config/overlays/istio/deployment.yaml
+++ b/components/notebook-controller/config/overlays/istio/deployment.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        env:
+          - name: USE_ISTIO
+            value: $(USE_ISTIO)
+          - name: ISTIO_GATEWAY
+            value: $(ISTIO_GATEWAY)

--- a/components/notebook-controller/config/overlays/istio/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/istio/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml
+configMapGenerator:
+- name: parameters
+  behavior: merge
+  envs:
+  - params.env
+generatorOptions:
+  disableNameSuffixHash: true

--- a/components/notebook-controller/config/overlays/istio/params.env
+++ b/components/notebook-controller/config/overlays/istio/params.env
@@ -1,0 +1,2 @@
+USE_ISTIO=true
+ISTIO_GATEWAY=kubeflow/kubeflow-gateway


### PR DESCRIPTION
### Issue Resolved

Resolves: https://github.com/kubeflow/kubeflow/issues/5592
Umbrella issue: https://github.com/kubeflow/manifests/issues/1740

### Description

As part of the work of wg-manifests for 1.3
(https://github.com/kubeflow/manifests/issues/1735), we are moving manifests
development in upstream repos. This gives the application developers full
ownership of their manifests, tracked in a single place.

This PR copies the manifests for application `Notebook Controller`
from path `apps/jupyter/notebook-controller/upstream` of kubeflow/manifests to path
`components/notebook-controller/config` of the upstream repo (https://github.com/kubeflow/kubeflow).

cc @kubeflow/wg-notebooks-leads 