### PR TITLE
Fix conda activation in notebook-server-base for JupyterLab

### DIFF
--- a/components/example-notebook-servers/jupyter/Dockerfile
+++ b/components/example-notebook-servers/jupyter/Dockerfile
@@ -24,7 +24,12 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 ENV CONDA_DIR /opt/conda
 ENV PATH "${CONDA_DIR}/bin:${PATH}"
 RUN mkdir -p ${CONDA_DIR} \
- && chown -R ${NB_USER}:users ${CONDA_DIR}
+ && echo ". /opt/conda/etc/profile.d/conda.sh" >> ${HOME}/.bashrc \
+ && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/profile \
+ && echo "conda activate base" >> ${HOME}/.bashrc \
+ && echo "conda activate base" >> /etc/profile \
+ && chown -R ${NB_USER}:users ${CONDA_DIR} \
+ && chown -R ${NB_USER}:users ${HOME}
 
 USER $NB_UID
 

--- a/components/example-notebook-servers/jupyter/s6/cont-init.d/02-conda-init
+++ b/components/example-notebook-servers/jupyter/s6/cont-init.d/02-conda-init
@@ -1,3 +1,0 @@
-#!/usr/bin/with-contenv bash
-conda init bash
-conda activate base


### PR DESCRIPTION
Due to how the Linux shells are being started by JupyterLab, the Conda environment wasn't being properly activated in the terminals started within JupyterLab. This PR fixes this. 

/cc @thesuperzapper 