### PR TITLE
Fix access-management OOMKilled during container build

### DIFF
--- a/py/kubeflow/kubeflow/cd/access_management.py
+++ b/py/kubeflow/kubeflow/cd/access_management.py
@@ -12,4 +12,5 @@ def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
 
     return builder.build(dockerfile="components/access-management/Dockerfile",
                          context="components/access-management/",
-                         destination=config.ACCESS_MANAGEMENT_IMAGE)
+                         destination=config.ACCESS_MANAGEMENT_IMAGE,
+                         mem_override="6Gi")

--- a/py/kubeflow/kubeflow/cd/kaniko_builder.py
+++ b/py/kubeflow/kubeflow/cd/kaniko_builder.py
@@ -9,10 +9,11 @@ class Builder(ci.workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
-    def build(self, dockerfile, context, destination):
+    def build(self, dockerfile, context, destination,
+              mem_override=None, deadline_override=None):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
-        task_template = self.build_task_template()
+        task_template = self.build_task_template(mem_override, deadline_override)
 
         # Build component OCI image using Kaniko
         dockerfile = ("%s/%s") % (self.src_dir, dockerfile)

--- a/py/kubeflow/kubeflow/ci/access_management_tests.py
+++ b/py/kubeflow/kubeflow/ci/access_management_tests.py
@@ -12,7 +12,7 @@ class Builder(workflow_utils.ArgoTestBuilder):
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
-        task_template = self.build_task_template()
+        task_template = self.build_task_template(mem_override="6Gi")
 
         # Build Access Management using Kaniko
         dockerfile = ("%s/components/access-management"

--- a/py/kubeflow/kubeflow/ci/workflow_utils.py
+++ b/py/kubeflow/kubeflow/ci/workflow_utils.py
@@ -125,7 +125,7 @@ class ArgoTestBuilder:
 
         return workflow
 
-    def build_task_template(self):
+    def build_task_template(self, mem_override=None, deadline_override=None):
         """Return a template for all the tasks"""
         volume_mounts = [{
             "mountPath": "/mnt/test-data-volume",
@@ -136,9 +136,15 @@ class ArgoTestBuilder:
             volume_mounts.append(DOCKER_CONFIG_MOUNT)
 
         image = AWS_WORKER_IMAGE
+        mem_lim = "4Gi"
+        if mem_override:
+            mem_lim = mem_override
+        active_deadline_sec=3000
+        if deadline_override:
+            active_deadline_sec = deadline_override
 
         task_template = {
-            "activeDeadlineSeconds": 3000,
+            "activeDeadlineSeconds": active_deadline_sec,
             "container": {
                 "command": [],
                 "env": [],
@@ -148,7 +154,7 @@ class ArgoTestBuilder:
                 "resources": {
                     "limits": {
                         "cpu": "4",
-                        "memory": "4Gi"
+                        "memory": mem_lim
                     },
                     "requests": {
                         "cpu": "1",


### PR DESCRIPTION
The Kaniko build process for access-management has a tendency to get OOMKilled (see https://github.com/kubeflow/kubeflow/pull/5673). This PR makes the `memory` and `activeDeadlineSeconds` configurable for workflows and increases the memory limit from 4Gi to 6Gi for building the Kaniko image. The `activeDeadlineSeconds` is not used in this PR specifically, but is used in other PRs I have open so adding it in here will make the large amount of rebasing I am going to need to do a little easier. 