### PR TITLE
(JWA and notebook controller): Set header needed for R-Studio

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -135,14 +135,6 @@ def set_notebook_image_pull_policy(notebook, body, defaults):
     )
 
 
-def set_notebook_root_url_rewrite(notebook, body, defaults):
-    notebook_annotations = notebook["metadata"]["annotations"]
-    if get_form_value(body, defaults, "useRootURL"):
-        notebook_annotations["use-root-url"] = "true"
-    else:
-        notebook_annotations["use-root-url"] = "false"
-
-
 def set_rstudio_request_header(notebook, body, defaults):
     notebook_annotations = notebook["metadata"]["annotations"]
     if get_form_value(body, defaults, "setRstudioPathHeader"):

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -137,7 +137,7 @@ def set_notebook_image_pull_policy(notebook, body, defaults):
 
 def set_request_headers(notebook, body, defaults):
     notebook_annotations = notebook["metadata"]["annotations"]
-    request_headers = notebook_annotations["request-headers"]
+    request_headers = get_form_value(body, defaults, "requestHeaders")
     if request_headers:
         notebook_annotations["request-headers"] = request_headers
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -135,12 +135,11 @@ def set_notebook_image_pull_policy(notebook, body, defaults):
     )
 
 
-def set_rstudio_request_header(notebook, body, defaults):
+def set_request_headers(notebook, body, defaults):
     notebook_annotations = notebook["metadata"]["annotations"]
-    if get_form_value(body, defaults, "setRstudioPathHeader"):
-        notebook_annotations["set-rstudio-path-header"] = "true"
-    else:
-        notebook_annotations["set-rstudio-path-header"] = "false"
+    request_headers = notebook_annotations["request-headers"]
+    if request_headers:
+        notebook_annotations["request-headers"] = request_headers
 
 
 def set_notebook_cpu(notebook, body, defaults):

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -143,6 +143,14 @@ def set_notebook_root_url_rewrite(notebook, body, defaults):
         notebook_annotations["use-root-url"] = "false"
 
 
+def set_rstudio_request_header(notebook, body, defaults):
+    notebook_annotations = notebook["metadata"]["annotations"]
+    if get_form_value(body, defaults, "setRstudioPathHeader"):
+        notebook_annotations["set-rstudio-path-header"] = "true"
+    else:
+        notebook_annotations["set-rstudio-path-header"] = "false"
+
+
 def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -135,6 +135,14 @@ def set_notebook_image_pull_policy(notebook, body, defaults):
     )
 
 
+def set_notebook_root_url_rewrite(notebook, body, defaults):
+    notebook_annotations = notebook["metadata"]["annotations"]
+    if get_form_value(body, defaults, "useRootURL"):
+        notebook_annotations["use-root-url"] = "true"
+    else:
+        notebook_annotations["use-root-url"] = "false"
+
+
 def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: {name}
   annotations:
-    set-rstudio-path-header: 
+    request-headers: 
 spec:
   template:
     spec:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -6,7 +6,8 @@ metadata:
   labels:
     app: {name}
   annotations:
-    request-headers: 
+    request-headers: |-
+      
 spec:
   template:
     spec:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -6,7 +6,6 @@ metadata:
   labels:
     app: {name}
   annotations:
-    use-root-url: 
     set-rstudio-path-header: 
 spec:
   template:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {name}
   annotations:
     use-root-url: 
+    set-rstudio-path-header: 
 spec:
   template:
     spec:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: {namespace}
   labels:
     app: {name}
+  annotations:
+    use-root-url: 
 spec:
   template:
     spec:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -56,6 +56,10 @@ spawnerFormDefaults:
     # Memory for user's Notebook
     value: 1.0Gi
     readOnly: false
+  useRootURL:
+    # Use root URL during Istio rewrite
+    value: false
+    readOnly: false
   environment:
     value: {}
     readOnly: false

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -60,6 +60,10 @@ spawnerFormDefaults:
     # Use root URL during Istio rewrite
     value: false
     readOnly: false
