### PR TITLE
Update centraldashboard manifests to use configMap

### DIFF
--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -31,13 +31,22 @@ spec:
           protocol: TCP
         env:
         - name: USERID_HEADER
-          value: $(CD_USERID_HEADER)
+          valueFrom:
+            configMapKeyRef:
+              name: centraldashboard-parameters
+              key: CD_USERID_HEADER
         - name: USERID_PREFIX
-          value: $(CD_USERID_PREFIX)
+          valueFrom:
+            configMapKeyRef:
+              name: centraldashboard-parameters
+              key: CD_USERID_PREFIX
+        - name: REGISTRATION_FLOW
+          valueFrom:
+            configMapKeyRef:
+              name: centraldashboard-parameters
+              key: CD_REGISTRATION_FLOW
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
-        - name: REGISTRATION_FLOW
-          value: $(CD_REGISTRATION_FLOW)
         - name: DASHBOARD_LINKS_CONFIGMAP
           value: $(CD_CONFIGMAP_NAME)
       serviceAccountName: centraldashboard


### PR DESCRIPTION
Hello, 

there already was a configMap for the centraldashboard-parameters but it wasn't used by the Deployment yet. This commit enables the configMap centraldashboard-parameters

Fixes https://github.com/kubeflow/kubeflow/issues/5958

Let me know if I should change the PR in any way.

Cheers
Markus