### PR TITLE
CI: Correct the name of the workflow

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -8,7 +8,7 @@ python_paths:
 workflows:
   # Run unittests for the shared frontend code
   - py_func: kubeflow.kubeflow.ci.shared_ui_tests.create_workflow
-    name: shared_ui_tests
+    name: shared-ui-tests
     job_types:
       - presubmit
     include_dirs:

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -7,7 +7,7 @@ python_paths:
   - kubeflow/kubeflow/py
 workflows:
   # Run unittests for the shared frontend code
-  - py_func: kubeflow.kubeflow.ci.shared_ui_tests.create_workflow
+  - py_func: kubeflow.kubeflow.ci.common_ui_tests.create_workflow
     name: common-ui
     job_types:
       - presubmit

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -8,7 +8,7 @@ python_paths:
 workflows:
   # Run unittests for the shared frontend code
   - py_func: kubeflow.kubeflow.ci.shared_ui_tests.create_workflow
-    name: shared-ui-tests
+    name: common-ui
     job_types:
       - presubmit
     include_dirs:

--- a/py/kubeflow/kubeflow/ci/Makefile
+++ b/py/kubeflow/kubeflow/ci/Makefile
@@ -6,11 +6,11 @@ KUBEFLOW_TESTING_REPO ?= /tmp/kubeflow/testing
 KUBEFLOW_KUBEFLOW_REPO ?= /tmp/kubeflow/kubeflow
 PYTHONPATH ?= "${KUBEFLOW_KUBEFLOW_REPO}/py:${KUBEFLOW_TESTING_REPO}/py"
 
-check-local-shared-ui-tests:
+check-local-common-ui-tests:
 	PYTHONPATH=${PYTHONPATH} \
 	LOCAL_TESTING=True \
-	python shared_ui_tests_runner.py
+	python common_ui_tests_runner.py
 
-check-prod-shared-ui-tests:
+check-prod-common-ui-tests:
 	PYTHONPATH=${PYTHONPATH} \
-	python shared_ui_tests_runner.py
+	python common_ui_tests_runner.py

--- a/py/kubeflow/kubeflow/ci/common_ui_tests.py
+++ b/py/kubeflow/kubeflow/ci/common_ui_tests.py
@@ -27,7 +27,7 @@ class Builder(workflow_utils.ArgoTestBuilder):
         ui_tests = argo_build_util.deep_copy(task_template)
 
         img = "browserless/chrome:1.44-chrome-stable"
-        ui_tests["name"] = "shared-ui-tests"
+        ui_tests["name"] = "common-ui-tests"
         ui_tests["container"]["image"] = img
         ui_tests["container"]["command"] = ["npm"]
         ui_tests["container"]["args"] = ["run", "test-ci"]
@@ -41,7 +41,7 @@ class Builder(workflow_utils.ArgoTestBuilder):
     def _create_ui_build_task(self, task_template):
         ui_build = argo_build_util.deep_copy(task_template)
 
-        ui_build["name"] = "build-shared-ui-library"
+        ui_build["name"] = "build-common-ui-library"
         ui_build["container"]["image"] = "node:12.20.1-stretch-slim"
         ui_build["container"]["command"] = ["npm"]
         ui_build["container"]["args"] = ["run", "build"]

--- a/py/kubeflow/kubeflow/ci/common_ui_tests_runner.py
+++ b/py/kubeflow/kubeflow/ci/common_ui_tests_runner.py
@@ -3,11 +3,11 @@ import os
 
 import yaml
 
-from kubeflow.kubeflow.ci import shared_ui_tests
+from kubeflow.kubeflow.ci import common_ui_tests
 
-WORKFLOW_NAME = os.getenv("WORKFLOW_NAME", "shared-ui-tests")
+WORKFLOW_NAME = os.getenv("WORKFLOW_NAME", "common-ui-tests")
 WORKFLOW_NAMESPACE = os.getenv("WORKFLOW_NAMESPACE", "kubeflow-user")
 
 if __name__ == "__main__":
-    print(yaml.dump(shared_ui_tests.create_workflow(WORKFLOW_NAME,
+    print(yaml.dump(common_ui_tests.create_workflow(WORKFLOW_NAME,
                                                     WORKFLOW_NAMESPACE)))

--- a/py/kubeflow/kubeflow/ci/shared_ui_tests.py
+++ b/py/kubeflow/kubeflow/ci/shared_ui_tests.py
@@ -88,12 +88,10 @@ class Builder(workflow_utils.ArgoTestBuilder):
                                         build_step,
                                         [modules_install_task["name"]])
 
-        # remove node_modules folder as exit handler
+        # EXIT-HANDLER: remove node_modules folder as exit handler
         rm_node_modules = self._create_exit_handler(task_template)
         argo_build_util.add_task_to_dag(workflow, workflow_utils.EXIT_DAG_NAME,
-                                        rm_node_modules,
-                                        [build_step["name"],
-                                         ui_tests_task["name"]])
+                                        rm_node_modules, [])
 
         # Set the labels on all templates
         workflow = argo_build_util.set_task_template_labels(workflow)

--- a/py/kubeflow/kubeflow/ci/shared_ui_tests.py
+++ b/py/kubeflow/kubeflow/ci/shared_ui_tests.py
@@ -26,8 +26,9 @@ class Builder(workflow_utils.ArgoTestBuilder):
     def _create_ui_tests_task(self, task_template):
         ui_tests = argo_build_util.deep_copy(task_template)
 
+        img = "browserless/chrome:1.44-chrome-stable"
         ui_tests["name"] = "shared-ui-tests"
-        ui_tests["container"]["image"] = "node:12.20.1-stretch-slim"
+        ui_tests["container"]["image"] = img
         ui_tests["container"]["command"] = ["npm"]
         ui_tests["container"]["args"] = ["run", "test-ci"]
 


### PR DESCRIPTION
right now the PR's tests fail, for the common code, because the name of the workflow is not DNS1123 compatible 
https://github.com/kubeflow/kubeflow/pull/5642#issuecomment-786877663

This is needed to fix our CI tests #5482 

I'll use this PR to fix the test-case. I also introduced a test file just to trigger the tests. Once we ensure the CI works as expected then I'll push a commit to delete it

/cc @PatrickXYS 