+  setRstudioPathHeader:
+    # Set the X-RStudio-Root-Path request header to NB_PREFIX
+    value: false
+    readOnly: false
   environment:
     value: {}
     readOnly: false

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -56,9 +56,9 @@ spawnerFormDefaults:
     # Memory for user's Notebook
     value: 1.0Gi
     readOnly: false
-  setRstudioPathHeader:
+  requestHeaders:
     # Set the X-RStudio-Root-Path request header to NB_PREFIX
-    value: false
+    value: ''
     readOnly: false
   environment:
     value: {}

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -56,10 +56,6 @@ spawnerFormDefaults:
     # Memory for user's Notebook
     value: 1.0Gi
     readOnly: false
-  useRootURL:
-    # Use root URL during Istio rewrite
-    value: false
-    readOnly: false
   setRstudioPathHeader:
     # Set the X-RStudio-Root-Path request header to NB_PREFIX
     value: false

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -27,7 +27,7 @@ def post_pvc(namespace):
 
     form.set_notebook_image(notebook, body, defaults)
     form.set_notebook_image_pull_policy(notebook, body, defaults)
-    form.set_rstudio_request_header(notebook, body, defaults)
+    form.set_request_headers(notebook, body, defaults)
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -27,7 +27,6 @@ def post_pvc(namespace):
 
     form.set_notebook_image(notebook, body, defaults)
     form.set_notebook_image_pull_policy(notebook, body, defaults)
-    form.set_notebook_root_url_rewrite(notebook, body, defaults)
     form.set_rstudio_request_header(notebook, body, defaults)
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -27,6 +27,7 @@ def post_pvc(namespace):
 
     form.set_notebook_image(notebook, body, defaults)
     form.set_notebook_image_pull_policy(notebook, body, defaults)
+    form.set_notebook_root_url_rewrite(notebook, body, defaults)
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -28,6 +28,7 @@ def post_pvc(namespace):
     form.set_notebook_image(notebook, body, defaults)
     form.set_notebook_image_pull_policy(notebook, body, defaults)
     form.set_notebook_root_url_rewrite(notebook, body, defaults)
+    form.set_rstudio_request_header(notebook, body, defaults)
     form.set_notebook_cpu(notebook, body, defaults)
     form.set_notebook_memory(notebook, body, defaults)
     form.set_notebook_gpus(notebook, body, defaults)

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -54,12 +54,15 @@
           <mat-option value="Never">Never</mat-option>
         </mat-select>
       </mat-form-field>
-      <mat-checkbox class="column" appearance="outline"
-        *ngIf="!readonly"
-        [formControl]="parentForm.get('setRstudioPathHeader')"
-      >
-        Set R-Studio Root-Path request header location
-      </mat-checkbox>
+      <mat-form-field class="column" appearance="outline">
+        <mat-label>Headers for Istio to add to requests</mat-label>
+        <input
+          matInput
+          placeholder="Headers for Istio to add to requests"
+          [formControl]="parentForm.get('requestHeaders')"
+          #cstmimg
+        />
+      </mat-form-field>
     </div>
   </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -60,6 +60,12 @@
       >
         Use root URL
       </mat-checkbox>
+      <mat-checkbox class="column" appearance="outline"
+        *ngIf="!readonly"
+        [formControl]="parentForm.get('setRstudioPathHeader')"
+      >
+        Set R-Studio Root-Path request header location
+      </mat-checkbox>
     </div>
   </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -56,12 +56,6 @@
       </mat-form-field>
       <mat-checkbox class="column" appearance="outline"
         *ngIf="!readonly"
-        [formControl]="parentForm.get('useRootURL')"
-      >
-        Use root URL
-      </mat-checkbox>
-      <mat-checkbox class="column" appearance="outline"
-        *ngIf="!readonly"
         [formControl]="parentForm.get('setRstudioPathHeader')"
       >
         Set R-Studio Root-Path request header location

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -45,13 +45,21 @@
   </mat-form-field>
 
   <lib-advanced-options>
