### PR TITLE
Take [[disabled]] parameter into account on registration page namespace input

### DIFF
--- a/components/centraldashboard/public/components/resources/md2-input/md2-input.pug
+++ b/components/centraldashboard/public/components/resources/md2-input/md2-input.pug
@@ -3,7 +3,8 @@
     slot(name='prefix', slot='prefix')
     iron-input#ironInput(allowed-pattern='[[allowedPattern]]', bind-value='{{value}}')
         input#inputElement(placeholder='[[placeholder]]', maxlength$='[[maxlength]]'
-            on-focus='inputFocused', on-blur='inputBlurred', on-keydown='validateRange')
+            on-focus='inputFocused', on-blur='inputBlurred', on-keydown='validateRange',
+            disabled='[[disabled]]')
     slot(name='suffix', slot='suffix')
     iron-a11y-keys#keys(target='[[inputElement]]', keys='enter', on-keys-pressed='fireEnter')
 aside.Error [[error]]


### PR DESCRIPTION
Namespace input element parameters for registration page are defined on [registration-page.pug#L17](https://github.com/dejangolubovic/kubeflow/blob/1b2cbc0de947b49b0169df935b4bf19b72d091f0/components/centraldashboard/public/components/registration-page.pug#L17) and [md2-input.js#L15](https://github.com/kubeflow/kubeflow/blob/096d31783c0924d0a1e8fd9606feaae203711b0f/components/centraldashboard/public/components/resources/md2-input/md2-input.js#L15). Then, parameters defining the input element are used on [md2-input.pug](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/public/components/resources/md2-input/md2-input.pug). Parameter [[disabled]] is missing in this configuration, which this PR is fixing.