### PR TITLE
Add notebook-server-codeserver-python dockerfile and CI/CD

### DIFF
--- a/components/example-notebook-servers/codeserver-python/Dockerfile
+++ b/components/example-notebook-servers/codeserver-python/Dockerfile
@@ -3,6 +3,7 @@ FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver:master-53099b
 USER root
 
 # args - software versions
+ARG CODESERVER_PYTHON_VERSION="2021.3.658691958"
 ARG CONDA_VERSION="4.9.2"
 ARG MINIFORGE_ARCH="x86_64"
 ARG MINIFORGE_SHA256="91d5aa5f732b5e02002a371196a2607f839bab166970ea06e6ecc602cb446848"
@@ -42,6 +43,9 @@ RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt \
  && chown -R ${NB_USER}:users ${CONDA_DIR} \
  && chown -R ${NB_USER}:users ${HOME}
+
+# install - codeserver extensions
+RUN code-server --install-extension "ms-python.python@${CODESERVER_PYTHON_VERSION}"
 
 # s6 - copy scripts
 COPY --chown=jovyan:users s6/ /etc

--- a/components/example-notebook-servers/codeserver-python/Dockerfile
+++ b/components/example-notebook-servers/codeserver-python/Dockerfile
@@ -1,0 +1,54 @@
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver:master-53099bbd
+
+USER root
+
+# args - software versions
+ARG CONDA_VERSION="4.9.2"
+ARG MINIFORGE_ARCH="x86_64"
+ARG MINIFORGE_SHA256="91d5aa5f732b5e02002a371196a2607f839bab166970ea06e6ecc602cb446848"
+ARG MINIFORGE_VERSION="${CONDA_VERSION}-7"
+ARG PIP_VERSION="21.0.1"
+ARG PYTHON_VERSION="3.8.8"
+
+# setup environment for conda
+ENV CONDA_DIR /opt/conda
+ENV PATH "${CONDA_DIR}/bin:${PATH}"
+RUN mkdir -p ${CONDA_DIR} \
+ && chown -R ${NB_USER}:users ${CONDA_DIR}
+
+USER $NB_UID
+
+# install - conda, pip, python
+RUN curl -sL "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-${MINIFORGE_ARCH}.sh" -o /tmp/Miniforge3.sh \
+ && echo "${MINIFORGE_SHA256} /tmp/Miniforge3.sh" | sha256sum --check \
+ && /bin/bash /tmp/Miniforge3.sh -b -f -p ${CONDA_DIR} \
+ && rm /tmp/Miniforge3.sh \
+ && conda config --system --set auto_update_conda false \
+ && conda config --system --set show_channel_urls true \
+ && echo "conda ${CONDA_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+ && echo "python ${PYTHON_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+ && conda install -y -q \
+    python=${PYTHON_VERSION} \
+    conda=${CONDA_VERSION} \
+    pip=${PIP_VERSION} \
+ && conda update -y -q --all \
+ && conda clean -a -f -y \
+ && chown -R ${NB_USER}:users ${CONDA_DIR} \
+ && chown -R ${NB_USER}:users ${HOME}
+
+# install - requirements.txt
+COPY --chown=jovyan:users requirements.txt /tmp
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt \
+ && chown -R ${NB_USER}:users ${CONDA_DIR} \
+ && chown -R ${NB_USER}:users ${HOME}
+
+# s6 - copy scripts
+COPY --chown=jovyan:users s6/ /etc
+
+# s6 - 01-copy-tmp-home
+USER root
+RUN mkdir -p /tmp_home \
+ && cp -r ${HOME} /tmp_home \
+ && chown -R ${NB_USER}:users /tmp_home
+USER ${NB_UID}

--- a/components/example-notebook-servers/codeserver-python/requirements.txt
+++ b/components/example-notebook-servers/codeserver-python/requirements.txt
@@ -1,0 +1,3 @@
+kfp==1.0.4
+kfp-server-api==1.0.4
+kfserving==0.4.1

--- a/components/example-notebook-servers/codeserver-python/s6/cont-init.d/02-conda-init
+++ b/components/example-notebook-servers/codeserver-python/s6/cont-init.d/02-conda-init
@@ -1,0 +1,3 @@
+#!/usr/bin/with-contenv bash
+conda init bash
+conda activate base

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_codeserver_python.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_codeserver_python.py
@@ -1,0 +1,15 @@
+""""Argo Workflow for building notebook-server-codeserver-python's OCI image using Kaniko"""
+from kubeflow.kubeflow.cd import config, kaniko_builder
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = kaniko_builder.Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build(dockerfile="components/example-notebook-servers/codeserver-python/Dockerfile",
+                         context="components/example-notebook-servers/codeserver-python/",
+                         destination=config.NOTEBOOK_SERVER_CODESERVER_PYTHON)

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_codeserver_python_runner.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_codeserver_python_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.cd import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_codeserver_python",
+                 workflow_name="nb-code-p-build")

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_codeserver_python_tests.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_codeserver_python_tests.py
@@ -1,0 +1,43 @@
+""""Argo Workflow for testing notebook-server-codeserver-python OCI image"""
+from kubeflow.kubeflow.ci import workflow_utils
+from kubeflow.testing import argo_build_util
+
+
+class Builder(workflow_utils.ArgoTestBuilder):
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None, **kwargs):
+        super().__init__(name=name, namespace=namespace, bucket=bucket,
+                         test_target_name=test_target_name, **kwargs)
+
+    def build(self):
+        """Build the Argo workflow graph"""
+        workflow = self.build_init_workflow(exit_dag=False)
+        task_template = self.build_task_template()
+
+        # Test building notebook-server-codeserver-python image using Kaniko
+        dockerfile = ("%s/components/example-notebook-servers"
+                      "/codeserver-python/Dockerfile") % self.src_dir
+        context = "dir://%s/components/example-notebook-servers/codeserver-python/" % self.src_dir
+        destination = "notebook-server-codeserver-python-test"
+
+        kaniko_task = self.create_kaniko_task(task_template, dockerfile,
+                                              context, destination, no_push=True)
+        argo_build_util.add_task_to_dag(workflow,
+                                        workflow_utils.E2E_DAG_NAME,
+                                        kaniko_task, [self.mkdir_task_name])
+
+        # Set the labels on all templates
+        workflow = argo_build_util.set_task_template_labels(workflow)
+
+        return workflow
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build()

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_codeserver_python_tests_runner.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_codeserver_python_tests_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.ci import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_codeserver_python_tests",
+                 workflow_name="nb-codeserver-python-tests")


### PR DESCRIPTION
Part of #5575.

Initial images were built and pushed to test CI/CD and facilitate downstream testing:
public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:master-28af7716