### PR TITLE
Extend root owners to help CI/CD PRs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,4 +3,6 @@
 approvers:
   - Bobgy
   - jlewi
+  - kimwnasptd
+  - PatrickXYS
   - pdmack

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -2,14 +2,14 @@
 # see kubeflow/testing/py/run_e2e_workflow.py
 python_paths:
   - kubeflow/kubeflow/py
-workflows:
+workflows: []
   # Run unittests
   # TODO(jlewi): Need to add step to run go and python unittests
-  - app_dir: kubeflow/kubeflow/testing/workflows
-    component: unit_tests
-    name: unittests
-    params:
-      workflowName: unittest
+  # - app_dir: kubeflow/kubeflow/testing/workflows
+  #   component: unit_tests
+  #   name: unittests
+  #   params:
+  #     workflowName: unittest
   # Image Auto Release workflows.
   # The workflows below are related to auto building our Docker images.
   # We have separate pre/postsubmit jobs because we want to use different


### PR DESCRIPTION
Right now in order to merge a PR that modifies `kubeflow/kubeflow`'s [prow_config.yaml](https://github.com/kubeflow/kubeflow/blob/0c4a738625f52092f66ec462e800ddd2837e0f6d/prow_config.yaml) file, i.e https://github.com/kubeflow/kubeflow/pull/5600, we need to ping someone from the existing OWNERS file.

In order to reduce the friction of expecting users that are not tightly coupled with the CI/CD effort #5482  of this repo, like @Bobgy, we should add @PatrickXYS and myself in the root OWNERS file. 

This will allow us to move faster with our PRs wrt to the CI/CD of the `kubeflow/kubeflow` repo, without requiring cycles from developers that are not working on this part.

/cc @Bobgy 