### PR TITLE
Notebook servers: Add explanation about kernel not connecting

### DIFF
--- a/components/example-notebook-servers/README.md
+++ b/components/example-notebook-servers/README.md
@@ -1,9 +1,9 @@
+# Example Notebook Servers
+
 > 🛑️️ These server images are provided as __examples only__ and are supported on a best-effort basis.
 > Contributions are greatly appreciated.
 
-# Example Notebook Servers
-
-## Overview:
+## Overview
 
 In this folder, we have tried to make an extendable image structure which you can easily augment with additional tools and packages.
 
@@ -23,25 +23,35 @@ __Important points about the images:__
 - they make use of the [s6-overlay](https://github.com/just-containers/s6-overlay) init system
 - they all run as the non-root `jovyan` user
 
+## Common problems and solutions
+
+### The kernel fails to connect or gets stuck in `connecting` state
+
+This is a problem that occurs from time to time and is not
+a Kubeflow problem, but rather a browser. It can be identified
+by looking in the browser error console, which will show errors
+regarding the websocket not connecting. To solve the problem,
+please restart your browser or try using a different browser.
+
 ## How do I extend these images?
 
 > ⚠️ any changes made by users __after spawning__ a Kubeflow notebook will only last the lifetime of the pod, unless they are installed into a PVC-backed directory
 
-### Adding conda/pip packages:
+### Adding conda/pip packages
 
-Extend one of the base images and install any `pip` or `conda` packages your Kubeflow Notebook users are likely to need. 
+Extend one of the base images and install any `pip` or `conda` packages your Kubeflow Notebook users are likely to need.
 
 As a guide, look at [jupyter-pytorch-full.cpu](./jupyter-pytorch-full/cpu.Dockerfile) for a `pip install ...` example, and the [rstudio-tidyverse](./rstudio-tidyverse/Dockerfile) for `conda install ...`.
 
 __WARNING:__ a common cause of errors is users running `pip install --user ...`, causing the home-directory (which is backed by a PVC) to contain a different or incompatible version of a package contained in  `/opt/conda/...`
 
-### Adding apt-get packages:
+### Adding apt-get packages
 
 Extend one of the base images and install any `apt-get` packages your Kubeflow Notebook users are likely to need.
 
 __WARNING:__ ensure you swap to `root` in the Dockerfile before running `apt-get`, and swap back to `jovyan` after.
 
-### Adding container startup scripts:
+### Adding container startup scripts
 
 Some use-cases might require custom scripts to run during the startup of the Notebook Server container, or advanced users might want to add additional services that run inside the container (for example, an Apache or NGINX web server).
 To make this easy, we use the [s6-overlay](https://github.com/just-containers/s6-overlay).
@@ -59,7 +69,7 @@ The purpose of this script is to snapshot any `KUBERNETES_*` environment variabl
 
 __Custom service scripts:__
 
-Extra services to be monitored by `s6-overlay` should be placed in their own folder under `/etc/services.d/` containing a script called `run` and optionally a finishing script `finish`. 
+Extra services to be monitored by `s6-overlay` should be placed in their own folder under `/etc/services.d/` containing a script called `run` and optionally a finishing script `finish`.
 
 An example of a service can be found in [jupyter/s6/services.d/jupyterlab](jupyter/s6/services.d/jupyterlab) which is used to start JupyterLab itself.
 For more information about the `run` and `finish` scripts, please see the [s6-overlay documentation](https://github.com/just-containers/s6-overlay#writing-a-service-script).


### PR DESCRIPTION
Closes: https://github.com/kubeflow/kubeflow/issues/5904

There is a common but sporadic problem where the kernel in JupyterLab is stuck in a `connecting` state (see https://github.com/kubeflow/kubeflow/issues/5904). This problem is not related to Kubeflow, but rather originates in the user's browser. It can be identified by looking in the browser logs in the developer tools where there will be errors related to problems connecting to the websocket. The fix for this is restarting the browser (refreshing usually doesn't work) or (temporarily) using a different browser if the current one cannot be restarted. This PR adds a common problems and solutions sections to the notebook image README that explains this issue and the solution.

/cc @thesuperzapper 