### PR TITLE
Tesorboard-Controller: use updateStatus instead of update

### DIFF
--- a/components/tensorboard-controller/api/v1alpha1/tensorboard_types.go
+++ b/components/tensorboard-controller/api/v1alpha1/tensorboard_types.go
@@ -50,6 +50,7 @@ type TensorboardStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:subresource:status
 
 // Tensorboard is the Schema for the tensorboards API
 type Tensorboard struct {

--- a/components/tensorboard-controller/api/v1alpha1/zz_generated.deepcopy.go
+++ b/components/tensorboard-controller/api/v1alpha1/zz_generated.deepcopy.go
@@ -70,7 +70,7 @@ func (in *TensorboardCondition) DeepCopy() *TensorboardCondition {
 func (in *TensorboardList) DeepCopyInto(out *TensorboardList) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	in.ListMeta.DeepCopyInto(&out.ListMeta)
+	out.ListMeta = in.ListMeta
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
 		*out = make([]Tensorboard, len(*in))

--- a/components/tensorboard-controller/config/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml
+++ b/components/tensorboard-controller/config/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml
@@ -15,6 +15,8 @@ spec:
     plural: tensorboards
     singular: tensorboard
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Tensorboard is the Schema for the tensorboards API
@@ -22,12 +24,12 @@ spec:
         apiVersion:
           description: 'APIVersion defines the versioned schema of this representation
             of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
           description: 'Kind is a string value representing the REST resource this
             object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -133,7 +133,7 @@ func (r *TensorboardReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error)
 			instance.Status.ReadyReplicas = foundDeployment.Status.ReadyReplicas
 		}
 
-		_err = r.Update(ctx, instance)
+		_err = r.Status().Update(ctx, instance)
 		if _err != nil {
 			return ctrl.Result{}, _err
 		}


### PR DESCRIPTION
The status of `Tensorboard` should be a subresource of the CRD, which is like [`Notebook`](https://github.com/kubeflow/kubeflow/blob/743310d977f6dbac55a0676c94ce645b0276d05f/components/notebook-controller/api/v1/notebook_types.go#L62). Therefore, when updating the instance, we use `r.Status().Update(ctx, instance)` instead of `r.Update(ctx, instance)`.