### PR TITLE
Centraldashboard: update menu items in manifests

### DIFF
--- a/components/centraldashboard/manifests/base/configmap.yaml
+++ b/components/centraldashboard/manifests/base/configmap.yaml
@@ -4,79 +4,118 @@ data:
     {
       "menuLinks": [
         {
-          "link": "/pipeline/",
-          "text": "Pipelines"
-        },
-        {
+          "type": "item",
           "link": "/jupyter/",
-          "text": "Notebook Servers"
+          "text": "Notebooks",
+          "icon": "book"
         },
         {
-          "link": "/katib/",
-          "text": "Katib"
-        }
+          "type": "item",
+          "link": "/pipeline/#/pipelines",
+          "text": "Pipelines",
+          "icon": "kubeflow:pipeline-centered"
+        },
+        {
+          "type": "section",
+          "text": "Experiments",
+          "icon": "done-all",
+          "items": [
+            {
+              "link": "/pipeline/#/experiments",
+              "text": "Pipelines"
+            },
+            {
+              "link": "/katib/",
+              "text": "AutoML"
+            }
+          ]
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/runs",
+          "text": "Runs",
+          "icon": "maps:directions-run"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/recurringruns",
+          "text": "Recurring Runs",
+          "icon": "device:access-alarm"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/artifacts",
+          "text": "Artifacts",
+          "icon": "editor:bubble-chart"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/executions",
+          "text": "Executions",
+          "icon": "av:play-arrow"
+        },
       ],
