### PR TITLE
Add notebook-server-jupyter-scipy dockerfile and CI/CD

### DIFF
--- a/components/example-notebook-servers/jupyter-scipy/Dockerfile
+++ b/components/example-notebook-servers/jupyter-scipy/Dockerfile
@@ -1,0 +1,6 @@
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-b3fe73b2
+
+# install - requirements.txt
+COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-scipy/requirements.txt
+++ b/components/example-notebook-servers/jupyter-scipy/requirements.txt
@@ -1,0 +1,26 @@
+beautifulsoup4==4.9.3
+bokeh==2.3.0
+#Bottleneck==1.3.2 Could not build wheels for Bottleneck which use PEP 517 and cannot be installed directly
+cloudpickle==1.6.0
+cython==0.29.22
+dask==2021.3.0
+dill==0.3.3
+h5py==3.2.1
+ipywidgets==7.6.3
+ipympl==0.6.3
+matplotlib==3.3.4
+numba==0.53.0
+numexpr==2.7.3
+pandas==1.2.3
+patsy==0.5.1
+protobuf==3.15.6
+tables==3.6.1
+scikit-image==0.18.1
+scikit-learn==0.24.1
+scipy==1.6.1
+seaborn==0.11.1
+SQLAlchemy==1.3.23
+statsmodels==0.12.2
+sympy==1.7.1
+vincent==0.4.4
+xlrd==2.0.1

--- a/components/example-notebook-servers/jupyter-scipy/requirements.txt
+++ b/components/example-notebook-servers/jupyter-scipy/requirements.txt
@@ -6,15 +6,14 @@ cython==0.29.22
 dask==2021.3.0
 dill==0.3.3
 h5py==3.2.1
-ipywidgets==7.6.3
 ipympl==0.6.3
+ipywidgets==7.6.3
 matplotlib==3.3.4
 numba==0.53.0
 numexpr==2.7.3
 pandas==1.2.3
 patsy==0.5.1
 protobuf==3.15.6
-tables==3.6.1
 scikit-image==0.18.1
 scikit-learn==0.24.1
 scipy==1.6.1
@@ -22,5 +21,6 @@ seaborn==0.11.1
 SQLAlchemy==1.3.23
 statsmodels==0.12.2
 sympy==1.7.1
+tables==3.6.1
 vincent==0.4.4
 xlrd==2.0.1

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_scipy.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_scipy.py
@@ -1,0 +1,15 @@
+""""Argo Workflow for building notebook-server-scipy's OCI image using Kaniko"""
+from kubeflow.kubeflow.cd import config, kaniko_builder
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = kaniko_builder.Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build(dockerfile="components/example-notebook-servers/jupyter-scipy/Dockerfile",
+                         context="components/example-notebook-servers/jupyter-scipy/",
+                         destination=config.NOTEBOOK_SERVER_JUPYTER_SCIPY)

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_scipy_runner.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_jupyter_scipy_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.cd import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_jupyter_scipy",
+                 workflow_name="nb-j-sp-build")

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_scipy_tests.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_scipy_tests.py
@@ -1,0 +1,43 @@
+""""Argo Workflow for testing notebook-server-jupyter-scipy OCI image"""
+from kubeflow.kubeflow.ci import workflow_utils
+from kubeflow.testing import argo_build_util
+
+
+class Builder(workflow_utils.ArgoTestBuilder):
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None, **kwargs):
+        super().__init__(name=name, namespace=namespace, bucket=bucket,
+                         test_target_name=test_target_name, **kwargs)
+
+    def build(self):
+        """Build the Argo workflow graph"""
+        workflow = self.build_init_workflow(exit_dag=False)
+        task_template = self.build_task_template()
+
+        # Test building notebook-server-jupyter-scipy image using Kaniko
+        dockerfile = ("%s/components/example-notebook-servers"
+                      "/jupyter-scipy/Dockerfile") % self.src_dir
+        context = "dir://%s/components/example-notebook-servers/jupyter-scipy/" % self.src_dir
+        destination = "notebook-server-jupyter-scipy-test"
+
+        kaniko_task = self.create_kaniko_task(task_template, dockerfile,
+                                              context, destination, no_push=True)
+        argo_build_util.add_task_to_dag(workflow,
+                                        workflow_utils.E2E_DAG_NAME,
+                                        kaniko_task, [self.mkdir_task_name])
+
+        # Set the labels on all templates
+        workflow = argo_build_util.set_task_template_labels(workflow)
+
+        return workflow
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build()

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_scipy_tests_runner.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_jupyter_scipy_tests_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.ci import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_jupyter_scipy_tests",
+                 workflow_name="nb-j-sp-tests")


### PR DESCRIPTION
Part of https://github.com/kubeflow/kubeflow/issues/5575.

Initial images were built and pushed to test CI/CD and facilitate downstream testing:
public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-28af7716
