### PR TITLE
Make it possible to add Namespaced menu items

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -291,6 +291,18 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         // A temporary workaround is  to use "this.queryParams" as an input
         // instead of "queryParamsChange.base".
         // const queryParams = queryParamsChange.base;
+        const queryParams = this.queryParams;
+        if (queryParams) {
+            if (queryParams["ns"]) {
+                if (queryParams["ns"] !== null){
+                    return this.buildHref(
+                        href.replace('{ns}', queryParams["ns"]),
+                        queryParams
+                    );
+                }
+            }
+        }
+
         return this.buildHref(href, this.queryParams);
     }
 
@@ -345,7 +357,18 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         let matchingLink = '';
         const allLinks = this.menuLinks.map((m) => {
             return m.type === 'section' ? m.items.map((x) => x.link) : m.link;
-        }).flat().sort();
+        }).flat().sort().map((m) => {
+            // replace namespaced menu items
+            const queryParams = this.queryParams
+            if (queryParams) {
+                if (queryParams["ns"]) {
+                    if (queryParams["ns"] !== null){
+                        return m.replace('{ns}', queryParams["ns"]);
+                    }
+                }
+            }
+            return m;
+        });
         if (hashPath) {
             matchPath = path + '#' + hashPath;
             matchingLink = allLinks

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -292,18 +292,11 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         // instead of "queryParamsChange.base".
         // const queryParams = queryParamsChange.base;
         const queryParams = this.queryParams;
-        if (queryParams) {
-            if (queryParams["ns"]) {
-                if (queryParams["ns"] !== null){
-                    return this.buildHref(
-                        href.replace('{ns}', queryParams["ns"]),
-                        queryParams
-                    );
-                }
-            }
+        if (!queryParams || !queryParams["ns"]) {
+            return this.buildHref(href, this.queryParams);
         }
-
-        return this.buildHref(href, this.queryParams);
+        return this.buildHref(href.replace('{ns}', queryParams["ns"]),
+                              queryParams);
     }
 
     /**
@@ -360,14 +353,10 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         }).flat().sort().map((m) => {
             // replace namespaced menu items
             const queryParams = this.queryParams
-            if (queryParams) {
-                if (queryParams["ns"]) {
-                    if (queryParams["ns"] !== null){
-                        return m.replace('{ns}', queryParams["ns"]);
-                    }
-                }
+            if (!queryParams || !queryParams["ns"]) {
+                return m;
             }
-            return m;
+            return m.replace('{ns}', queryParams["ns"]);
         });
         if (hashPath) {
             matchPath = path + '#' + hashPath;

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -46,6 +46,10 @@ const MENU_LINKS = [
         link: '/pipeline/#/runs',
         text: 'Runs',
     },
+    {
+        link: '/myapp/{ns}',
+        text: 'MyApp',
+    }
 ];
 
 describe('Main Page', () => {
@@ -330,4 +334,27 @@ describe('Main Page', () => {
             expect(activeMenuItem.length).toBe(1);
             expect(activeMenuItem[0].parentElement.href).toBe('/katib/trials');
         });
+
+    it('Replace namespace path by current namespace',
+        () => {
+            mainPage.menuLinks = MENU_LINKS;
+            flush();
+            mainPage.set('queryParams.ns', 'test');
+            expect(mainPage._buildHref('/myapp/{ns}', {ns: 'test'})).toBe(
+                   '/myapp/test?ns=test');
+       })
+
+    it('Sets active menu item from namespaced URL',
+        () => {
+            mainPage.menuLinks = MENU_LINKS;
+            flush();
+            mainPage.set('queryParams.ns', 'test');
+            mainPage._setActiveMenuLink('/myapp/test', '');
+            flush();
+            const activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe(
+                   '/myapp/test?ns=test');
+       });
+
 });


### PR DESCRIPTION

Fix
#5863

This PR make it possible to add namespaced items on side bar menu.
The users can define the side bar menu as below.

```
        {
          "type": "item",
          "link": "/pipeline/#/artifacts",
          "text": "Artifacts",
          "icon": "editor:bubble-chart"
        },
        {
          "type": "item",
          "link": "/pipeline/#/executions",
          "text": "Executions",
          "icon": "av:play-arrow"
        },
        {
          "type": "item",
          "link": "/myapp1/{ns}/",
          "text": "MyApp1",
          "icon": "icon"
        },
        {
          "type": "item",
          "link": "/myapp2/{ns}/",
          "text": "MyApp2",
          "icon": "icon"
        },
```

{ns}s are replaced by current namespace. The full URL should be https://gateway/myapp1/workspace1/ (when ns=workspace1) or https://gateway/myapp1/workspace2/ (when ns=workspace2).

This feature help cluster admin to add own apps for each namespace.
