### PR TITLE
Make menu bar scrollable again

### DIFF
--- a/components/centraldashboard/public/components/main-page.css
+++ b/components/centraldashboard/public/components/main-page.css
@@ -22,6 +22,11 @@
     flex: 1
 }
 
+.scrollable {
+    height: 100%;
+    overflow: auto;
+}
+
 #MainDrawer {
     color: white;
     --app-drawer-content-container: {

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -16,7 +16,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
     app-drawer#MainDrawer(slot='drawer')
         figure.logo
             |!{logo}
-        div.flex
+        div.flex.scrollable
             a(href$='[[_buildHref("/", queryParams.*)]]', tabindex='-1')
                 paper-item.menu-item#home
                     iron-icon(icon='home')


### PR DESCRIPTION
Fix
#5963 

This PR makes it possible to scroll the menu bar.
It was available in KF1.2 but it is **not** available in KF1.3. That's why the title of this PR is `Make menu bar scrollable again`.

As an attached image, the laptop users will be able to scroll the side bar.
![scrollable](https://user-images.githubusercontent.com/10993535/120666404-85f69d80-c4c7-11eb-8b59-e66071bb52ea.png)

The style of scroll bar is suitable to kubeflow UI enough.

ref) This tip is written in official document of PolymerElements.<br>https://github.com/PolymerElements/app-layout/tree/master/app-drawer
```
To make the contents of the drawer scrollable, create a wrapper for the scroll content, and apply height and overflow styles to it.
  <app-drawer>
    <div style="height: 100%; overflow: auto;"></div>
  </app-drawer>
```