### PR TITLE
Add support for ServiceAccountName and AutomountServiceAccountName to admission-webhook

### DIFF
--- a/components/admission-webhook/main.go
+++ b/components/admission-webhook/main.go
@@ -392,6 +392,12 @@ func applyPodDefaultsOnPod(pod *corev1.Pod, podDefaults []*settingsapi.PodDefaul
 	for i, pd := range podDefaults {
 		defaultAnnotations[i] = &pd.Spec.Annotations
 		defaultLabels[i] = &pd.Spec.Labels
+		if pd.Spec.AutomountServiceAccountToken != nil {
+			pod.Spec.AutomountServiceAccountToken = pd.Spec.AutomountServiceAccountToken
+		}
+		if pd.Spec.ServiceAccountName != "" {
+			pod.Spec.ServiceAccountName = pd.Spec.ServiceAccountName
+		}
 	}
 	annotations, err := mergeMap(pod.Annotations, defaultAnnotations)
 	if err != nil {

--- a/components/admission-webhook/main_test.go
+++ b/components/admission-webhook/main_test.go
@@ -72,6 +72,11 @@ func TestMergeMapGood(t *testing.T) {
 	}
 }
 
+func newTrue() *bool {
+	b := true
+	return &b
+}
+
 func TestApplyPodDefaultsOnPod(t *testing.T) {
 	for _, test := range []struct {
 		name        string
@@ -90,6 +95,8 @@ func TestApplyPodDefaultsOnPod(t *testing.T) {
 				{
 					Spec: settingsapi.PodDefaultSpec{
 						Annotations: map[string]string{"baz": "bux"},
+						ServiceAccountName: "some-service-account",
+						AutomountServiceAccountToken: newTrue(),
 					},
 				},
 			},
@@ -101,6 +108,10 @@ func TestApplyPodDefaultsOnPod(t *testing.T) {
 						"poddefault.admission.kubeflow.org/poddefault-": "",
 					},
 					Labels: map[string]string{},
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName: "some-service-account",
+					AutomountServiceAccountToken: newTrue(),
 				},
 			},
 		}, {

--- a/components/admission-webhook/manifests/base/crd.yaml
+++ b/components/admission-webhook/manifests/base/crd.yaml
@@ -25,6 +25,8 @@ spec:
               type: string
             serviceAccountName:
               type: string
+            automountServiceAccountToken:
+              type: boolean
             env:
               items:
                 type: object

--- a/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
+++ b/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
@@ -38,6 +38,14 @@ type PodDefaultSpec struct {
 	// +optional
 	Desc string `json:"desc,omitempty"`
 
+	// ServiceAccountName defines the service account to attach to the pod.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// AutomountServiceAccountToken defines whether or not the service account access token should automatically be mounted to the pod.
+	// +optional
+	AutomountServiceAccountToken *bool `json:"automountServiceAccountToken,omitempty"`
+
 	// Env defines the collection of EnvVar to inject into containers.
 	// +optional
 	Env []v1.EnvVar `json:"env,omitempty"`


### PR DESCRIPTION
The admission-webhook CRD appears to define support for the `serviceAccountName`, however, the code didn't actually read it. I've added support for both `serviceAccountName` and `automountServiceAccountToken` fields since my organization needs those.

Also, this is the first contribution from Signifyd, Inc. We should have a CLA on file as of about a week ago.