### PR TITLE
profile-controller: Limit access to serving paths to KNative sa

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -450,6 +450,15 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 				},
 			},
 			{
+				From: []*istioSecurity.Rule_From{
+					{
+						Source: &istioSecurity.Source{
+							Principals: []string{
+								"cluster.local/ns/knative-serving/sa/controller",
+							},
+						},
+					},
+				},
 				To: []*istioSecurity.Rule_To{
 					{
 						Operation: &istioSecurity.Operation{
@@ -459,7 +468,9 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 							Paths: []string{
 								"/healthz",
 								"/metrics",
+								"/ready",
 								"/wait-for-drain",
+								"/v1/models/*",
 							},
 						},
 					},

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -450,15 +450,6 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 				},
 			},
 			{
-				From: []*istioSecurity.Rule_From{
-					{
-						Source: &istioSecurity.Source{
-							Principals: []string{
-								"cluster.local/ns/knative-serving/sa/controller",
-							},
-						},
-					},
-				},
 				To: []*istioSecurity.Rule_To{
 					{
 						Operation: &istioSecurity.Operation{
@@ -473,6 +464,13 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 								"/v1/models/*",
 							},
 						},
+					},
+				},
+				When: []*istioSecurity.Condition{
+					{
+						// Allow access to above paths from the knative-serving namespace
+						Key:    fmt.Sprintf("source.namespace"),
+						Values: []string{"knative-serving"},
 					},
 				},
 			},


### PR DESCRIPTION
In https://github.com/kubeflow/kubeflow/pull/5848 the profile controller was updated to allow access to paths in user namespaces that KNative requires for launching workloads. However, the implementation allows all access to the `/healthz`, /metrics` and ``/wait-for-drain` paths in a user's namespace. This means that a user can get data from these (commonly used) paths from all other user namespaces, breaking multi-user isolation. This PR fixes this by only allowing the service account used by KNative access to these paths in user namespaces. It also adds 2 more paths, `/ready` which is used by KNative, and `/v1/models/*` which is used by KFServing as outlined in [this comment](https://github.com/kubeflow/kfserving/issues/1558#issuecomment-833271258).

/cc @kubeflow/wg-notebooks-leads @yanniszark @kubeflow/wg-serving-leads 