### PR TITLE
update testing OWNERS with Notebook WG leads

### DIFF
--- a/py/OWNERS
+++ b/py/OWNERS
@@ -1,3 +1,7 @@
 approvers:
-- kimwnasptd
-- PatrickXYS
+  - elikatsis
+  - kimwnasptd
+  - PatrickXYS
+  - StefanoFioravanzo
+  - thesuperzapper
+  - yanniszark


### PR DESCRIPTION
Updates the new testing OWNERS file with leads of the Notebook Working Group, (and changes to indented list format).