### PR TITLE
Add dropdown for existing volumes when creating a Notebook

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/volume.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/volume.component.html
@@ -1,7 +1,7 @@
 <div *ngIf="volume" [formGroup]="volume" class="row">
   <mat-form-field class="column" appearance="outline" id="type">
     <mat-label>{{ 'common.type' | translate }}</mat-label>
-    <mat-select formControlName="type">
+    <mat-select (selectionChange)="selectType($event)" formControlName="type">
       <mat-option *ngIf="defaultStorageClass" value="New">
         {{ 'jupyter.volume.optNew' | translate }}
       </mat-option>
@@ -12,11 +12,18 @@
   </mat-form-field>
 
   <!-- Volume Name Input -->
-  <lib-name-input
-    class="column"
-    [nameControl]="volume.get('name')"
-    id="name"
-  ></lib-name-input>
+  <mat-form-field *ngIf="typeSelected === 'New'" class="wide" appearance="outline" id="name">
+    <mat-label>Name</mat-label>
+    <input matInput formControlName="name"/>
+  </mat-form-field>
+
+  <mat-form-field *ngIf="typeSelected === 'Existing'" class="wide" appearance="outline" id="name">
+    <mat-label>Name</mat-label>
+    <mat-select formControlName="name">
+      <mat-option *ngFor="let i of existingPVCs"
+                  value="{{i}}">{{i}}</mat-option>
+    </mat-select>
+  </mat-form-field>
 
   <!-- Size Input -->
   <lib-positive-number-input

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/volume.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/volume.component.ts
@@ -15,6 +15,7 @@ export class VolumeComponent implements OnInit, OnDestroy {
 
   currentPVC: Volume;
   existingPVCs: Set<string> = new Set();
+  typeSelected = 'New';
 
   subscriptions = new Subscription();
 
@@ -86,6 +87,13 @@ export class VolumeComponent implements OnInit, OnDestroy {
       this.volume.controls.size.enable();
       this.volume.controls.mode.enable();
     }
+  }
+
+  // ----- onChange of the New / Existing Volume -----
+  selectType(event): void {
+    this.typeSelected = event.value;
+    if (this.typeSelected != 'New') return;
+    this.volume.controls.name.setValue(this.currentVolName);
   }
 
   updateVolInputFields(): void {


### PR DESCRIPTION
I noticed with the new jupyter-web-app (refactor to use common code) that the dropdown for existing volumes was missing. 
I recreated the feature by copying parts of the old web app, so if I missed anything please let me know. It has been tested in our Kubeflow environment. 