### PR TITLE
releasing: Add WG-Notebooks leads to release owners

### DIFF
--- a/releasing/OWNERS
+++ b/releasing/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+  - elikatsis
+  - kimwnasptd
+  - StefanoFioravanzo
+  - thesuperzapper
+  - yanniszark


### PR DESCRIPTION
cc @Bobgy 

This is in order to be able to release new manifests / image versions for the notebooks wg.