### PR TITLE
Fix ECR registry to add /notebooks prefix

### DIFF
--- a/py/kubeflow/kubeflow/cd/config.py
+++ b/py/kubeflow/kubeflow/cd/config.py
@@ -1,4 +1,4 @@
-AWS_REGISTRY = "public.ecr.aws/j1r0q0g6"
+AWS_REGISTRY = "public.ecr.aws/j1r0q0g6/notebooks"
 
 # list of public images
 JUPYTER_WEB_APP_IMAGE = "%s/jupyter-web-app" % AWS_REGISTRY


### PR DESCRIPTION
This PR fixes the ECR prefix for the OCI image artifacts to the new folder structure from https://github.com/kubeflow/kubeflow/issues/5675 as the registries have been created.

/cc @kubeflow/wg-notebooks-leads 