### PR TITLE
fix(notebooks) make culling work with multi-user (#5128)

### DIFF
--- a/components/notebook-controller/config/manager/manager.yaml
+++ b/components/notebook-controller/config/manager/manager.yaml
@@ -15,8 +15,6 @@ spec:
       labels:
         app: notebook-controller
         kustomize.component: notebook-controller
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: manager

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -381,6 +381,24 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 					},
 				},
 			},
+			{
+				// allow the notebook-controller in the kubeflow namespace to access the api/status endpoint of the notebook servers.
+				From: []*istioSecurity.Rule_From{
+					{
+						Source: &istioSecurity.Source{
+							Principals: []string{"cluster.local/ns/kubeflow/sa/notebook-controller-service-account"},
+						},
+					},
+				},
+				To: []*istioSecurity.Rule_To{
+					{
+						Operation: &istioSecurity.Operation{
+							Methods: []string{"GET"},
+							Paths:   []string{"*/api/status"}, // wildcard for the name of the notebook server
+						},
+					},
+				},
+			},
 		},
 	}
 }


### PR DESCRIPTION
Hi 

This fixed #5128 according to the guidelines of this comment: https://github.com/kubeflow/kubeflow/issues/5128#issuecomment-859814573 . I wasn't sure where to place the `AuthorizationPolicy`, I think it belongs in the `overlays/kubeflow` directory, as istio is only used in combination with kubeflow. In addition it needs to be created in the `istio-system` namespace and not in the `kubeflow` namespace. Therefore I separated the manifests in `overlays/kubeflow` into a `kubebflow/` and `istio-sytem/` directory, representing the namespaces of the manifests in both directories. Of course, please let me know if you have any better location/setup for this file.

Looking forward to your feedback!