### PR TITLE
CI/CD: add kustomize build tests

### DIFF
--- a/py/kubeflow/kubeflow/ci/admission_webhook_tests.py
+++ b/py/kubeflow/kubeflow/ci/admission_webhook_tests.py
@@ -9,10 +9,29 @@ class Builder(workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
+    def _kustomize_build_task(self, task_template):
+        k_build = argo_build_util.deep_copy(task_template)
+
+        k_build["name"] = "kustomize-build-test"
+        k_build["container"]["image"] = "k8s.gcr.io/kustomize/kustomize:v4.1.2"
+        k_build["container"]["args"] = ["build"]
+
+        manifest_dir = ("%s/components/admission-webhook/manifests/"
+                        "overlays/cert-manager/") % self.src_dir
+        k_build["container"]["workingDir"] = manifest_dir
+
+        return k_build
+
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
         task_template = self.build_task_template()
+
+        # build manifests with kustomize
+        kustomize_build_task = self._kustomize_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        kustomize_build_task,
+                                        [self.mkdir_task_name])
 
         # Test building Admission Webhook image using Kaniko
         dockerfile = ("%s/components/admission-webhook"
@@ -21,7 +40,8 @@ class Builder(workflow_utils.ArgoTestBuilder):
         destination = "admission-webhook-test"
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
-                                              context, destination, no_push=True)
+                                              context, destination,
+                                              no_push=True)
         argo_build_util.add_task_to_dag(workflow,
                                         workflow_utils.E2E_DAG_NAME,
                                         kaniko_task, [self.mkdir_task_name])

--- a/py/kubeflow/kubeflow/ci/jwa_tests.py
+++ b/py/kubeflow/kubeflow/ci/jwa_tests.py
@@ -9,18 +9,36 @@ class Builder(workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
+    def _kustomize_build_task(self, task_template):
+        k_build = argo_build_util.deep_copy(task_template)
+
+        k_build["name"] = "kustomize-build-test"
+        k_build["container"]["image"] = "k8s.gcr.io/kustomize/kustomize:v4.1.2"
+        k_build["container"]["args"] = ["build"]
+
+        manifest_dir = ("%s/components/crud-web-apps/jupyter/manifests/"
+                        "overlays/istio/") % self.src_dir
+        k_build["container"]["workingDir"] = manifest_dir
+
+        return k_build
+
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
         task_template = self.build_task_template()
         app_dir = "%s/components/crud-web-apps/jupyter" % self.src_dir
 
+        # build manifests with kustomize
+        kustomize_build_task = self._kustomize_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        kustomize_build_task,
+                                        [self.mkdir_task_name])
+
         # Test build JWA image using Kaniko
         dockerfile = "%s/Dockerfile" % app_dir
         context = "dir://%s/components/crud-web-apps" % self.src_dir
         destination = "jwa-test"
 
-        # check that the image can be build
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
                                               context, destination,
                                               no_push=True)

--- a/py/kubeflow/kubeflow/ci/notebook_controller_tests.py
+++ b/py/kubeflow/kubeflow/ci/notebook_controller_tests.py
@@ -9,10 +9,29 @@ class Builder(workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
+    def _kustomize_build_task(self, task_template):
+        k_build = argo_build_util.deep_copy(task_template)
+
+        k_build["name"] = "kustomize-build-test"
+        k_build["container"]["image"] = "k8s.gcr.io/kustomize/kustomize:v4.1.2"
+        k_build["container"]["args"] = ["build"]
+
+        manifest_dir = ("%s/components/notebook-controller/config/"
+                        "overlays/kubeflow/") % self.src_dir
+        k_build["container"]["workingDir"] = manifest_dir
+
+        return k_build
+
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
         task_template = self.build_task_template()
+
+        # build manifests with kustomize
+        kustomize_build_task = self._kustomize_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        kustomize_build_task,
+                                        [self.mkdir_task_name])
 
         # Test building Notebook Controller image using Kaniko
         dockerfile = ("%s/components/notebook-controller"
@@ -21,7 +40,8 @@ class Builder(workflow_utils.ArgoTestBuilder):
         destination = "notebok-controller-test"
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
-                                              context, destination, no_push=True)
+                                              context, destination,
+                                              no_push=True)
         argo_build_util.add_task_to_dag(workflow,
                                         workflow_utils.E2E_DAG_NAME,
                                         kaniko_task, [self.mkdir_task_name])

--- a/py/kubeflow/kubeflow/ci/profile_controller_tests.py
+++ b/py/kubeflow/kubeflow/ci/profile_controller_tests.py
@@ -9,10 +9,29 @@ class Builder(workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
+    def _kustomize_build_task(self, task_template):
+        k_build = argo_build_util.deep_copy(task_template)
+
+        k_build["name"] = "kustomize-build-test"
+        k_build["container"]["image"] = "k8s.gcr.io/kustomize/kustomize:v4.1.2"
+        k_build["container"]["args"] = ["build"]
+
+        manifest_dir = ("%s/components/profile-controller/config/"
+                        "overlays/kubeflow/") % self.src_dir
+        k_build["container"]["workingDir"] = manifest_dir
+
+        return k_build
+
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
         task_template = self.build_task_template()
+
+        # build manifests with kustomize
+        kustomize_build_task = self._kustomize_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        kustomize_build_task,
+                                        [self.mkdir_task_name])
 
         # Test building Profile Controller image using Kaniko
         dockerfile = ("%s/components/profile-controller"
@@ -21,7 +40,8 @@ class Builder(workflow_utils.ArgoTestBuilder):
         destination = "profile-controller-test"
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
-                                              context, destination, no_push=True)
+                                              context, destination,
+                                              no_push=True)
         argo_build_util.add_task_to_dag(workflow,
                                         workflow_utils.E2E_DAG_NAME,
                                         kaniko_task, [self.mkdir_task_name])

