### PR TITLE
PodDefaults Webhook: Move manifests development upstream

### DIFF
--- a/components/admission-webhook/manifests/bootstrap/base/cluster-role-binding.yaml
+++ b/components/admission-webhook/manifests/bootstrap/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-role
+subjects:
+- kind: ServiceAccount
+  name: service-account

--- a/components/admission-webhook/manifests/bootstrap/base/cluster-role.yaml
+++ b/components/admission-webhook/manifests/bootstrap/base/cluster-role.yaml
@@ -1,0 +1,25 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: cluster-role
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - delete  
+    

--- a/components/admission-webhook/manifests/bootstrap/base/config-map.yaml
+++ b/components/admission-webhook/manifests/bootstrap/base/config-map.yaml
@@ -1,0 +1,131 @@
+apiVersion: v1
+data:
+  create_ca.sh: |
+    #!/bin/bash
+
+    set -e
+
+    usage() {
+        cat <<EOF
+    Generate certificate suitable for use with an sidecar-injector webhook service.
+    This script uses k8s' CertificateSigningRequest API to a generate a
+    certificate signed by k8s CA suitable for use with sidecar-injector webhook
+    services. This requires permissions to create and approve CSR. See
+    https://kubernetes.io/docs/tasks/tls/managing-tls-in-a-cluster for
+    detailed explantion and additional instructions.
+    The server key/cert k8s CA cert are stored in a k8s secret.
+    usage: ${0} [OPTIONS]
+    The following flags are required.
+           --service          Service name of webhook.
+           --namespace        Namespace where webhook service and secret reside.
+           --secret           Secret name for CA certificate and server certificate/key pair.
+    EOF
+        exit 1
+    }
+
+    while [[ $# -gt 0 ]]; do
+        case ${1} in
+            --service)
+                service="$2"
+                shift
+                ;;
+            --secret)
+                secret="$2"
+                shift
+                ;;
+            --namespace)
+                namespace="$2"
+                shift
+                ;;
+            *)
+                usage
+                ;;
+        esac
+        shift
+    done
+
+    [ -z ${service} ] && service=$(webhookNamePrefix)service
+    [ -z ${secret} ] && secret=webhook-certs
+    [ -z ${namespace} ] && namespace=$(namespace)
+    [ -z ${namespace} ] && namespace=default
+
+    webhookDeploymentName=$(webhookNamePrefix)deployment
+    mutatingWebhookConfigName=$(webhookNamePrefix)mutating-webhook-configuration
+    echo ${service}
+    echo ${namespace}
+    echo ${secret}
+    echo ${webhookDeploymentName}
+    echo ${mutatingWebhookconfigName}
+    if [ ! -x "$(command -v openssl)" ]; then
+        echo "openssl not found"
+        exit 1
+    fi
+    csrName=${service}.${namespace}
+    tmpdir=$(mktemp -d)
+    echo "creating certs in tmpdir ${tmpdir} "
+
+    # x509 outputs a self signed certificate instead of certificate request, later used as self signed root CA
+    openssl req -x509 -newkey rsa:2048 -keyout ${tmpdir}/self_ca.key -out ${tmpdir}/self_ca.crt -days 365 -nodes -subj /C=/ST=/L=/O=/OU=/CN=test-certificate-authority
+
+    cat <<EOF >> ${tmpdir}/csr.conf
+    [req]
+    req_extensions = v3_req
+    distinguished_name = req_distinguished_name
+    [req_distinguished_name]
+    [ v3_req ]
+    basicConstraints = CA:FALSE
+    keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+    extendedKeyUsage = serverAuth
+    subjectAltName = @alt_names
+    [alt_names]
+    DNS.1 = ${service}
+    DNS.2 = ${service}.${namespace}
+    DNS.3 = ${service}.${namespace}.svc
+    EOF
+
+    openssl genrsa -out ${tmpdir}/server-key.pem 2048
+    openssl req -new -key ${tmpdir}/server-key.pem -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
+
+    # Self sign
+    openssl x509 -req -days 365 -in ${tmpdir}/server.csr -CA ${tmpdir}/self_ca.crt -CAkey ${tmpdir}/self_ca.key -CAcreateserial -out ${tmpdir}/server-cert.pem
+
+    # create the secret with CA cert and server cert/key
+    kubectl create secret generic ${secret} \
+            --from-file=key.pem=${tmpdir}/server-key.pem \
+            --from-file=cert.pem=${tmpdir}/server-cert.pem \
+            --dry-run -o yaml |
+        kubectl -n ${namespace} apply -f -
+
+    # Webhook pod needs to be restarted so that the service reload the secret
+    # http://github.com/kueflow/kubeflow/issues/3227
+    webhookPod=$(kubectl get pods -n ${namespace} |grep ${webhookDeploymentName} |awk '{print $1;}')
+    # ignore error if webhook pod does not exist
+    kubectl delete pod ${webhookPod} 2>/dev/null || true
+    echo "webhook ${webhookPod} is restarted to utilize the new secret"
+    
+    cat ${tmpdir}/self_ca.crt
+    
+    # -a means base64 encode
+    caBundle=$(cat ${tmpdir}/self_ca.crt | openssl enc -a -A)
+    echo ${caBundle}
+
+    patchString='[{"op": "replace", "path": "/webhooks/0/clientConfig/caBundle", "value":"{{CA_BUNDLE}}"}]'
+    patchString=$(echo ${patchString} | sed "s|{{CA_BUNDLE}}|${caBundle}|g")
+    echo ${patchString}
+
+    checkWebhookConfig() {
+      currentBundle=$(kubectl get mutatingwebhookconfigurations -n ${namespace} ${mutatingWebhookConfigName} -o jsonpath='{.webhooks[0].clientConfig.caBundle}')
+      [[ "$currentBundle" == "$caBundle" ]]
+    }
+
+    while true; do
+      if ! checkWebhookConfig; then
+        echo "patching ca bundle for webhook configuration..."
+        kubectl patch mutatingwebhookconfiguration ${mutatingWebhookConfigName} \
+            --type='json' -p="${patchString}"
+      fi
+      sleep 10
+    done
+kind: ConfigMap
+metadata:
+  name: config-map

