### PR TITLE
Add notebook-server-jupyter-tensorflow-full dockerfiles and CI/CD

### DIFF
--- a/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow:master-d609b9e1
+
+# install - requirements.txt
+COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda:master-d609b9e1
+
+# install - requirements.txt
+COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
@@ -1,0 +1,16 @@
+kfp==1.0.4
+kfp-server-api==1.0.4
+kfserving==0.4.1
+ipywidgets==7.6.3
+ipympl==0.6.3
+cloudpickle==1.6.0
+dill==0.3.3
+bokeh==2.3.0
+seaborn==0.11.1
+scipy==1.6.1
+scikit-learn==0.24.1
+scikit-image==0.18.1
+pandas==1.2.3
+matplotlib==3.3.4
+xgboost==1.3.3
+keras==2.4.3

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_tensorflow_full.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_tensorflow_full.py
@@ -1,0 +1,19 @@
+""""Argo Workflow for building notebook-server-tensorflow-full OCI images using Kaniko"""
+from kubeflow.kubeflow.cd import config, kaniko_builder
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = kaniko_builder.Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build(dockerfile="components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile",
+                         context="components/example-notebook-servers/jupyter-tensorflow-full/",
+                         destination=config.NOTEBOOK_SERVER_JUPYTER_TENSORFLOW_FULL,
+                         second_dockerfile="components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile",
+                         second_destination=config.NOTEBOOK_SERVER_JUPYTER_TENSORFLOW_CUDA_FULL,
+                         mem_override="8Gi",
+                         deadline_override=6000)

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_tensorflow_full_runner.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_tensorflow_full_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.cd import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_jupyter_tensorflow_full",
+                 workflow_name="nb-j-tf-f-build")

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_tensorflow_full_tests.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_tensorflow_full_tests.py
@@ -1,0 +1,53 @@
+""""Argo Workflow for testing notebook-server-jupyter-tensorflow-full OCI images"""
+from kubeflow.kubeflow.ci import workflow_utils
+from kubeflow.testing import argo_build_util
+
+
+class Builder(workflow_utils.ArgoTestBuilder):
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None, **kwargs):
+        super().__init__(name=name, namespace=namespace, bucket=bucket,
+                         test_target_name=test_target_name, **kwargs)
+
+    def build(self):
+        """Build the Argo workflow graph"""
+        workflow = self.build_init_workflow(exit_dag=False)
+        task_template = self.build_task_template(mem_override="8Gi", deadline_override=6000)
+
+        # Test building notebook-server-jupyter-tensorflow-full images using Kaniko
+        dockerfile = ("%s/components/example-notebook-servers"
+                      "/jupyter-tensorflow-full/cpu.Dockerfile") % self.src_dir
+        context = "dir://%s/components/example-notebook-servers/jupyter-tensorflow-full/" % self.src_dir
+        destination = "notebook-server-jupyter-tensorflow-full-cpu-test"
+
+        kaniko_task = self.create_kaniko_task(task_template, dockerfile,
+                                              context, destination, no_push=True)
+        argo_build_util.add_task_to_dag(workflow,
+                                        workflow_utils.E2E_DAG_NAME,
+                                        kaniko_task, [self.mkdir_task_name])
+
+        dockerfile_cuda = ("%s/components/example-notebook-servers"
+                      "/jupyter-tensorflow-full/cuda.Dockerfile") % self.src_dir
+        destination_cuda = "notebook-server-jupyter-tensorflow-cuda-full-test"
+
+        kaniko_task_cuda = self.create_kaniko_task(task_template, dockerfile_cuda,
+                                              context, destination_cuda, no_push=True)
+        argo_build_util.add_task_to_dag(workflow,
+                                        workflow_utils.E2E_DAG_NAME,
+                                        kaniko_task_cuda, [self.mkdir_task_name])
+
+        # Set the labels on all templates
+        workflow = argo_build_util.set_task_template_labels(workflow)
+
+        return workflow
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build()

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_tensorflow_full_tests_runner.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_tensorflow_full_tests_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.ci import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_jupyter_tensorflow_full_tests",
+                 workflow_name="nb-j-tf-f-tests")


### PR DESCRIPTION
This PR adds the TensorFlow Jupyter opinionated images from #5582 that will serve as a starting point for (new) users and projects by adding an opinionated set of common tools. It uses https://github.com/kubeflow/kubeflow/pull/5627 and https://github.com/kubeflow/kubeflow/pull/5628 as the base images. These images also serve as important examples for people that would like to customize the TensorFlow base image for their distinct needs. More details about the downstream use of this image can be seen in the PR linked above. 

Initial images were built and pushed to test CI/CD:
public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:master-28af7716
public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:master-28af7716


/cc @kubeflow/wg-notebooks-leads @thesuperzapper