### PR TITLE
CRUD backend: Add volumesnapshot and get_pvc functions

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/__init__.py
@@ -7,5 +7,6 @@ from .pod import *  # noqa F401, F403
 from .poddefault import *  # noqa F401, F403
 from .pvc import *  # noqa F401, F403
 from .secret import *  # noqa F401, F403
+from .snapshot import *  # noqa F401, F403
 from .storageclass import *  # noqa F401, F403
 from .utils import *  # noqa F401, F403

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/__init__.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/__init__.py
@@ -7,6 +7,6 @@ from .pod import *  # noqa F401, F403
 from .poddefault import *  # noqa F401, F403
 from .pvc import *  # noqa F401, F403
 from .secret import *  # noqa F401, F403
-from .snapshot import *  # noqa F401, F403
+from .volumesnapshot import *  # noqa F401, F403
 from .storageclass import *  # noqa F401, F403
 from .utils import *  # noqa F401, F403

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
@@ -2,6 +2,13 @@ from .. import authz
 from . import v1_core
 
 
+def get_pvc(pvc, namespace):
+    authz.ensure_authorized(
+        "get", "", "v1", "persistentvolumeclaims", namespace
+    )
+    return v1_core.read_namespaced_persistent_volume_claim(pvc, namespace)
+
+
 def create_pvc(pvc, namespace):
     authz.ensure_authorized(
         "create", "", "v1", "persistentvolumeclaims", namespace

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/snapshot.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/snapshot.py
@@ -1,0 +1,61 @@
+from kubernetes import client
+
+from .. import authz
+from . import custom_api, v1_core
+
+
+def get_snapshot(snapshot, namespace):
+    authz.ensure_authorized(
+        "get", "snapshot.storage.k8s.io", "v1beta1",
+        "volumesnapshots", namespace
+    )
+    return custom_api.get_namespaced_custom_object(
+        "snapshot.storage.k8s.io", "v1beta1",
+        namespace, "volumesnapshots", snapshot
+    )
+
+
+def create_snapshot(snapshot, namespace):
+    authz.ensure_authorized(
+        "create", "snapshot.storage.k8s.io", "v1beta1",
+        "volumesnapshots", namespace
+    )
+    return custom_api.create_namespaced_custom_object(
+        "snapshot.storage.k8s.io", "v1beta1",
+        namespace, "volumesnapshots", snapshot
+    )
+
+
+def list_snapshots(namespace):
+    authz.ensure_authorized(
+        "list", "snapshot.storage.k8s.io", "v1beta1",
+        "volumesnapshots", namespace
+    )
+    return custom_api.list_namespaced_custom_object(
+        "snapshot.storage.k8s.io", "v1beta1",
+        namespace, "volumesnapshots"
+    )
+
+
+def delete_snapshot(snapshot, namespace):
+    authz.ensure_authorized(
+        "delete", "snapshot.storage.k8s.io", "v1beta1",
+        "volumesnapshots", namespace
+    )
+    return custom_api.delete_namespaced_custom_object(
+        "snapshot.storage.k8s.io",
+        "v1beta1",
+        namespace,
+        "volumesnapshots",
+        snapshot,
+        client.V1DeleteOptions(propagation_policy="Foreground"),
+    )
+
+
+def list_snapshot_events(snapshot, namespace):
+    selector = "involvedObject.kind=VolumeSnapshot,involvedObject.name="
+    + snapshot
+
+    return v1_core.list_namespaced_event(
+        namespace=namespace, field_selector=selector
+    )

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/volumesnapshot.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/volumesnapshot.py
@@ -4,29 +4,29 @@ from .. import authz
 from . import custom_api, v1_core
 
 
-def get_snapshot(snapshot, namespace):
+def get_volumesnapshot(volumesnapshot, namespace):
     authz.ensure_authorized(
         "get", "snapshot.storage.k8s.io", "v1beta1",
         "volumesnapshots", namespace
     )
     return custom_api.get_namespaced_custom_object(
         "snapshot.storage.k8s.io", "v1beta1",
-        namespace, "volumesnapshots", snapshot
+        namespace, "volumesnapshots", volumesnapshot
     )
 
 
-def create_snapshot(snapshot, namespace):
+def create_volumesnapshot(volumesnapshot, namespace):
     authz.ensure_authorized(
         "create", "snapshot.storage.k8s.io", "v1beta1",
         "volumesnapshots", namespace
     )
     return custom_api.create_namespaced_custom_object(
         "snapshot.storage.k8s.io", "v1beta1",
-        namespace, "volumesnapshots", snapshot
+        namespace, "volumesnapshots", volumesnapshot
     )
 
 
-def list_snapshots(namespace):
+def list_volumesnapshots(namespace):
     authz.ensure_authorized(
         "list", "snapshot.storage.k8s.io", "v1beta1",
         "volumesnapshots", namespace
@@ -37,7 +37,7 @@ def list_snapshots(namespace):
     )
 
 
-def delete_snapshot(snapshot, namespace):
+def delete_volumesnapshot(volumesnapshot, namespace):
     authz.ensure_authorized(
         "delete", "snapshot.storage.k8s.io", "v1beta1",
         "volumesnapshots", namespace
@@ -47,14 +47,14 @@ def delete_snapshot(snapshot, namespace):
         "v1beta1",
         namespace,
         "volumesnapshots",
-        snapshot,
+        volumesnapshot,
         client.V1DeleteOptions(propagation_policy="Foreground"),
     )
 
 
-def list_snapshot_events(snapshot, namespace):
+def list_volumesnapshot_events(volumesnapshot, namespace):
     selector = "involvedObject.kind=VolumeSnapshot,involvedObject.name="
-    + snapshot
+    + volumesnapshot
 
     return v1_core.list_namespaced_event(
         namespace=namespace, field_selector=selector


### PR DESCRIPTION
Part of: https://github.com/kubeflow/kubeflow/issues/5523

This PR adds functions for creating volume snapshots to the common backend code for the CRUD web apps. It also adds a function to get an existing PVC.

/cc @kimwnasptd @thesuperzapper @StefanoFioravanzo 