### PR TITLE
(JWA): Allow setting container port

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -151,6 +151,14 @@ def set_notebook_memory(notebook, body, defaults):
     container["resources"]["requests"]["memory"] = memory
 
 
+def set_notebook_port(notebook, body, defaults):
+    container = notebook["spec"]["template"]["spec"]["containers"][0]
+
+    containerPort = get_form_value(body, defaults, "containerPort")
+
+    container["ports"][0]["containerPort"] = containerPort
+
+
 def set_notebook_tolerations(notebook, body, defaults):
     tolerations_group_key = get_form_value(body, defaults, "tolerationGroup")
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -14,6 +14,10 @@ spec:
           image: ""
           volumeMounts: []
           env: []
+          ports:
+          - name: notebook-port
+            containerPort: 
+            protocol: TCP
           resources:
             requests:
               cpu: "0.1"

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -48,6 +48,10 @@ spawnerFormDefaults:
     # Supported values: Always, IfNotPresent, Never
     value: IfNotPresent
     readOnly: false
+  containerPort:
+    # Port exposed in the container image
+    value: '8888'
+    readOnly: false
   cpu:
     # CPU for user's Notebook
     value: '0.5'

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -29,6 +29,7 @@ def post_pvc(namespace):
     form.set_notebook_image_pull_policy(notebook, body, defaults)
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
+    form.set_notebook_port(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)
     form.set_notebook_tolerations(notebook, body, defaults)
     form.set_notebook_affinity(notebook, body, defaults)

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -109,6 +109,13 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
       notebook.image = notebook.customImage;
     }
 
+    if (typeof notebook.containerPort === 'number') {
+    } else {
+      notebook.containerPort = parseInt(notebook.containerPort, 10);
+    }
+
+    notebook.cpu = notebook.cpu.toString()
+
     // Add Gi to all sizes
     notebook.memory = notebook.memory.toString() + 'Gi';
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -45,13 +45,21 @@
   </mat-form-field>
 
   <lib-advanced-options>
-    <mat-form-field class="wide" appearance="outline">
-      <mat-label>Image pull policy</mat-label>
-      <mat-select [formControl]="parentForm.get('imagePullPolicy')">
-        <mat-option value="Always">Always</mat-option>
-        <mat-option value="IfNotPresent">IfNotPresent</mat-option>
-        <mat-option value="Never">Never</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <div class="row">
+      <mat-form-field class="column" appearance="outline">
+        <mat-label>Image pull policy</mat-label>
+        <mat-select [formControl]="parentForm.get('imagePullPolicy')">
+          <mat-option value="Always">Always</mat-option>
+          <mat-option value="IfNotPresent">IfNotPresent</mat-option>
+          <mat-option value="Never">Never</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <lib-positive-number-input class="column" appearance="outline"
+        min="80"
+        step="1"
+        label="Provide a container port"
+        [sizeControl]="parentForm.get('containerPort')"
+      ></lib-positive-number-input>
+    </div>
   </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -11,6 +11,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
   @Input() parentForm: FormGroup;
   @Input() images: string[];
   @Input() readonly: boolean;
+  @Input() port: number;
 
   subs = new Subscription();
 
@@ -19,7 +20,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.subs.add(
       this.parentForm.get('customImageCheck').valueChanges.subscribe(check => {
-        // Make sure that the use will insert and Image value
+        // Make sure that the uses inserts an image value
         if (check) {
           this.parentForm.get('customImage').setValidators(Validators.required);
           this.parentForm.get('image').setValidators([]);
@@ -30,6 +31,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
         this.parentForm.get('customImage').updateValueAndValidity();
         this.parentForm.get('image').updateValueAndValidity();
+        this.parentForm.get('containerPort').updateValueAndValidity();
       }),
     );
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -12,6 +12,7 @@ export function getFormDefaults(): FormGroup {
     imagePullPolicy: ['IfNotPresent', [Validators.required]],
     customImage: ['', []],
     customImageCheck: [false, []],
+    containerPort: ['', [Validators.required]],
     cpu: [1, [Validators.required]],
     memory: [1, [Validators.required]],
     gpus: fb.group({
@@ -148,6 +149,11 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
   formCtrl.controls.image.setValue(config.image.value);
   if (config.image.readOnly) {
     formCtrl.controls.image.disable();
+  }
+
+  formCtrl.controls.containerPort.setValue(config.containerPort.value);
+  if (config.containerPort.readOnly) {
+    formCtrl.controls.containerPort.disable();
   }
 
   formCtrl.controls.imagePullPolicy.setValue(config.imagePullPolicy.value);

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -37,6 +37,7 @@ export interface NotebookFormObject {
   namespace: string;
   image: string;
   imagePullPolicy: string;
+  containerPort: number;
   customImage?: string;
   customImageCheck: boolean;
   cpu: number | string;
@@ -138,6 +139,11 @@ export interface Config {
 
   imagePullPolicy?: {
     value: string;
+    readOnly?: boolean;
+  };
+
+  containerPort?: {
+    value: number;
     readOnly?: boolean;
   };
 


### PR DESCRIPTION
This PR adds the ability to set the container port for the "Notebook" server, which is an important step towards providing support for more generic web-apps. This PR relies on https://github.com/kubeflow/kubeflow/pull/5606. 
Together with https://github.com/kubeflow/kubeflow/pull/5601, it should be possible to launch any web-app, provided that app supports being hosted at a subfolder URI. For things like jupyter or R-Studio, the `NB_PREFIX` and `www-root-path` must still be set. For code-server, the official image at `codercom/code-server:3.8.1` can now be used. However, the user in that image is not `jovyan` so the workspace volume will not be correct and authentication is enabled, so it might still be better to use a custom built image. 

![image](https://user-images.githubusercontent.com/28541758/107951887-4c8e3680-6f99-11eb-87c6-fa98ba8e4cb1.png)

`davidspek/jupyter-web-app:0.12`
/cc @kimwnasptd @thesuperzapper @StefanoFioravanzo 