### PR TITLE
First iteration and common utils for Jupyter web app CD

### DIFF
--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -14,17 +14,12 @@ workflows:
     include_dirs:
       - components/crud-web-apps/common/frontend/kubeflow-common-lib/*
     kwargs: {}
-  # Image Auto Release workflows.
-  # The workflows below are related to auto building our Docker images.
-  # We have separate pre/postsubmit jobs because we want to use different
-  # registries
-  #- app_dir: kubeflow/kubeflow/components/tensorflow-notebook-image/releaser
-  #  component: workflows
-  #  name: tf-notebook-release
-  #  job_types:
-  #    - presubmit
-  #  params:
-  #    registry: "gcr.io/kubeflow-ci"
-  #    step_image: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4"
-  #  include_dirs:
-  #    - components/tensorflow-notebook-image/*
+  # post submit jobs
+  - py_func: kubeflow.kubeflow.cd.jwa.create_workflow
+    name: jwa-build
+    job_types:
+      - postsubmit
+    include_dirs:
+      - components/crud-web-apps/common/frontend/kubeflow-common-lib/*
+      - components/crud-web-apps/jupyter/*
+    kwargs: {}

--- a/py/kubeflow/kubeflow/cd/Makefile
+++ b/py/kubeflow/kubeflow/cd/Makefile
@@ -1,0 +1,16 @@
+# This file is only intended for development purposes
+
+# change this env var based on where kubeflow/testing repo lives
+# in your local machine
+KUBEFLOW_TESTING_REPO ?= /tmp/kubeflow/testing
+KUBEFLOW_KUBEFLOW_REPO ?= /tmp/kubeflow/kubeflow
+PYTHONPATH ?= "${KUBEFLOW_KUBEFLOW_REPO}/py:${KUBEFLOW_TESTING_REPO}/py"
+
+check-local-jwa-kaniko-build:
+	@PYTHONPATH=${PYTHONPATH} \
+	LOCAL_TESTING=True \
+	python jwa_runner.py
+
+check-prod-jwa-kaniko-build:
+	@PYTHONPATH=${PYTHONPATH} \
+	python jwa_runner.py

--- a/py/kubeflow/kubeflow/cd/config.py
+++ b/py/kubeflow/kubeflow/cd/config.py
@@ -1,0 +1,12 @@
+AWS_REGISTRY = "public.ecr.aws/j1r0q0g6"
+
+# list of public images
+JUPYTER_WEB_APP_IMAGE = "%s/jupyter-web-app" % AWS_REGISTRY
+TENSORBOARDS_WEB_APP_IMAGE = "%s/tensorboards-web-app" % AWS_REGISTRY
+CENTRAL_DASHBOARD_IMAGE = "%s/central-dashboard" % AWS_REGISTRY
+
+ADMISSION_WEBHOOK_IMAGE = "%s/admission-webhook" % AWS_REGISTRY
+
+PROFILE_CONTROLLER_IMAGE = "%s/profile_controller" % AWS_REGISTRY
+NOTEBOOK_CONTROLLER_IMAGE = "%s/notebook-controller" % AWS_REGISTRY
+TENSORBOARD_CONTROLLER_IMAGE = "%s/tensorboard-controller" % AWS_REGISTRY

--- a/py/kubeflow/kubeflow/cd/jwa.py
+++ b/py/kubeflow/kubeflow/cd/jwa.py
@@ -1,0 +1,48 @@
+""""Argo Workflow for building Jupyter web app's OCI image using Kaniko"""
+import os
+
+from kubeflow.kubeflow import ci
+from kubeflow.testing import argo_build_util
+
+TAG = os.getenv("PULL_BASE_SHA", "kaniko-local-test")
+AWS_REGISTRY = "public.ecr.aws/j1r0q0g6/jupyter-web-app"
+
+
+class Builder(ci.workflow_utils.ArgoTestBuilder):
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None, **kwargs):
+        super().__init__(name=name, namespace=namespace, bucket=bucket,
+                         test_target_name=test_target_name, **kwargs)
+
+    def build(self):
+        """Build the Argo workflow graph"""
+        workflow = self.build_init_workflow(exit_dag=False)
+        task_template = self.build_task_template()
+
+        # Build JWA using Kaniko
+        dockerfile = ("%s/components/crud-web-apps"
+                      "/jupyter/Dockerfile") % self.src_dir
+        context = "dir://%s/components/crud-web-apps" % self.src_dir
+        destination = "%s:%s" % (AWS_REGISTRY, TAG)
+
+        kaniko_task = self.create_kaniko_task(task_template, dockerfile,
+                                              context, destination)
+        argo_build_util.add_task_to_dag(workflow,
+                                        ci.workflow_utils.E2E_DAG_NAME,
+                                        kaniko_task, [self.mkdir_task_name])
+
+        # Set the labels on all templates
+        workflow = argo_build_util.set_task_template_labels(workflow)
+
+        return workflow
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build()

--- a/py/kubeflow/kubeflow/cd/jwa.py
+++ b/py/kubeflow/kubeflow/cd/jwa.py
@@ -1,10 +1,7 @@
 """"Argo Workflow for building Jupyter web app's OCI image using Kaniko"""
-import os
-
 from kubeflow.kubeflow import ci
 from kubeflow.testing import argo_build_util
 
-TAG = os.getenv("PULL_BASE_SHA", "kaniko-local-test")
 AWS_REGISTRY = "public.ecr.aws/j1r0q0g6/jupyter-web-app"
 
 
@@ -23,7 +20,7 @@ class Builder(ci.workflow_utils.ArgoTestBuilder):
         dockerfile = ("%s/components/crud-web-apps"
                       "/jupyter/Dockerfile") % self.src_dir
         context = "dir://%s/components/crud-web-apps" % self.src_dir
-        destination = "%s:%s" % (AWS_REGISTRY, TAG)
+        destination = AWS_REGISTRY
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
                                               context, destination)

--- a/py/kubeflow/kubeflow/cd/jwa.py
+++ b/py/kubeflow/kubeflow/cd/jwa.py
@@ -1,8 +1,7 @@
 """"Argo Workflow for building Jupyter web app's OCI image using Kaniko"""
 from kubeflow.kubeflow import ci
+from kubeflow.kubeflow.cd import config
 from kubeflow.testing import argo_build_util
-
-AWS_REGISTRY = "public.ecr.aws/j1r0q0g6/jupyter-web-app"
 
 
 class Builder(ci.workflow_utils.ArgoTestBuilder):
@@ -20,7 +19,7 @@ class Builder(ci.workflow_utils.ArgoTestBuilder):
         dockerfile = ("%s/components/crud-web-apps"
                       "/jupyter/Dockerfile") % self.src_dir
         context = "dir://%s/components/crud-web-apps" % self.src_dir
-        destination = AWS_REGISTRY
+        destination = config.JUPYTER_WEB_APP_IMAGE
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
                                               context, destination)

--- a/py/kubeflow/kubeflow/cd/jwa_runner.py
+++ b/py/kubeflow/kubeflow/cd/jwa_runner.py
@@ -1,0 +1,12 @@
+# This file is only intended for development purposes
+import os
+
+import yaml
+
+from kubeflow.kubeflow.cd import jwa
+
+WORKFLOW_NAME = os.getenv("WORKFLOW_NAME", "jwa-build")
+WORKFLOW_NAMESPACE = os.getenv("WORKFLOW_NAMESPACE", "kubeflow-user")
+
+if __name__ == "__main__":
+    print(yaml.dump(jwa.create_workflow(WORKFLOW_NAME, WORKFLOW_NAMESPACE)))

--- a/py/kubeflow/kubeflow/ci/__init__.py
+++ b/py/kubeflow/kubeflow/ci/__init__.py
@@ -1,0 +1,1 @@
+from . import workflow_utils  # noqa F401, F403

--- a/py/kubeflow/kubeflow/ci/workflow_utils.py
+++ b/py/kubeflow/kubeflow/ci/workflow_utils.py
@@ -201,6 +201,12 @@ class ArgoTestBuilder:
         """
         kaniko = argo_build_util.deep_copy(task_template)
 
+        # append the tag base-commit[0:7]
+        if ":" not in destination:
+            sha = os.getenv("PULL_BASE_SHA", "12341234kanikotest")
+            base = os.getenv("PULL_BASE_REF", "master")
+            destination += ":%s-%s" % (base, sha[0:8])
+
         kaniko["name"] = "kaniko-build-push"
         kaniko["container"]["image"] = "gcr.io/kaniko-project/executor:v1.5.0"
         kaniko["container"]["command"] = ["/kaniko/executor"]

--- a/py/kubeflow/kubeflow/ci/workflow_utils.py
+++ b/py/kubeflow/kubeflow/ci/workflow_utils.py
@@ -13,10 +13,14 @@ EXIT_DAG_NAME = "exit-handler"
 
 
 LOCAL_TESTING = os.getenv("LOCAL_TESTING", "False")
-CREDENTIALS_VOLUME = {"name": "aws-secret",
-                      "secret": {"secretName": "aws-secret"}}
-CREDENTIALS_MOUNT = {"mountPath": "/root/.aws/",
-                     "name": "aws-secret"}
+DOCKER_CONFIG_VOLUME = {"name": "docker-config",
+                        "configMap": {"name": "docker-config"}}
+DOCKER_CONFIG_MOUNT = {"name": "docker-config",
+                       "mountPath": "/kaniko/.docker/"}
+AWS_CREDENTIALS_VOLUME = {"name": "aws-secret",
+                          "secret": {"secretName": "aws-secret"}}
+AWS_CREDENTIALS_MOUNT = {"mountPath": "/root/.aws/",
+                         "name": "aws-secret"}
 
 AWS_WORKER_IMAGE = "public.ecr.aws/j1r0q0g6/kubeflow-testing:latest"
 
@@ -77,7 +81,8 @@ class ArgoTestBuilder:
             },
         }]
         if LOCAL_TESTING == "False":
-            volumes.append(CREDENTIALS_VOLUME)
+            volumes.append(AWS_CREDENTIALS_VOLUME)
+            volumes.append(DOCKER_CONFIG_VOLUME)
 
         workflow = {
             "apiVersion": "argoproj.io/v1alpha1",
@@ -127,7 +132,8 @@ class ArgoTestBuilder:
             "name": DATA_VOLUME
         }]
         if LOCAL_TESTING == "False":
-            volume_mounts.append(CREDENTIALS_MOUNT)
+            volume_mounts.append(AWS_CREDENTIALS_MOUNT)
+            volume_mounts.append(DOCKER_CONFIG_MOUNT)
 
         image = AWS_WORKER_IMAGE
 


### PR DESCRIPTION
This is part of our effort to use the Optional-test infra for 1.3 going forward #5482 

This PR introduces the following assumptions:
1. The produced Argo Workflow will **not** try to push the produced image to a registry [ `--no-push` Kaniko arg] if the code is not run in the upstream AWS cluster [ `LOCAL_TESTING=True` env var ]. This will make it easier for more people to run the code in their Kubernetes cluster with Argo installed
2. We expect some workflows to not have an `exit dag`. This is the case for now at least, where the CD only builds our public images and pushes them to the registry
3. We will be using `gcr.io/kaniko-project/executor:v1.5.0`. This is a newer version from what's used from [KFServing](https://github.com/kubeflow/kfserving/blob/ec9e8ca569ea173de3717a41130e37cfb756ac8d/test/workflows/components/workflows.libsonnet#L47)
4. The produced images will use the SHA of the PR as the tag, which is what [KFServing does](https://github.com/kubeflow/kfserving/blob/ec9e8ca569ea173de3717a41130e37cfb756ac8d/test/workflows/components/workflows.libsonnet#L348) 

@DavidSpek in the end while working on trying out Kaniko I ended up writing code for it. So let's use this PR to test the first iteration only with JWA and then once we ensure it works lets use your PR #5640 to add workflows for the other components as well.

@PatrickXYS I have two questions:
1. Can we use the `public.ecr.aws/j1r0q0g6/jupyter-web-app` yet, or do you still need to do some setup?
2. What kind of credentials do I need to inject to the workflow in order for the Kaniko container to have permissions to push to the public AWS ECR? Is it just the [docker-config](https://github.com/kubeflow/kfserving/blob/ec9e8ca569ea173de3717a41130e37cfb756ac8d/test/workflows/components/workflows.libsonnet#L197-L202) [ and if yes, where should I mount it ] ?

cc @kubeflow/wg-notebooks-leads 
/cc @PatrickXYS 