### PR TITLE
Add Tensorboards and Volumes to central-dashboard

### DIFF
--- a/components/centraldashboard/config/centraldashboard-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-config.yaml
@@ -8,14 +8,24 @@ data:
     {
       "menuLinks": [
         {
+          "link": "/jupyter/",
+          "text": "Notebooks",
+          "icon": "book"
+        },
+        {
+          "link": "/tensorboards/",
+          "text": "Tensorboards",
+          "icon": "assessment"
+        },
+        {
+          "link": "/volumes/",
+          "text": "Volumes",
+          "icon": "device:storage"
+        },
+        {
           "link": "/pipeline/",
           "text": "Pipelines",
           "icon": "kubeflow:pipeline-centered"
-        },
-        {
-          "link": "/jupyter/",
-          "text": "Notebook Servers",
-          "icon": "book"
         },
         {
           "link": "/katib/",

--- a/components/centraldashboard/manifests/base/configmap.yaml
+++ b/components/centraldashboard/manifests/base/configmap.yaml
@@ -15,6 +15,18 @@ data:
         },
         {
           "type": "item",
+          "link": "/tensorboards/",
+          "text": "Tensorboards",
+          "icon": "assessment"
+        },
+        {
+          "type": "item",
+          "link": "/volumes/",
+          "text": "Volumes",
+          "icon": "device:storage"
+        },
+        {
+          "type": "item",
           "link": "/pipeline/#/pipelines",
           "text": "Pipelines",
           "icon": "kubeflow:pipeline-centered"


### PR DESCRIPTION
The Tensorboards and Volumes Web Apps haven't been added to the Central Dashboard. This PR adds them to them to the Central Dashboard in preparation for the upcoming release.

![image](https://user-images.githubusercontent.com/28541758/112313559-48e08480-8ca8-11eb-8924-a462e08ab88b.png)


/cc @StefanoFioravanzo @kimwnasptd 