### PR TITLE
use DeepEqual to comapre ContainerState

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -219,7 +220,8 @@ func (r *NotebookReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 				if pod.Status.ContainerStatuses[i].Name != instance.Name {
 					continue
 				}
-				if pod.Status.ContainerStatuses[i].State == instance.Status.ContainerState {
+				if reflect.DeepEqual(pod.Status.ContainerStatuses[i].State, instance.Status.ContainerState) {
+					notebookContainerFound = true
 					continue
 				}
 


### PR DESCRIPTION
`ContainerState` in `pod.Status.ContainerStatuses[i].State == instance.Status.ContainerState` contains pointer, == will always be false. Change to deepcopy to compare value.