### PR TITLE
Update the manifests for the Jupyter web app

### DIFF
--- a/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
@@ -29,6 +29,8 @@ rules:
   - list
   - create
   - delete
+  - patch
+  - update
 - apiGroups:
   - ""
   resources:

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -17,16 +17,28 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    # If readonly, this value must be a member of the list below
-    value: gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-78840844
     # The list of available standard container Images
     options:
-      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-cpu:1.0.0
-      - gcr.io/kubeflow-images-public/tensorflow-1.15.2-notebook-gpu:1.0.0
-      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-cpu:1.0.0
-      - gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu:1.0.0
-    # By default, custom container Images are allowed
-    # Uncomment the following line to only enable standard container Images
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-78840844
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:master-de7c3f00
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:master-de7c3f00
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:master-a9821baa
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:master-a9821baa
+  imageVSCode:
+    # The container Image for the user's VS-Code Server
+    value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:master-c99f886b
+    # The list of available standard container Images
+    options:
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:master-c99f886b
+  imageRStudio:
+    # The container Image for the user's RStudio Server
+    value: "none"
+    # The list of available standard container Images
+    options: []
+  allowCustomImage: true
+  imagePullPolicy:
+    value: IfNotPresent
     readOnly: false
   cpu:
     # CPU for user's Notebook
@@ -133,10 +145,7 @@ spawnerFormDefaults:
     # If readonly, the default value will be the only option
     value: "none"
     # The list of available affinity configs
-    options:
-      - configKey: "none"
-        displayName: "None"
-        affinity: {}
+    options: []
     # # (DESC) Pod gets an exclusive "n1-standard-2" Node
     # # (TIP) set PreferNoSchedule taint on this node-pool
     # # (TIP) enable cluster-autoscaler on this node-pool
@@ -168,10 +177,7 @@ spawnerFormDefaults:
     # If readonly, the default value will be the only option
     value: "none"
     # The list of available tolerationGroup configs
-    options:
-      - groupKey: "none"
-        displayName: "None"
-        tolerations: []
+    options: []
     # - groupKey: "group_1"
     #   displayName: "Group 1: description"
     #   tolerations:

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -20,11 +20,11 @@ spawnerFormDefaults:
     value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-78840844
     # The list of available standard container Images
     options:
-      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-78840844
-      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:master-de7c3f00
-      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:master-de7c3f00
-      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:master-a9821baa
-      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:master-a9821baa
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-abf9ec48
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-full:master-1831e436
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda-full:master-1831e436
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-full:master-1831e436
+      - public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda-full:master-1831e436
   imageVSCode:
     # The container Image for the user's VS-Code Server
     value: public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver-python:master-c99f886b

--- a/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
       - name: jupyter-web-app
-        image: gcr.io/kubeflow-images-public/jupyter-web-app
+        image: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
         ports:
         - containerPort: 5000
         volumeMounts:

--- a/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         env:
         - name: ROK_SECRET_NAME
           value: $(JWA_ROK_SECRET_NAME)
+        - name: APP_PREFIX
+          value: $(JWA_PREFIX)
         - name: UI
           value: $(JWA_UI)
         - name: USERID_HEADER

--- a/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
@@ -29,5 +29,5 @@ spec:
       serviceAccountName: service-account
       volumes:
       - configMap:
-          name: jupyter-web-app-config
+          name: config
         name: config-volume

--- a/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
@@ -18,8 +18,6 @@ spec:
         - mountPath: /etc/config
           name: config-volume
         env:
-        - name: ROK_SECRET_NAME
-          value: $(JWA_ROK_SECRET_NAME)
         - name: APP_PREFIX
           value: $(JWA_PREFIX)
         - name: UI

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -31,7 +31,7 @@ configMapGenerator:
   name: parameters
 - files:
   - configs/spawner_ui_config.yaml
-  name: jupyter-web-app-config
+  name: config
 vars:
 - fieldref:
     fieldPath: data.JWA_CLUSTER_DOMAIN

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -75,5 +75,12 @@ vars:
     apiVersion: v1
     kind: ConfigMap
     name: parameters
+- fieldref:
+    fieldPath: data.JWA_PREFIX
+  name: JWA_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
 configurations:
 - params.yaml

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -62,13 +62,6 @@ vars:
     kind: ConfigMap
     name: parameters
 - fieldref:
-    fieldPath: data.JWA_ROK_SECRET_NAME
-  name: JWA_ROK_SECRET_NAME
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
     fieldPath: data.JWA_UI
   name: JWA_UI
   objref:

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -20,9 +20,9 @@ commonLabels:
   app: jupyter-web-app
   kustomize.component: jupyter-web-app
 images:
-- name: gcr.io/kubeflow-images-public/jupyter-web-app
-  newName: gcr.io/kubeflow-images-public/jupyter-web-app
-  newTag: vmaster-ge4456300
+- name: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
+  newName: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
+  newTag: master-f753ef1a
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/components/crud-web-apps/jupyter/manifests/base/params.env
+++ b/components/crud-web-apps/jupyter/manifests/base/params.env
@@ -1,6 +1,5 @@
 JWA_UI=default
 JWA_PREFIX=/jupyter
-JWA_ROK_SECRET_NAME=secret-rok-{username}
 JWA_CLUSTER_DOMAIN=cluster.local
 JWA_USERID_HEADER=kubeflow-userid
 JWA_USERID_PREFIX=

--- a/components/crud-web-apps/jupyter/manifests/base/params.env
+++ b/components/crud-web-apps/jupyter/manifests/base/params.env
@@ -1,4 +1,5 @@
 JWA_UI=default
+JWA_PREFIX=/jupyter
 JWA_ROK_SECRET_NAME=secret-rok-{username}
 JWA_CLUSTER_DOMAIN=cluster.local
 JWA_USERID_HEADER=kubeflow-userid


### PR DESCRIPTION
This PR updates the manifests of the Jupyter web app to work with the latest AWS image.

The used image also contains the code from #5646 and config contains the currently built and merged notebook server images https://github.com/kubeflow/kubeflow/issues/5575#issuecomment-804021135. Once https://github.com/kubeflow/kubeflow/pull/5624 and https://github.com/kubeflow/kubeflow/pull/5711 are merged we will also make a new PR to add the RStudio images to the web app's config.

cc @thesuperzapper @DavidSpek 
/cc @yanniszark 