### PR TITLE
Fix conda activation for JupyterLab in full images + cleanup

### DIFF
--- a/components/example-notebook-servers/jupyter-pytorch-full/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-full/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch:master-8dea1707
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch:master-abf9ec48
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-full/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-full/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda:master-8dea1707
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda:master-abf9ec48
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-pytorch-full/requirements.txt
@@ -1,17 +1,22 @@
+# kubeflow packages
 kfp==1.0.4
 kfp-server-api==1.0.4
 kfserving==0.4.1
-ipywidgets==7.6.3
-ipympl==0.6.3
+
+# common packages
+bokeh==2.3.0
 cloudpickle==1.6.0
 dill==0.3.3
-bokeh==2.3.0
-seaborn==0.11.1
-scipy==1.6.1
-scikit-learn==0.24.1
-scikit-image==0.18.1
-pandas==1.2.3
+ipympl==0.6.3
+ipywidgets==7.6.3
 matplotlib==3.3.4
+pandas==1.2.3
+scikit-image==0.18.1
+scikit-learn==0.24.1
+scipy==1.6.1
+seaborn==0.11.1
 xgboost==1.3.3
+
+# pytorch packages
 #torchelastic==0.2.2 this currently causes a dependency conflict, should be fixed very soon
 fastai==2.2.7

--- a/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow:master-d609b9e1
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow:master-abf9ec48
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda:master-d609b9e1
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda:master-abf9ec48
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
@@ -1,16 +1,21 @@
+# kubeflow packages
 kfp==1.0.4
 kfp-server-api==1.0.4
 kfserving==0.4.1
-ipywidgets==7.6.3
-ipympl==0.6.3
+
+# common packages
+bokeh==2.3.0
 cloudpickle==1.6.0
 dill==0.3.3
-bokeh==2.3.0
-seaborn==0.11.1
-scipy==1.6.1
-scikit-learn==0.24.1
-scikit-image==0.18.1
-pandas==1.2.3
+ipympl==0.6.3
+ipywidgets==7.6.3
 matplotlib==3.3.4
+pandas==1.2.3
+scikit-image==0.18.1
+scikit-learn==0.24.1
+scipy==1.6.1
+seaborn==0.11.1
 xgboost==1.3.3
+
+# tensorflow packages
 keras==2.4.3


### PR DESCRIPTION
Changes the base images of the PyTorch, TensorFlow and SciPy images to the new Jupyter image that fixes the conda environment activation.

/cc @thesuperzapper