### PR TITLE
Add notebook-server-rstudio-tidyverse dockerfile and CI/CD

### DIFF
--- a/components/example-notebook-servers/rstudio-tidyverse/Dockerfile
+++ b/components/example-notebook-servers/rstudio-tidyverse/Dockerfile
@@ -1,13 +1,18 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio:master-87b7d015
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio:master-15d229d4
 
-# Switching to the root user for this installation
-# is only necessary when building the image with Kaniko
+# args - software versions
+ARG R_TIDYVERSE_VERSION="1.3.0"
+
+# switch to root user for conda installation
+# (only necessary when installing r-tidyverse with Kaniko)
 USER root
 
-RUN conda install --quiet --yes \
-    'r-tidyverse=1.3.0' && \
-    conda clean --all -f -y && \
-    chown -R ${NB_USER}:users $CONDA_DIR && \
-    chown -R ${NB_USER}:users $HOME
+# install - r-tidyverse
+RUN conda install -y -q \
+    r-tidyverse=${R_TIDYVERSE_VERSION} \
+ && conda update -y -q --all \
+ && conda clean -a -f -y \
+ && chown -R ${NB_USER}:users ${CONDA_DIR} \
+ && chown -R ${NB_USER}:users ${HOME}
 
-USER $NB_UID
+USER ${NB_USER}

--- a/components/example-notebook-servers/rstudio-tidyverse/Dockerfile
+++ b/components/example-notebook-servers/rstudio-tidyverse/Dockerfile
@@ -1,0 +1,13 @@
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio:master-87b7d015
+
+# Switching to the root user for this installation
+# is only necessary when building the image with Kaniko
+USER root
+
+RUN conda install --quiet --yes \
+    'r-tidyverse=1.3.0' && \
+    conda clean --all -f -y && \
+    chown -R ${NB_USER}:users $CONDA_DIR && \
+    chown -R ${NB_USER}:users $HOME
+
+USER $NB_UID

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_rstudio_tidyverse.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_rstudio_tidyverse.py
@@ -1,0 +1,15 @@
+""""Argo Workflow for building notebook-server-rstudio-tidyverse's OCI image using Kaniko"""
+from kubeflow.kubeflow.cd import config, kaniko_builder
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = kaniko_builder.Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build(dockerfile="components/example-notebook-servers/rstudio-tidyverse/Dockerfile",
+                         context="components/example-notebook-servers/rstudio-tidyverse/",
+                         destination=config.NOTEBOOK_SERVER_RSTUDIO_TIDYVERSE)

--- a/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_rstudio_tidyverse_runner.py
+++ b/py/kubeflow/kubeflow/cd/notebook_servers/notebook_server_rstudio_tidyverse_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.cd import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_rstudio_tidyverse",
+                 workflow_name="nb-rs-tidy-build")

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_rstudio_tidyverse_tests.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_rstudio_tidyverse_tests.py
@@ -1,0 +1,43 @@
+""""Argo Workflow for testing notebook-server-rstudio-tidyverse OCI image"""
+from kubeflow.kubeflow.ci import workflow_utils
+from kubeflow.testing import argo_build_util
+
+
+class Builder(workflow_utils.ArgoTestBuilder):
+    def __init__(self, name=None, namespace=None, bucket=None,
+                 test_target_name=None, **kwargs):
+        super().__init__(name=name, namespace=namespace, bucket=bucket,
+                         test_target_name=test_target_name, **kwargs)
+
+    def build(self):
+        """Build the Argo workflow graph"""
+        workflow = self.build_init_workflow(exit_dag=False)
+        task_template = self.build_task_template()
+
+        # Test building notebook-server-rstudio-tidyverse image using Kaniko
+        dockerfile = ("%s/components/example-notebook-servers"
+                      "/rstudio-tidyverse/Dockerfile") % self.src_dir
+        context = "dir://%s/components/example-notebook-servers/rstudio-tidyverse/" % self.src_dir
+        destination = "notebook-server-rstudio-tidyverse-test"
+
+        kaniko_task = self.create_kaniko_task(task_template, dockerfile,
+                                              context, destination, no_push=True)
+        argo_build_util.add_task_to_dag(workflow,
+                                        workflow_utils.E2E_DAG_NAME,
+                                        kaniko_task, [self.mkdir_task_name])
+
+        # Set the labels on all templates
+        workflow = argo_build_util.set_task_template_labels(workflow)
+
+        return workflow
+
+
+def create_workflow(name=None, namespace=None, bucket=None, **kwargs):
+    """
+    Args:
+        name: Name to give to the workflow. This can also be used to name
+              things associated with the workflow.
+    """
+    builder = Builder(name=name, namespace=namespace, bucket=bucket, **kwargs)
+
+    return builder.build()

--- a/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_rstudio_tidyverse_tests_runner.py
+++ b/py/kubeflow/kubeflow/ci/notebook_servers/notebook_server_rstudio_tidyverse_tests_runner.py
@@ -1,0 +1,5 @@
+# This file is only intended for development purposes
+from kubeflow.kubeflow.ci import base_runner
+
+base_runner.main(component_name="notebook_servers.notebook_server_rstudio_tidyverse_tests",
+                 workflow_name="nb-rs-tidy-tests")


### PR DESCRIPTION
Part of #5575.

Initial images were built and pushed to test CI/CD:
public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:master-87b7d015