### PR TITLE
Central Dashboard: Move manifests development upstream

### DIFF
--- a/components/centraldashboard/manifests/base/clusterrole-binding.yaml
+++ b/components/centraldashboard/manifests/base/clusterrole-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: kubeflow

--- a/components/centraldashboard/manifests/base/clusterrole.yaml
+++ b/components/centraldashboard/manifests/base/clusterrole.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: centraldashboard
+  template:
+    metadata:
+      labels:
+        app: centraldashboard
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-images-public/centraldashboard
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8082
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        name: centraldashboard
+        ports:
+        - containerPort: 8082
+          protocol: TCP
+      serviceAccountName: centraldashboard

--- a/components/centraldashboard/manifests/base/deployment_patch.yaml
+++ b/components/centraldashboard/manifests/base/deployment_patch.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: centraldashboard
+spec:
+  template:
+    spec:
+      containers:
+      - name: centraldashboard
+        env:
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)
+        - name: PROFILES_KFAM_SERVICE_HOST
+          value: profiles-kfam.kubeflow
+        - name: REGISTRATION_FLOW
+          value: $(registration-flow)
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config

--- a/components/centraldashboard/manifests/base/kustomization.yaml
+++ b/components/centraldashboard/manifests/base/kustomization.yaml
@@ -1,0 +1,64 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- clusterrole-binding.yaml
+- clusterrole.yaml
+- deployment.yaml
+- role-binding.yaml
+- role.yaml
+- service-account.yaml
+- service.yaml
+patchesStrategicMerge:
+- deployment_patch.yaml
+namespace: kubeflow
+commonLabels:
+  kustomize.component: centraldashboard
+images:
+- name: gcr.io/kubeflow-images-public/centraldashboard
+  newName: gcr.io/kubeflow-images-public/centraldashboard
+  newTag: vmaster-g8097cfeb
+configMapGenerator:
+- envs:
+  - params.env
+  name: parameters
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- fieldref:
+    fieldPath: metadata.namespace
+  name: namespace
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: centraldashboard
+- fieldref:
+    fieldPath: data.clusterDomain
+  name: clusterDomain
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.userid-header
+  name: userid-header
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.userid-prefix
+  name: userid-prefix
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.registration-flow
+  name: registration-flow
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+configurations:
+- params.yaml

--- a/components/centraldashboard/manifests/base/links-configmap.yaml
+++ b/components/centraldashboard/manifests/base/links-configmap.yaml
@@ -1,0 +1,82 @@
+apiVersion: v1
+data:
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "link": "/pipeline/",
+          "text": "Pipelines"
+        },
+        {
+          "link": "/jupyter/",
+          "text": "Notebook Servers"
+        },
+        {
+          "link": "/katib/",
+          "text": "Katib"
+        }
+      ],
+      "externalLinks": [],
+      "quickLinks": [
+        {
+          "text": "Upload a pipeline",
+          "desc": "Pipelines",
+          "link": "/pipeline/"
+        },
+        {
+          "text": "View all pipeline runs",
+          "desc": "Pipelines",
+          "link": "/pipeline/#/runs"
+        },
+        {
+          "text": "Create a new Notebook server",
+          "desc": "Notebook Servers",
+          "link": "/jupyter/new?namespace=kubeflow"
+        },
+        {
+          "text": "View Katib Experiments",
+          "desc": "Katib",
+          "link": "/katib/"
+        }
+      ],
+      "documentationItems": [
+        {
+          "text": "Getting Started with Kubeflow",
+          "desc": "Get your machine-learning workflow up and running on Kubeflow",
+          "link": "https://www.kubeflow.org/docs/started/getting-started/"
+        },
+        {
+          "text": "MiniKF",
+          "desc": "A fast and easy way to deploy Kubeflow locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+        },
+        {
+          "text": "Microk8s for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally on native hypervisors",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+        },
+        {
+          "text": "Minikube for Kubeflow",
+          "desc": "Quickly get Kubeflow running locally",
+          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+        },
+        {
+          "text": "Kubeflow on GCP",
+          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+          "link": "https://www.kubeflow.org/docs/gke/"
+        },
+        {
+          "text": "Kubeflow on AWS",
+          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+          "link": "https://www.kubeflow.org/docs/aws/"
+        },
+        {
+          "text": "Requirements for Kubeflow",
+          "desc": "Get more detailed information about using Kubeflow and its components",
+          "link": "https://www.kubeflow.org/docs/started/requirements/"
+        }
+      ]
+    }
+kind: ConfigMap
+metadata:
+  name: centraldashboard-links-config

--- a/components/centraldashboard/manifests/base/params.env
+++ b/components/centraldashboard/manifests/base/params.env
@@ -1,0 +1,4 @@
+clusterDomain=cluster.local
+userid-header=
+userid-prefix=
+registration-flow=true

--- a/components/centraldashboard/manifests/base/params.yaml
+++ b/components/centraldashboard/manifests/base/params.yaml
@@ -1,0 +1,9 @@
+varReference:
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service
+- path: spec/http/route/destination/host
+  kind: VirtualService
+- path: spec/template/spec/containers/0/env/0/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/1/value
+  kind: Deployment

--- a/components/centraldashboard/manifests/base/role-binding.yaml
+++ b/components/centraldashboard/manifests/base/role-binding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: centraldashboard
+subjects:
+- kind: ServiceAccount
+  name: centraldashboard
+  namespace: kubeflow

--- a/components/centraldashboard/manifests/base/role.yaml
+++ b/components/centraldashboard/manifests/base/role.yaml
@@ -1,0 +1,26 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+rules:
+- apiGroups:
+  - ""
+  - "app.k8s.io"
+  resources:
+  - applications
+  - pods
+  - pods/exec
+  - pods/log
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  verbs:
+  - get

