### PR TITLE
Make notebook limits configurable with a multiplication factor

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -164,7 +164,13 @@ def set_notebook_cpu(notebook, body, defaults):
 
     cpu = get_form_value(body, defaults, "cpu")
 
+    limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
+    if not limit_factor:
+        limit_factor = 1.2
+    limit = str(float(cpu) * limit_factor)
+
     container["resources"]["requests"]["cpu"] = cpu
+    container["resources"]["limits"]["cpu"] = limit
 
 
 def set_notebook_memory(notebook, body, defaults):
@@ -172,7 +178,13 @@ def set_notebook_memory(notebook, body, defaults):
 
     memory = get_form_value(body, defaults, "memory")
 
+    limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")
+    if not limit_factor:
+        limit_factor = 1.2
+    limit = str(float(memory.replace('Gi', '')) * limit_factor) + "Gi"
+
     container["resources"]["requests"]["memory"] = memory
+    container["resources"]["limits"]["memory"] = limit
 
 
 def set_notebook_tolerations(notebook, body, defaults):

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -173,14 +173,18 @@ def set_notebook_cpu(notebook, body, defaults):
                 utils.load_spawner_ui_config()["cpu"].get(
                     "value")) * float(limit_factor)), 1))
 
-    if cpu_limit is not (None and ''):
-        if float(cpu_limit) < float(cpu):
-            raise BadRequest("CPU limit must be greater than the request")
-        limits = container["resources"].get("limits", {})
-        limits["cpu"] = cpu_limit
-        container["resources"]["limits"] = limits
-
     container["resources"]["requests"]["cpu"] = cpu
+
+    if cpu_limit is None or cpu_limit == "":
+        # user explicitly asked for no limits
+        return
+
+    if float(cpu_limit) < float(cpu):
+        raise BadRequest("CPU limit must be greater than the request")
+
+    limits = container["resources"].get("limits", {})
+    limits["cpu"] = cpu_limit
+    container["resources"]["limits"] = limits
 
 
 def set_notebook_memory(notebook, body, defaults):
@@ -201,15 +205,19 @@ def set_notebook_memory(notebook, body, defaults):
                     "value").replace('Gi', '')) * float(
                         limit_factor)), 1)) + "Gi"
 
-    if memory_limit is not (None and ''):
-        if float(memory_limit.replace('Gi', '')) < float(
-                memory.replace('Gi', '')):
-            raise BadRequest("Memory limit must be greater than the request")
-        limits = container["resources"].get("limits", {})
-        limits["memory"] = memory_limit
-        container["resources"]["limits"] = limits
-
     container["resources"]["requests"]["memory"] = memory
+
+    if memory_limit is None or memory_limit == "":
+        # user explicitly asked for no limits
+        return
+
+    if float(memory_limit.replace('Gi', '')) < float(
+            memory.replace('Gi', '')):
+        raise BadRequest("Memory limit must be greater than the request")
+
+    limits = container["resources"].get("limits", {})
+    limits["memory"] = memory_limit
+    container["resources"]["limits"] = limits
 
 
 def set_notebook_tolerations(notebook, body, defaults):

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -163,21 +163,21 @@ def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     cpu = get_form_value(body, defaults, "cpu")
-    cpuLimit = get_form_value(body, defaults, "cpuLimit")
+    cpu_limit = get_form_value(body, defaults, "cpuLimit")
 
     limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
-    if not cpuLimit and limit_factor != "none":
-        cpuLimit = str(round((float(cpu) * float(limit_factor)), 1))
+    if not cpu_limit and limit_factor != "none":
+        cpu_limit = str(round((float(cpu) * float(limit_factor)), 1))
         if not cpu:
