### PR TITLE
Jupyter Web App: Move manifests development upstream

### DIFF
--- a/components/crud-web-apps/jupyter/manifests/base/cluster-role-binding.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-role
+subjects:
+- kind: ServiceAccount
+  name: service-account

--- a/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
@@ -1,0 +1,112 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-notebook-ui-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+rules: []
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-notebook-ui-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-notebook-ui-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  - notebooks/finalizers
+  - poddefaults
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -1,0 +1,186 @@
+# Configuration file for the Jupyter UI.
+#
+# Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
+# - The 'value' key contains the default value
+# - The 'readOnly' key determines if the option will be available to users
+#
+# If the 'readOnly' key is present and set to 'true', the respective option
+# will be disabled for users and only set by the admin. Also when a
+# Notebook is POSTED to the API if a necessary field is not present then
+# the value from the config will be used.
+#
+# If the 'readOnly' key is missing (defaults to 'false'), the respective option
+# will be available for users to edit.
+#
+# Note that some values can be templated. Such values are the names of the
+# Volumes as well as their StorageClass
+spawnerFormDefaults:
+  image:
+    # The container Image for the user's Jupyter Notebook
+    # If readonly, this value must be a member of the list below
+    value: gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+    # The list of available standard container Images
+    options:
+      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
+      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu:1.0.0
+    # By default, custom container Images are allowed
+    # Uncomment the following line to only enable standard container Images
+    readOnly: false
+  cpu:
+    # CPU for user's Notebook
+    value: '0.5'
+    readOnly: false
+  memory:
+    # Memory for user's Notebook
+    value: 1.0Gi
+    readOnly: false
+  workspaceVolume:
+    # Workspace Volume to be attached to user's Notebook
+    # Each Workspace Volume is declared with the following attributes:
+    # Type, Name, Size, MountPath and Access Mode
+    value:
+      type:
+        # The Type of the Workspace Volume
+        # Supported values: 'New', 'Existing'
+        value: New
+      name:
+        # The Name of the Workspace Volume
+        # Note that this is a templated value. Special values:
+        # {notebook-name}: Replaced with the name of the Notebook. The frontend
+        #                  will replace this value as the user types the name
+        value: 'workspace-{notebook-name}'
+      size:
+        # The Size of the Workspace Volume (in Gi)
+        value: '10Gi'
+      mountPath:
+        # The Path that the Workspace Volume will be mounted
+        value: /home/jovyan
+      accessModes:
+        # The Access Mode of the Workspace Volume
+        # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
+        value: ReadWriteOnce
+      class:
+        # The StrageClass the PVC will use if type is New. Special values are:
+        # {none}: default StorageClass
+        # {empty}: empty string ""
+        value: '{none}'
+    readOnly: false
+  dataVolumes:
+    # List of additional Data Volumes to be attached to the user's Notebook
+    value: []
+    # Each Data Volume is declared with the following attributes:
+    # Type, Name, Size, MountPath and Access Mode
+    #
+    # For example, a list with 2 Data Volumes:
+    # value:
+    #   - value:
+    #       type:
+    #         value: New
+    #       name:
+    #         value: '{notebook-name}-vol-1'
+    #       size:
+    #         value: '10Gi'
+    #       class:
+    #         value: standard
+    #       mountPath:
+    #         value: /home/jovyan/vol-1
+    #       accessModes:
+    #         value: ReadWriteOnce
+    #       class:
+    #         value: {none}
+    #   - value:
+    #       type:
+    #         value: New
+    #       name:
+    #         value: '{notebook-name}-vol-2'
+    #       size:
+    #         value: '10Gi'
+    #       mountPath:
+    #         value: /home/jovyan/vol-2
+    #       accessModes:
+    #         value: ReadWriteMany
+    #       class:
+    #         value: {none}
+    readOnly: false
+  gpus:
+    # Number of GPUs to be assigned to the Notebook Container
+    value:
+      # values: "none", "1", "2", "4", "8"
+      num: "none"
+      # Determines what the UI will show and send to the backend
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+        - limitsKey: "amd.com/gpu"
+          uiName: "AMD"
+      # Values: "" or a `limits-key` from the vendors list
+      vendor: ""
+    readOnly: false
+  shm:
+    value: true
+    readOnly: false
+  configurations:
+    # List of labels to be selected, these are the labels from PodDefaults
+    # value:
+    #   - add-gcp-secret
+    #   - default-editor
+    value: []
+    readOnly: false
+  affinityConfig:
+    # The default `configKey` from the options list
+    # If readonly, the default value will be the only option
+    value: "none"
+    # The list of available affinity configs
+    options:
+      - configKey: "none"
+        displayName: "None"
+        affinity: {}
+    # # (DESC) Pod gets an exclusive "n1-standard-2" Node
+    # # (TIP) set PreferNoSchedule taint on this node-pool
+    # # (TIP) enable cluster-autoscaler on this node-pool
+    # # (TIP) dont let users request more CPU/MEMORY than the size of this node
+    # - configKey: "exclusive__n1-standard-2"
+    #   displayName: "Exclusive: n1-standard-2"
+    #   affinity:
+    #     # (Require) Node having label: `node_pool=notebook-n1-standard-2`
+    #     nodeAffinity:
+    #       requiredDuringSchedulingIgnoredDuringExecution:
+    #         nodeSelectorTerms:
+    #           - matchExpressions:
+    #               - key: "node_pool"
+    #                 operator: "In"
+    #                 values:
+    #                   - "notebook-n1-standard-2"
+    #     # (Require) Node WITHOUT existing Pod having label: `notebook-name`
+    #     podAntiAffinity:
+    #       requiredDuringSchedulingIgnoredDuringExecution:
+    #         - labelSelector:
+    #             matchExpressions:
+    #               - key: "notebook-name"
+    #                 operator: "Exists"
+    #           namespaces: []
+    #           topologyKey: "kubernetes.io/hostname"
+    readOnly: false
+  tolerationGroup:
+    # The default `groupKey` from the options list
+    # If readonly, the default value will be the only option
+    value: "none"
+    # The list of available tolerationGroup configs
+    options:
+      - groupKey: "none"
+        displayName: "None"
+        tolerations: []
+    # - groupKey: "group_1"
+    #   displayName: "Group 1: description"
+    #   tolerations:
+    #     - key: "key1"
+    #       operator: "Equal"
+    #       value: "value1"
+    #       effect: "NoSchedule"
+    #     - key: "key2"
+    #       operator: "Equal"
+    #       value: "value2"
+    #       effect: "NoSchedule"
+    readOnly: false

