### PR TITLE
Profiles   KFAM: Move manifests development upstream

### DIFF
--- a/components/profile-controller/config/base/README.md
+++ b/components/profile-controller/config/base/README.md
@@ -1,0 +1,5 @@
+When profile-controller image updated, you can run below command to update it in manifest.
+
+```
+kustomize edit set image gcr.io/kubeflow-images-public/profile-controller:$NEW_TAG
+```

--- a/components/profile-controller/config/base/cluster-role-binding.yaml
+++ b/components/profile-controller/config/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: controller-service-account

--- a/components/profile-controller/config/base/crd.yaml
+++ b/components/profile-controller/config/base/crd.yaml
@@ -1,0 +1,156 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: profiles.kubeflow.org
+spec:
+  conversion:
+    strategy: None
+  group: kubeflow.org
+  names:
+    kind: Profile
+    plural: profiles
+  scope: Cluster
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: Profile is the Schema for the profiles API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ProfileSpec defines the desired state of Profile
+          properties:
+            owner:
+              description: The profile owner
+              properties:
+                apiGroup:
+                  description: APIGroup holds the API group of the referenced subject.
+                    Defaults to "" for ServiceAccount subjects. Defaults to "rbac.authorization.k8s.io"
+                    for User and Group subjects.
+                  type: string
+                kind:
+                  description: Kind of object being referenced. Values defined by
+                    this API group are "User", "Group", and "ServiceAccount". If the
+                    Authorizer does not recognized the kind value, the Authorizer
+                    should report an error.
+                  type: string
+                name:
+                  description: Name of the object being referenced.
+                  type: string
+              required:
+                - kind
+                - name
+              type: object
+            plugins:
+              items:
+                description: Plugin is for customize actions on different platform.
+                properties:
+                  apiVersion:
+                    description: 'APIVersion defines the versioned schema of this
+                      representation of an object. Servers should convert recognized
+                      schemas to the latest internal value, and may reject unrecognized
+                      values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+                    type: string
+                  kind:
+                    description: 'Kind is a string value representing the REST resource
+                      this object represents. Servers may infer this from the endpoint
+                      the client submits requests to. Cannot be updated. In CamelCase.
+                      More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+                    type: string
+                  spec:
+                    type: object
+                type: object
+              type: array
+            resourceQuotaSpec:
+              description: Resourcequota that will be applied to target namespace
+              properties:
+                hard:
+                  additionalProperties:
+                    type: string
+                  description: 'hard is the set of desired hard limits for each named
+                    resource. More info: https://kubernetes.io/docs/concepts/policy/resource-quotas/'
+                  type: object
+                scopeSelector:
+                  description: scopeSelector is also a collection of filters like
+                    scopes that must match each object tracked by a quota but expressed
+                    using ScopeSelectorOperator in combination with possible values.
+                    For a resource to match, both scopes AND scopeSelector (if specified
+                    in spec), must be matched.
+                  properties:
+                    matchExpressions:
+                      description: A list of scope selector requirements by scope
+                        of the resources.
+                      items:
+                        description: A scoped-resource selector requirement is a selector
+                          that contains values, a scope name, and an operator that
+                          relates the scope name and values.
+                        properties:
+                          operator:
+                            description: Represents a scope's relationship to a set
+                              of values. Valid operators are In, NotIn, Exists, DoesNotExist.
+                            type: string
+                          scopeName:
+                            description: The name of the scope that the selector applies
+                              to.
+                            type: string
+                          values:
+                            description: An array of string values. If the operator
+                              is In or NotIn, the values array must be non-empty.
+                              If the operator is Exists or DoesNotExist, the values
+                              array must be empty. This array is replaced during a
+                              strategic merge patch.
+                            items:
+                              type: string
+                            type: array
+                        required:
+                          - operator
+                          - scopeName
+                        type: object
+                      type: array
+                  type: object
+                scopes:
+                  description: A collection of filters that must match each object
+                    tracked by a quota. If not specified, the quota matches all objects.
+                  items:
+                    description: A ResourceQuotaScope defines a filter that must match
+                      each object tracked by a quota
+                    type: string
+                  type: array
+              type: object
+          type: object
+        status:
+          description: ProfileStatus defines the observed state of Profile
+          properties:
+            conditions:
+              items:
+                properties:
+                  message:
+                    type: string
+                  status:
+                    type: string
+                  type:
+                    type: string
+                type: object
+              type: array
+          type: object
+      type: object
+  version: v1
+  versions:
+    - name: v1
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false

