### PR TITLE
feat(jupyter): Support hiding image registry/tag

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -49,6 +49,8 @@ spawnerFormDefaults:
   allowCustomImage: true
   # If true, users can input custom images
   # If false, users can only select from the images in this config
+  hideRegistry: false
+  hideTag: false
   imagePullPolicy:
     # Supported values: Always, IfNotPresent, Never
     value: IfNotPresent

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -25,8 +25,6 @@ spawnerFormDefaults:
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:master-1831e436
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:master-1831e436
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:master-1831e436
-    hideRegistry: true
-    hideTag: false
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -48,6 +46,9 @@ spawnerFormDefaults:
     # The list of available standard container Images
     options:
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:master-164fa2ea
+  # If true, hide registry and/or tag name in the image selection dropdown
+  hideRegistry: true
+  hideTag: false
   allowCustomImage: true
   # If true, users can input custom images
   # If false, users can only select from the images in this config

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -25,7 +25,7 @@ spawnerFormDefaults:
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:master-1831e436
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:master-1831e436
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:master-1831e436
-    hideRegistry: false
+    hideRegistry: true
     hideTag: false
   imageGroupOne:
     # The container Image for the user's Group One Server

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -25,6 +25,8 @@ spawnerFormDefaults:
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:master-1831e436
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:master-1831e436
       - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:master-1831e436
+    hideRegistry: false
+    hideTag: false
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -49,8 +51,6 @@ spawnerFormDefaults:
   allowCustomImage: true
   # If true, users can input custom images
   # If false, users can only select from the images in this config
-  hideRegistry: false
-  hideTag: false
   imagePullPolicy:
     # Supported values: Always, IfNotPresent, Never
     value: IfNotPresent

--- a/components/crud-web-apps/jupyter/frontend/package-lock.json
+++ b/components/crud-web-apps/jupyter/frontend/package-lock.json
@@ -2535,9 +2535,9 @@
       "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "@types/underscore": {
-      "version": "1.10.24",
-      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.10.24.tgz",
-      "integrity": "sha512-T3NQD8hXNW2sRsSbLNjF/aBo18MyJlbw0lSpQHB/eZZtScPdexN4HSa8cByYwTw9Wy7KuOFr81mlDQcQQaZ79w=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.11.0.tgz",
+      "integrity": "sha512-ipNAQLgRnG0EWN1cTtfdVHp5AyTW/PAMJ1PxLN4bAKSHbusSZbj48mIHiydQpN7GgQrYqwfnvZ573OVfJm5Nzg=="
     },
     "@types/webpack-sources": {
       "version": "0.1.6",
@@ -8084,9 +8084,9 @@
       }
     },
     "openid-client": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.4.0.tgz",