-    <mat-form-field class="wide" appearance="outline">
-      <mat-label>Image pull policy</mat-label>
-      <mat-select [formControl]="parentForm.get('imagePullPolicy')">
-        <mat-option value="Always">Always</mat-option>
-        <mat-option value="IfNotPresent">IfNotPresent</mat-option>
-        <mat-option value="Never">Never</mat-option>
-      </mat-select>
-    </mat-form-field>
+    <div class="row">
+      <mat-form-field class="column" appearance="outline">
+        <mat-label>Image pull policy</mat-label>
+        <mat-select [formControl]="parentForm.get('imagePullPolicy')">
+          <mat-option value="Always">Always</mat-option>
+          <mat-option value="IfNotPresent">IfNotPresent</mat-option>
+          <mat-option value="Never">Never</mat-option>
+        </mat-select>
+      </mat-form-field>
+      <mat-checkbox class="column" appearance="outline"
+        *ngIf="!readonly"
+        [formControl]="parentForm.get('useRootURL')"
+      >
+        Use root URL
+      </mat-checkbox>
+    </div>
   </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -30,7 +30,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
         this.parentForm.get('customImage').updateValueAndValidity();
         this.parentForm.get('image').updateValueAndValidity();
-        this.parentForm.get('setRstudioPathHeader').updateValueAndValidity();
+        this.parentForm.get('requestHeaders').updateValueAndValidity();
       }),
     );
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -31,6 +31,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
         this.parentForm.get('customImage').updateValueAndValidity();
         this.parentForm.get('image').updateValueAndValidity();
         this.parentForm.get('useRootURL').updateValueAndValidity();