--- a/components/profile-controller/config/base/deployment.yaml
+++ b/components/profile-controller/config/base/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - command:
+        - /manager
+        args:
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
+        - "-workload-identity"
+        - $(gcp-sa)
+        image: gcr.io/kubeflow-images-public/profile-controller:v20190619-v0-219-gbd3daa8c-dirty-1ced0e
+        imagePullPolicy: Always
+        name: manager
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        ports:
+        - containerPort: 8080
+          name: manager-http
+          protocol: TCP
+      - command:
+        - /access-management
+        args:
+        - "-cluster-admin"
+        - $(admin)
+        - "-userid-header"
+        - $(userid-header)
+        - "-userid-prefix"
+        - $(userid-prefix)
+        image: gcr.io/kubeflow-images-public/kfam:v20190612-v0-170-ga06cdb79-dirty-a33ee4
+        imagePullPolicy: Always
+        name: kfam
+        livenessProbe:
+          httpGet:
+            path: /metrics
+            port: 8081
+          initialDelaySeconds: 30
+          periodSeconds: 30
+        ports:
+        - containerPort: 8081
+          name: kfam-http
+          protocol: TCP
+      serviceAccountName: controller-service-account

--- a/components/profile-controller/config/base/kustomization.yaml
+++ b/components/profile-controller/config/base/kustomization.yaml
@@ -1,0 +1,65 @@
+# TODO(jlewi): This kustomization.yaml is deprecated. We want the
+# base_v3 version. This version uses a bunch of problematic patterns e.g.
+# i) Using vars to do command line substitution
+# ii) Not using a configmap to make application and global config available
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- crd.yaml
+- deployment.yaml
+- service.yaml
+- service-account.yaml
+namePrefix: profiles-
+namespace: kubeflow
+commonLabels:
+  kustomize.component: profiles
+configMapGenerator:
+- envs:
+  - params.env
+  name: profiles-parameters
+images:
+- name: gcr.io/kubeflow-images-public/kfam
+  newName: gcr.io/kubeflow-images-public/kfam
+  newTag: vmaster-g9f3bfd00
+- name: gcr.io/kubeflow-images-public/profile-controller
+  newName: gcr.io/kubeflow-images-public/profile-controller
+  newTag: vmaster-ga49f658f
+vars:
+- fieldref:
+    fieldPath: data.admin
+  name: admin
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: profiles-parameters
+- fieldref:
+    fieldPath: data.gcp-sa
+  name: gcp-sa
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: profiles-parameters
+- fieldref:
+    fieldPath: data.userid-header
+  name: userid-header
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: profiles-parameters
+- fieldref:
+    fieldPath: data.userid-prefix
+  name: userid-prefix
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: profiles-parameters
+- fieldref:
+    fieldPath: metadata.namespace
+  name: namespace
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: kfam
+configurations:
+- params.yaml

--- a/components/profile-controller/config/base/params.env
+++ b/components/profile-controller/config/base/params.env
@@ -1,0 +1,4 @@
+admin=anonymous
+gcp-sa=
+userid-header=
+userid-prefix=

--- a/components/profile-controller/config/base/params.yaml
+++ b/components/profile-controller/config/base/params.yaml
@@ -1,0 +1,13 @@
+varReference:
+- path: spec/template/spec/containers/0/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/0/args/5
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/1
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/3
+  kind: Deployment
+- path: spec/template/spec/containers/1/args/5
+  kind: Deployment

--- a/components/profile-controller/config/base/service-account.yaml
+++ b/components/profile-controller/config/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: controller-service-account

