### PR TITLE
Add listing nodes to JWA ClusterRole for GPU vendor detection

### DIFF
--- a/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
@@ -42,6 +42,7 @@ rules:
   - ""
   resources:
   - events
+  - nodes
   verbs:
   - list
 - apiGroups:


### PR DESCRIPTION
This fix is needed so that the JWA is able to detect which GPU vendors are available in the cluster. Without it an error will be displayed to the users. 

/cc @kimwnasptd @yanniszark 