### PR TITLE
Update last batch of notebook server Dockerfiles

### DIFF
--- a/components/example-notebook-servers/jupyter-pytorch-full/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-full/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch:master-3dbc352f
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch:master-c7ed4a32
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-full/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-full/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda:master-3dbc352f
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-pytorch-cuda:master-c7ed4a32
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-pytorch-full/requirements.txt
@@ -1,22 +1,23 @@
 # kubeflow packages
-kfp==1.0.4
-kfp-server-api==1.0.4
-kfserving==0.4.1
+kfp==1.6.3
+kfp-server-api==1.6.0
+kfserving==0.5.1
 
 # common packages
-bokeh==2.3.1
+bokeh==2.3.2
 cloudpickle==1.6.0
-dill==0.3.3
+dill==0.3.4
 ipympl==0.7.0
 ipywidgets==7.6.3
-matplotlib==3.4.1
-pandas==1.2.3
+jupyterlab-git==0.30.1
+matplotlib==3.4.2
+pandas==1.2.4
 scikit-image==0.18.1
-scikit-learn==0.24.1
-scipy==1.6.2
+scikit-learn==0.24.2
+scipy==1.7.0
 seaborn==0.11.1
-xgboost==1.3.3
+xgboost==1.4.2
 
 # pytorch packages
 #torchelastic==0.2.2 this currently causes a dependency conflict, should be fixed very soon
-fastai==2.3.0
+fastai==2.4

--- a/components/example-notebook-servers/jupyter-scipy/requirements.txt
+++ b/components/example-notebook-servers/jupyter-scipy/requirements.txt
@@ -10,11 +10,12 @@ bokeh==2.3.2
 #Bottleneck==1.3.2 Could not build wheels for Bottleneck which use PEP 517 and cannot be installed directly
 cloudpickle==1.6.0
 cython==0.29.23
-dask==2021.6.0
+dask==2021.6.1
 dill==0.3.4
 h5py==3.2.1
 ipympl==0.7.0
 ipywidgets==7.6.3
+jupyterlab-git==0.30.1
 matplotlib==3.4.2
 numba==0.53.1
 numexpr==2.7.3
@@ -23,7 +24,7 @@ patsy==0.5.1
 protobuf==3.17.3
 scikit-image==0.18.1
 scikit-learn==0.24.2
-scipy==1.6.3
+scipy==1.7.0
 seaborn==0.11.1
 SQLAlchemy==1.4.18
 statsmodels==0.12.2

--- a/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/cpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow:master-3dbc352f
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow:master-e9324d39
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/cuda.Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda:master-3dbc352f
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter-tensorflow-cuda:master-e9324d39
 
 # install - requirements.txt
 COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
@@ -1,21 +1,22 @@
 # kubeflow packages
-kfp==1.0.4
-kfp-server-api==1.0.4
-kfserving==0.4.1
+kfp==1.6.3
+kfp-server-api==1.6.0
+kfserving==0.5.1
 
 # common packages
-bokeh==2.3.1
+bokeh==2.3.2
 cloudpickle==1.6.0
-dill==0.3.3
+dill==0.3.4
 ipympl==0.7.0
 ipywidgets==7.6.3
-matplotlib==3.4.1
-pandas==1.2.3
+jupyterlab-git==0.30.1
+matplotlib==3.4.2
+pandas==1.2.4
 scikit-image==0.18.1
-scikit-learn==0.24.1
-scipy==1.6.2
+scikit-learn==0.24.2
+scipy==1.7.0
 seaborn==0.11.1
-xgboost==1.3.3
+xgboost==1.4.2
 
 # tensorflow packages
 keras==2.4.3


### PR DESCRIPTION
This is the last PR to update the notebook server dockerfiles so they include the latest packages. After this PR, the `spawner_ui_config.yaml` needs updating so the new images are included for the upcoming 1.3.1 release of Kubeflow.

/cc @kubeflow/wg-notebooks-leads 