--- a/components/admission-webhook/manifests/bootstrap/base/kustomization.yaml
+++ b/components/admission-webhook/manifests/bootstrap/base/kustomization.yaml
@@ -1,0 +1,40 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- config-map.yaml
+- service-account.yaml
+- stateful-set.yaml
+commonLabels:
+  kustomize.component: admission-webhook-bootstrap
+namePrefix: admission-webhook-bootstrap-
+images:
+- name: gcr.io/kubeflow-images-public/ingress-setup
+  newName: gcr.io/kubeflow-images-public/ingress-setup
+  newTag: latest
+generatorOptions:
+  disableNameSuffixHash: true
+configurations:
+- params.yaml
+namespace: kubeflow
+configMapGenerator:
+- name: config-map
+  behavior: merge
+  envs:
+  - params.env
+vars:
+- name: webhookNamePrefix
+  objref:
+    kind: ConfigMap
+    name: config-map
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.webhookNamePrefix
+- name: namespace
+  objref:
+    kind: ConfigMap
+    name: config-map
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.namespace

--- a/components/admission-webhook/manifests/bootstrap/base/params.env
+++ b/components/admission-webhook/manifests/bootstrap/base/params.env
@@ -1,0 +1,2 @@
+namespace=kubeflow
+webhookNamePrefix=admission-webhook-

--- a/components/admission-webhook/manifests/bootstrap/base/params.yaml
+++ b/components/admission-webhook/manifests/bootstrap/base/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: data/create_ca.sh
+  kind: ConfigMap

--- a/components/admission-webhook/manifests/bootstrap/base/service-account.yaml
+++ b/components/admission-webhook/manifests/bootstrap/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account

--- a/components/admission-webhook/manifests/bootstrap/base/stateful-set.yaml
+++ b/components/admission-webhook/manifests/bootstrap/base/stateful-set.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: stateful-set
+spec:
+  replicas: 1
+  serviceName: service
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - command:
+        - sh
+        - /var/webhook-config/create_ca.sh
+        image: gcr.io/kubeflow-images-public/ingress-setup:latest
+        name: bootstrap
+        volumeMounts:
+        - mountPath: /var/webhook-config/
+          name: admission-webhook-config
+      restartPolicy: Always
+      serviceAccountName: service-account
+      volumes:
+      - configMap:
+          name: config-map
+        name: admission-webhook-config
+  # Workaround for https://github.com/kubernetes-sigs/kustomize/issues/677
+  volumeClaimTemplates: []