+        this.parentForm.get('setRstudioPathHeader').updateValueAndValidity();
       }),
     );
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -19,7 +19,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.subs.add(
       this.parentForm.get('customImageCheck').valueChanges.subscribe(check => {
-        // Make sure that the use will insert and Image value
+        // Make sure that the user inserts an Image value
         if (check) {
           this.parentForm.get('customImage').setValidators(Validators.required);
           this.parentForm.get('image').setValidators([]);
@@ -30,6 +30,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
         this.parentForm.get('customImage').updateValueAndValidity();
         this.parentForm.get('image').updateValueAndValidity();
+        this.parentForm.get('useRootURL').updateValueAndValidity();
       }),
     );
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -30,7 +30,6 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
         this.parentForm.get('customImage').updateValueAndValidity();
         this.parentForm.get('image').updateValueAndValidity();
-        this.parentForm.get('useRootURL').updateValueAndValidity();
         this.parentForm.get('setRstudioPathHeader').updateValueAndValidity();
       }),
     );

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -12,6 +12,7 @@ export function getFormDefaults(): FormGroup {
     imagePullPolicy: ['IfNotPresent', [Validators.required]],
     customImage: ['', []],
     customImageCheck: [false, []],
+    useRootURL: [false, []],
     cpu: [1, [Validators.required]],
     memory: [1, [Validators.required]],
     gpus: fb.group({

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -12,7 +12,7 @@ export function getFormDefaults(): FormGroup {
     imagePullPolicy: ['IfNotPresent', [Validators.required]],
     customImage: ['', []],
     customImageCheck: [false, []],
-    setRstudioPathHeader: [false, []],
+    requestHeaders: ['', []],
     cpu: [1, [Validators.required]],
     memory: [1, [Validators.required]],
     gpus: fb.group({

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -12,7 +12,6 @@ export function getFormDefaults(): FormGroup {
     imagePullPolicy: ['IfNotPresent', [Validators.required]],
     customImage: ['', []],
     customImageCheck: [false, []],
-    useRootURL: [false, []],
     setRstudioPathHeader: [false, []],
     cpu: [1, [Validators.required]],
     memory: [1, [Validators.required]],

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -13,6 +13,7 @@ export function getFormDefaults(): FormGroup {
     customImage: ['', []],
     customImageCheck: [false, []],
     useRootURL: [false, []],
+    setRstudioPathHeader: [false, []],
     cpu: [1, [Validators.required]],
     memory: [1, [Validators.required]],
     gpus: fb.group({

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -39,7 +39,6 @@ export interface NotebookFormObject {
   imagePullPolicy: string;
   customImage?: string;
   customImageCheck: boolean;
-  useRootURL: boolean;
   setRstudioPathHeader: boolean;
   cpu: number | string;
   memory: number | string;
@@ -140,11 +139,6 @@ export interface Config {
 
   imagePullPolicy?: {
     value: string;
-    readOnly?: boolean;
-  };
-
-  useRootURL?: {
-    value: boolean;
     readOnly?: boolean;
   };
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -40,6 +40,7 @@ export interface NotebookFormObject {
   customImage?: string;
   customImageCheck: boolean;
   useRootURL: boolean;
+  setRstudioPathHeader: boolean;
   cpu: number | string;
   memory: number | string;
   gpus: GPU;
@@ -143,6 +144,11 @@ export interface Config {
   };
 
   useRootURL?: {
+    value: boolean;
+    readOnly?: boolean;
+  };
+
+  setRstudioPathHeader?: {
     value: boolean;
     readOnly?: boolean;
   };

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -39,7 +39,7 @@ export interface NotebookFormObject {
   imagePullPolicy: string;
   customImage?: string;
   customImageCheck: boolean;
-  setRstudioPathHeader: boolean;
+  requestHeaders: string;
   cpu: number | string;
   memory: number | string;
   gpus: GPU;
@@ -142,8 +142,8 @@ export interface Config {
     readOnly?: boolean;
   };
 
-  setRstudioPathHeader?: {
-    value: boolean;
+  requestHeaders?: {
+    value: string;
     readOnly?: boolean;
   };
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -39,6 +39,7 @@ export interface NotebookFormObject {
   imagePullPolicy: string;
   customImage?: string;
   customImageCheck: boolean;
+  useRootURL: boolean;
   cpu: number | string;
   memory: number | string;
   gpus: GPU;
@@ -138,6 +139,11 @@ export interface Config {
 
   imagePullPolicy?: {
     value: string;
+    readOnly?: boolean;
+  };
+
+  useRootURL?: {
+    value: boolean;
     readOnly?: boolean;
   };
 

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -400,7 +400,17 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	namespace := instance.Namespace
 	clusterDomain := "cluster.local"
 	prefix := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
-	rewrite := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
+	annotations := make(map[string]string)
+	for k, v := range instance.ObjectMeta.Annotations {
+		annotations[k] = v
+	}
+
+	var rewrite string
+	if annotations["use-root-url"] == "true" {
+		rewrite = fmt.Sprintf("/")
+	} else {
+		rewrite = fmt.Sprintf("/notebook/%s/%s/", namespace, name)
+	}
 	if clusterDomainFromEnv, ok := os.LookupEnv("CLUSTER_DOMAIN"); ok {
 		clusterDomain = clusterDomainFromEnv
 	}

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -401,16 +401,8 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 	clusterDomain := "cluster.local"
 	prefix := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
 	annotations := make(map[string]string)
-	for k, v := range instance.ObjectMeta.Annotations {
-		annotations[k] = v
-	}
+	rewrite := fmt.Sprintf("/notebook/%s/%s/", namespace, name)
 
-	var rewrite string
-	if annotations["use-root-url"] == "true" {
-		rewrite = fmt.Sprintf("/")
-	} else {
-		rewrite = fmt.Sprintf("/notebook/%s/%s/", namespace, name)
-	}
 	if clusterDomainFromEnv, ok := os.LookupEnv("CLUSTER_DOMAIN"); ok {
 		clusterDomain = clusterDomainFromEnv
 	}


### PR DESCRIPTION
This PR add a checkbox under the advanced settings section and changes to the notebook-controller that are needed for running R-Studio without Istio. More specifically, when the checkbox is selected, the Istio VirtualService will add the `X-RStudio-Root-Path` header with the `NB_PREFIX` to the requests. This is needed to fix the redirect R-Studio does to `/auth-sign-in` to get a cookie (with this fix, R-Studio redirects to `/NB_PREFIX/auth-sign-in` as it should). This PR also contains the changes from https://github.com/kubeflow/kubeflow/pull/5601, but will be reworked once the notebook-controller code is fixed up a bit. 