### PR TITLE
(Notebooks rework): Add DataScience opinionated image

### DIFF
--- a/components/notebook-images/datascience-full/Dockerfile
+++ b/components/notebook-images/datascience-full/Dockerfile
@@ -1,0 +1,29 @@
+FROM davidspek/kubeflow-ubuntu-datascience-base:0.2
+
+USER $NB_UID
+
+COPY requirements.txt .
+RUN python3 -m pip install -r \
+    requirements.txt --quiet --no-cache-dir \
+    && rm -f requirements.txt
+
+# R packages which gets installed globally.
+RUN conda install --quiet --yes \
+    'r-caret=6.0*' \
+    'r-crayon=1.3*' \
+    'r-devtools=2.3*' \
+    'r-forecast=8.13*' \ 
+    'r-hexbin=1.28*' \
+    'r-htmltools=0.5*' \
+    'r-htmlwidgets=1.5*' \ 
+    'r-nycflights13=1.0*' \
+    'r-randomforest=4.6*' \
+    'r-rcurl=1.98*' \
+    'r-rmarkdown=2.6*' \
+    'r-rsqlite=2.2*' \
+    'r-shiny=1.5*' \
+    'r-tidyverse=1.3*' \
+    'rpy2=3.4*' && \
+    conda clean --all -f -y && \
+    chown -R ${NB_USER}:users $CONDA_DIR && \
+    chown -R ${NB_USER}:users /home/$NB_USER

--- a/components/notebook-images/datascience-full/Dockerfile
+++ b/components/notebook-images/datascience-full/Dockerfile
@@ -1,4 +1,4 @@
-FROM davidspek/kubeflow-ubuntu-datascience-base:0.2
+FROM davidspek/kubeflow-ubuntu-datascience-base:0.4
 
 USER $NB_UID
 

--- a/components/notebook-images/datascience-full/Dockerfile
+++ b/components/notebook-images/datascience-full/Dockerfile
@@ -10,7 +10,7 @@ RUN python3 -m pip install -r \
 # R packages which gets installed globally.
 RUN conda install --quiet --yes \
     'r-caret=6.0*' \
-    'r-crayon=1.3*' \
+    'r-crayon=1.4*' \
     'r-devtools=2.3*' \
     'r-forecast=8.13*' \ 
     'r-hexbin=1.28*' \
@@ -19,9 +19,9 @@ RUN conda install --quiet --yes \
     'r-nycflights13=1.0*' \
     'r-randomforest=4.6*' \
     'r-rcurl=1.98*' \
-    'r-rmarkdown=2.6*' \
+    'r-rmarkdown=2.7*' \
     'r-rsqlite=2.2*' \
-    'r-shiny=1.5*' \
+    'r-shiny=1.6*' \
     'r-tidyverse=1.3*' \
     'rpy2=3.4*' && \
     conda clean --all -f -y && \

--- a/components/notebook-images/datascience-full/requirements.txt
+++ b/components/notebook-images/datascience-full/requirements.txt
@@ -5,10 +5,10 @@ ipywidgets==7.6.3
 ipympl==0.6.3
 cloudpickle==1.6.0
 dill==0.3.3
-bokeh==2.2.3
+bokeh==2.3.0
 seaborn==0.11.1
 scipy==1.6.1
 scikit-learn==0.24.1
 scikit-image==0.18.1
-pandas==1.2.2
+pandas==1.2.3
 matplotlib==3.3.4

--- a/components/notebook-images/datascience-full/requirements.txt
+++ b/components/notebook-images/datascience-full/requirements.txt
@@ -7,8 +7,8 @@ cloudpickle==1.6.0
 dill==0.3.3
 bokeh==2.2.3
 seaborn==0.11.1
-scipy==1.6.0
+scipy==1.6.1
 scikit-learn==0.24.1
 scikit-image==0.18.1
-pandas==1.2.1
+pandas==1.2.2
 matplotlib==3.3.4

--- a/components/notebook-images/datascience-full/requirements.txt
+++ b/components/notebook-images/datascience-full/requirements.txt
@@ -1,0 +1,14 @@
+kfp==1.0.4
+kfp-server-api==1.0.4
+kfserving==0.4.1
+ipywidgets==7.6.3
+ipympl==0.6.3
+cloudpickle==1.6.0
+dill==0.3.3
+bokeh==2.2.3
+seaborn==0.11.1
+scipy==1.6.0
+scikit-learn==0.24.1
+scikit-image==0.18.1
+pandas==1.2.1
+matplotlib==3.3.4


### PR DESCRIPTION
This PR adds the opinionated datascience Jupyter image from #5582 that will serve as a starting point for (new) users and projects by adding an opinionated set of common tools.. This image install almost all the packages found in the official [jupyter docker-stacks](https://github.com/jupyter/docker-stacks) datascience image. 

The base image will need to be changed once https://github.com/kubeflow/kubeflow/pull/5629 is merged and has been pushed to the image registry. 

/cc @kubeflow/wg-notebooks-leads @thesuperzapper