### PR TITLE
tensorboard-controller: Fix scheduling unbound PVCs

### DIFF
--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -204,7 +204,7 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 			//If the PVC is mounted as a ReadWriteOnce volume by a pod that is running on a node X,
 			//then we find the NodeName of X so that the Tensorboard server
 			//(that must access the volume) will be deployed on X using nodeAffinity.
-			if pvc.Status.AccessModes[0] == corev1.ReadWriteOnce {
+			if len(pvc.Status.AccessModes) > 0 && pvc.Status.AccessModes[0] == corev1.ReadWriteOnce {
 				if err := generateNodeAffinity(affinity, pvcname, r, tb); err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
When the TB controller attempts to schedule a RWO PVC it checks its
accessModes in the PVC status. The controller panics if the list is
empty.

This commit adds a check to ensure the list is not empty.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>

/cc @kubeflow/wg-notebooks-leads 
/assign @StefanoFioravanzo 