### PR TITLE
Tensorboards web app manifests: Don't use specific namespace in base

### DIFF
--- a/components/tensorboard-controller/config/base/kustomization.yaml
+++ b/components/tensorboard-controller/config/base/kustomization.yaml
@@ -19,7 +19,6 @@ patches:
     subjects:
     - kind: ServiceAccount
       name: tensorboard-controller
-      namespace: system
   target:
     kind: "RoleBinding"
     group: "rbac.authorization.k8s.io"
@@ -31,7 +30,6 @@ patches:
     subjects:
     - kind: ServiceAccount
       name: tensorboard-controller
-      namespace: system
   target:
     kind: "ClusterRoleBinding"
     group: "rbac.authorization.k8s.io"


### PR DESCRIPTION
Right now we specifically use `namespace: system` in the [base manifests](https://github.com/kubeflow/kubeflow/blob/0cb715bec96528ff7af66fcd8b15d347e6eec077/components/tensorboard-controller/config/base/kustomization.yaml#L34). This results in the ClusterRoleBindings to be set to the `tensorboard-controller` service account that lives in the `system` namespace.

We should remove these lines and let namespace transformer to inject the correct values for the Namespace.

/cc @yanniszark 