### PR TITLE
(JWA): Add RStudio trademark statement in Notebook Spawner UI

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -20,7 +20,7 @@
       <mat-button-toggle value="vs-code" aria-label="Use VS-Code based server">
         <mat-icon class="server-type" svgIcon="vs-code"></mat-icon>
       </mat-button-toggle>
-      <mat-button-toggle value="rstudio" aria-label="Use RStudio based server">
+      <mat-button-toggle value="rstudio" aria-label="Use RStudio based server" matTooltip="RStudio® and the RStudio logo are registered trademarks of RStudio, PBC">
         <mat-icon class="server-type" svgIcon="rstudio"></mat-icon>
       </mat-button-toggle>
     </mat-button-toggle-group>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -20,7 +20,7 @@
       <mat-button-toggle value="vs-code" aria-label="Use VS-Code based server">
         <mat-icon class="server-type" svgIcon="vs-code"></mat-icon>
       </mat-button-toggle>
-      <mat-button-toggle value="rstudio" aria-label="Use RStudio based server" matTooltip="RStudio® and the RStudio logo are registered trademarks of RStudio, PBC">
+      <mat-button-toggle value="rstudio" aria-label="Use RStudio based server" matTooltip="RStudio® and the RStudio logo are registered trademarks of RStudio, PBC" matTooltipPosition="after">
         <mat-icon class="server-type" svgIcon="rstudio"></mat-icon>
       </mat-button-toggle>
     </mat-button-toggle-group>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/server-type/server-type.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/server-type/server-type.component.html
@@ -1,3 +1,3 @@
 <mat-icon *ngIf="notebookServerType === 'jupyter'" svgIcon="jupyterlab-icon" aria-hidden="false" aria-label="JupyterLab based server"></mat-icon>
 <mat-icon *ngIf="notebookServerType === 'vs-code'" svgIcon="vs-code-icon" aria-hidden="false" aria-label="VS-Code based server"></mat-icon>
-<mat-icon *ngIf="notebookServerType === 'rstudio'" svgIcon="rstudio-icon" aria-hidden="false" aria-label="RStudio based server"></mat-icon>
+<mat-icon *ngIf="notebookServerType === 'rstudio'" svgIcon="rstudio-icon" aria-hidden="false" aria-label="RStudio based server" matTooltip="RStudio® and the RStudio logo are registered trademarks of RStudio, PBC"></mat-icon>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/server-type/server-type.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/server-type/server-type.component.html
@@ -1,3 +1,3 @@
-<mat-icon *ngIf="notebookServerType === 'jupyter'" svgIcon="jupyterlab-icon" aria-hidden="false" aria-label="Example thumbs up SVG icon"></mat-icon>
-<mat-icon *ngIf="notebookServerType === 'vs-code'" svgIcon="vs-code-icon" aria-hidden="false" aria-label="Example thumbs up SVG icon"></mat-icon>
-<mat-icon *ngIf="notebookServerType === 'rstudio'" svgIcon="rstudio-icon" aria-hidden="false" aria-label="Example thumbs up SVG icon"></mat-icon>
+<mat-icon *ngIf="notebookServerType === 'jupyter'" svgIcon="jupyterlab-icon" aria-hidden="false" aria-label="JupyterLab based server"></mat-icon>
+<mat-icon *ngIf="notebookServerType === 'vs-code'" svgIcon="vs-code-icon" aria-hidden="false" aria-label="VS-Code based server"></mat-icon>
+<mat-icon *ngIf="notebookServerType === 'rstudio'" svgIcon="rstudio-icon" aria-hidden="false" aria-label="RStudio based server"></mat-icon>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index.module.ts
@@ -5,10 +5,11 @@ import { IndexRokModule } from './index-rok/index-rok.module';
 import { IndexDefaultModule } from './index-default/index-default.module';
 import { IndexComponent } from './index.component';
 import { ServerTypeComponent } from './index-default/server-type/server-type.component';
+import {MatTooltipModule} from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [IndexComponent, ServerTypeComponent],
-  imports: [CommonModule, IndexRokModule, IndexDefaultModule, MatIconModule],
+  imports: [CommonModule, IndexRokModule, IndexDefaultModule, MatIconModule, MatTooltipModule],
   entryComponents: [ServerTypeComponent],
 })
 export class IndexModule {}

--- a/components/crud-web-apps/jupyter/frontend/src/assets/jupyter-icon.svg
+++ b/components/crud-web-apps/jupyter/frontend/src/assets/jupyter-icon.svg
@@ -1,5 +1,4 @@
 <svg width="44" height="51" viewBox="0 0 44 51" version="2.0" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:figma="http://www.figma.com/figma/ns">
-<title>Group.svg</title>
 <desc>Created using Figma 0.90</desc>
 <g id="Canvas" transform="translate(-1640 -2453)" figma:type="canvas">
 <g id="Group" style="mix-blend-mode:normal;" figma:type="group">


### PR DESCRIPTION
As per the guideline: `Identification of source the first time the Licensed Mark is displayed in connection with the Services or in materials advertising or promoting the Services:`. The Spawner UI is the first time users come into contact with the RStudio logo. As such, they need to be informed of the trademark usage: `RStudio® and the RStudio logo are registered trademarks of RStudio, PBC`. 

This PR adds this as a tool tip to the button toggle that uses the RStudio logo for lack of a better way to fix this so quickly. 

/cc @kimwnasptd @yanniszark 