--- a/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - image: gcr.io/kubeflow-images-public/jupyter-web-app        
+        name: jupyter-web-app
+        ports:
+        - containerPort: 5000
+        volumeMounts:
+        - mountPath: /etc/config
+          name: config-volume
+      serviceAccountName: service-account
+      volumes:
+      - configMap:
+          name: jupyter-web-app-config
+        name: config-volume

--- a/components/crud-web-apps/jupyter/manifests/base/deployment_patch.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment_patch.yaml
@@ -1,0 +1,27 @@
+# TODO(https://github.com/kubeflow/manifests/issues/774): This is a patch
+# that pulls out from core the parts that should be in pulled into stacks.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: jupyter-web-app
+        imagePullPolicy: $(policy)
+        env:
+        - name: ROK_SECRET_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: parameters
+              key: ROK_SECRET_NAME
+        - name: UI
+          valueFrom:
+            configMapKeyRef:
+              name: parameters
+              key: UI
+        - name: USERID_HEADER
+          value: $(userid-header)
+        - name: USERID_PREFIX
+          value: $(userid-prefix)

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -1,0 +1,85 @@
+# TODO(https://github.com/kubeflow/manifests/issues/774): 
+# This is a legacy package. Hopefully we can get rid of it once
+# 774 is complete.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# TODO(jlewi): We can't depend on base because of the deployment_patch.
+# but maybe if we changed that to use ConfigMapRef then the patch would correctly
+# override the patch applied in base_v3
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- role-binding.yaml
+- role.yaml
+- service-account.yaml
+- service.yaml
+namePrefix: jupyter-web-app-
+namespace: kubeflow
+commonLabels:
+  app: jupyter-web-app
+  kustomize.component: jupyter-web-app
+images:
+- name: gcr.io/kubeflow-images-public/jupyter-web-app
+  newName: gcr.io/kubeflow-images-public/jupyter-web-app
+  newTag: vmaster-ge4456300
+# We need the name to be unique without the suffix because the original name is what
+# gets used with patches
+configMapGenerator:
+- envs:
+  - params.env
+  name: parameters
+- files:
+  - configs/spawner_ui_config.yaml
+  name: jupyter-web-app-config
+  # TODO(jlewi): Why are we setting disableNameSuffixHash true? Don't we want a content hash so that if the config map
+  # changes we would update the configmap?
+generatorOptions:
+  disableNameSuffixHash: true
+patchesStrategicMerge:
+- deployment_patch.yaml
+vars:
+- fieldref:
+    fieldPath: data.policy
+  name: policy
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.prefix
+  name: prefix
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.clusterDomain
+  name: clusterDomain
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: metadata.namespace
+  name: namespace
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: data.userid-header
+  name: userid-header
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.userid-prefix
+  name: userid-prefix
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+configurations:
+- params.yaml

