### PR TITLE
FIX The number of gpu must be set as string in Kubernetes/Openshift

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -281,7 +281,7 @@ def set_notebook_gpus(notebook, body, defaults):
         raise BadRequest("gpus.num is not a valid number: %s" % gpus["num"])
 
     limits = container["resources"].get("limits", {})
-    limits[vendor] = str(num)
+    limits[vendor] = num
 
     container["resources"]["limits"] = limits
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -281,7 +281,7 @@ def set_notebook_gpus(notebook, body, defaults):
         raise BadRequest("gpus.num is not a valid number: %s" % gpus["num"])
 
     limits = container["resources"].get("limits", {})
-    limits[vendor] = num
+    limits[vendor] = str(num)
 
     container["resources"]["limits"] = limits
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -123,6 +123,11 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
     if (typeof notebook.cpu === 'number') {
       notebook.cpu = notebook.cpu.toString();
     }
+    
+    // Ensure GPU input is a string
+    if (typeof notebook.gpus.num === 'number') {
+      notebook.gpus.num = notebook.gpus.num.toString();
+    }
 
     // Remove cpuLimit from request if null
     if (notebook.cpuLimit == null) {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -123,7 +123,7 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
     if (typeof notebook.cpu === 'number') {
       notebook.cpu = notebook.cpu.toString();
     }
-    
+
     // Ensure GPU input is a string
     if (typeof notebook.gpus.num === 'number') {
       notebook.gpus.num = notebook.gpus.num.toString();


### PR DESCRIPTION
@DavidSpek 

The following line https://github.com/kubeflow/kubeflow/blob/c3d97bb125fa4b828bfa59cd427d5cba96952ee6/components/crud-web-apps/jupyter/backend/apps/common/form.py#L279
produces nvidia.com/gpu: 1 instead of nvidia.com/gpu: '1' which lets the pod fail with 

```
2021-05-03 11:31:24,011 | apps.default.routes.post | INFO | Creating Notebook: {'apiVersion': 'kubeflow.org/v1beta1', 'kind': 'Notebook', 'metadata': {'name': 'test1', 'namespace': 'admin', 'labels': {'app': 'test1'}, 'annotations': {'notebooks.kubeflow.org/server-type': 'jupyter'}}, 'spec': {'template': {'spec': {'serviceAccountName': 'default-editor', 'containers': [{'name': 'test1', 'image': '...', 'volumeMounts': [{'mountPath': '/dev/shm', 'name': 'dshm'}], 'env': [], 'resources': {'requests': {'cpu': '0.1', 'memory': '0.25Gi'}, 'limits': {'nvidia.com/gpu': 1}}, 'imagePullPolicy': 'IfNotPresent'}], 'volumes': [{'name': 'dshm', 'emptyDir': {'medium': 'Memory'}}], 'tolerations': []}}}}
2021-05-03 11:31:24,022 | kubeflow.kubeflow.crud_backend.errors.handlers | ERROR | An error occured talking to k8s while working on http://.../api/namespaces/admin/notebooks: (422)
Reason: Unprocessable Entity
HTTP response headers: HTTPHeaderDict({'Audit-Id': '4fc9b971-7e73-48b4-9dda-27a756c7871a', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Kubernetes-Pf-Flowschema-Uid': 'e1b1c024-605e-412c-9d64-a8ef267eb67b', 'X-Kubernetes-Pf-Prioritylevel-Uid': '8a864d24-181a-44a6-9ce6-f003c50e5952', 'Date': 'Mon, 03 May 2021 11:31:24 GMT', 'Content-Length': '680'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Notebook.kubeflow.org \"test1\" is invalid: spec.template.spec.containers.resources.limits.nvidia.com/gpu: Invalid value: \"integer\": spec.template.spec.containers.resources.limits.nvidia.com/gpu in body must be of type string: \"integer\"","reason":"Invalid","details":{"name":"test1","group":"kubeflow.org","kind":"Notebook","causes":[{"reason":"FieldValueInvalid","message":"Invalid value: \"integer\": spec.template.spec.containers.resources.limits.nvidia.com/gpu in body must be of type string: \"integer\"","field":"spec.template.spec.containers.resources.limits.nvidia.com/gpu"}]},"code":422}
``` 
on openshift 4.7 (kubernetes 1.20) with the GPU operator installed

I would prefer a backport to 1.3.