### PR TITLE
Add notebook-server-base dockerfile and CI/CD

### DIFF
--- a/components/example-notebook-servers/OWNERS
+++ b/components/example-notebook-servers/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - elikatsis
+  - kimwnasptd
+  - StefanoFioravanzo
+  - thesuperzapper
+  - DavidSpek
+reviewers:

--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -1,18 +1,21 @@
 FROM ubuntu:20.04
 
+# common environemnt variables
 ENV NB_USER jovyan
 ENV NB_UID 1000
 ENV NB_PREFIX /
 ENV HOME /home/$NB_USER
+ENV SHELL /bin/bash
 
-# set version for s6 overlay
-ARG OVERLAY_VERSION="v2.2.0.3"
-ARG OVERLAY_ARCH="amd64"
+# args - software versions
+ARG ARCH="amd64"
+ARG S6_VERSION="v2.2.0.3"
+ARG KUBECTL_VERSION="v1.20.5"
 
-# Install -- Linux Dependencies
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get -yq update \
-    && apt-get -yq install --no-install-recommends \
+# install - usefull linux packages
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get -yq update \
+ && apt-get -yq install --no-install-recommends \
     apt-transport-https \
     bash \
     bzip2 \
@@ -30,34 +33,38 @@ RUN apt-get -yq update \
     vim \
     wget \
     zip \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
 
-# Set locale
-RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
-    locale-gen
-ENV LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8 \
-    LANGUAGE=en_US.UTF-8 \
-    SHELL=/bin/bash
+# install - s6 overlay
+RUN export GNUPGHOME=/tmp/ \
+ && curl -sL "https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-${ARCH}-installer" -o /tmp/s6-overlay-${ARCH}-installer \
+ && curl -sL "https://github.com/just-containers/s6-overlay/releases/download/${S6_VERSION}/s6-overlay-${ARCH}-installer.sig" -o /tmp/s6-overlay-${ARCH}-installer.sig \
+ && curl -sL "https://keybase.io/justcontainers/key.asc" | gpg -q --import \
+ && gpg -q --verify /tmp/s6-overlay-${ARCH}-installer.sig /tmp/s6-overlay-${ARCH}-installer \
+ && chmod +x /tmp/s6-overlay-${ARCH}-installer \
+ && /tmp/s6-overlay-${ARCH}-installer / \
+ && rm /tmp/s6-overlay-${ARCH}-installer.sig /tmp/s6-overlay-${ARCH}-installer
 
-# add s6 overlay
-ADD https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
-RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && rm /tmp/s6-overlay-${OVERLAY_ARCH}-installer
+# install - kubectl
+RUN curl -sL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl" -o /usr/local/bin/kubectl \
+ && curl -sL "https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl.sha256" -o /tmp/kubectl.sha256 \
+ && echo "$(cat /tmp/kubectl.sha256) /usr/local/bin/kubectl" | sha256sum --check \
+ && rm /tmp/kubectl.sha256 \
+ && chmod +x /usr/local/bin/kubectl
 
