### PR TITLE
Update manifests to use ECR and fix fieldPath in kustomization files

### DIFF
--- a/components/admission-webhook/manifests/base/deployment.yaml
+++ b/components/admission-webhook/manifests/base/deployment.yaml
@@ -9,7 +9,7 @@ spec:
         sidecar.istio.io/inject: "false"
     spec:
       containers:
-      - image: gcr.io/kubeflow-images-public/admission-webhook:v20190520-v0-139-gcee39dbc-dirty-0d8f4c
+      - image: public.ecr.aws/j1r0q0g6/notebooks/admission-webhook
         name: admission-webhook
         volumeMounts:
         - mountPath: /etc/webhook/certs

--- a/components/admission-webhook/manifests/base/kustomization.yaml
+++ b/components/admission-webhook/manifests/base/kustomization.yaml
@@ -14,9 +14,9 @@ commonLabels:
   app.kubernetes.io/component: poddefaults
   app.kubernetes.io/name: poddefaults
 images:
-- name: gcr.io/kubeflow-images-public/admission-webhook
-  newName: gcr.io/kubeflow-images-public/admission-webhook
-  newTag: vmaster-ge5452b6f
+- name: public.ecr.aws/j1r0q0g6/notebooks/admission-webhook
+  newName: public.ecr.aws/j1r0q0g6/notebooks/admission-webhook
+  newTag: master-1831e436
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: centraldashboard
-        image: gcr.io/kubeflow-images-public/centraldashboard
+        image: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/components/centraldashboard/manifests/base/kustomization.yaml
+++ b/components/centraldashboard/manifests/base/kustomization.yaml
@@ -17,9 +17,9 @@ commonLabels:
   app.kubernetes.io/component: centraldashboard
   app.kubernetes.io/name: centraldashboard
 images:
-- name: gcr.io/kubeflow-images-public/centraldashboard
-  newName: gcr.io/kubeflow-images-public/centraldashboard
-  newTag: vmaster-g8097cfeb
+- name: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard
+  newName: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard
+  newTag: master-1831e436
 configMapGenerator:
 - envs:
   - params.env

--- a/components/centraldashboard/manifests/base/kustomization.yaml
+++ b/components/centraldashboard/manifests/base/kustomization.yaml
@@ -10,7 +10,6 @@ resources:
 - service-account.yaml
 - service.yaml
 - configmap.yaml
-namespace: kubeflow
 commonLabels:
   kustomize.component: centraldashboard
   app: centraldashboard

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -22,7 +22,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app
-  newTag: master-f753ef1a
+  newTag: master-05ba7a65
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/tensorboards-web-app
-  newTag: master-24bcb8e8
+  newTag: master-1831e436
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/volumes-web-app
   newName: public.ecr.aws/j1r0q0g6/notebooks/volumes-web-app
-  newTag: master-24bcb8e8
+  newTag: master-1831e436
 # We need the name to be unique without the suffix because the original name is what
 # gets used with patches
 configMapGenerator:

--- a/components/notebook-controller/config/base/kustomization.yaml
+++ b/components/notebook-controller/config/base/kustomization.yaml
@@ -2,3 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../default
+images:
+- name: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
+  newName: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
+  newTag: master-1831e436

--- a/components/notebook-controller/config/manager/manager.yaml
+++ b/components/notebook-controller/config/manager/manager.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: manager
-        image: gcr.io/kubeflow-images-public/notebook-controller:vmaster-g6eb007d0
+        image: public.ecr.aws/j1r0q0g6/notebooks/notebook-controller
         command:
           - /manager
         env:

--- a/components/profile-controller/config/base/kustomization.yaml
+++ b/components/profile-controller/config/base/kustomization.yaml
@@ -6,3 +6,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../default
+images:
+- name: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
+  newName: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
+  newTag: master-1831e436

--- a/components/profile-controller/config/manager/manager.yaml
+++ b/components/profile-controller/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
         envFrom:
           - configMapRef:
               name: config
-        image: gcr.io/kubeflow-images-public/profile-controller:vmaster-ga49f658f
+        image: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
         imagePullPolicy: Always
         name: manager
         livenessProbe:

--- a/components/profile-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/kustomization.yaml
@@ -24,3 +24,8 @@ vars:
     name: profiles-kfam
     kind: Service
     apiVersion: v1
+
+images:
+- name: public.ecr.aws/j1r0q0g6/notebooks/access-management
+  newName: public.ecr.aws/j1r0q0g6/notebooks/access-management
+  newTag: master-1831e436

--- a/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
@@ -17,7 +17,7 @@ spec:
         envFrom:
           - configMapRef:
               name: config
-        image: gcr.io/kubeflow-images-public/kfam:vmaster-g9f3bfd00
+        image: public.ecr.aws/j1r0q0g6/notebooks/access-management
         imagePullPolicy: Always
         name: kfam
         livenessProbe:

--- a/components/tensorboard-controller/config/base/kustomization.yaml
+++ b/components/tensorboard-controller/config/base/kustomization.yaml
@@ -36,4 +36,4 @@ patches:
 images:
 - name: public.ecr.aws/j1r0q0g6/notebooks/tensorboard-controller
   newName: public.ecr.aws/j1r0q0g6/notebooks/tensorboard-controller
-  newTag: master-9d688f73
+  newTag: master-f779f93b


### PR DESCRIPTION
Some of the manifests were still using gcr and didn't contain an `images:` section in the `kustomization.yaml` making it more difficult to update the image tags when new ones are pushed (Renovate can do this as well). This PR fixes the manifests so all components are using ECR, have an `images:` section in the `kustomization.yaml` and have the current latest image tags. 

I've added a fix to this PR changes `fieldPath` to `fieldpath` in the `kustomization.yaml` files according to the Kustomize reference docs: https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/vars/

/cc @kimwnasptd @yanniszark 