--- a/components/admission-webhook/manifests/bootstrap/overlays/application/application.yaml
+++ b/components/admission-webhook/manifests/bootstrap/overlays/application/application.yaml
@@ -1,0 +1,34 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: bootstrap
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bootstrap
+      app.kubernetes.io/instance: bootstrap-v0.7.0
+      app.kubernetes.io/managed-by: kfctl
+      app.kubernetes.io/component: bootstrap
+      app.kubernetes.io/part-of: kubeflow
+      app.kubernetes.io/version: v0.7.0
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: StatefulSet
+  - group: core
+    kind: ServiceAccount
+  descriptor:
+    type: bootstrap
+    version: v1beta1
+    description: Bootstraps the admission-webhook controller
+    maintainers: []
+    owners: []
+    keywords: 
+     - admission-webhook
+     - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook
+  addOwnerRef: true
+

--- a/components/admission-webhook/manifests/bootstrap/overlays/application/kustomization.yaml
+++ b/components/admission-webhook/manifests/bootstrap/overlays/application/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+commonLabels:
+  app.kubernetes.io/component: bootstrap
+  app.kubernetes.io/name: bootstrap
+kind: Kustomization
+resources:
+- application.yaml

--- a/components/admission-webhook/manifests/webhook/base/cluster-role-binding.yaml
+++ b/components/admission-webhook/manifests/webhook/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-role
+subjects:
+- kind: ServiceAccount
+  name: service-account

--- a/components/admission-webhook/manifests/webhook/base/cluster-role.yaml
+++ b/components/admission-webhook/manifests/webhook/base/cluster-role.yaml
@@ -1,0 +1,65 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-role
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - poddefaults
+  verbs:
+  - get
+  - watch
+  - list
+  - update
+  - create
+  - patch
+  - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-poddefaults-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-poddefaults-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-poddefaults-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-admin: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-poddefaults-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/admission-webhook/manifests/webhook/base/crd.yaml
+++ b/components/admission-webhook/manifests/webhook/base/crd.yaml
@@ -1,0 +1,51 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: poddefaults.kubeflow.org
+spec:
+  group: kubeflow.org
+  names:
+    kind: PodDefault
+    plural: poddefaults
+    singular: poddefault
+  scope: Namespaced
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            desc:
+              type: string
+            serviceAccountName:
+              type: string
+            env:
+              items:
+                type: object
+              type: array
+            envFrom:
+              items:
+                type: object
+              type: array
+            selector:
+              type: object
+            volumeMounts:
+              items:
+                type: object
+              type: array
+            volumes:
+              items:
+                type: object
+              type: array
+          required:
+          - selector
+          type: object
+        status:
+          type: object
+      type: object

--- a/components/admission-webhook/manifests/webhook/base/deployment.yaml
+++ b/components/admission-webhook/manifests/webhook/base/deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-images-public/admission-webhook:v20190520-v0-139-gcee39dbc-dirty-0d8f4c
+        name: admission-webhook
+        volumeMounts:
+        - mountPath: /etc/webhook/certs
+          name: webhook-cert
+          readOnly: true
+      volumes:
+      - name: webhook-cert
+        secret:
+          secretName: webhook-certs
+      serviceAccountName: service-account