-# Install kubectl
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
-    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
-    apt-get update && \
-    apt-get install -y kubectl && \
-    rm -rf /var/lib/apt/lists/*
+# create user and set required ownership
+RUN useradd -M -s /bin/bash -N -u ${NB_UID} ${NB_USER} \
+ && mkdir -p ${HOME} \
+ && chown -R ${NB_USER}:users ${HOME} \
+ && chown -R ${NB_USER}:users /usr/local/bin \
+ && chown -R ${NB_USER}:users /etc/s6
 
-# Create NB_USER user with UID=1000 in the 'users' group
-# Change ownership of /etc/s6 to user jovyan
-RUN useradd -M -s /bin/bash -N -u ${NB_UID} ${NB_USER} && \
-    chown -R ${NB_USER}:users /usr/local/bin && \
-    mkdir -p $HOME && \
-    chown -R ${NB_USER}:users ${HOME} && \
-    chown -R ${NB_USER}:users /etc/s6
+# set locale configs
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
+ && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
 
 USER $NB_UID

--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -1,0 +1,63 @@
+FROM ubuntu:20.04
+
+ENV NB_USER jovyan
+ENV NB_UID 1000
+ENV NB_PREFIX /
+ENV HOME /home/$NB_USER
+
+# set version for s6 overlay
+ARG OVERLAY_VERSION="v2.2.0.3"
+ARG OVERLAY_ARCH="amd64"
+
+# Install -- Linux Dependencies
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get -yq update \
+    && apt-get -yq install --no-install-recommends \
+    apt-transport-https \
+    bash \
+    bzip2 \
+    ca-certificates \
+    curl \
+    git \
+    gnupg \
+    gnupg2 \
+    locales \
+    lsb-release \
+    nano \
+    software-properties-common \
+    tzdata \
+    unzip \
+    vim \
+    wget \
+    zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set locale
+RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+ENV LC_ALL=en_US.UTF-8 \
+    LANG=en_US.UTF-8 \
+    LANGUAGE=en_US.UTF-8 \
+    SHELL=/bin/bash
+
+# add s6 overlay
+ADD https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}-installer /tmp/
+RUN chmod +x /tmp/s6-overlay-${OVERLAY_ARCH}-installer && /tmp/s6-overlay-${OVERLAY_ARCH}-installer / && rm /tmp/s6-overlay-${OVERLAY_ARCH}-installer
+
+# Install kubectl
+RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \
+    echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list && \
+    apt-get update && \
+    apt-get install -y kubectl && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create NB_USER user with UID=1000 in the 'users' group
+# Change ownership of /etc/s6 to user jovyan
+RUN useradd -M -s /bin/bash -N -u ${NB_UID} ${NB_USER} && \
+    chown -R ${NB_USER}:users /usr/local/bin && \
+    mkdir -p $HOME && \
+    chown -R ${NB_USER}:users ${HOME} && \
+    chown -R ${NB_USER}:users /etc/s6
+
+USER $NB_UID

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_base.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_base.py
@@ -1,0 +1,15 @@
+""""Argo Workflow for building notebook-server-base's OCI image using Kaniko"""
+from kubeflow.kubeflow.cd import config, kaniko_builder
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = kaniko_builder.Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build(dockerfile="components/example-notebook-servers/base/Dockerfile",
+                         context="components/example-notebook-servers/base/",
+                         destination=config.NOTEBOOK_SERVER_BASE)

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_base_runner.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_base_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.cd import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_base",
+                 workflow_name="nb-base-build")

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_base_tests.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_base_tests.py
@@ -1,0 +1,43 @@
+""""Argo Workflow for testing notebook-server-base OCI image"""
+from kubeflow.kubeflow.ci import workflow_utils
+from kubeflow.testing import argo_build_util
+
+
+class Builder(workflow_utils.ArgoTestBuilder):
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None, **kwargs):
+        super().__init__(name=name, namespace=namespace, bucket=bucket,
+                         test_target_name=test_target_name, **kwargs)
+
+    def build(self):
+        """Build the Argo workflow graph"""
+        workflow = self.build_init_workflow(exit_dag=False)
+        task_template = self.build_task_template()
+
+        # Test building notebook-server-base image using Kaniko
+        dockerfile = ("%s/components/example-notebook-servers"
+                      "/base/Dockerfile") % self.src_dir
+        context = "dir://%s/components/example-notebook-servers/base/" % self.src_dir
+        destination = "notebook-server-base-test"
+
+        kaniko_task = self.create_kaniko_task(task_template, dockerfile,
+                                              context, destination, no_push=True)
+        argo_build_util.add_task_to_dag(workflow,
+                                        workflow_utils.E2E_DAG_NAME,
+                                        kaniko_task, [self.mkdir_task_name])
+
+        # Set the labels on all templates
+        workflow = argo_build_util.set_task_template_labels(workflow)
+
+        return workflow
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build()

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_base_tests_runner.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_base_tests_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.ci import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_base_tests",
+                 workflow_name="nb-base-tests")


### PR DESCRIPTION
This PR adds the Web-IDE base image from https://github.com/kubeflow/kubeflow/pull/5582 that will serve as the base image for all Jupyter, R-Studio and Code-Server (VS-Code) images downstream. More details about the downstream use of this image can be seen in the PR linked above. 

Initial image was built and pushed to test CI/CD and facilitate downstream testing:
public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/base:master-9d688f73

/cc @kubeflow/wg-notebooks-leads @thesuperzapper 