### PR TITLE
notebook-servers: Update JupyterLab and add Git Extension

### DIFF
--- a/components/example-notebook-servers/jupyter/requirements.txt
+++ b/components/example-notebook-servers/jupyter/requirements.txt
@@ -1,2 +1,3 @@
-jupyterlab==3.0.12
+jupyterlab==3.0.14
+jupyterlab-git==0.30.0
 notebook==6.3.0


### PR DESCRIPTION
Closes: https://github.com/kubeflow/kubeflow/issues/5843

This PR updates the JupyterLab packages and adds the JupyterLab-Git extension package to the Jupyter notebook server image. For the JupyterLab-Git extension to work properly it must be installed before running JupyterLab. Given the popularity of this extension (it is mention in the [charter](https://github.com/kubeflow/community/blob/master/wg-notebooks/charter.md#code-web-apps-controllers-and-services) of the working group depending on how you interpret it), it makes sense to install it in the notebook server images.

/cc @thesuperzapper 