--- a/components/profile-controller/config/base/service.yaml
+++ b/components/profile-controller/config/base/service.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kfam
+spec:
+  ports:
+    - port: 8081

--- a/components/profile-controller/config/base_v3/deployment_patch.yaml
+++ b/components/profile-controller/config/base_v3/deployment_patch.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - /manager 
+        - -userid-header 
+        - $(USERID_HEADER) 
+        - -userid-prefix 
+        - $(USERID_PREFIX) 
+        - -workload-identity 
+        - $(WORKLOAD_IDENTITY)
+        args: []
+        name: manager
+        env:
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-header
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-prefix
+        - name: WORKLOAD_IDENTITY
+          valueFrom:
+            configMapKeyRef:
+              name: profiles-config
+              key: gcp-sa
+      - command:
+        - /access-management 
+        - -cluster-admin 
+        - $(CLUSTER_ADMIN) 
+        - -userid-prefix 
+        - $(USERID_PREFIX)
+        - -userid-header
+        - $(USERID_HEADER)
+        args: []
+        name: kfam
+        env:
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-header
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-prefix
+        - name: CLUSTER_ADMIN
+          valueFrom:
+            configMapKeyRef:
+              name: profiles-config
+              key: admin

--- a/components/profile-controller/config/base_v3/kustomization.yaml
+++ b/components/profile-controller/config/base_v3/kustomization.yaml
@@ -1,0 +1,29 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: profiles-
+commonLabels:
+  kustomize.component: profiles
+images:
+- name: gcr.io/kubeflow-images-public/kfam
+  newName: gcr.io/kubeflow-images-public/kfam
+  newTag: vmaster-g9f3bfd00
+- name: gcr.io/kubeflow-images-public/profile-controller
+  newName: gcr.io/kubeflow-images-public/profile-controller
+  newTag: vmaster-ga49f658f
+resources:
+- ../base/cluster-role-binding.yaml
+- ../base/crd.yaml
+- ../base/deployment.yaml
+- ../base/service.yaml
+- ../base/service-account.yaml
+- ../overlays/istio/virtual-service.yaml
+- ../overlays/application/application.yaml
+patchesStrategicMerge:
+- deployment_patch.yaml
+configMapGenerator:
+# We need the name to be unique without the suffix because the original name is what
+# gets used with patches
+- name: profiles-config
+  literals:
+  - admin=
+  - gcp-sa=

--- a/components/profile-controller/config/overlays/application/application.yaml
+++ b/components/profile-controller/config/overlays/application/application.yaml
@@ -1,0 +1,37 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: profiles
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: profiles
+      app.kubernetes.io/name: profiles
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  descriptor:
+    type: profiles
+    version: v1
+    description: ""
+    maintainers:
+    - name: Kunming Qu
+      email: kunming@google.com
+    owners:
+    - name: Kunming Qu
+      email: kunming@google.com
+    keywords:
+     - profiles
+     - kubeflow
+    links:
+    - description: profiles
+      url: "https://github.com/kubeflow/kubeflow/tree/master/components/profile-controller"
+    - description: kfam
+      url: "https://github.com/kubeflow/kubeflow/tree/master/components/access-management"
+  addOwnerRef: true

--- a/components/profile-controller/config/overlays/application/kustomization.yaml
+++ b/components/profile-controller/config/overlays/application/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+commonLabels:
+  app.kubernetes.io/component: profiles
+  app.kubernetes.io/name: profiles
+kind: Kustomization
+resources:
+- application.yaml

--- a/components/profile-controller/config/overlays/debug/deployment.yaml
+++ b/components/profile-controller/config/overlays/debug/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        command: ["/go/bin/dlv"]
+        args: ["--listen=:2345", "--headless=true", "--api-version=2", "exec", "/go/src/github.com/kubeflow/kubeflow/components/profile-controller/manager"]
+        env:
+        - name: project
+          valueFrom:
+            configMapKeyRef:
+              name: parameters
+              key: project
+        image: gcr.io/$(project)/profile-controller:latest
+        ports:
+        - containerPort: 2345
+        securityContext:
+          privileged: true

