### PR TITLE
Fix conda activation for JupyterLab + cleanup

### DIFF
--- a/components/example-notebook-servers/jupyter-pytorch/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-b3fe73b2
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements-cpu.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-b3fe73b2
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
 
 # nvidia configs
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/components/example-notebook-servers/jupyter-scipy/Dockerfile
+++ b/components/example-notebook-servers/jupyter-scipy/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-b3fe73b2
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-scipy/requirements.txt
+++ b/components/example-notebook-servers/jupyter-scipy/requirements.txt
@@ -1,3 +1,10 @@
+# kubeflow packages
+kfp==1.0.4
+kfp-server-api==1.0.4
+kfserving==0.4.1
+
+# scipy packages
+# https://github.com/jupyter/docker-stacks/blob/master/scipy-notebook/Dockerfile
 beautifulsoup4==4.9.3
 bokeh==2.3.0
 #Bottleneck==1.3.2 Could not build wheels for Bottleneck which use PEP 517 and cannot be installed directly

--- a/components/example-notebook-servers/jupyter-tensorflow/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-b3fe73b2
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements-cpu.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-b3fe73b2
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
 
 USER root
 


### PR DESCRIPTION
Changes the base images of the PyTorch, TensorFlow and SciPy images to the new Jupyter image that fixes the conda environment activation. 

/cc @thesuperzapper 