### PR TITLE
tensorboard-controller: fix binding issue

### DIFF
--- a/components/tensorboard-controller/config/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml
+++ b/components/tensorboard-controller/config/crd/bases/tensorboard.kubeflow.org_tensorboards.yaml
@@ -3,6 +3,8 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
   creationTimestamp: null
   name: tensorboards.tensorboard.kubeflow.org
 spec:
@@ -12,7 +14,7 @@ spec:
     listKind: TensorboardList
     plural: tensorboards
     singular: tensorboard
-  scope: ""
+  scope: Namespaced
   subresources:
     status: {}
   validation:

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -255,6 +255,7 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 							WorkingDir:      "/",
 							Args: []string{
 								"--logdir=" + mountpath,
+								"--bind_all",
 							},
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
Part of https://github.com/kubeflow/kubeflow/issues/5938

This PR adds the `--bind_all` argument for tensorboard, solving the problem described in the issue mentioned above, as well as fixing support for Istio 1.10.

/cc @kubeflow/wg-notebooks-leads 