-            cpuLimit = str(round((float(
+            cpu_limit = str(round((float(
                 utils.load_spawner_ui_config()["cpu"].get(
                     "value")) * float(limit_factor)), 1))
 
-    if cpuLimit is not (None and ''):
-        if float(cpuLimit) < float(cpu):
+    if cpu_limit is not (None and ''):
+        if float(cpu_limit) < float(cpu):
             raise BadRequest("CPU limit must be greater than the request")
         limits = container["resources"].get("limits", {})
-        limits["cpu"] = cpuLimit
+        limits["cpu"] = cpu_limit
         container["resources"]["limits"] = limits
 
     container["resources"]["requests"]["cpu"] = cpu
@@ -187,26 +187,26 @@ def set_notebook_memory(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     memory = get_form_value(body, defaults, "memory")
-    memoryLimit = get_form_value(body, defaults, "memoryLimit")
+    memory_limit = get_form_value(body, defaults, "memoryLimit")
 
     limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")
-    if not memoryLimit and limit_factor != "none":
-        memoryLimit = str(
+    if not memory_limit and limit_factor != "none":
+        memory_limit = str(
             round((
                 float(memory.replace('Gi', '')) * float(
                     limit_factor)), 1)) + "Gi"
         if not memory:
-            memoryLimit = str(round((float(
+            memory_limit = str(round((float(
                 utils.load_spawner_ui_config()["memory"].get(
                     "value").replace('Gi', '')) * float(
                         limit_factor)), 1)) + "Gi"
 
-    if memoryLimit is not (None and ''):
-        if float(memoryLimit.replace('Gi', '')) < float(
+    if memory_limit is not (None and ''):
+        if float(memory_limit.replace('Gi', '')) < float(
                 memory.replace('Gi', '')):
             raise BadRequest("Memory limit must be greater than the request")
         limits = container["resources"].get("limits", {})
-        limits["memory"] = memoryLimit
+        limits["memory"] = memory_limit
         container["resources"]["limits"] = limits
 
     container["resources"]["requests"]["memory"] = memory

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -169,9 +169,11 @@ def set_notebook_cpu(notebook, body, defaults):
     if not limit_factor:
         limit_factor = 1.2
     if not cpuLimit:
-        cpuLimit = str(float(cpu) * limit_factor)
+        cpuLimit = str(round(float(cpu) * limit_factor), 1)
         if not cpu:
-            cpuLimit = str(float(utils.load_spawner_ui_config()["cpu"].get("value")) * limit_factor)
+            cpuLimit = str(round(float(
+                utils.load_spawner_ui_config()["cpu"].get(
+                    "value")) * limit_factor), 1)
 
     container["resources"]["requests"]["cpu"] = cpu
     container["resources"]["limits"]["cpu"] = cpuLimit
@@ -187,9 +189,12 @@ def set_notebook_memory(notebook, body, defaults):
     if not limit_factor:
         limit_factor = 1.2
     if not memoryLimit:
-        memoryLimit = str(float(memory.replace('Gi', '')) * limit_factor) + "Gi"
+        memoryLimit = str(
+            round(float(memory.replace('Gi', '')) * limit_factor), 1) + "Gi"
         if not memory:
-            memoryLimit = str(float(utils.load_spawner_ui_config()["memory"].get("value").replace('Gi', '')) * limit_factor) + "Gi"
+            memoryLimit = str(round(float(
+                utils.load_spawner_ui_config()["memory"].get(
+                    "value").replace('Gi', '')) * limit_factor), 1) + "Gi"
 
     container["resources"]["requests"]["memory"] = memory
     container["resources"]["limits"]["memory"] = memoryLimit

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -163,28 +163,36 @@ def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     cpu = get_form_value(body, defaults, "cpu")
+    cpuLimit = get_form_value(body, defaults, "cpuLimit")
 
     limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
     if not limit_factor:
         limit_factor = 1.2
-    limit = str(float(cpu) * limit_factor)
+    if not cpuLimit:
+        cpuLimit = str(float(cpu) * limit_factor)
+        if not cpu:
+            cpuLimit = str(float(utils.load_spawner_ui_config()["cpu"].get("value")) * limit_factor)
 
     container["resources"]["requests"]["cpu"] = cpu
-    container["resources"]["limits"]["cpu"] = limit
+    container["resources"]["limits"]["cpu"] = cpuLimit
 
 
 def set_notebook_memory(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     memory = get_form_value(body, defaults, "memory")
-
+    memoryLimit = get_form_value(body, defaults, "memoryLimit")
+    
     limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")
     if not limit_factor:
         limit_factor = 1.2
-    limit = str(float(memory.replace('Gi', '')) * limit_factor) + "Gi"
+    if not memoryLimit:
+        memoryLimit = str(float(memory.replace('Gi', '')) * limit_factor) + "Gi"
+        if not memory:
+            memoryLimit = str(float(utils.load_spawner_ui_config()["memory"].get("value").replace('Gi', '')) * limit_factor) + "Gi"
 
     container["resources"]["requests"]["memory"] = memory
-    container["resources"]["limits"]["memory"] = limit
+    container["resources"]["limits"]["memory"] = memoryLimit
 
 
 def set_notebook_tolerations(notebook, body, defaults):

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -182,7 +182,7 @@ def set_notebook_memory(notebook, body, defaults):
 
     memory = get_form_value(body, defaults, "memory")
     memoryLimit = get_form_value(body, defaults, "memoryLimit")
-    
+
     limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")
     if not limit_factor:
         limit_factor = 1.2

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -168,10 +168,6 @@ def set_notebook_cpu(notebook, body, defaults):
     limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
     if not cpu_limit and limit_factor != "none":
         cpu_limit = str(round((float(cpu) * float(limit_factor)), 1))
-        if not cpu:
-            cpu_limit = str(round((float(
-                utils.load_spawner_ui_config()["cpu"].get(
-                    "value")) * float(limit_factor)), 1))
 
     container["resources"]["requests"]["cpu"] = cpu
 
@@ -199,11 +195,6 @@ def set_notebook_memory(notebook, body, defaults):
             round((
                 float(memory.replace('Gi', '')) * float(
                     limit_factor)), 1)) + "Gi"
-        if not memory:
-            memory_limit = str(round((float(
-                utils.load_spawner_ui_config()["memory"].get(
-                    "value").replace('Gi', '')) * float(
-                        limit_factor)), 1)) + "Gi"
 
     container["resources"]["requests"]["memory"] = memory
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -175,6 +175,9 @@ def set_notebook_cpu(notebook, body, defaults):
                 utils.load_spawner_ui_config()["cpu"].get(
                     "value")) * limit_factor), 1)
 
+    if float(cpuLimit) < float(cpu):
+        raise BadRequest("CPU limit must be greater than the request")
+
     container["resources"]["requests"]["cpu"] = cpu
     container["resources"]["limits"]["cpu"] = cpuLimit
 
@@ -195,6 +198,9 @@ def set_notebook_memory(notebook, body, defaults):
             memoryLimit = str(round(float(
                 utils.load_spawner_ui_config()["memory"].get(
                     "value").replace('Gi', '')) * limit_factor), 1) + "Gi"
+
+    if float(memoryLimit.replace('Gi', '')) < float(memory.replace('Gi', '')):
+        raise BadRequest("Memory limit must be greater than the request")
 
     container["resources"]["requests"]["memory"] = memory
     container["resources"]["limits"]["memory"] = memoryLimit

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -17,9 +17,6 @@ spec:
           volumeMounts: []
           env: []
           resources:
-            limits:
-              cpu: "0.2"
-              memory: "0.2Gi"
             requests:
               cpu: "0.1"
               memory: "0.1Gi"

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -17,6 +17,9 @@ spec:
           volumeMounts: []
           env: []
           resources:
+            limits:
+              cpu: "0.2"
+              memory: "0.2Gi"
             requests:
               cpu: "0.1"
               memory: "0.1Gi"

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -56,12 +56,16 @@ spawnerFormDefaults:
   cpu:
     # CPU for user's Notebook
     value: '0.5'
-    limitFactor: 1.2
+    # Factor by with to multiply request to calculate limit
+    # if no limit is set, to disable set "none"
+    limitFactor: "1.2"
     readOnly: false
   memory:
     # Memory for user's Notebook
     value: 1.0Gi
-    limitFactor: 1.2
+    # Factor by with to multiply request to calculate limit
+    # if no limit is set, to disable set "none"
+    limitFactor: "1.2"
     readOnly: false
   environment:
     value: {}

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -56,10 +56,12 @@ spawnerFormDefaults:
   cpu:
     # CPU for user's Notebook
     value: '0.5'
+    limitFactor: 1.2
     readOnly: false
   memory:
     # Memory for user's Notebook
     value: 1.0Gi
+    limitFactor: 1.2
     readOnly: false
   environment:
     value: {}

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -57,12 +57,12 @@ spawnerFormDefaults:
     # CPU for user's Notebook
     value: '0.5'
     limitFactor: 1.2
-    readOnly: true
+    readOnly: false
   memory:
     # Memory for user's Notebook
     value: 1.0Gi
     limitFactor: 1.2
-    readOnly: true
+    readOnly: false
   environment:
     value: {}
     readOnly: false

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -57,12 +57,12 @@ spawnerFormDefaults:
     # CPU for user's Notebook
     value: '0.5'
     limitFactor: 1.2
-    readOnly: false
+    readOnly: true
   memory:
     # Memory for user's Notebook
     value: 1.0Gi
     limitFactor: 1.2
-    readOnly: false
+    readOnly: true
   environment:
     value: {}
     readOnly: false

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
@@ -11,7 +11,7 @@
       min="0.1"
       step="0.1"
       [sizeControl]="parentForm.get('cpu')"
-      label="CPUs"
+      label="Requested CPUs"
     ></lib-positive-number-input>
 
     <!--RAM-->
@@ -20,7 +20,28 @@
       min="0.1"
       step="0.1"
       [sizeControl]="parentForm.get('memory')"
-      label="RAM size in Gi"
+      label="Requested memory in Gi"
     ></lib-positive-number-input>
   </div>
+  <lib-advanced-options>
+    <div class="row">
+      <!--CPU-->
+      <lib-positive-number-input
+        class="column"
+        min="0.1"
+        step="0.1"
+        [sizeControl]="parentForm.get('cpuLimit')"
+        label="CPU limit"
+      ></lib-positive-number-input>
+  
+      <!--RAM-->
+      <lib-positive-number-input
+        class="column"
+        min="0.1"
+        step="0.1"
+        [sizeControl]="parentForm.get('memoryLimit')"
+        label="Memory limit in Gi"
+      ></lib-positive-number-input>
+    </div>
+  </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
@@ -33,7 +33,7 @@
         [sizeControl]="parentForm.get('cpuLimit')"
         label="CPU limit"
       ></lib-positive-number-input>
-  
+
       <!--RAM-->
       <lib-positive-number-input
         class="column"

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html
@@ -26,22 +26,31 @@
   <lib-advanced-options>
     <div class="row">
       <!--CPU-->
-      <lib-positive-number-input
-        class="column"
-        min="0.1"
-        step="0.1"
-        [sizeControl]="parentForm.get('cpuLimit')"
-        label="CPU limit"
-      ></lib-positive-number-input>
-
+      <div class="column">
+        <mat-form-field appearance="outline" class="wide">
+          <mat-label>CPU limit</mat-label>
+          <input
+            matInput
+            type="number"
+            min="0.1"
+            step="0.1"
+            [formControl]="parentForm.get('cpuLimit')"
+          />
+        </mat-form-field>
+      </div>
       <!--RAM-->
-      <lib-positive-number-input
-        class="column"
-        min="0.1"
-        step="0.1"
-        [sizeControl]="parentForm.get('memoryLimit')"
-        label="Memory limit in Gi"
-      ></lib-positive-number-input>
+      <div class="column">
+        <mat-form-field appearance="outline" class="wide">
+          <mat-label>Memory limit in Gi</mat-label>
+          <input
+            matInput
+            type="number"
+            min="0.1"
+            step="0.1"
+            [formControl]="parentForm.get('memoryLimit')"
+          />
+        </mat-form-field>
+      </div>
     </div>
   </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
@@ -18,24 +18,39 @@ export class FormCpuRamComponent implements OnInit {
   ngOnInit() {
     this.parentForm.get('cpu').valueChanges.subscribe(val => {
       //set cpu limit when value of the cpu request changes
-      this.parentForm.get('cpuLimit').setValue((this.cpuLimitFactor * this.parentForm.get('cpu').value).toFixed(1))
+      this.parentForm
+        .get('cpuLimit')
+        .setValue(
+          (this.cpuLimitFactor * this.parentForm.get('cpu').value).toFixed(1),
+        );
     });
     this.parentForm.get('memory').valueChanges.subscribe(val => {
       //set memory limit when value of the memory request changes
-      this.parentForm.get('memoryLimit').setValue((this.memoryLimitFactor * this.parentForm.get('memory').value).toFixed(1))
+      this.parentForm
+        .get('memoryLimit')
+        .setValue(
+          (
+            this.memoryLimitFactor * this.parentForm.get('memory').value
+          ).toFixed(1),
+        );
     });
     this.parentForm.get('cpuLimit').valueChanges.subscribe(val => {
       //make sure cpu limit is equal to or more than cpu request
-      if (this.parentForm.get('cpuLimit').value < this.parentForm.get('cpu').value) {
-        console.log('error cpu limit')
-      //   this.parentForm.get('cpuLimit').setValue(this.parentForm.get('cpu'))
+      if (
+        this.parentForm.get('cpuLimit').value < this.parentForm.get('cpu').value
+      ) {
+        console.log('error cpu limit');
+        //   this.parentForm.get('cpuLimit').setValue(this.parentForm.get('cpu'))
       }
     });
     this.parentForm.get('memoryLimit').valueChanges.subscribe(val => {
       //make sure memory limit is equal to or more than cpu request
-      if (this.parentForm.get('memoryLimit').value < this.parentForm.get('memory').value) {
-        console.log('error memory limit')
-      //   this.parentForm.get('memoryLimit').setValue(this.parentForm.get('memory'))
+      if (
+        this.parentForm.get('memoryLimit').value <
+        this.parentForm.get('memory').value
+      ) {
+        console.log('error memory limit');
+        //   this.parentForm.get('memoryLimit').setValue(this.parentForm.get('memory'))
       }
     });
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
@@ -10,29 +10,36 @@ export class FormCpuRamComponent implements OnInit {
   @Input() parentForm: FormGroup;
   @Input() readonlyCPU: boolean;
   @Input() readonlyMemory: boolean;
-  @Input() cpuLimitFactor: number;
-  @Input() memoryLimitFactor: number;
+  @Input() cpuLimitFactor: string;
+  @Input() memoryLimitFactor: string;
 
   constructor() {}
 
   ngOnInit() {
     this.parentForm.get('cpu').valueChanges.subscribe(val => {
       //set cpu limit when value of the cpu request changes
-      this.parentForm
-        .get('cpuLimit')
-        .setValue(
-          (this.cpuLimitFactor * this.parentForm.get('cpu').value).toFixed(1),
-        );
+      if (this.cpuLimitFactor !== null) {
+        this.parentForm
+          .get('cpuLimit')
+          .setValue(
+            (
+              parseFloat(this.cpuLimitFactor) * this.parentForm.get('cpu').value
+            ).toFixed(1),
+          );
+      }
     });
     this.parentForm.get('memory').valueChanges.subscribe(val => {
       //set memory limit when value of the memory request changes
-      this.parentForm
-        .get('memoryLimit')
-        .setValue(
-          (
-            this.memoryLimitFactor * this.parentForm.get('memory').value
-          ).toFixed(1),
-        );
+      if (this.memoryLimitFactor !== null) {
+        this.parentForm
+          .get('memoryLimit')
+          .setValue(
+            (
+              parseFloat(this.memoryLimitFactor) *
+              this.parentForm.get('memory').value
+            ).toFixed(1),
+          );
+      }
     });
   }
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
@@ -34,25 +34,6 @@ export class FormCpuRamComponent implements OnInit {
           ).toFixed(1),
         );
     });
-    this.parentForm.get('cpuLimit').valueChanges.subscribe(val => {
-      //make sure cpu limit is equal to or more than cpu request
-      if (
-        this.parentForm.get('cpuLimit').value < this.parentForm.get('cpu').value
-      ) {
-        console.log('error cpu limit');
-        //   this.parentForm.get('cpuLimit').setValue(this.parentForm.get('cpu'))
-      }
-    });
-    this.parentForm.get('memoryLimit').valueChanges.subscribe(val => {
-      //make sure memory limit is equal to or more than cpu request
-      if (
-        this.parentForm.get('memoryLimit').value <
-        this.parentForm.get('memory').value
-      ) {
-        console.log('error memory limit');
-        //   this.parentForm.get('memoryLimit').setValue(this.parentForm.get('memory'))
-      }
-    });
   }
 
   getCPUError() {}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.ts
@@ -10,10 +10,35 @@ export class FormCpuRamComponent implements OnInit {
   @Input() parentForm: FormGroup;
   @Input() readonlyCPU: boolean;
   @Input() readonlyMemory: boolean;
+  @Input() cpuLimitFactor: number;
+  @Input() memoryLimitFactor: number;
 
   constructor() {}
 
-  ngOnInit() {}
+  ngOnInit() {
+    this.parentForm.get('cpu').valueChanges.subscribe(val => {
+      //set cpu limit when value of the cpu request changes
+      this.parentForm.get('cpuLimit').setValue((this.cpuLimitFactor * this.parentForm.get('cpu').value).toFixed(1))
+    });
+    this.parentForm.get('memory').valueChanges.subscribe(val => {
+      //set memory limit when value of the memory request changes
+      this.parentForm.get('memoryLimit').setValue((this.memoryLimitFactor * this.parentForm.get('memory').value).toFixed(1))
+    });
+    this.parentForm.get('cpuLimit').valueChanges.subscribe(val => {
+      //make sure cpu limit is equal to or more than cpu request
+      if (this.parentForm.get('cpuLimit').value < this.parentForm.get('cpu').value) {
+        console.log('error cpu limit')
+      //   this.parentForm.get('cpuLimit').setValue(this.parentForm.get('cpu'))
+      }
+    });
+    this.parentForm.get('memoryLimit').valueChanges.subscribe(val => {
+      //make sure memory limit is equal to or more than cpu request
+      if (this.parentForm.get('memoryLimit').value < this.parentForm.get('memory').value) {
+        console.log('error memory limit')
+      //   this.parentForm.get('memoryLimit').setValue(this.parentForm.get('memory'))
+      }
+    });
+  }
 
   getCPUError() {}
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
@@ -15,11 +15,11 @@
         ></app-form-image>
 
         <app-form-cpu-ram
-        [parentForm]="formCtrl"
-        [readonlyCPU]="config?.cpu?.readOnly"
-        [readonlyMemory]="config?.memory?.readOnly"
-        [cpuLimitFactor]="config?.cpu?.limitFactor"
-        [memoryLimitFactor]="config?.memory?.limitFactor"
+          [parentForm]="formCtrl"
+          [readonlyCPU]="config?.cpu?.readOnly"
+          [readonlyMemory]="config?.memory?.readOnly"
+          [cpuLimitFactor]="config?.cpu?.limitFactor"
+          [memoryLimitFactor]="config?.memory?.limitFactor"
         ></app-form-cpu-ram>
 
         <app-form-gpus

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
@@ -14,7 +14,13 @@
           [allowCustomImage]="config?.allowCustomImage"
         ></app-form-image>
 
-        <app-form-cpu-ram [parentForm]="formCtrl"></app-form-cpu-ram>
+        <app-form-cpu-ram
+        [parentForm]="formCtrl"
+        [readonlyCPU]="config?.cpu?.readOnly"
+        [readonlyMemory]="config?.memory?.readOnly"
+        [cpuLimitFactor]="config?.cpu?.limitFactor"
+        [memoryLimitFactor]="config?.memory?.limitFactor"
+        ></app-form-cpu-ram>
 
         <app-form-gpus
           [parentForm]="formCtrl"

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -124,17 +124,25 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
       notebook.cpu = notebook.cpu.toString();
     }
 
-    // Ensure CPU Limit input is a string
-    if (typeof notebook.cpuLimit === 'number') {
+    // Remove cpuLimit from request if null
+    if (notebook.cpuLimit == null) {
+      delete notebook.cpuLimit;
+      // Ensure CPU Limit input is a string
+    } else if (typeof notebook.cpuLimit === 'number') {
       notebook.cpuLimit = notebook.cpuLimit.toString();
+    }
+
+    // Remove memoryLimit from request if null
+    if (notebook.memoryLimit == null) {
+      delete notebook.memoryLimit;
+      // Add Gi to memoryLimit
+    } else if (notebook.memoryLimit) {
+      notebook.memoryLimit = notebook.memoryLimit.toString() + 'Gi';
     }
 
     // Add Gi to all sizes
     if (notebook.memory) {
       notebook.memory = notebook.memory.toString() + 'Gi';
-    }
-    if (notebook.memoryLimit) {
-      notebook.memoryLimit = notebook.memoryLimit.toString() + 'Gi';
     }
 
     if (notebook.workspace.size) {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -124,8 +124,18 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
       notebook.cpu = notebook.cpu.toString();
     }
 
+    // Ensure CPU Limit input is a string
+    if (typeof notebook.cpuLimit === 'number') {
+      notebook.cpuLimit = notebook.cpuLimit.toString();
+    }
+
     // Add Gi to all sizes
-    notebook.memory = notebook.memory.toString() + 'Gi';
+    if (notebook.memory) {
+      notebook.memory = notebook.memory.toString() + 'Gi';
+    }
+    if (notebook.memoryLimit) {
+      notebook.memoryLimit = notebook.memoryLimit.toString() + 'Gi';
+    }
 
     if (notebook.workspace.size) {
       notebook.workspace.size = notebook.workspace.size.toString() + 'Gi';

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -17,7 +17,9 @@ export function getFormDefaults(): FormGroup {
     customImageCheck: [false, []],
     serverType: ['jupyter', [Validators.required]],
     cpu: [1, [Validators.required]],
+    cpuLimit: [1, [Validators.required]],
     memory: [1, [Validators.required]],
+    memoryLimit: [1, [Validators.required]],
     gpus: fb.group({
       vendor: ['', []],
       num: ['', []],
@@ -140,13 +142,17 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
   // Sets the values from our internal dict. This is an initialization step
   // that should be only run once
   formCtrl.controls.cpu.setValue(configSizeToNumber(config.cpu.value));
+  formCtrl.controls.cpuLimit.setValue((configSizeToNumber(config.cpu.value) * config.cpu.limitFactor).toFixed(1));
   if (config.cpu.readOnly) {
     formCtrl.controls.cpu.disable();
+    formCtrl.controls.cpuLimit.disable();
   }
 
   formCtrl.controls.memory.setValue(configSizeToNumber(config.memory.value));
+  formCtrl.controls.memoryLimit.setValue((configSizeToNumber(config.memory.value) * config.memory.limitFactor).toFixed(1));
   if (config.memory.readOnly) {
     formCtrl.controls.memory.disable();
+    formCtrl.controls.memoryLimit.disable();
   }
 
   formCtrl.controls.image.setValue(config.image.value);

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -17,9 +17,9 @@ export function getFormDefaults(): FormGroup {
     customImageCheck: [false, []],
     serverType: ['jupyter', [Validators.required]],
     cpu: [1, [Validators.required]],
-    cpuLimit: [1, [Validators.required]],
+    cpuLimit: ['', []],
     memory: [1, [Validators.required]],
-    memoryLimit: [1, [Validators.required]],
+    memoryLimit: ['', []],
     gpus: fb.group({
       vendor: ['', []],
       num: ['', []],
@@ -142,20 +142,28 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
   // Sets the values from our internal dict. This is an initialization step
   // that should be only run once
   formCtrl.controls.cpu.setValue(configSizeToNumber(config.cpu.value));
-  formCtrl.controls.cpuLimit.setValue(
-    (configSizeToNumber(config.cpu.value) * config.cpu.limitFactor).toFixed(1),
-  );
+  if (config.cpu.limitFactor !== 'none') {
+    formCtrl.controls.cpuLimit.setValue(
+      (
+        configSizeToNumber(config.cpu.value) *
+        configSizeToNumber(config.cpu.limitFactor)
+      ).toFixed(1),
+    );
+  }
   if (config.cpu.readOnly) {
     formCtrl.controls.cpu.disable();
     formCtrl.controls.cpuLimit.disable();
   }
 
   formCtrl.controls.memory.setValue(configSizeToNumber(config.memory.value));
-  formCtrl.controls.memoryLimit.setValue(
-    (
-      configSizeToNumber(config.memory.value) * config.memory.limitFactor
-    ).toFixed(1),
-  );
+  if (config.memory.limitFactor !== 'none') {
+    formCtrl.controls.memoryLimit.setValue(
+      (
+        configSizeToNumber(config.memory.value) *
+        configSizeToNumber(config.memory.limitFactor)
+      ).toFixed(1),
+    );
+  }
   if (config.memory.readOnly) {
     formCtrl.controls.memory.disable();
     formCtrl.controls.memoryLimit.disable();

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -142,14 +142,20 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
   // Sets the values from our internal dict. This is an initialization step
   // that should be only run once
   formCtrl.controls.cpu.setValue(configSizeToNumber(config.cpu.value));
-  formCtrl.controls.cpuLimit.setValue((configSizeToNumber(config.cpu.value) * config.cpu.limitFactor).toFixed(1));
+  formCtrl.controls.cpuLimit.setValue(
+    (configSizeToNumber(config.cpu.value) * config.cpu.limitFactor).toFixed(1),
+  );
   if (config.cpu.readOnly) {
     formCtrl.controls.cpu.disable();
     formCtrl.controls.cpuLimit.disable();
   }
 
   formCtrl.controls.memory.setValue(configSizeToNumber(config.memory.value));
-  formCtrl.controls.memoryLimit.setValue((configSizeToNumber(config.memory.value) * config.memory.limitFactor).toFixed(1));
+  formCtrl.controls.memoryLimit.setValue(
+    (
+      configSizeToNumber(config.memory.value) * config.memory.limitFactor
+    ).toFixed(1),
+  );
   if (config.memory.readOnly) {
     formCtrl.controls.memory.disable();
     formCtrl.controls.memoryLimit.disable();

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -20,11 +20,11 @@ export interface NotebookResponseObject {
   image: string;
   volumes: string[];
   cpu: string;
+  memory: string;
   gpus: {
     count: number;
     message: string;
   };
-  memory: string;
   environment: string;
   shortImage: string;
 }
@@ -47,7 +47,9 @@ export interface NotebookFormObject {
   customImageCheck: boolean;
   serverType: string;
   cpu: number | string;
+  cpuLimit: number | string;
   memory: number | string;
+  memoryLimit: number | string;
   gpus: GPU;
   environment?: string;
   noWorkspace: boolean;
@@ -161,11 +163,13 @@ export interface Config {
 
   cpu?: {
     value: string;
+    limitFactor: number;
     readOnly?: boolean;
   };
 
   memory?: {
     value: string;
+    limitFactor: number;
     readOnly?: boolean;
   };
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/types.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types.ts
@@ -163,13 +163,13 @@ export interface Config {
 
   cpu?: {
     value: string;
-    limitFactor: number;
+    limitFactor: string;
     readOnly?: boolean;
   };
 
   memory?: {
     value: string;
-    limitFactor: number;
+    limitFactor: string;
     readOnly?: boolean;
   };
 

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -53,10 +53,16 @@ spawnerFormDefaults:
   cpu:
     # CPU for user's Notebook
     value: '0.5'
+    # Factor by with to multiply request to calculate limit
+    # if no limit is set, to disable set "none"
+    limitFactor: "1.2"
     readOnly: false
   memory:
     # Memory for user's Notebook
     value: 1.0Gi
+    # Factor by with to multiply request to calculate limit
+    # if no limit is set, to disable set "none"
+    limitFactor: "1.2"
     readOnly: false
   workspaceVolume:
     # Workspace Volume to be attached to user's Notebook


### PR DESCRIPTION
Closes: https://github.com/kubeflow/kubeflow/issues/5814

This PR makes it possible for admins to set a factor that gets multiplied against the resource request of a notebook to set a limit for the resource. According to the above issue,  it is not possible to create notebooks when profiles have resourcequotas  and no resource limit is set. 
By default, the limit of a notebook server is set to 20% more than the request. This gives users that might not expect a Pod to get killed if the memory limit is reached a buffer.

/cc @kimwnasptd I think we need to get this merged quickly as without it current installations will break with the new web app. The fix is quite small luckily. 