--- a/components/admission-webhook/manifests/webhook/base/kustomization.yaml
+++ b/components/admission-webhook/manifests/webhook/base/kustomization.yaml
@@ -1,0 +1,55 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- mutating-webhook-configuration.yaml
+- service-account.yaml
+- service.yaml
+- crd.yaml
+commonLabels:
+  app: admission-webhook
+  kustomize.component: admission-webhook
+namePrefix: admission-webhook-
+images:
+- name: gcr.io/kubeflow-images-public/admission-webhook
+  newName: gcr.io/kubeflow-images-public/admission-webhook
+  newTag: vmaster-ge5452b6f
+namespace: kubeflow
+configMapGenerator:
+- envs:
+  - params.env
+  name: admission-webhook-parameters
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+# These vars are used to substitute in the namespace, service name and
+# deployment name into the mutating WebHookConfiguration.
+# Since its a CR kustomize isn't aware of those fields and won't
+# transform them.
+# We need the var names to be relatively unique so that when we
+# compose with other applications they won't conflict.
+- fieldref:
+    fieldPath: data.namespace
+  name: podDefaultsNamespace
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: admission-webhook-parameters
+- fieldref:
+    fieldPath: metadata.name
+  name: podDefaultsServiceName
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: metadata.name
+  name: podDefaultsDeploymentName
+  objref:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: deployment
+configurations:
+- params.yaml

--- a/components/admission-webhook/manifests/webhook/base/mutating-webhook-configuration.yaml
+++ b/components/admission-webhook/manifests/webhook/base/mutating-webhook-configuration.yaml
@@ -1,0 +1,24 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+webhooks:
+- clientConfig:
+    caBundle: ""
+    service:
+      name: $(podDefaultsServiceName)
+      namespace: $(podDefaultsNamespace)
+      path: /apply-poddefault
+  name: $(podDefaultsDeploymentName).kubeflow.org
+  namespaceSelector:
+    matchLabels:
+      app.kubernetes.io/part-of: kubeflow-profile
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods

--- a/components/admission-webhook/manifests/webhook/base/params.env
+++ b/components/admission-webhook/manifests/webhook/base/params.env
@@ -1,0 +1,1 @@
+namespace=kubeflow

--- a/components/admission-webhook/manifests/webhook/base/params.yaml
+++ b/components/admission-webhook/manifests/webhook/base/params.yaml
@@ -1,0 +1,7 @@
+varReference:
+- path: webhooks/clientConfig/service/namespace
+  kind: MutatingWebhookConfiguration
+- path: webhooks/clientConfig/service/name
+  kind: MutatingWebhookConfiguration
+- path: webhooks/name
+  kind: MutatingWebhookConfiguration

--- a/components/admission-webhook/manifests/webhook/base/service-account.yaml
+++ b/components/admission-webhook/manifests/webhook/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account

--- a/components/admission-webhook/manifests/webhook/base/service.yaml
+++ b/components/admission-webhook/manifests/webhook/base/service.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service
+spec:
+  ports:
+  - port: 443
+    targetPort: 443

--- a/components/admission-webhook/manifests/webhook/overlays/application/application.yaml
+++ b/components/admission-webhook/manifests/webhook/overlays/application/application.yaml
@@ -1,0 +1,41 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: webhook
+spec:
+  selector:
+    matchLabels:
+      # TODO(jlewi): We should probably rename the app to PodDefaults
+      # as that is what the admission controller is actually doing.
+      # webhook is generic and uninformative.      
+      app.kubernetes.io/component: webhook
+      app.kubernetes.io/name: webhook
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: apps
+    kind: StatefulSet
+  descriptor:
+    type: bootstrap
+    version: v1beta1
+    description: injects volume, volume mounts, env vars into PodDefault
+    maintainers: []
+    owners: []
+    keywords: 
+     - admission-webhook
+     - kubeflow
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook
+  addOwnerRef: true
+

--- a/components/admission-webhook/manifests/webhook/overlays/application/kustomization.yaml
+++ b/components/admission-webhook/manifests/webhook/overlays/application/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+bases:
+- ../../base
+commonLabels:
+  app.kubernetes.io/component: webhook
+  app.kubernetes.io/name: webhook
+kind: Kustomization
+resources:
+- application.yaml

--- a/components/admission-webhook/manifests/webhook/overlays/cert-manager/certificate.yaml
+++ b/components/admission-webhook/manifests/webhook/overlays/cert-manager/certificate.yaml
@@ -1,0 +1,14 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: admission-webhook-cert
+spec:
+  isCA: true
+  commonName: $(podDefaultsServiceName).$(podDefaultsNamespace).svc
+  dnsNames:
+  - $(podDefaultsServiceName).$(podDefaultsNamespace).svc
+  - $(podDefaultsServiceName).$(podDefaultsNamespace).svc.cluster.local
+  issuerRef:
+    kind: ClusterIssuer
+    name: $(podDefaultsIssuer)
+  secretName: webhook-certs

