### PR TITLE
web-apps: Extend common code for the apps to work in standalone mode

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
@@ -9,6 +9,7 @@ from . import config
 bp = Blueprint("authn", __name__)
 log = logging.getLogger(__name__)
 
+NO_AUTHNZ = os.getenv("APP_NO_AUTHNZ", "False")
 USER_HEADER = os.getenv("USERID_HEADER", "kubeflow-userid")
 USER_PREFIX = os.getenv("USERID_PREFIX", ":")
 
@@ -44,6 +45,10 @@ def check_authentication():
     """
     if config.dev_mode_enabled():
         log.debug("Skipping authentication check in development mode")
+        return
+
+    if NO_AUTHNZ == "True":
+        log.info("APP_NO_AUTHNZ set to True. Skipping authentication check.")
         return
 
     # If a function was decorated with `no_authentication` then we will skip

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authn.py
@@ -1,28 +1,23 @@
 import logging
-import os
 
 from flask import Blueprint, current_app, request
 from werkzeug.exceptions import Unauthorized
 
-from . import config
+from . import config, settings
 
 bp = Blueprint("authn", __name__)
 log = logging.getLogger(__name__)
 
-NO_AUTHNZ = os.getenv("APP_NO_AUTHNZ", "False")
-USER_HEADER = os.getenv("USERID_HEADER", "kubeflow-userid")
-USER_PREFIX = os.getenv("USERID_PREFIX", ":")
-
 
 def get_username():
-    if USER_HEADER not in request.headers:
+    if settings.USER_HEADER not in request.headers:
         log.debug("User header not present!")
         username = None
     else:
-        user = request.headers[USER_HEADER]
-        username = user.replace(USER_PREFIX, "")
+        user = request.headers[settings.USER_HEADER]
+        username = user.replace(settings.USER_PREFIX, "")
         log.debug("User: '%s' | Headers: '%s' '%s'",
-                  username, USER_HEADER, USER_PREFIX)
+                  username, settings.USER_HEADER, settings.USER_PREFIX)
 
     return username
 
@@ -47,8 +42,8 @@ def check_authentication():
         log.debug("Skipping authentication check in development mode")
         return
 
-    if NO_AUTHNZ == "True":
-        log.info("APP_NO_AUTHNZ set to True. Skipping authentication check.")
+    if settings.DISABLE_AUTH:
+        log.info("APP_DISABLE_AUTH set to True. Skipping authentication check")
         return
 
     # If a function was decorated with `no_authentication` then we will skip

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import os
 
 from kubernetes import client
 from kubernetes import config as k8s_config
@@ -10,6 +11,8 @@ from werkzeug.exceptions import Forbidden, Unauthorized
 from . import authn, config
 
 log = logging.getLogger(__name__)
+
+NO_AUTHNZ = os.getenv("APP_NO_AUTHNZ", "False")
 
 try:
     # Load configuration inside the Pod
@@ -52,6 +55,11 @@ def is_authorized(user, verb, group, version, resource, namespace=None,
     # Skip authz check if in dev mode
     if config.dev_mode_enabled():
         log.debug("Skipping authorization check in development mode")
+        return True
+
+    # Skip authz check if admin explicitly requested it
+    if NO_AUTHNZ == "True":
+        log.info("APP_NO_AUTHNZ set to True. Skipping authorization check.")
         return True
 
     if user is None:

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/authz.py
@@ -1,6 +1,5 @@
 import functools
 import logging
-import os
 
 from kubernetes import client
 from kubernetes import config as k8s_config
@@ -8,11 +7,9 @@ from kubernetes.client.rest import ApiException
 from kubernetes.config import ConfigException
 from werkzeug.exceptions import Forbidden, Unauthorized
 
-from . import authn, config
+from . import authn, config, settings
 
 log = logging.getLogger(__name__)
-
-NO_AUTHNZ = os.getenv("APP_NO_AUTHNZ", "False")
 
 try:
     # Load configuration inside the Pod
@@ -58,8 +55,8 @@ def is_authorized(user, verb, group, version, resource, namespace=None,
         return True
 
     # Skip authz check if admin explicitly requested it
-    if NO_AUTHNZ == "True":
-        log.info("APP_NO_AUTHNZ set to True. Skipping authorization check.")
+    if settings.DISABLE_AUTH:
+        log.info("APP_DISABLE_AUTH set to True. Skipping authorization check")
         return True
 
     if user is None:

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/settings.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/settings.py
@@ -1,0 +1,5 @@
+import os
+
+DISABLE_AUTH = os.getenv("APP_DISABLE_AUTH", "false").lower == "true"
+USER_HEADER = os.getenv("USERID_HEADER", "kubeflow-userid")
+USER_PREFIX = os.getenv("USERID_PREFIX", ":")

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/enums/dashboard.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/enums/dashboard.ts
@@ -1,0 +1,5 @@
+export enum DashboardState {
+  Connecting = 0,
+  Connected,
+  Disconnected,
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ReplaySubject, Subscription, fromEvent } from 'rxjs';
+import { ReplaySubject, Subscription, fromEvent, BehaviorSubject } from 'rxjs';
 
 declare global {
   interface Window {
@@ -15,9 +15,11 @@ export class NamespaceService {
 
   // Observable string sources
   private selectedNamespaceSource = new ReplaySubject<string>(1);
+  private dashboardConnectedSource = new BehaviorSubject<boolean>(true);
 
   // Observable string streams
   selectedNamespace$ = this.selectedNamespaceSource.asObservable();
+  dashboardConnected$ = this.dashboardConnectedSource.asObservable();
 
   constructor() {
     fromEvent(window, 'load').subscribe(_ => {
@@ -34,7 +36,13 @@ export class NamespaceService {
             cdeh.onNamespaceSelected = this.updateSelectedNamespace.bind(this);
           },
         );
-      } else if (this.currNamespace === undefined) {
+
+        return;
+      }
+
+      this.dashboardConnectedSource.next(false);
+
+      if (this.currNamespace === undefined) {
         this.updateSelectedNamespace('kubeflow-user');
       }
     });

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ReplaySubject, Subscription, fromEvent, BehaviorSubject } from 'rxjs';
+import { DashboardState } from '../enums/dashboard';
 
 declare global {
   interface Window {
@@ -15,7 +16,9 @@ export class NamespaceService {
 
   // Observable string sources
   private selectedNamespaceSource = new ReplaySubject<string>(1);
-  private dashboardConnectedSource = new BehaviorSubject<boolean>(true);
+  private dashboardConnectedSource = new BehaviorSubject<DashboardState>(
+    DashboardState.Connecting,
+  );
 
   // Observable string streams
   selectedNamespace$ = this.selectedNamespaceSource.asObservable();
@@ -37,10 +40,11 @@ export class NamespaceService {
           },
         );
 
+        this.dashboardConnectedSource.next(DashboardState.Connected);
         return;
       }
 
-      this.dashboardConnectedSource.next(false);
+      this.dashboardConnectedSource.next(DashboardState.Disconnected);
 
       if (this.currNamespace === undefined) {
         this.updateSelectedNamespace('kubeflow-user');

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
@@ -57,6 +57,8 @@ export * from './lib/form/validators';
 export * from './lib/form/utils';
 export * from './lib/form/error-state-matcher';
 
+export * from './lib/enums/dashboard';
+
 export * from './lib/utils/kubernetes';
 export * from './lib/utils/kubernetes.model';
 


### PR DESCRIPTION
Partially fixes #5566 

This PR makes the following changes:
* Introduce a new `APP_NO_AUTHNZ` env var that configures the app to completely skip authnz checks
* Extend the Namespace Service to expose if the Central Dashboard is found

With these changes the admin could configure the apps to skip any authnz checks, which is the case for standalone mode as we've described in #5566.

The next step will be to make our different web apps use the updated `NamespaceService` to understand if the Central Dashboard is present. In that case they should show the namespace selector, which was previously found in the Dashboard.