-      "externalLinks": [],
-      "quickLinks": [
-        {
-          "text": "Upload a pipeline",
-          "desc": "Pipelines",
-          "link": "/pipeline/"
-        },
-        {
-          "text": "View all pipeline runs",
-          "desc": "Pipelines",
-          "link": "/pipeline/#/runs"
-        },
-        {
-          "text": "Create a new Notebook server",
-          "desc": "Notebook Servers",
-          "link": "/jupyter/new?namespace=kubeflow"
-        },
-        {
-          "text": "View Katib Experiments",
-          "desc": "Katib",
-          "link": "/katib/"
-        }
-      ],
-      "documentationItems": [
-        {
-          "text": "Getting Started with Kubeflow",
-          "desc": "Get your machine-learning workflow up and running on Kubeflow",
-          "link": "https://www.kubeflow.org/docs/started/getting-started/"
-        },
-        {
-          "text": "MiniKF",
-          "desc": "A fast and easy way to deploy Kubeflow locally",
-          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
-        },
-        {
-          "text": "Microk8s for Kubeflow",
-          "desc": "Quickly get Kubeflow running locally on native hypervisors",
-          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
-        },
-        {
-          "text": "Minikube for Kubeflow",
-          "desc": "Quickly get Kubeflow running locally",
-          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
-        },
-        {
-          "text": "Kubeflow on GCP",
-          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
-          "link": "https://www.kubeflow.org/docs/gke/"
-        },
-        {
-          "text": "Kubeflow on AWS",
-          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
-          "link": "https://www.kubeflow.org/docs/aws/"
-        },
-        {
-          "text": "Requirements for Kubeflow",
-          "desc": "Get more detailed information about using Kubeflow and its components",
-          "link": "https://www.kubeflow.org/docs/started/requirements/"
-        }
-      ]
-    }
+      "externalLinks": [ ],
+        "quickLinks": [
+          {
+            "text": "Upload a pipeline",
+            "desc": "Pipelines",
+            "link": "/pipeline/"
+          },
+          {
+            "text": "View all pipeline runs",
+            "desc": "Pipelines",
+            "link": "/pipeline/#/runs"
+          },
+          {
+            "text": "Create a new Notebook server",
+            "desc": "Notebook Servers",
+            "link": "/jupyter/new?namespace=kubeflow"
+          },
+          {
+            "text": "View Katib Experiments",
+            "desc": "Katib",
+            "link": "/katib/"
+          }
+        ],
+        "documentationItems": [
+          {
+            "text": "Getting Started with Kubeflow",
+            "desc": "Get your machine-learning workflow up and running on Kubeflow",
+            "link": "https://www.kubeflow.org/docs/started/getting-started/"
+          },
+          {
+            "text": "MiniKF",
+            "desc": "A fast and easy way to deploy Kubeflow locally",
+            "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+          },
+          {
+            "text": "Microk8s for Kubeflow",
+            "desc": "Quickly get Kubeflow running locally on native hypervisors",
+            "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+          },
+          {
+            "text": "Minikube for Kubeflow",
+            "desc": "Quickly get Kubeflow running locally",
+            "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+          },
+          {
+            "text": "Kubeflow on GCP",
+            "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+            "link": "https://www.kubeflow.org/docs/gke/"
+          },
+          {
+            "text": "Kubeflow on AWS",
+            "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+            "link": "https://www.kubeflow.org/docs/aws/"
+          },
+          {
+            "text": "Requirements for Kubeflow",
+            "desc": "Get more detailed information about using Kubeflow and its components",
+            "link": "https://www.kubeflow.org/docs/started/requirements/"
+          }
+        ]
+}
 kind: ConfigMap
 metadata:
   name: centraldashboard-config

--- a/components/centraldashboard/manifests/base/configmap.yaml
+++ b/components/centraldashboard/manifests/base/configmap.yaml
@@ -79,4 +79,4 @@ data:
     }
 kind: ConfigMap
 metadata:
-  name: centraldashboard-links-config
+  name: centraldashboard-config


### PR DESCRIPTION
This PR updates the Centraldashboard ConfigMap to populate the sidebar menu. As part of Kubeflow 1.3 we want to make Centraldashboard the unified place for navigating between Kubeflow components. We have been discussing this in the context of the Web Apps here https://github.com/kubeflow/kubeflow/issues/5566#issue-796194300.

Quoting the relevant passage:

> Kubeflow mode
> When we say that an app is deployed alongside Kubeflow this means the following things:
>
> 1. [...]
> 2. There is a CentralDashboard which:
    - decides what Namespaces to show to the user and feeds to the app the selected Namespace
    - **has a left hand sidebar, which can have subsections https://github.com/kubeflow/kubeflow/pull/5474. This side bar can be used for navigating the user between different pages of the underlying deployed app**

Pipelines already supports hiding its sidebar in Kubeflow mode: https://github.com/kubeflow/pipelines/pull/5200

Katib comes with a new beta UI, which will replace the existing one in the near future. Still, for Kubeflow 1.3, Centraldashboard will expose only the existing one and users will be able to provision the new UI by thenmselves and add a sidebar item by editing the ConfigMap, if they wish. See https://github.com/kubeflow/katib/issues/1421#issuecomment-800147949. The existing UI stil does not support hiding the sidebar, so we can include a single menu item to direct to the Katib main page.

Proposed menu structure:

- `Home`
- `Notebooks`      -> Jupyter Web App
- `Pipelines`      -> KFP Pipelines Page
- `Experiments` (Collapsible Section)
	- `Pipelines`       -> KFP Experiments Page
	- `AutoML`       -> Katib main page
- `Runs`           -> KFP Recurring Runs Page
- `Recurring Runs` -> KFP Recurring Runs Page
- `Artifacts`      -> KFP Artifacts Page
- `Executions`     -> KFP Executions Page

Two top-level menu items that we hope we can include are:

- `Volumes`: Blocking issue https://github.com/kubeflow/kubeflow/pull/5684 and missing manifests
- `Tensorboard`: Blocking issue https://github.com/kubeflow/kubeflow/pull/5693 and missing manifests 

![Screenshot 2021-03-17 at 10 37 35](https://user-images.githubusercontent.com/3354305/111446532-cd615f00-870c-11eb-9ca5-b85d00a55333.png)

@kubeflow/wg-automl-leads
@kubeflow/wg-notebooks-leads
@kubeflow/wg-pipeline-leads
@kubeflow/wg-serving-leads
@kubeflow/wg-training-leads