-      "integrity": "sha512-FZq6rMaItawQc0mMrxlya96fydO7jlkW4I0Hrke3E4ogLAYcFbSefcJlKFLRvr+S5x9N6PMH6OZl9LHgu7JXvw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-4.4.1.tgz",
+      "integrity": "sha512-un5ZoCwUklVxDJKUtzToLGdlpIJork3rPzXgMU4bZONNM/+vZVvKs1LRkNNVsoultBtWBpGwRNcXAL3VhLi+9g==",
       "requires": {
         "got": "^11.8.0",
         "jose": "^2.0.4",

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
@@ -12,8 +12,8 @@
           [imagesGroupOne]="config?.imageGroupOne?.options"
           [imagesGroupTwo]="config?.imageGroupTwo?.options"
           [allowCustomImage]="config?.allowCustomImage"
-          [hideRegistry]="config?.image?.hideRegistry"
-          [hideTag]="config?.image?.hideTag"
+          [hideRegistry]="config?.hideRegistry"
+          [hideTag]="config?.hideTag"
         ></app-form-image>
 
         <app-form-cpu-ram

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
@@ -12,6 +12,8 @@
           [imagesGroupOne]="config?.imageGroupOne?.options"
           [imagesGroupTwo]="config?.imageGroupTwo?.options"
           [allowCustomImage]="config?.allowCustomImage"
+          [hideRegistry]="config?.image?.hideRegistry"
+          [hideTag]="config?.image?.hideTag"
         ></app-form-image>
 
         <app-form-cpu-ram

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -56,7 +56,7 @@
         {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
-    <mat-error>Please provide and Image to use</mat-error>
+    <mat-error>Please provide an Image to use</mat-error>
   </mat-form-field>
 
   <mat-form-field
@@ -77,7 +77,7 @@
         {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
-    <mat-error>Please provide and Image to use</mat-error>
+    <mat-error>Please provide an Image to use</mat-error>
   </mat-form-field>
 
   <mat-form-field
@@ -98,7 +98,7 @@
         {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
-    <mat-error>Please provide and Image to use</mat-error>
+    <mat-error>Please provide an Image to use</mat-error>
   </mat-form-field>
 
   <mat-form-field
@@ -113,7 +113,7 @@
       [formControl]="parentForm.get('customImage')"
       #cstmimg
     />
-    <mat-error>Please provide and Image to use</mat-error>
+    <mat-error>Please provide an Image to use</mat-error>
   </mat-form-field>
 
   <lib-advanced-options>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -74,7 +74,7 @@
       [formControl]="parentForm.get('imageGroupOne')"
     >
       <mat-option *ngFor="let img of imagesGroupOne" [value]="img">
-        {{ img }}
+        {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
     <mat-error>Please provide and Image to use</mat-error>
@@ -95,7 +95,7 @@
       [formControl]="parentForm.get('imageGroupTwo')"
     >
       <mat-option *ngFor="let img of imagesGroupTwo" [value]="img">
-        {{ img }}
+        {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
     <mat-error>Please provide and Image to use</mat-error>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -52,7 +52,7 @@
       placeholder="Docker Image"
       [formControl]="parentForm.get('image')"
     >
-      <mat-option *ngFor="let img of images" [value]="img">
+      <mat-option *ngFor="let img of images" [value]="img" [matTooltip]="img">
         {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
@@ -73,7 +73,11 @@
       placeholder="Docker Image"
       [formControl]="parentForm.get('imageGroupOne')"
     >
-      <mat-option *ngFor="let img of imagesGroupOne" [value]="img">
+      <mat-option
+        *ngFor="let img of imagesGroupOne"
+        [value]="img"
+        [matTooltip]="img"
+      >
         {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
@@ -94,7 +98,11 @@
       placeholder="Docker Image"
       [formControl]="parentForm.get('imageGroupTwo')"
     >
-      <mat-option *ngFor="let img of imagesGroupTwo" [value]="img">
+      <mat-option
+        *ngFor="let img of imagesGroupTwo"
+        [value]="img"
+        [matTooltip]="img"
+      >
         {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -53,7 +53,7 @@
       [formControl]="parentForm.get('image')"
     >
       <mat-option *ngFor="let img of images" [value]="img">
-        {{ img }}
+        {{ imageDisplayName(img) }}
       </mat-option>
     </mat-select>
     <mat-error>Please provide and Image to use</mat-error>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -82,7 +82,7 @@ export class FormImageComponent implements OnInit, OnDestroy {
   }
   imageDisplayName(image: string): string {
     const [name, tag = null] = image.split(':');
-    let tokens = name.split('/')
+    let tokens = name.split('/');
 
     if (this.hideRegistry && tokens.length > 1 && tokens[0].includes('.')) {
       tokens.shift();
@@ -96,5 +96,4 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
     return displayName;
   }
-
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -16,6 +16,8 @@ export class FormImageComponent implements OnInit, OnDestroy {
   @Input() imagesGroupOne: string[];
   @Input() imagesGroupTwo: string[];
   @Input() allowCustomImage: boolean;
+  @Input() hideRegistry: boolean;
+  @Input() hideTag: boolean;
 
   subs = new Subscription();
 
@@ -78,4 +80,21 @@ export class FormImageComponent implements OnInit, OnDestroy {
   ngOnDestroy() {
     this.subs.unsubscribe();
   }
+  imageDisplayName(image: string): string {
+    const [name, tag = null] = image.split(':');
+    let tokens = name.split('/')
+
+    if (this.hideRegistry && tokens.length > 1 && tokens[0].includes('.')) {
+      tokens.shift();
+    }
+
+    let displayName = tokens.join('/');
+
+    if (!this.hideTag && tag !== null) {
+      displayName = `${displayName}:${tag}`;
+    }
+
+    return displayName;
+  }
+
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -155,7 +155,7 @@ export interface Config {
   };
 
   hideRegistry?: boolean;
-  
+
   hideTag?: boolean;
 
   allowCustomImage?: boolean;

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -142,8 +142,6 @@ export interface Config {
   image?: {
     value: string;
     options: string[];
-    hideRegistry?: boolean;
-    hideTag?: boolean;
   };
 
   imageGroupOne?: {
@@ -155,6 +153,10 @@ export interface Config {
     value: string;
     options: string[];
   };
+
+  hideRegistry?: boolean;
+  
+  hideTag?: boolean;
 
   allowCustomImage?: boolean;
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -142,6 +142,8 @@ export interface Config {
   image?: {
     value: string;
     options: string[];
+    hideRegistry?: boolean;
+    hideTag?: boolean;
   };
 
   imageGroupOne?: {


### PR DESCRIPTION
Closes https://github.com/StatCan/kubeflow/issues/51

In the notebook server creation view, the fully qualified name of available images is currently displayed as:
- gcr.io/kubeflow-images-public/tensorflow-1.5.1-notebook-cpu:v0.5.0

We implemented an optional feature to hide the registry and tag in the image dropdown list as the names can get unwieldly when the registry domain is much longer than, for example, `gcr.io`. Tags can also be the same (e.g. for organizations that use full commit SHAs for tags). 

This is an optional feature for a more approachable and understandable list, with the new images displayed in the form:
- kubeflow-images-public/tensorflow-1.5.1-notebook-cpu

This PR adds two new configuration options to the `crud-web-apps/jupyter-web-app` supported `spawnerFormDefaults`:
- hideRegistry
- hideTag

If these values are set as `true`, the notebook spawner UI will hide these portions of the image tags in the list of available images. Options were set to "hide" rather than "show" for backwards compatibility: the absence of the values will default to false, which results in the original behaviour of showing the entire image tag.