--- a/components/crud-web-apps/jupyter/manifests/base/params.env
+++ b/components/crud-web-apps/jupyter/manifests/base/params.env
@@ -1,0 +1,7 @@
+UI=default
+ROK_SECRET_NAME=secret-rok-{username}
+policy=Always
+prefix=jupyter
+clusterDomain=cluster.local
+userid-header=
+userid-prefix=

--- a/components/crud-web-apps/jupyter/manifests/base/params.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/params.yaml
@@ -1,0 +1,9 @@
+varReference:
+- path: spec/template/spec/containers/imagePullPolicy
+  kind: Deployment
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment

--- a/components/crud-web-apps/jupyter/manifests/base/role-binding.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: jupyter-notebook-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: jupyter-notebook-role
+subjects:
+- kind: ServiceAccount
+  name: jupyter-notebook

--- a/components/crud-web-apps/jupyter/manifests/base/role.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/role.yaml
@@ -1,0 +1,35 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: jupyter-notebook-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  - secrets
+  - services
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  - apps
+  - extensions
+  resources:
+  - deployments
+  - replicasets
+  verbs:
+  - '*'
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - '*'

--- a/components/crud-web-apps/jupyter/manifests/base/service-account.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account

--- a/components/crud-web-apps/jupyter/manifests/base/service.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/service.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: webapp_mapping
+      prefix: /$(prefix)/
+      service: jupyter-web-app-service.$(namespace)
+      add_request_headers:
+        x-forwarded-prefix: /jupyter
+  labels:
+    run: jupyter-web-app
+  name: service
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 5000
+  type: ClusterIP

--- a/components/crud-web-apps/jupyter/manifests/base_v3/deployment_patch.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base_v3/deployment_patch.yaml
@@ -1,0 +1,22 @@
+# TODO(https://github.com/kubeflow/manifests/issues/774): This is a patch
+# that pulls out from core the parts that should be in pulled into stacks.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: jupyter-web-app        
+        env:
+        - name: USERID_HEADER
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-header
+        - name: USERID_PREFIX
+          valueFrom:
+            configMapKeyRef:
+              name: kubeflow-config
+              key: userid-prefix

--- a/components/crud-web-apps/jupyter/manifests/base_v3/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base_v3/kustomization.yaml
@@ -1,0 +1,42 @@
+# TODO(https://github.com/kubeflow/manifests/issues/774):
+# This is a new kustomization file intended to get rid of the
+# need to rely on kfctl to build the kustomization.yaml file.
+# We might want to eventually move it to jupyter/jupyter-web-app/kustomization.yaml
+# We currently don't do that because we don't want to interfere with existing behavior.
+#
+# This kustomization.yaml file doesn't depend on base/kustomization.yaml
+# because that file contains changes that won't work with the new stack kustomize
+# packages that we want to define. For example, we can't define vars namespace, clusterDomain
+# etc... because we want those to be defined at the stack level and reused across applications.
+# We don't want to modify jupyter-web-app/kustomization.yaml because that would
+# break the existing KFDef files. So we want to make the stacks work 
+# and then replace it.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namePrefix: jupyter-web-app-
+namespace: kubeflow
+commonLabels:
+  app: jupyter-web-app
+  kustomize.component: jupyter-web-app
+images:
+- name: gcr.io/kubeflow-images-public/jupyter-web-app
+  newName: gcr.io/kubeflow-images-public/jupyter-web-app
+  newTag: vmaster-ge4456300
+resources:
+- ../base/cluster-role-binding.yaml
+- ../base/cluster-role.yaml
+- ../base/deployment.yaml
+- ../base/role-binding.yaml
+- ../base/role.yaml
+- ../base/service-account.yaml
+- ../base/service.yaml
+- ../overlays/istio
+- ../overlays/application
+configMapGenerator:
+# We need the name to be unique without the suffix because the original name is what
+# gets used with patches
+- name: jupyter-web-app-config
+  files:
+  - ../base/configs/spawner_ui_config.yaml
+patchesStrategicMerge:
+- deployment_patch.yaml

