### PR TITLE
Manifests for Tensorboards web app

### DIFF
--- a/components/crud-web-apps/tensorboards/manifests/base/cluster-role-binding.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/cluster-role-binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-role
+subjects:
+- kind: ServiceAccount
+  name: service-account

--- a/components/crud-web-apps/tensorboards/manifests/base/cluster-role.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/cluster-role.yaml
@@ -1,0 +1,95 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-role
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+- apiGroups:
+  - tensorboard.kubeflow.org
+  resources:
+  - tensorboards
+  - tensorboards/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-tensorboard-ui-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-tensorboard-ui-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+rules:
+- apiGroups:
+  - tensorboard.kubeflow.org
+  resources:
+  - tensorboards
+  - tensorboards/finalizers
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-tensorboard-ui-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups:
+  - tensorboard.kubeflow.org
+  resources:
+  - tensorboards
+  - tensorboards/finalizers
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - get
+  - list
+  - watch

--- a/components/crud-web-apps/tensorboards/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+spec:
+  replicas: 1
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - name: tensorboards-web-app
+        image: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
+        ports:
+        - containerPort: 5000
+        env:
+        - name: APP_PREFIX
+          value: $(TWA_PREFIX)
+        - name: USERID_HEADER
+          value: $(TWA_USERID_HEADER)
+        - name: USERID_PREFIX
+          value: $(TWA_USERID_PREFIX)
+      serviceAccountName: service-account

--- a/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
@@ -1,0 +1,61 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- service-account.yaml
+- service.yaml
+namePrefix: tensorboards-web-app-
+namespace: kubeflow
+commonLabels:
+  app: tensorboards-web-app
+  kustomize.component: tensorboards-web-app
+images:
+- name: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
+  newName: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
+  newTag: master-24bcb8e8
+# We need the name to be unique without the suffix because the original name is what
+# gets used with patches
+configMapGenerator:
+- envs:
+  - params.env
+  name: parameters
+vars:
+- fieldref:
+    fieldPath: data.TWA_CLUSTER_DOMAIN
+  name: TWA_CLUSTER_DOMAIN
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: metadata.namespace
+  name: TWA_NAMESPACE
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: data.TWA_USERID_HEADER
+  name: TWA_USERID_HEADER
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.TWA_USERID_PREFIX
+  name: TWA_USERID_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.TWA_PREFIX
+  name: TWA_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+configurations:
+- params.yaml

--- a/components/crud-web-apps/tensorboards/manifests/base/params.env
+++ b/components/crud-web-apps/tensorboards/manifests/base/params.env
@@ -1,0 +1,4 @@
+TWA_CLUSTER_DOMAIN=cluster.local
+TWA_USERID_HEADER=kubeflow-userid
+TWA_USERID_PREFIX=
+TWA_PREFIX=/tensorboards

--- a/components/crud-web-apps/tensorboards/manifests/base/params.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/params.yaml
@@ -1,0 +1,11 @@
+varReference:
+- path: spec/template/spec/containers/imagePullPolicy
+  kind: Deployment
+- path: metadata/annotations/getambassador.io\/config
+  kind: Service
+- path: spec/template/spec/containers/0/env/2/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/3/value
+  kind: Deployment
+- path: spec/template/spec/containers/0/env/4/value
+  kind: Deployment

--- a/components/crud-web-apps/tensorboards/manifests/base/service-account.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: service-account

--- a/components/crud-web-apps/tensorboards/manifests/base/service.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: tensorboards-web-app
+  name: service
+spec:
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 5000
+  type: ClusterIP

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- virtual-service.yaml
+namespace: kubeflow
+commonLabels:
+  app: tensorboards-web-app
+  kustomize.component: tensorboards-web-app
+configurations:
+- params.yaml

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/params.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/params.yaml
@@ -1,0 +1,3 @@
+varReference:
+- path: spec/http/route/destination/host
+  kind: VirtualService

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/virtual-service.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/virtual-service.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: tensorboards-web-app-tensorboards-web-app
+spec:
+  gateways:
+  - kubeflow-gateway
+  hosts:
+  - '*'
+  http:
+  - headers:
+      request:
+        add:
+          x-forwarded-prefix: /tensorboards
+    match:
+    - uri:
+        prefix: /tensorboards/
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: tensorboards-web-app-service.$(TWA_NAMESPACE).svc.$(TWA_CLUSTER_DOMAIN)
+        port:
+          number: 80


### PR DESCRIPTION
Manifests for the Tensorboards web app.

The app will be exposed under the `/tensorboards` prefix. The next step will now be to include it in the dashboard.

cc @kubeflow/wg-notebooks-leads 
/cc @yanniszark