### PR TITLE
Interact with the namespace selector

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -291,11 +291,9 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         // update namespaced menu item when namespace is changed
         // by namespace selector
         if (this.namespacedItemTemplete &&
-            this.namespacedItemTemplete.includes('{ns}') &&
-            this.queryParams && this.queryParams["ns"]) {
+            this.namespacedItemTemplete.includes('{ns}')) {
             this.set('subRouteData.path',
-                this.namespacedItemTemplete.replace(
-                '{ns}', this.queryParams["ns"]))
+                this.namespacedItemTemplete.replace('{ns}', namespace))
         }
     }
 

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -106,6 +106,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
                 // eslint-disable-next-line max-len
                 computed: 'computeShouldFetchEnv(registrationFlow, workgroupStatusHasLoaded)',
             },
+            matchingIndex: Number,
             namespacedItemTemplete: String,
         };
     }
@@ -371,26 +372,25 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             }
             return m.replace('{ns}', queryParams["ns"]);
         });
-        let matchingIndex = 0
         if (hashPath) {
             matchPath = path + '#' + hashPath;
-            matchingIndex = allLinks
+            this.matchingIndex = allLinks
                 .findIndex((l) => this.compareLinks(l, matchPath));
         } else {
             allLinks.forEach((link, index) => {
                 if (path.startsWith(link)) {
-                    matchingIndex = index
+                    this.matchingIndex = index
                 }
             });
         }
-        matchingLink = allLinks[matchingIndex]
+        matchingLink = allLinks[this.matchingIndex]
 
         // find the HTML element that references the active link
         const activeMenuEl = Array.from(htmlElements).find(
             (x) => this.compareLinks(x.parentElement.href, matchingLink));
         if (activeMenuEl) {
             // in case the item is a section item, open its section
-            this.namespacedItemTemplete = allLinksTemplete[matchingIndex]
+            this.namespacedItemTemplete = allLinksTemplete[this.matchingIndex]
             activeMenuEl.parentElement.parentElement.opened = true;
             activeMenuEl.classList.add('iron-selected');
         }

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -357,4 +357,26 @@ describe('Main Page', () => {
                    '/myapp/test?ns=test');
        });
 
+    it('Update namespaced item along with namespace selection',
+        () => {
+            mainPage.menuLinks = MENU_LINKS;
+            flush();
+            mainPage.set('queryParams.ns', 'test');
+            mainPage.subRouteData.path = '/myapp/test/';
+            mainPage._routePageChanged('_', '/myapp/test/');
+            flush();
+            let activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe(
+                   '/myapp/test?ns=test');
+            expect(mainPage.subRouteData.path).toBe('/myapp/test/');
+
+            mainPage.set('queryParams.ns', 'other-namespace');
+            activeMenuItem = getSelectedMenuItem();
+            expect(activeMenuItem.length).toBe(1);
+            expect(activeMenuItem[0].parentElement.href).toBe(
+                   '/myapp/other-namespace?ns=other-namespace');
+            expect(mainPage.subRouteData.path).toBe('/myapp/other-namespace');
+        });
 });
+


### PR DESCRIPTION
Fix
#5994 

This PR enables namespaced menu items to interact with the namespace selector.
It means the URL of namespaced menu items will follow the selection of namespace selector.

The feature of namespaced menu items is merged by #5871, and described in [here](https://www.kubeflow.org/docs/components/central-dash/customizing-menu/) .

When the user chooses namespace=workspace1, the URL well be `https://gateway/_/mlflow/workspace1/?ns=workspace1`. If he chooses namespace=workspace2 later, the URL will change into `https://gateway/_/mlflow/workspace2/?ns=workspace2` dynamically.

/cc @kimwnasptd @DavidSpek 