--- a/components/crud-web-apps/jupyter/manifests/overlays/application/application.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/application/application.yaml
@@ -1,0 +1,45 @@
+apiVersion: app.k8s.io/v1beta1
+kind: Application
+metadata:
+  name: jupyter-web-app
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: jupyter-web-app
+      app.kubernetes.io/name: jupyter-web-app
+  componentKinds:
+  - group: core
+    kind: ConfigMap
+  - group: apps
+    kind: Deployment
+  - group: rbac.authorization.k8s.io
+    kind: Role
+  - group: rbac.authorization.k8s.io
+    kind: RoleBinding
+  - group: core
+    kind: Service
+  - group: core
+    kind: ServiceAccount
+  - group: networking.istio.io
+    kind: VirtualService
+  descriptor:
+    type: jupyter-web-app
+    version: v1beta1
+    description: Provides a UI which allows the user to create/conect/delete jupyter notebooks.
+    maintainers:
+    - name: Kimonas Sotirchos
+      email: kimwnasptd@arrikto.com
+    owners:
+    - name: Kimonas Sotirchos
+      email: kimwnasptd@arrikto.com
+    keywords:
+     - jupyterhub
+     - jupyter ui
+     - notebooks  
+    links:
+    - description: About
+      url: https://github.com/kubeflow/kubeflow/tree/master/components/jupyter-web-app
+    - description: Docs
+      url: https://www.kubeflow.org/docs/notebooks 
+  addOwnerRef: true
+

--- a/components/crud-web-apps/jupyter/manifests/overlays/application/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/application/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonLabels:
+  app.kubernetes.io/component: jupyter-web-app
+  app.kubernetes.io/name: jupyter-web-app
+kind: Kustomization
+resources:
+- application.yaml

