### PR TITLE
WA: Use relative paths for fetching translation files

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/app.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/app.module.ts
@@ -37,5 +37,5 @@ import { HttpClientModule, HttpClient } from '@angular/common/http';
 export class AppModule {}
 
 export function createTranslateLoader(http: HttpClient) {
-  return new TranslateHttpLoader(http, '../static/assets/i18n/', '.json');
+  return new TranslateHttpLoader(http, 'static/assets/i18n/', '.json');
 }

--- a/components/crud-web-apps/tensorboards/frontend/src/app/app.module.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/app.module.ts
@@ -59,5 +59,5 @@ import { HttpClientModule, HttpClient } from '@angular/common/http';
 export class AppModule {}
 
 export function createTranslateLoader(http: HttpClient) {
-  return new TranslateHttpLoader(http, '../static/assets/i18n/', '.json');
+  return new TranslateHttpLoader(http, 'static/assets/i18n/', '.json');
 }

--- a/components/crud-web-apps/volumes/frontend/src/app/app.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/app.module.ts
@@ -62,5 +62,5 @@ import { HttpClientModule, HttpClient } from '@angular/common/http';
 export class AppModule {}
 
 export function createTranslateLoader(http: HttpClient) {
-  return new TranslateHttpLoader(http, '../static/assets/i18n/', '.json');
+  return new TranslateHttpLoader(http, 'static/assets/i18n/', '.json');
 }


### PR DESCRIPTION
fixes #6033 

The web apps should use the relative path `static/assets/il8n/` to fetch the translation files. This way the browser will construct the correct path, by using the `<base href="...">` element, even if the app lives under a prefix.

/cc @tasos-ale 
/assign @StefanoFioravanzo 