--- a/components/admission-webhook/manifests/webhook/overlays/cert-manager/deployment.yaml
+++ b/components/admission-webhook/manifests/webhook/overlays/cert-manager/deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: admission-webhook
+        args:
+        - --tlsCertFile=/etc/webhook/certs/tls.crt
+        - --tlsKeyFile=/etc/webhook/certs/tls.key

--- a/components/admission-webhook/manifests/webhook/overlays/cert-manager/kustomization.yaml
+++ b/components/admission-webhook/manifests/webhook/overlays/cert-manager/kustomization.yaml
@@ -1,0 +1,49 @@
+# This overlay uses CertManager to provision a certificate for the
+# PodDefaults admission controller. This is preferred over the old
+# way of using "bootstrap" which was running a shell script to create
+# the certificate.
+# TODO(jlewi): We should eventually refactor the manifests to delete
+# bootstrap and use certmanager by default.
+bases:
+- ../../base
+
+resources:
+- certificate.yaml
+
+patchesStrategicMerge:
+- mutating-webhook-configuration.yaml
+- deployment.yaml
+
+configMapGenerator:
+- name: admission-webhook-parameters
+  behavior: merge
+  envs:
+  - params.env
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+# These vars are used to substitute in the namespace, service name and
+# deployment name into the mutating WebHookConfiguration.
+# Since its a CR kustomize isn't aware of those fields and won't
+# transform them.
+# We need the var names to be relatively unique so that when we
+# compose with other applications they won't conflict.
+- name: podDefaultsIssuer
+  objref:
+    kind: ConfigMap
+    name: admission-webhook-parameters
+    apiVersion: v1
+  fieldref:
+    fieldpath: data.issuer
+- name: podDefaultsCertName
+  objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1alpha2
+      name: admission-webhook-cert
+  fieldref:
+    fieldpath: metadata.name
+
+configurations:
+- params.yaml

--- a/components/admission-webhook/manifests/webhook/overlays/cert-manager/mutating-webhook-configuration.yaml
+++ b/components/admission-webhook/manifests/webhook/overlays/cert-manager/mutating-webhook-configuration.yaml
@@ -1,0 +1,7 @@
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(podDefaultsNamespace)/$(podDefaultsCertName)
+  

--- a/components/admission-webhook/manifests/webhook/overlays/cert-manager/params.env
+++ b/components/admission-webhook/manifests/webhook/overlays/cert-manager/params.env
@@ -1,0 +1,1 @@
+issuer=kubeflow-self-signing-issuer

--- a/components/admission-webhook/manifests/webhook/overlays/cert-manager/params.yaml
+++ b/components/admission-webhook/manifests/webhook/overlays/cert-manager/params.yaml
@@ -1,0 +1,9 @@
+varReference:
+- path: spec/commonName
+  kind: Certificate
+- path: spec/dnsNames
+  kind: Certificate
+- path: spec/issuerRef/name
+  kind: Certificate
+- path: metadata/annotations
+  kind: MutatingWebhookConfiguration

--- a/components/admission-webhook/manifests/webhook/v3/kustomization.yaml
+++ b/components/admission-webhook/manifests/webhook/v3/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app.kubernetes.io/component: poddefaults
+  app.kubernetes.io/name: poddefaults
+kind: Kustomization
+resources:
+- ../overlays/cert-manager/
+- ../overlays/application/application.yaml


### PR DESCRIPTION

### Issue Resolved

Resolves: https://github.com/kubeflow/kubeflow/issues/5596
Umbrella issue: https://github.com/kubeflow/manifests/issues/1740

### Description

As part of the work of wg-manifests for 1.3
(https://github.com/kubeflow/manifests/issues/1735), we are moving manifests
development in upstream repos. This gives the application developers full
ownership of their manifests, tracked in a single place.

This PR copies the manifests for application `PodDefaults Webhook`
from path `apps/admission-webhook/upstream` of kubeflow/manifests to path
`components/admission-webhook/manifests` of the upstream repo (https://github.com/kubeflow/kubeflow).

cc @kubeflow/wg-notebooks-leads