### PR TITLE
Add support for pyspark notebook kernel for data analysis.

### DIFF
--- a/components/example-notebook-servers/jupyter-pyspark/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pyspark/Dockerfile
@@ -1,0 +1,57 @@
+FROM public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-434b10ab
+
+# Fix DL4006
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+USER root
+
+# Spark dependencies
+# Default values can be overridden at build time
+# (ARGS are in lower case to distinguish them from ENV)
+ARG spark_version="3.1.2"
+ARG hadoop_version="3.2"
+ARG spark_checksum="2385CB772F21B014CE2ABD6B8F5E815721580D6E8BC42A26D70BBCDDA8D303D886A6F12B36D40F6971B5547B70FAE62B5A96146F0421CB93D4E51491308EF5D5"
+ARG openjdk_version="11"
+
+ENV APACHE_SPARK_VERSION="${spark_version}" \
+    HADOOP_VERSION="${hadoop_version}"
+
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends \
+    "openjdk-${openjdk_version}-jre-headless" \
+    ca-certificates-java && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Spark installation
+WORKDIR /tmp
+RUN wget -q "https://archive.apache.org/dist/spark/spark-${APACHE_SPARK_VERSION}/spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" && \
+    echo "${spark_checksum} *spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" | sha512sum -c - && \
+    tar xzf "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz" -C /usr/local --owner root --group root --no-same-owner && \
+    rm "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}.tgz"
+
+WORKDIR /usr/local
+
+# Configure Spark
+ENV SPARK_HOME=/usr/local/spark
+ENV SPARK_OPTS="--driver-java-options=-Xms1024M --driver-java-options=-Xmx4096M --driver-java-options=-Dlog4j.logLevel=info" \
+    PATH="${PATH}:${SPARK_HOME}/bin"
+
+RUN ln -s "spark-${APACHE_SPARK_VERSION}-bin-hadoop${HADOOP_VERSION}" spark && \
+    # Add a link in the before_notebook hook in order to source automatically PYTHONPATH
+    mkdir -p /usr/local/bin/before-notebook.d && \
+    ln -s "${SPARK_HOME}/sbin/spark-config.sh" /usr/local/bin/before-notebook.d/spark-config.sh
+
+# Fix Spark installation for Java 11 and Apache Arrow library
+# see: https://github.com/apache/spark/pull/27356, https://spark.apache.org/docs/latest/#downloading
+RUN cp -p "${SPARK_HOME}/conf/spark-defaults.conf.template" "${SPARK_HOME}/conf/spark-defaults.conf" && \
+    echo 'spark.driver.extraJavaOptions -Dio.netty.tryReflectionSetAccessible=true' >> "${SPARK_HOME}/conf/spark-defaults.conf" && \
+    echo 'spark.executor.extraJavaOptions -Dio.netty.tryReflectionSetAccessible=true' >> "${SPARK_HOME}/conf/spark-defaults.conf"
+
+USER ${NB_UID}
+
+# Install Pyspark, Pyarrow packages.
+COPY --chown=jovyan:users requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt
+
+WORKDIR "${HOME}"

--- a/components/example-notebook-servers/jupyter-pyspark/README.md
+++ b/components/example-notebook-servers/jupyter-pyspark/README.md
@@ -1,0 +1,31 @@
+# Example Notebook Servers
+
+Below is an example of using pyspark kernel in non-client mode. 
+
+*It can also be used to execute queries in client mode, to overcome envoy-proxy not able to communicate with driver refer to the workaround [here](https://github.com/kubeflow/kubeflow/issues/4306#issuecomment-719162698).* 
+
+
+## Non-Client mode
+
+In this mode, spark query is executed within the notebook server.
+```python
+from pyspark.sql import SparkSession
+import random
+
+spark = SparkSession \
+    .builder \
+    .appName("Python Spark SQL basic example") \
+    .getOrCreate()
+
+num_samples = 5000000
+
+def inside(p):     
+  x, y = random.random(), random.random()
+  return x*x + y*y < 1
+
+count = spark.sparkContext.parallelize(range(0, num_samples)).filter(inside).count()
+
+pi = 4 * count / num_samples
+print(pi)
+
+```

--- a/components/example-notebook-servers/jupyter-pyspark/requirements.txt
+++ b/components/example-notebook-servers/jupyter-pyspark/requirements.txt
@@ -1,0 +1,2 @@
+pyspark==3.1.2
+pyarrow==4.0.*


### PR DESCRIPTION
Implements #6038.

This PR adds pyspark kernel support to Jupyter. Running spark queries in kubeflow is very beneficial for data exploration as part of developing pipelines and other scenarios. This can be used to run spark queries in both non-client mode and client-mode (more involved).