### PR TITLE
Centraldashboard: Fix active menu item for path-based URLs

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -73,6 +73,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             menuLinks: {
                 type: Array,
                 value: [],
+                observer: '_menuLinksChanged',
             },
             externalLinks: {
                 type: Array,
@@ -201,6 +202,21 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         }
         this._setWorkgroupStatusHasLoaded(true);
     }
+
+    /**
+     * Simulate page changed to activate the correct menu link. This callback
+     * is called in response to the async call to /api/dashboard-links that
+     * happens at every page refresh.
+     *
+     * @param {Array} newValue - new menu links
+     */
+    _menuLinksChanged(newValue) {
+        if (newValue) {
+            this._routePageChanged(this.routeData.page, this.subRouteData.path,
+                this.routeHash.path);
+        }
+    }
+
     /**
      * Handles route changes by evaluating the page path component
      * @param {string} newPage

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -342,14 +342,20 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
     _setActiveMenuLink(path, hashPath) {
         const htmlElements = this._clearActiveLink();
         let matchPath = path;
-        if (hashPath) {
-            matchPath = path + '#' + hashPath;
-        }
+        let matchingLink = '';
         const allLinks = this.menuLinks.map((m) => {
             return m.type === 'section' ? m.items.map((x) => x.link) : m.link;
         }).flat().sort();
-        const matchingLink = allLinks
-            .find((l) => this.compareLinks(l, matchPath));
+        if (hashPath) {
+            matchPath = path + '#' + hashPath;
+            matchingLink = allLinks
+                .find((l) => this.compareLinks(l, matchPath));
+        } else {
+            // longest prefix match - allLinks is sorted
+            allLinks.forEach((link) => {
+                matchingLink = path.startsWith(link) ? link : matchingLink;
+            });
+        }
         // find the HTML element that references the active link
         const activeMenuEl = Array.from(htmlElements).find(
             (x) => this.compareLinks(x.parentElement.href, matchingLink));

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -15,6 +15,39 @@ const TEMPLATE = `
 </test-fixture>
 `;
 
+const MENU_LINKS = [
+    {
+        link: '/jupyter/',
+        text: 'Notebooks',
+    },
+    {
+        link: '/pipeline/#/pipelines',
+        text: 'Pipelines',
+    },
+    {
+        link: '/katib/trials',
+        text: 'Katib Trials',
+    },
+    {
+        type: 'section',
+        text: 'Experiments',
+        items: [
+            {
+                link: '/pipeline/#/experiments',
+                text: 'Pipelines',
+            },
+            {
+                link: '/katib/experiments',
+                text: 'Katib Experiments',
+            },
+        ],
+    },
+    {
+        link: '/pipeline/#/runs',
+        text: 'Runs',
+    },
+];
+
 describe('Main Page', () => {
     let mainPage;
     let beforeHash;
@@ -241,5 +274,60 @@ describe('Main Page', () => {
             flush();
 
             expect(mainPage.iframeSrc).toBe('about:blank');
+        });
+
+    function getSelectedMenuItem() {
+        return mainPage.shadowRoot.querySelectorAll(
+            '.menu-item.iron-selected');
+    }
+
+    it('Sets active menu item from simple URL',
+        () => {
+            mainPage.menuLinks = MENU_LINKS;
+            flush();
+            mainPage._setActiveMenuLink('/jupyter/', '');
+            flush();
+            const activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe('/jupyter/');
+        });
+
+    it('Sets active menu item from hash-based URL with common prefix',
+        () => {
+            mainPage.menuLinks = MENU_LINKS;
+            flush();
+            mainPage._setActiveMenuLink('/pipeline/',
+                '/experiments/details/12345');
+            flush();
+            let activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe(
+                '/pipeline/#/experiments');
+
+            mainPage._setActiveMenuLink('/pipeline/',
+                '/runs/details/12345');
+            flush();
+            activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe(
+                '/pipeline/#/runs');
+        });
+
+    it('Sets active menu item from path-based URL with common prefix ',
+        () => {
+            mainPage.menuLinks = MENU_LINKS;
+            flush();
+            mainPage._setActiveMenuLink('/katib/experiments/id/12345', '');
+            flush();
+            let activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe(
+                '/katib/experiments');
+
+            mainPage._setActiveMenuLink('/katib/trials/id/12345', '');
+            flush();
+            activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe('/katib/trials');
         });
 });

--- a/components/centraldashboard/public/components/pipelines-card.js
+++ b/components/centraldashboard/public/components/pipelines-card.js
@@ -137,7 +137,7 @@ export class PipelinesCard extends utilitiesMixin(PolymerElement) {
                 created: date.toLocaleString(),
                 href: this.buildHref(
                     `/pipeline/#/${this.artifactType}/details/${p.id}`,
-                    { ns: this.namespace }
+                    {ns: this.namespace}
                 ),
                 name: p.name,
                 icon,


### PR DESCRIPTION
This PR fixes two bugs resulting in Centraldashboard not showing an active menu item:

## 1. No active menu item upon refresh

When refreshing the page, the main page fetches menu links by calling the `/api/dashboard-links` endpoint. The callback of this endpoint fires *after* the callback for URL changes, which in turn triggers the activation of the selected menu item. This results in no active menu link. The first commit fixes this by adding an observer to the list of menu items and forcing the activation of one of them, based on the URL.

## 2. Missing support for path-based URLs

We were taking into consideration Apps that do hash-based routing, so URLs with path-based routing would not be matched against the correct menu item. The second commit handles this.

---

This PR also introduces some unit tests to make sure that the selection of the active menu item happens as expected.

/assign @StefanoFioravanzo 
/cc @kimwnasptd 
/cc @elikatsis 
/cc @tasos-ale 