### PR TITLE
web-apps: Introduce an APP_SECURE_COOKIES env var

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/csrf.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/csrf.py
@@ -42,7 +42,7 @@ import secrets
 from flask import Blueprint, current_app, request
 from werkzeug.exceptions import Forbidden
 
-from . import config
+from . import settings
 
 bp = Blueprint("csrf", __name__)
 log = logging.getLogger(__name__)
@@ -69,10 +69,9 @@ def set_cookie(resp):
     """
     cookie = secrets.token_urlsafe(32)
 
-    secure = True
-    if config.dev_mode_enabled():
-        log.info("Allowing the cookie to be sent through http for dev mode")
-        secure = False
+    secure = settings.SECURE_COOKIES
+    if not secure:
+        log.info("Not setting Secure in CSRF cookie.")
 
     samesite = os.getenv("CSRF_SAMESITE", "Strict")
     if samesite not in SAMESITE_VALUES:

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/csrf.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/csrf.py
@@ -94,13 +94,13 @@ def check_endpoint():
         return
 
     log.debug("Ensuring endpoint is CSRF protected: %s", request.path)
-    if CSRF_HEADER not in request.headers:
-        raise Forbidden("Could not detect CSRF protection header %s."
-                        % CSRF_HEADER)
-
     if CSRF_COOKIE not in request.cookies:
         raise Forbidden("Could not find CSRF cookie %s in the request."
                         % CSRF_COOKIE)
+
+    if CSRF_HEADER not in request.headers:
+        raise Forbidden("Could not detect CSRF protection header %s."
+                        % CSRF_HEADER)
 
     header_token = request.headers[CSRF_HEADER]
     cookie_token = request.cookies[CSRF_COOKIE]

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/settings.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/settings.py
@@ -1,5 +1,6 @@
 import os
 
-DISABLE_AUTH = os.getenv("APP_DISABLE_AUTH", "false").lower == "true"
+SECURE_COOKIES = os.getenv("APP_SECURE_COOKIES", "true").lower() == "true"
+DISABLE_AUTH = os.getenv("APP_DISABLE_AUTH", "false").lower() == "true"
 USER_HEADER = os.getenv("USERID_HEADER", "kubeflow-userid")
 USER_PREFIX = os.getenv("USERID_PREFIX", ":")

--- a/components/crud-web-apps/jupyter/backend/Makefile
+++ b/components/crud-web-apps/jupyter/backend/Makefile
@@ -19,6 +19,7 @@ run-dev:
 	UI_FLAVOR=default \
 	BACKEND_MODE=dev \
 	APP_PREFIX=/ \
+	APP_SECURE_COOKIES=False \
 	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
 
 run-dev-rok:
@@ -26,4 +27,5 @@ run-dev-rok:
 	BACKEND_MODE=dev \
 	ROK_URL=http://10.10.10.10:8080/rok \
 	APP_PREFIX=/ \
+	APP_SECURE_COOKIES=False \
 	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app

--- a/components/crud-web-apps/tensorboards/backend/Makefile
+++ b/components/crud-web-apps/tensorboards/backend/Makefile
@@ -6,4 +6,5 @@ run:
 
 run-dev:
 	BACKEND_MODE=dev \
+	APP_SECURE_COOKIES=False \
 	python entrypoint.py

--- a/components/crud-web-apps/volumes/backend/Makefile
+++ b/components/crud-web-apps/volumes/backend/Makefile
@@ -19,10 +19,12 @@ run-dev:
 	UI_FLAVOR=default \
 	BACKEND_MODE=dev \
 	APP_PREFIX=/ \
+	APP_SECURE_COOKIES=False \
 	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
 
 run-dev-rok:
 	UI_FLAVOR=rok \
 	BACKEND_MODE=dev \
 	APP_PREFIX=/ \
+	APP_SECURE_COOKIES=False \
 	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app


### PR DESCRIPTION
closes #5763 

In this PR I:
1. Introduce a new `APP_SECURE_COOKIES` as described in the issue above
2. Switched the CSRF check orderings. It's misleading for the app to first report that the CSRF header is missing when the cookie is missing as well. In that case the end user might believe that the cookie is there, which could not be the case.
3. Extended the makefiles to use this env var when we run the backends in dev mode, since in that case the apps are exposed over http

/cc @yanniszark @elikatsis 
/assign @kimwnasptd 