### PR TITLE
[fix]: Make jupyter-web-app parse workspace volume MountPath

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -48,7 +48,7 @@ def post_pvc(namespace):
             notebook,
             workspace_vol["name"],
             workspace_vol["name"],
-            workspace_vol["path"],
+            workspace_vol["templatedPath"],
         )
 
     # Add the Data Volumes

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -48,7 +48,7 @@ def post_pvc(namespace):
             notebook,
             workspace_vol["name"],
             workspace_vol["name"],
-            "/home/jovyan",
+            workspace_vol["path"],
         )
 
     # Add the Data Volumes


### PR DESCRIPTION
## BUG

At jupyter-web-app's backend's source code, workspace volume path was fixed with "/home/jovyan"

Thus, when I changed my jupyter-web-app-config's data (mountPath) to "/home/jovyan/workspace":
![image](https://user-images.githubusercontent.com/37469330/120170737-3ea8ac80-c23c-11eb-931a-b523b43153da.png)


Thus, the UI (jupyter-web-app's frontend) shows the mountPath correctly like:
![image](https://user-images.githubusercontent.com/37469330/120170412-e5407d80-c23b-11eb-8960-1643f8feb5c8.png)

Also, the POST /notebook API was sent with correct path like:
![image](https://user-images.githubusercontent.com/37469330/120170544-0903c380-c23c-11eb-8140-c7e3827883df.png)

However, spawned notebook's mountPath was fixed with "/home/jovyan":
![image](https://user-images.githubusercontent.com/37469330/120171412-fc339f80-c23c-11eb-96c1-5d0e7f4be7d5.png)

Thus, corresponding statefulset and pod's mountPath was all fixed with "/home/jovyan"

---

## What this PR do

As you can see easily, workspace volume path was fixed with "/home/jovyan" at jupyter-web-app's backend's source code.
So, change it to parse from config file

---

## My image tag :
- public.ecr.aws/j1r0q0g6/notebooks/jupyter-web-app:v1.3.0-rc.1