### PR TITLE
Remove jlewi as an approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,5 +2,4 @@
 # Approvers listed here is just a backup in case someone is out.
 approvers:
   - Bobgy
-  - jlewi
   - pdmack


### PR DESCRIPTION
Removing myself as an owner. This should lead to better auto-assignment of code reviews.