### PR TITLE
(Notebooks rework): Add DataScience base image

### DIFF
--- a/components/notebook-images/datascience-base/Dockerfile
+++ b/components/notebook-images/datascience-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM davidspek/kubeflow-ubuntu-jupyter-base:0.7
+FROM davidspek/kubeflow-ubuntu-jupyter-base:0.8
 
 USER root
 

--- a/components/notebook-images/datascience-base/Dockerfile
+++ b/components/notebook-images/datascience-base/Dockerfile
@@ -1,0 +1,71 @@
+FROM davidspek/kubeflow-ubuntu-jupyter-base:0.5
+
+USER root
+
+# Julia installation
+# Default values can be overridden at build time
+# (ARGS are in lower case to distinguish them from ENV)
+# Check https://julialang.org/downloads/
+ARG julia_version="1.5.3"
+# SHA256 checksum
+ARG julia_checksum="f190c938dd6fed97021953240523c9db448ec0a6760b574afd4e9924ab5615f1"
+
+# R pre-requisites
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    fonts-dejavu \
+    gfortran \
+    gcc && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Julia dependencies
+# install Julia packages in /opt/julia instead of $HOME
+ENV JULIA_DEPOT_PATH=/opt/julia \
+    JULIA_PKGDIR=/opt/julia \
+    JULIA_VERSION="${julia_version}"
+
+WORKDIR /tmp
+
+# hadolint ignore=SC2046
+RUN mkdir "/opt/julia-${JULIA_VERSION}" && \
+    wget -q https://julialang-s3.julialang.org/bin/linux/x64/$(echo "${JULIA_VERSION}" | cut -d. -f 1,2)"/julia-${JULIA_VERSION}-linux-x86_64.tar.gz" && \
+    echo "${julia_checksum} *julia-${JULIA_VERSION}-linux-x86_64.tar.gz" | sha256sum -c - && \
+    tar xzf "julia-${JULIA_VERSION}-linux-x86_64.tar.gz" -C "/opt/julia-${JULIA_VERSION}" --strip-components=1 && \
+    rm "/tmp/julia-${JULIA_VERSION}-linux-x86_64.tar.gz"
+RUN ln -fs /opt/julia-*/bin/julia /usr/local/bin/julia
+
+# Show Julia where conda libraries are \
+RUN mkdir /etc/julia && \
+    echo "push!(Libdl.DL_LOAD_PATH, \"$CONDA_DIR/lib\")" >> /etc/julia/juliarc.jl && \
+    # Create JULIA_PKGDIR \
+    mkdir "${JULIA_PKGDIR}" && \
+    chown "${NB_USER}" "${JULIA_PKGDIR}" && \
+    chown -R ${NB_USER}:users "${JULIA_PKGDIR}"
+
+USER $NB_UID
+
+# R packages including IRKernel which gets installed globally.
+RUN conda install --quiet --yes \
+    'r-irkernel=1.1*' \
+    'r-base=4.0.3' && \
+    conda clean --all -f -y && \
+    chown -R ${NB_USER}:users $CONDA_DIR && \
+    chown -R ${NB_USER}:users /home/$NB_USER
+
+# Add Julia packages. Only add HDF5 if this is not a test-only build since
+# it takes roughly half the entire build time of all of the images on Travis
+# to add this one package and often causes Travis to timeout.
+#
+# Install IJulia as jovyan and then move the kernelspec out
+# to the system share location. Avoids problems with runtime UID change not
+# taking effect properly on the .local folder in the jovyan home dir.
+RUN julia -e 'import Pkg; Pkg.update()' && \
+    (test $TEST_ONLY_BUILD || julia -e 'import Pkg; Pkg.add("HDF5")') && \
+    julia -e "using Pkg; pkg\"add IJulia\"; pkg\"precompile\"" && \
+    # move kernelspec out of home \
+    mv "${HOME}/.local/share/jupyter/kernels/julia"* "${CONDA_DIR}/share/jupyter/kernels/" && \
+    chmod -R go+rx "${CONDA_DIR}/share/jupyter" && \
+    rm -rf "${HOME}/.local" && \
+    chown -R ${NB_USER}:users "${JULIA_PKGDIR}" "${CONDA_DIR}/share/jupyter"
+
+WORKDIR $HOME

--- a/components/notebook-images/datascience-base/Dockerfile
+++ b/components/notebook-images/datascience-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM davidspek/kubeflow-ubuntu-jupyter-base:0.5
+FROM davidspek/kubeflow-ubuntu-jupyter-base:0.7
 
 USER root
 


### PR DESCRIPTION
This PR adds the datascience Jupyter base image from #5582 that will serve as a base for users to customize by adding their own choice of packages, as well as the base for the opinionated images that contain a set of commonly used tools to get users started. This adds Julia 1.5.3 and R 4.0.3 to the Jupyter Notebook base image. As such, it forms the basis for the second most popular image from the official [jupyter docker-stacks](https://github.com/jupyter/docker-stacks) see(https://github.com/kubeflow/kubeflow/pull/5582#issuecomment-773988530). More details about the downstream use of this image can be seen in the PR linked above.

The base image will need to be changed once https://github.com/kubeflow/kubeflow/pull/5623 is merged and has been pushed to the image registry. 

/cc @kubeflow/wg-notebooks-leads @thesuperzapper