--- a/components/profile-controller/config/overlays/debug/kustomization.yaml
+++ b/components/profile-controller/config/overlays/debug/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml
+configMapGenerator:
+- name: parameters
+  envs:
+  - params.env
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+- name: project
+  objref:
+    kind: ConfigMap
+    name: parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.project
+configurations:
+- params.yaml
+images:
+- name: gcr.io/$(project)/profile-controller
+  newName: gcr.io/$(project)/profile-controller
+  newTag: latest

--- a/components/profile-controller/config/overlays/debug/params.env
+++ b/components/profile-controller/config/overlays/debug/params.env
@@ -1,0 +1,1 @@
+project=

--- a/components/profile-controller/config/overlays/debug/params.yaml
+++ b/components/profile-controller/config/overlays/debug/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/template/spec/containers/image
+  kind: Deployment

--- a/components/profile-controller/config/overlays/devices/deployment.yaml
+++ b/components/profile-controller/config/overlays/devices/deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        resources:
+          requests:
+            memory: "64Mi"
+            cpu: "250m"
+          limits:
+            memory: "128Mi"
+            cpu: "500m"

--- a/components/profile-controller/config/overlays/devices/kustomization.yaml
+++ b/components/profile-controller/config/overlays/devices/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+patchesStrategicMerge:
+- deployment.yaml

--- a/components/profile-controller/config/overlays/istio/kustomization.yaml
+++ b/components/profile-controller/config/overlays/istio/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+resources:
+- virtual-service.yaml
+configurations:
+- params.yaml

--- a/components/profile-controller/config/overlays/istio/params.yaml
+++ b/components/profile-controller/config/overlays/istio/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/http/route/destination/host
+  kind: VirtualService

--- a/components/profile-controller/config/overlays/istio/virtual-service.yaml
+++ b/components/profile-controller/config/overlays/istio/virtual-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: kfam
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /kfam
+    match:
+    - uri:
+        prefix: /kfam/
+    rewrite:
+      uri: /kfam/
+    route:
+    - destination:
+        host: profiles-kfam.$(namespace).svc.cluster.local
+        port:
+          number: 8081

--- a/components/profile-controller/config/overlays/test/app_test.yaml
+++ b/components/profile-controller/config/overlays/test/app_test.yaml
@@ -1,0 +1,23 @@
+apiVersion: kfdef.apps.kubeflow.org/v1alpha1
+kind: KfDef
+metadata:
+  name: plugin-test
+spec:
+  appdir: .
+  componentParams:
+    profiles:
+    - name: overlay
+      value: debug
+    - name: overlay
+      value: devices
+  components:
+  - profiles
+  manifestsRepo: /Users/kdkasrav/plugin-test/.cache/manifests/pull/31/head
+  packageManager: kustomize@pull/31
+  packages:
+  - profiles
+  repo: /Users/kdkasrav/plugin-test/.cache/kubeflow/master/kubeflow
+  useBasicAuth: false
+  useIstio: true
+  version: master
+status: {}

--- a/components/profile-controller/config/overlays/test/kustomization.yaml
+++ b/components/profile-controller/config/overlays/test/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../../base
+#generators:
+#- app_test.yaml


### PR DESCRIPTION
### Issue Resolved

Resolves: https://github.com/kubeflow/kubeflow/issues/5595
Umbrella issue: https://github.com/kubeflow/manifests/issues/1740

### Description

As part of the work of wg-manifests for 1.3
(https://github.com/kubeflow/manifests/issues/1735), we are moving manifests
development in upstream repos. This gives the application developers full
ownership of their manifests, tracked in a single place.

This PR copies the manifests for application `Profiles   KFAM`
from path `apps/profiles/upstream` of kubeflow/manifests to path
`components/profile-controller/config` of the upstream repo (https://github.com/kubeflow/kubeflow).

cc @kubeflow/wg-notebooks-leads