### PR TITLE
Fix build failure on admission webhook component

### DIFF
--- a/components/admission-webhook/main.go
+++ b/components/admission-webhook/main.go
@@ -103,6 +103,11 @@ func safeToApplyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.Pod
 	if _, err := mergeVolumes(pod.Spec.Volumes, podDefaults); err != nil {
 		errs = append(errs, err)
 	}
+
+	if _, err := mergeTolerations(pod.Spec.Tolerations, podDefaults); err != nil {
+		errs = append(errs, err)
+	}
+
 	for _, ctr := range pod.Spec.Containers {
 		if err := safeToApplyPodDefaultsOnContainer(&ctr, podDefaults); err != nil {
 			errs = append(errs, err)
@@ -112,20 +117,15 @@ func safeToApplyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.Pod
 	var (
 		defaultAnnotations = make([]*map[string]string, len(podDefaults))
 		defaultLabels      = make([]*map[string]string, len(podDefaults))
-		defaultTolerations = make([]*corev1.Toleration, len(podDefaults))
 	)
 	for i, pd := range podDefaults {
 		defaultAnnotations[i] = &pd.Spec.Annotations
 		defaultLabels[i] = &pd.Spec.Labels
-		defaultTolerations[i] = &pd.Spec.Tolerations
 	}
 	if _, err := mergeMap(pod.Annotations, defaultAnnotations); err != nil {
 		errs = append(errs, err)
 	}
 	if _, err := mergeMap(pod.Labels, defaultLabels); err != nil {
-		errs = append(errs, err)
-	}
-	if _, err := mergeTolerations(pod.Spec.Tolerations, defaultTolerations); err != nil {
 		errs = append(errs, err)
 	}
 	return utilerrors.NewAggregate(errs)
@@ -295,7 +295,6 @@ func mergeVolumes(volumes []corev1.Volume, podDefaults []*settingsapi.PodDefault
 	return mergedVolumes, err
 }
 
-
 // mergeTolerations merges given list of Tolerations with the tolerations injected by given
 // podDefaults. It returns an error if it detects any conflict during the merge.
 func mergeTolerations(tolerations []corev1.Toleration, podDefaults []*settingsapi.PodDefault) ([]corev1.Toleration, error) {
@@ -339,7 +338,6 @@ func mergeTolerations(tolerations []corev1.Toleration, podDefaults []*settingsap
 	return mergedTolerations, err
 }
 
-
 // mergeMap copies the existing map and adds the keys in defaults. It returns
 // an error if it detects any conflict during the merge.
 func mergeMap(existing map[string]string, defaults []*map[string]string) (map[string]string, error) {
@@ -381,15 +379,19 @@ func applyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.PodDefaul
 	}
 	pod.Spec.Volumes = volumes
 
+	tolerations, err := mergeTolerations(pod.Spec.Tolerations, podDefaults)
+	if err != nil {
+		klog.Error(err)
+	}
+	pod.Spec.Tolerations = tolerations
+
 	var (
 		defaultAnnotations = make([]*map[string]string, len(podDefaults))
 		defaultLabels      = make([]*map[string]string, len(podDefaults))
-		defaultTolerations = make([]*corev1.Toleration, len(podDefaults))
 	)
 	for i, pd := range podDefaults {
 		defaultAnnotations[i] = &pd.Spec.Annotations
 		defaultLabels[i] = &pd.Spec.Labels
-		defaultTolerations = &pd.Spec.Tolerations
 	}
 	annotations, err := mergeMap(pod.Annotations, defaultAnnotations)
 	if err != nil {
@@ -402,12 +404,6 @@ func applyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.PodDefaul
 		klog.Error(err)
 	}
 	pod.ObjectMeta.Labels = labels
-
-	tolerations, err := mergeTolerations(pod.Spec.Tolerations, defaultTolerations)
-	if err != nil {
-		klog.Error(err)
-	}
-	pod.Spec.Tolerations = tolerations
 
 	for i, ctr := range pod.Spec.Containers {
 		applyPodDefaultsOnContainer(&ctr, podDefaults)

--- a/components/admission-webhook/main_test.go
+++ b/components/admission-webhook/main_test.go
@@ -130,45 +130,51 @@ func TestApplyPodDefaultsOnPod(t *testing.T) {
 			"Add tolerations",
 			&corev1.Pod{
 				Spec: corev1.PodSpec{
-					Tolerations: []*corev1.Toleration{
+					Tolerations: []corev1.Toleration{
 						{
-							Key: "oldToleration",
+							Key:      "oldToleration",
 							Operator: "Exists",
-							Effect: "NoSchedule",
+							Effect:   "NoSchedule",
 						},
-					}
-				}
+					},
+				},
 			},
 			[]*settingsapi.PodDefault{
 				{
 					Spec: settingsapi.PodDefaultSpec{
-						Tolerations: []*corev1.Toleration{
+						Tolerations: []corev1.Toleration{
 							{
-								Key: "newToleration",
+								Key:      "newToleration",
 								Operator: "Equal",
-								Value: "foo",
-								"Effect": "NoSchedule",
+								Value:    "foo",
+								Effect:   "NoSchedule",
 							},
 						},
 					},
 				},
 			},
 			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"poddefault.admission.kubeflow.org/poddefault-": "",
+					},
+					Labels: map[string]string{},
+				},
 				Spec: corev1.PodSpec{
-					Tolerations: []*corev1.Toleration{
+					Tolerations: []corev1.Toleration{
 						{
-							Key: "oldToleration",
+							Key:      "oldToleration",
 							Operator: "Exists",
-							Effect: "NoSchedule",
+							Effect:   "NoSchedule",
 						},
 						{
-							Key: "newToleration",
+							Key:      "newToleration",
 							Operator: "Equal",
-							Value: "foo",
-							"Effect": "NoSchedule",
+							Value:    "foo",
+							Effect:   "NoSchedule",
 						},
-					}
-				}
+					},
+				},
 			},
 		},
 	} {


### PR DESCRIPTION
Currently, build & test fails on the admission webhook component.

```sh
$ make build
go build -gcflags 'all=-N -l' -o bin/webhook .
# github.com/kubeflow/kubeflow/components/admission-webhook
./main.go:120:25: cannot use &pd.Spec.Tolerations (type *[]"k8s.io/api/core/v1".Toleration) as type *"k8s.io/api/core/v1".Toleration in assignment
./main.go:128:40: cannot use defaultTolerations (type []*"k8s.io/api/core/v1".Toleration) as type []*v1alpha1.PodDefault in argument to mergeTolerations
./main.go:392:22: cannot use &pd.Spec.Tolerations (type *[]"k8s.io/api/core/v1".Toleration) as type []*"k8s.io/api/core/v1".Toleration in assignment
./main.go:406:47: cannot use defaultTolerations (type []*"k8s.io/api/core/v1".Toleration) as type []*v1alpha1.PodDefault in argument to mergeTolerations
Makefile:7: recipe for target 'build' failed
make: *** [build] Error 2

$ go test ./...
# github.com/kubeflow/kubeflow/components/admission-webhook
main_test.go:139:7: missing ',' before newline in composite literal
main_test.go:140:6: missing ',' before newline in composite literal
main_test.go:170:7: missing ',' before newline in composite literal
main_test.go:171:6: missing ',' before newline in composite literal
FAIL    github.com/kubeflow/kubeflow/components/admission-webhook [setup failed]
?       github.com/kubeflow/kubeflow/components/admission-webhook/pkg/apis      [no test files]
?       github.com/kubeflow/kubeflow/components/admission-webhook/pkg/apis/settings     [no test files]
ok      github.com/kubeflow/kubeflow/components/admission-webhook/pkg/apis/settings/v1alpha1    0.007s
FAIL
```

The main cause was the type mismatch on the assignment of some variables. 
I also fixed test errors. Please take a look, thanks.
 