### PR TITLE
Parameterize Jupyter route handling

### DIFF
--- a/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/default/app.py
@@ -1,9 +1,8 @@
-from flask import Flask, request, jsonify, send_from_directory
-from ..common.base_app import app as base
-from ..common import utils, api
+from flask import Blueprint, jsonify, request
 
-app = Flask(__name__)
-app.register_blueprint(base)
+from ..common import api, utils
+
+app = Blueprint("ui", __name__)
 logger = utils.create_logger(__name__)
 
 NOTEBOOK = "./kubeflow_jupyter/common/yaml/notebook.yaml"
@@ -71,21 +70,3 @@ def post_notebook(namespace):
 
     logger.info("Creating Notebook: {}".format(notebook))
     return jsonify(api.create_notebook(notebook, namespace=namespace))
-
-
-# Since Angular is a SPA, we serve index.html every time
-@app.route("/")
-def serve_root():
-    return send_from_directory("./static/", "index.html")
-
-
-@app.route("/<path:path>", methods=["GET"])
-def static_proxy(path):
-    logger.info("Sending file '/static/{}' for path: {}".format(path, path))
-    return send_from_directory("./static/", path)
-
-
-@app.errorhandler(404)
-def page_not_found(e):
-    logger.info("Sending file 'index.html'")
-    return send_from_directory("./static/", "index.html")

--- a/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
+++ b/components/jupyter-web-app/backend/kubeflow_jupyter/rok/app.py
@@ -1,12 +1,12 @@
 import base64
-from flask import Flask, request, jsonify, send_from_directory
-from ..common.base_app import app as base
-from ..common import utils, api
+
+from flask import Blueprint, jsonify, request
+
+from ..common import api, utils
 from . import rok
 
 # Use the BaseApp, override the POST Notebook Endpoint
-app = Flask(__name__)
-app.register_blueprint(base)
+app = Blueprint("ui", __name__)
 logger = utils.create_logger(__name__)
 
 NOTEBOOK = "./kubeflow_jupyter/common/yaml/notebook.yaml"
@@ -119,20 +119,3 @@ def post_notebook(namespace):
 
     logger.info("Creating Notebook: {}".format(notebook))
     return jsonify(api.create_notebook(notebook, namespace=namespace))
-
-
-# Since Angular is a SPA, we serve index.html every time
-@app.route("/")
-def serve_root():
-    return send_from_directory("./static/", "index.html")
-
-
-@app.route("/<path:path>", methods=["GET"])
-def static_proxy(path):
-    return send_from_directory("./static/", path)
-
-
-@app.errorhandler(404)
-def page_not_found(e):
-    logger.info("Sending file 'index.html'")
-    return send_from_directory("./static/", "index.html")

--- a/components/jupyter-web-app/backend/main.py
+++ b/components/jupyter-web-app/backend/main.py
@@ -1,30 +1,59 @@
-import os
-import sys
 import logging
+import os
+from distutils.util import strtobool
+
+from flask import Flask, Blueprint
 from flask_cors import CORS
 from kubeflow_jupyter.common import settings
+from kubeflow_jupyter.common.base_app import app as base
 from kubeflow_jupyter.default.app import app as default
 from kubeflow_jupyter.rok.app import app as rok
 
 logger = logging.getLogger("entrypoint")
 
-# Get the UIs
-ui = os.environ.get("UI", "default")
-apps = {
-    "default": default,
-    "rok": rok
-}
+index_bp = Blueprint("static", __name__)
 
-try:
-    app = apps[ui]
 
-    if "--dev" in sys.argv:
+@index_bp.route("/")
+@index_bp.route("/new")
+def index():
+    logger.info("Serving index.html")
+    return index_bp.send_static_file("index.html")
+
+
+def main():
+    # Get the UIs
+    ui = os.environ.get("UI", "default")
+    prefix = os.environ.get("URL_PREFIX", "/jupyter")
+    dev_mode = strtobool(os.environ.get("DEV_MODE", "False"))
+
+    uis = {
+        "default": default,
+        "rok": rok,
+    }
+
+    try:
+        app_bp = uis[ui]
+    except KeyError:
+        logger.error("Unknown UI {ui}. Select from one of {list(uis.keys())}")
+        exit(1)
+
+    index_bp.static_folder = f"kubeflow_jupyter/{ui}/static/"
+    index_bp.static_url_path = "/static/"
+
+    app = Flask(__name__)
+    app.register_blueprint(index_bp, url_prefix=prefix)
+    app.register_blueprint(app_bp, url_prefix=prefix)
+    app.register_blueprint(base, url_prefix=prefix)
+
+    if dev_mode:
         settings.DEV_MODE = True
 
         logger.warning("Enabling CORS")
         CORS(app)
 
     app.run(host="0.0.0.0")
-except KeyError:
-    logger.warning("There is no " + ui + " UI to load.")
-    exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/components/jupyter-web-app/frontend/package.json
+++ b/components/jupyter-web-app/frontend/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "ng": "ng",
     "format": "prettier --write './**/*.{ts,html,css}'",
-    "start": "ng serve --base-href /jupyter/ --deploy-url /jupyter/",
-    "build": "ng build --base-href /jupyter/ --deploy-url /jupyter/",
+    "start": "ng serve --base-href /jupyter/ --deploy-url /jupyter/static/",
+    "build": "ng build --base-href /jupyter/ --deploy-url /jupyter/static/",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
Allows setting the prefix under which Jupyter mounts its routes. As part of this, also explicitly responds with index.html to / and /new, instead of any 404's.