### PR TITLE
fix(profile-controller): KNative probes

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -365,6 +365,22 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 					},
 				},
 			},
+			{
+				To: []*istioSecurity.Rule_To{
+					{
+						Operation: &istioSecurity.Operation{
+							// Workloads pathes should be accessible for KNative's
+							// `activator` and `controller` probes
+							// See: https://knative.dev/docs/serving/istio-authorization/#allowing-access-from-system-pods-by-paths
+							Paths: []string{
+								"/healthz",
+								"/metrics",
+								"/wait-for-drain",
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
This PR fixes the KNative's `activator` and `controller` probes on `/healthz`, `/metrics` paths on workloads for KFServing

/assign @yanniszark