### PR TITLE
Tensorboard Controller: Explicitly set scope to Namespaced in manifests

### DIFF
--- a/components/tensorboard-controller/api/v1alpha1/tensorboard_types.go
+++ b/components/tensorboard-controller/api/v1alpha1/tensorboard_types.go
@@ -50,6 +50,7 @@ type TensorboardStatus struct {
 }
 
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:path=tensorboards,scope=Namespaced
 // +kubebuilder:subresource:status
 
 // Tensorboard is the Schema for the tensorboards API

--- a/components/tensorboard-controller/config/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml
+++ b/components/tensorboard-controller/config/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml
@@ -12,7 +12,7 @@ spec:
     listKind: TensorboardList
     plural: tensorboards
     singular: tensorboard
-  scope: ""
+  scope: Namespaced
   subresources:
     status: {}
   validation:


### PR DESCRIPTION
While the default scope is `Namespaced`, it is probably best to set it explicitly in the CRD. Not doing so will make the manifest somewhat incompatible with GitOps tools. 

/cc @kimwnasptd @yanniszark 