--- a/components/crud-web-apps/jupyter/manifests/overlays/aws/config-map.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/aws/config-map.yaml
@@ -1,0 +1,143 @@
+apiVersion: v1
+data:
+  spawner_ui_config.yaml: |-
+    # Configuration file for the Jupyter UI.
+    #
+    # Each Jupyter UI option is configured by two keys: 'value' and 'readOnly'
+    # - The 'value' key contains the default value
+    # - The 'readOnly' key determines if the option will be available to users
+    #
+    # If the 'readOnly' key is present and set to 'true', the respective option
+    # will be disabled for users and only set by the admin. Also when a
+    # Notebook is POSTED to the API if a necessary field is not present then
+    # the value from the config will be used.
+    #
+    # If the 'readOnly' key is missing (defaults to 'false'), the respective option
+    # will be available for users to edit.
+    #
+    # Note that some values can be templated. Such values are the names of the
+    # Volumes as well as their StorageClass
+    spawnerFormDefaults:
+      image:
+        # The container Image for the user's Jupyter Notebook
+        # If readonly, this value must be a member of the list below
+        # value: 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
+        # The list of available standard container Images
+        options:
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-cpu:1.0.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-1.15.2-notebook-gpu:1.0.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-cpu:1.0.0
+          - 527798164940.dkr.ecr.us-west-2.amazonaws.com/tensorflow-2.1.0-notebook-gpu:1.0.0
+          - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+          - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
+          - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
+          - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu:1.0.0
+        # By default, custom container Images are allowed
+        # Uncomment the following line to only enable standard container Images
+        readOnly: false
+      cpu:
+        # CPU for user's Notebook
+        value: '0.5'
+        readOnly: false
+      memory:
+        # Memory for user's Notebook
+        value: 1.0Gi
+        readOnly: false
+      workspaceVolume:
+        # Workspace Volume to be attached to user's Notebook
+        # Each Workspace Volume is declared with the following attributes:
+        # Type, Name, Size, MountPath and Access Mode
+        value:
+          type:
+            # The Type of the Workspace Volume
+            # Supported values: 'New', 'Existing'
+            value: New
+          name:
+            # The Name of the Workspace Volume
+            # Note that this is a templated value. Special values:
+            # {notebook-name}: Replaced with the name of the Notebook. The frontend
+            #                  will replace this value as the user types the name
+            value: 'workspace-{notebook-name}'
+          size:
+            # The Size of the Workspace Volume (in Gi)
+            value: '10Gi'
+          mountPath:
+            # The Path that the Workspace Volume will be mounted
+            value: /home/jovyan
+          accessModes:
+            # The Access Mode of the Workspace Volume
+            # Supported values: 'ReadWriteOnce', 'ReadWriteMany', 'ReadOnlyMany'
+            value: ReadWriteOnce
+          class:
+            # The StrageClass the PVC will use if type is New. Special values are:
+            # {none}: default StorageClass
+            # {empty}: empty string ""
+            value: '{none}'
+        readOnly: false
+      dataVolumes:
+        # List of additional Data Volumes to be attached to the user's Notebook
+        value: []
+        # Each Data Volume is declared with the following attributes:
+        # Type, Name, Size, MountPath and Access Mode
+        #
+        # For example, a list with 2 Data Volumes:
+        # value:
+        #   - value:
+        #       type:
+        #         value: New
+        #       name:
+        #         value: '{notebook-name}-vol-1'
+        #       size:
+        #         value: '10Gi'
+        #       class:
+        #         value: standard
+        #       mountPath:
+        #         value: /home/jovyan/vol-1
+        #       accessModes:
+        #         value: ReadWriteOnce
+        #       class:
+        #         value: {none}
+        #   - value:
+        #       type:
+        #         value: New
+        #       name:
+        #         value: '{notebook-name}-vol-2'
+        #       size:
+        #         value: '10Gi'
+        #       mountPath:
+        #         value: /home/jovyan/vol-2
+        #       accessModes:
+        #         value: ReadWriteMany
+        #       class:
+        #         value: {none}
+        readOnly: false
+      gpus:
+        # Number of GPUs to be assigned to the Notebook Container
+        value:
+          # values: "none", "1", "2", "4", "8"
+          num: "none"
+          # Determines what the UI will show and send to the backend
+          vendors:
+            - limitsKey: "nvidia.com/gpu"
+              uiName: "NVIDIA"
+          # Values: "" or a `limits-key` from the vendors list
+          vendor: ""
+        readOnly: false
+      shm:
+        value: true
+        readOnly: false
+      configurations:
+        # List of labels to be selected, these are the labels from PodDefaults
+        # value:
+        #   - add-gcp-secret
+        #   - default-editor
+        value: []
+        readOnly: false
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
+  name: jupyter-web-app-jupyter-web-app-config-aws
+  namespace: kubeflow
+

--- a/components/crud-web-apps/jupyter/manifests/overlays/aws/deployment-aws-patch.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/aws/deployment-aws-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  template:
+    spec:
+      volumes:
+        - configMap:
+            name: jupyter-web-app-jupyter-web-app-config-aws
+          name: config-volume

--- a/components/crud-web-apps/jupyter/manifests/overlays/aws/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/aws/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+commonLabels:
+  app: jupyter-web-app
+  kustomize.component: jupyter-web-app
+bases:
+- ../../base
+resources:
+- config-map.yaml
+patchesStrategicMerge:
+- deployment-aws-patch.yaml

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- virtual-service.yaml
+configurations:
+- params.yaml

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/params.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/http/route/destination/host
+  kind: VirtualService

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/virtual-service.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/virtual-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: jupyter-web-app
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /jupyter
+    match:
+    - uri:
+        prefix: /jupyter/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: jupyter-web-app-service.$(namespace).svc.$(clusterDomain)
+        port:
+          number: 80


### PR DESCRIPTION

### Issue Resolved

Resolves: https://github.com/kubeflow/kubeflow/issues/5593
Umbrella issue: https://github.com/kubeflow/manifests/issues/1740

### Description

As part of the work of wg-manifests for 1.3
(https://github.com/kubeflow/manifests/issues/1735), we are moving manifests
development in upstream repos. This gives the application developers full
ownership of their manifests, tracked in a single place.

This PR copies the manifests for application `Jupyter Web App`
from path `apps/jupyter/jupyter-web-app/upstream` of kubeflow/manifests to path
`components/jupyter-web-app/manifests` of the upstream repo (https://github.com/kubeflow/kubeflow).

cc @kubeflow/wg-notebooks-leads