--- a/components/centraldashboard/manifests/base/service-account.yaml
+++ b/components/centraldashboard/manifests/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: centraldashboard

--- a/components/centraldashboard/manifests/base/service.yaml
+++ b/components/centraldashboard/manifests/base/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: centralui-mapping
+      prefix: /
+      rewrite: /
+      service: centraldashboard.$(namespace)
+  labels:
+    app: centraldashboard
+  name: centraldashboard
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: 8082
+  selector:
+    app: centraldashboard
+  sessionAffinity: None
+  type: ClusterIP

--- a/components/centraldashboard/manifests/base_v3/deployment_patch.yaml
+++ b/components/centraldashboard/manifests/base_v3/deployment_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: centraldashboard
+spec:
+  template:
+    spec:
+      containers:
+      - name: centraldashboard
+        env:
+        - name: DASHBOARD_LINKS_CONFIGMAP
+          value: centraldashboard-links-config

--- a/components/centraldashboard/manifests/base_v3/kustomization.yaml
+++ b/components/centraldashboard/manifests/base_v3/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: centraldashboard
+  kustomize.component: centraldashboard
+images:
+- name: gcr.io/kubeflow-images-public/centraldashboard
+  newName: gcr.io/kubeflow-images-public/centraldashboard
+  newTag: vmaster-g8097cfeb
+resources:
+- ../base/clusterrole-binding.yaml
+- ../base/clusterrole.yaml
+- ../base/deployment.yaml
+- ../base/role-binding.yaml
+- ../base/role.yaml
+- ../base/service-account.yaml
+- ../base/service.yaml
+- ../base/links-configmap.yaml
+patchesStrategicMerge:
+- deployment_patch.yaml

--- a/components/centraldashboard/manifests/overlays/application/application.yaml
+++ b/components/centraldashboard/manifests/overlays/application/application.yaml
@@ -1,0 +1,50 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: centraldashboard
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: centraldashboard
+      app.kubernetes.io/name: centraldashboard
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    type: centraldashboard
+    version: v1beta1
+    description: Provides a Dashboard UI for kubeflow
+    maintainers:
+    - name: Jason Prodonovich
+      email: prodonjs@gmail.com
+    - name: Apoorv Verma
+      email: apverma@google.com
+    - name: Adhita Selvaraj
+      email: adhita94@gmail.com
+    owners:
+    - name: Jason Prodonovich
+      email: prodonjs@gmail.com
+    - name: Apoorv Verma
+      email: apverma@google.com
+    - name: Adhita Selvaraj
+      email: adhita94@gmail.com
+    keywords:
+     - centraldashboard
+     - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/centraldashboard
+  addOwnerRef: true
+

--- a/components/centraldashboard/manifests/overlays/application/kustomization.yaml
+++ b/components/centraldashboard/manifests/overlays/application/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app.kubernetes.io/component: centraldashboard
+  app.kubernetes.io/name: centraldashboard
+kind: Kustomization
+resources:
+- application.yaml

--- a/components/centraldashboard/manifests/overlays/istio/kustomization.yaml
+++ b/components/centraldashboard/manifests/overlays/istio/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- virtual-service.yaml
+configurations:
+- params.yaml
+

--- a/components/centraldashboard/manifests/overlays/istio/params.yaml
+++ b/components/centraldashboard/manifests/overlays/istio/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/http/route/destination/host
+  kind: VirtualService

--- a/components/centraldashboard/manifests/overlays/istio/virtual-service.yaml
+++ b/components/centraldashboard/manifests/overlays/istio/virtual-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: centraldashboard
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - match:
+    - uri:
+        prefix: /
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: centraldashboard.$(namespace).svc.$(clusterDomain)
+        port:
+          number: 80

--- a/components/centraldashboard/manifests/overlays/stacks/deployment_kf_config.yaml
+++ b/components/centraldashboard/manifests/overlays/stacks/deployment_kf_config.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: centraldashboard
+spec:
+  template:
+    spec:
+        containers:
+          - name: centraldashboard
+            env:
+            - name: USERID_HEADER
+              valueFrom:
+                configMapKeyRef:
+                  name: kubeflow-config
+                  key: userid-header
+            - name: USERID_PREFIX
+              valueFrom:
+                configMapKeyRef:
+                  name: kubeflow-config
+                  key: userid-prefix

--- a/components/centraldashboard/manifests/overlays/stacks/kustomization.yaml
+++ b/components/centraldashboard/manifests/overlays/stacks/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app.kubernetes.io/component: centraldashboard
+  app.kubernetes.io/name: centraldashboard
+kind: Kustomization
+namespace: kubeflow
+patchesStrategicMerge:
+- deployment_kf_config.yaml
+resources:
+- ../../base_v3
+- ../../overlays/istio
+- ../../overlays/application


### PR DESCRIPTION

### Issue Resolved

Resolves: https://github.com/kubeflow/kubeflow/issues/5594
Umbrella issue: https://github.com/kubeflow/manifests/issues/1740

### Description

As part of the work of wg-manifests for 1.3
(https://github.com/kubeflow/manifests/issues/1735), we are moving manifests
development in upstream repos. This gives the application developers full
ownership of their manifests, tracked in a single place.

This PR copies the manifests for application `Central Dashboard`
from path `apps/centraldashboard/upstream` of kubeflow/manifests to path
`components/centraldashboard/manifests` of the upstream repo (https://github.com/kubeflow/kubeflow).

cc @kubeflow/wg-notebooks-leads