### PR TITLE
Create OWNERS file in .github folder for Renovate config + workflows

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,0 +1,7 @@
+approvers:
+  - DavidSpek
+  - elikatsis
+  - kimwnasptd
+  - StefanoFioravanzo
+  - thesuperzapper
+  - yanniszark


### PR DESCRIPTION
This PR adds an OWNERS file to the `.github` folder so that admins don't need to be bothered with merging PRs related to updating the Renovate configuration or other workflows (such as GitHub actions).

/cc @kubeflow/wg-notebooks-leads @Bobgy 