--- a/py/kubeflow/kubeflow/ci/tensorboard_controller_tests.py
+++ b/py/kubeflow/kubeflow/ci/tensorboard_controller_tests.py
@@ -9,10 +9,29 @@ class Builder(workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
+    def _kustomize_build_task(self, task_template):
+        k_build = argo_build_util.deep_copy(task_template)
+
+        k_build["name"] = "kustomize-build-test"
+        k_build["container"]["image"] = "k8s.gcr.io/kustomize/kustomize:v4.1.2"
+        k_build["container"]["args"] = ["build"]
+
+        manifest_dir = ("%s/components/tensorboard-controller/config/"
+                        "overlays/kubeflow/") % self.src_dir
+        k_build["container"]["workingDir"] = manifest_dir
+
+        return k_build
+
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
         task_template = self.build_task_template()
+
+        # build manifests with kustomize
+        kustomize_build_task = self._kustomize_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        kustomize_build_task,
+                                        [self.mkdir_task_name])
 
         # Test building Tensorboard Controller image using Kaniko
         dockerfile = ("%s/components/tensorboard-controller"
@@ -21,7 +40,8 @@ class Builder(workflow_utils.ArgoTestBuilder):
         destination = "tensorboard-controller-test"
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
-                                              context, destination, no_push=True)
+                                              context, destination,
+                                              no_push=True)
         argo_build_util.add_task_to_dag(workflow,
                                         workflow_utils.E2E_DAG_NAME,
                                         kaniko_task, [self.mkdir_task_name])

--- a/py/kubeflow/kubeflow/ci/twa_tests.py
+++ b/py/kubeflow/kubeflow/ci/twa_tests.py
@@ -9,10 +9,29 @@ class Builder(workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
+    def _kustomize_build_task(self, task_template):
+        k_build = argo_build_util.deep_copy(task_template)
+
+        k_build["name"] = "kustomize-build-test"
+        k_build["container"]["image"] = "k8s.gcr.io/kustomize/kustomize:v4.1.2"
+        k_build["container"]["args"] = ["build"]
+
+        manifest_dir = ("%s/components/crud-web-apps/tensorboards/manifests/"
+                        "overlays/istio/") % self.src_dir
+        k_build["container"]["workingDir"] = manifest_dir
+
+        return k_build
+
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
         task_template = self.build_task_template()
+
+        # build manifests with kustomize
+        kustomize_build_task = self._kustomize_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        kustomize_build_task,
+                                        [self.mkdir_task_name])
 
         # Test building TWA image using Kaniko
         dockerfile = ("%s/components/crud-web-apps"
@@ -21,7 +40,8 @@ class Builder(workflow_utils.ArgoTestBuilder):
         destination = "twa-test"
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
-                                              context, destination, no_push=True)
+                                              context, destination,
+                                              no_push=True)
         argo_build_util.add_task_to_dag(workflow,
                                         workflow_utils.E2E_DAG_NAME,
                                         kaniko_task, [self.mkdir_task_name])

--- a/py/kubeflow/kubeflow/ci/vwa_tests.py
+++ b/py/kubeflow/kubeflow/ci/vwa_tests.py
@@ -9,10 +9,29 @@ class Builder(workflow_utils.ArgoTestBuilder):
         super().__init__(name=name, namespace=namespace, bucket=bucket,
                          test_target_name=test_target_name, **kwargs)
 
+    def _kustomize_build_task(self, task_template):
+        k_build = argo_build_util.deep_copy(task_template)
+
+        k_build["name"] = "kustomize-build-test"
+        k_build["container"]["image"] = "k8s.gcr.io/kustomize/kustomize:v4.1.2"
+        k_build["container"]["args"] = ["build"]
+
+        manifest_dir = ("%s/components/crud-web-apps/volumes/manifests/"
+                        "overlays/istio/") % self.src_dir
+        k_build["container"]["workingDir"] = manifest_dir
+
+        return k_build
+
     def build(self):
         """Build the Argo workflow graph"""
         workflow = self.build_init_workflow(exit_dag=False)
         task_template = self.build_task_template()
+
+        # build manifests with kustomize
+        kustomize_build_task = self._kustomize_build_task(task_template)
+        argo_build_util.add_task_to_dag(workflow, workflow_utils.E2E_DAG_NAME,
+                                        kustomize_build_task,
+                                        [self.mkdir_task_name])
 
         # Test building VWA image using Kaniko
         dockerfile = ("%s/components/crud-web-apps"
@@ -21,7 +40,8 @@ class Builder(workflow_utils.ArgoTestBuilder):
         destination = "vwa-test"
 
         kaniko_task = self.create_kaniko_task(task_template, dockerfile,
-                                              context, destination, no_push=True)
+                                              context, destination,
+                                              no_push=True)
         argo_build_util.add_task_to_dag(workflow,
                                         workflow_utils.E2E_DAG_NAME,
                                         kaniko_task, [self.mkdir_task_name])


### PR DESCRIPTION
This PR adds CI tests to build the manifests with `kustomize build`. 

/cc @thesuperzapper