### PR TITLE
Update second layer docker images to new tags and some python deps

### DIFF
--- a/components/example-notebook-servers/codeserver-python/Dockerfile
+++ b/components/example-notebook-servers/codeserver-python/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver:master-53099bbd
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/codeserver:master-ebc0c4f0
 
 USER root
 

--- a/components/example-notebook-servers/jupyter-pytorch/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-ebc0c4f0
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements-cpu.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-ebc0c4f0
 
 # nvidia configs
 ENV NVIDIA_VISIBLE_DEVICES all

--- a/components/example-notebook-servers/jupyter-scipy/Dockerfile
+++ b/components/example-notebook-servers/jupyter-scipy/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-ebc0c4f0
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-scipy/requirements.txt
+++ b/components/example-notebook-servers/jupyter-scipy/requirements.txt
@@ -6,26 +6,26 @@ kfserving==0.4.1
 # scipy packages
 # https://github.com/jupyter/docker-stacks/blob/master/scipy-notebook/Dockerfile
 beautifulsoup4==4.9.3
-bokeh==2.3.0
+bokeh==2.3.1
 #Bottleneck==1.3.2 Could not build wheels for Bottleneck which use PEP 517 and cannot be installed directly
 cloudpickle==1.6.0
 cython==0.29.22
-dask==2021.3.0
+dask==2021.4.0
 dill==0.3.3
 h5py==3.2.1
-ipympl==0.6.3
+ipympl==0.7.0
 ipywidgets==7.6.3
-matplotlib==3.3.4
-numba==0.53.0
+matplotlib==3.4.1
+numba==0.53.1
 numexpr==2.7.3
 pandas==1.2.3
 patsy==0.5.1
-protobuf==3.15.6
+protobuf==3.15.7
 scikit-image==0.18.1
 scikit-learn==0.24.1
-scipy==1.6.1
+scipy==1.6.2
 seaborn==0.11.1
-SQLAlchemy==1.3.23
+SQLAlchemy==1.4.5
 statsmodels==0.12.2
 sympy==1.7.1
 tables==3.6.1

--- a/components/example-notebook-servers/jupyter-tensorflow/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-ebc0c4f0
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements-cpu.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-2dd0e3e4
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-ebc0c4f0
 
 USER root
 

--- a/components/example-notebook-servers/rstudio-tidyverse/Dockerfile
+++ b/components/example-notebook-servers/rstudio-tidyverse/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio:master-15d229d4
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio:master-ebc0c4f0
 
 # args - software versions
 ARG R_TIDYVERSE_VERSION="1.3.0"


### PR DESCRIPTION
Updates the downstream notebook server images to the tags created after merging https://github.com/kubeflow/kubeflow/pull/5804. Also updates some python packages in the scipy notebook server image. 
@kimwnasptd if you could quickly give your blessing on this PR I can move on to the last layer of downstream images (tensorflow and pytorch full). 