### PR TITLE
Remove dead link to Usage Reporting on Central Dashboard

### DIFF
--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -63,8 +63,6 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
         footer.footer
             section.information
                 a.privacy(title='Kubeflow Privacy Policy', target='_blank', href='https://policies.google.com/privacy') Privacy
-                .bullet
-                a.usage(title='Kubeflow Usage Reporting', target='_blank', href='https://www.kubeflow.org/docs/other-guides/usage-reporting/') Usage Reporting
             section.build build version&nbsp;
                 span(title="Build: [[buildVersion]] | Dashboard: v[[dashVersion]] | Isolation-Mode: [[isolationMode]]") [[buildVersion]]
     app-header-layout(fullbleed)


### PR DESCRIPTION
Hello, 

while working with KF I noticed the link to the " Usage Reporting" is dead. This PR removes the link from the Central Dashboard.

According to the Issue https://github.com/kubeflow/website/issues/2708 the usage tracking is no longer active.

- https://github.com/kubeflow/website/issues/2708
- https://github.com/kubeflow/website/pull/2709

Please let me know I if the PR needs to be updated in any way

All the best,
Markus