### PR TITLE
Specify commonLabels for tensorboard-controller

### DIFF
--- a/components/tensorboard-controller/config/default/kustomization.yaml
+++ b/components/tensorboard-controller/config/default/kustomization.yaml
@@ -9,8 +9,9 @@ namespace: tensorboard-controller-system
 namePrefix: tensorboard-controller-
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app: tensorboard-controller
+  kustomize.component: tensorboard-controller
 
 bases:
 - ../crd


### PR DESCRIPTION
Currently, no labels are being set for the tensorboard-controller. Without these labels, the selector for the deployment and service of the tensorboard-controller are generic and will cause compatibility problems with other KubeBuilder based controllers if they are in the same namespace. This PR adds the labels `app: tensorboard-controller` and `kustomize.component: tensorboard-controller` to the manifests so that specific selectors are used. 

/cc @yanniszark 