### PR TITLE
Fix NaN in Kubeflow Notebooks

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -163,10 +163,12 @@ def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     cpu = get_form_value(body, defaults, "cpu")
+    if 'nan' in cpu.lower():
+        raise BadRequest("'%s' is an invalid value for CPU" % cpu)
 
     cpu_limit = get_form_value(body, defaults, "cpuLimit")
-    if cpu_limit == "NaN":
-        cpu_limit = None
+    if 'nan' in cpu_limit.lower():
+        raise BadRequest("'%s' is an invalid value for CPU limit" % cpu_limit)
 
     limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
     if not cpu_limit and limit_factor != "none":
@@ -190,10 +192,12 @@ def set_notebook_memory(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     memory = get_form_value(body, defaults, "memory")
+    if 'nan' in memory.lower():
+        raise BadRequest("'%s' is an invalid value for memory" % memory)
 
     memory_limit = get_form_value(body, defaults, "memoryLimit")
-    if memory_limit == "NaNGi":
-        memory_limit = None
+    if 'nan' in memory_limit.lower():
+        raise BadRequest("'%s' is an invalid value for memory limit" % memory_limit)
 
     limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")
     if not memory_limit and limit_factor != "none":

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -163,7 +163,10 @@ def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     cpu = get_form_value(body, defaults, "cpu")
+
     cpu_limit = get_form_value(body, defaults, "cpuLimit")
+    if cpu_limit == "NaN":
+        cpu_limit = None
 
     limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
     if not cpu_limit and limit_factor != "none":
@@ -187,7 +190,10 @@ def set_notebook_memory(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     memory = get_form_value(body, defaults, "memory")
+
     memory_limit = get_form_value(body, defaults, "memoryLimit")
+    if memory_limit == "NaNGi":
+        memory_limit = None
 
     limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")
     if not memory_limit and limit_factor != "none":

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -163,11 +163,11 @@ def set_notebook_cpu(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     cpu = get_form_value(body, defaults, "cpu")
-    if 'nan' in cpu.lower():
+    if cpu and 'nan' in cpu.lower():
         raise BadRequest("'%s' is an invalid value for CPU" % cpu)
 
     cpu_limit = get_form_value(body, defaults, "cpuLimit")
-    if 'nan' in cpu_limit.lower():
+    if cpu_limit and 'nan' in cpu_limit.lower():
         raise BadRequest("'%s' is an invalid value for CPU limit" % cpu_limit)
 
     limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
@@ -192,11 +192,11 @@ def set_notebook_memory(notebook, body, defaults):
     container = notebook["spec"]["template"]["spec"]["containers"][0]
 
     memory = get_form_value(body, defaults, "memory")
-    if 'nan' in memory.lower():
+    if memory and 'nan' in memory.lower():
         raise BadRequest("'%s' is an invalid value for memory" % memory)
 
     memory_limit = get_form_value(body, defaults, "memoryLimit")
-    if 'nan' in memory_limit.lower():
+    if memory_limit and 'nan' in memory_limit.lower():
         raise BadRequest("'%s' is an invalid value for memory limit" % memory_limit)
 
     limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")

--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -164,11 +164,11 @@ def set_notebook_cpu(notebook, body, defaults):
 
     cpu = get_form_value(body, defaults, "cpu")
     if cpu and 'nan' in cpu.lower():
-        raise BadRequest("'%s' is an invalid value for CPU" % cpu)
+        raise BadRequest("Invalid value for cpu: %s" % cpu)
 
     cpu_limit = get_form_value(body, defaults, "cpuLimit")
     if cpu_limit and 'nan' in cpu_limit.lower():
-        raise BadRequest("'%s' is an invalid value for CPU limit" % cpu_limit)
+        raise BadRequest("Invalid value for cpu limit: %s" % cpu_limit)
 
     limit_factor = utils.load_spawner_ui_config()["cpu"].get("limitFactor")
     if not cpu_limit and limit_factor != "none":
@@ -193,11 +193,11 @@ def set_notebook_memory(notebook, body, defaults):
 
     memory = get_form_value(body, defaults, "memory")
     if memory and 'nan' in memory.lower():
-        raise BadRequest("'%s' is an invalid value for memory" % memory)
+        raise BadRequest("Invalid value for memory: %s" % memory)
 
     memory_limit = get_form_value(body, defaults, "memoryLimit")
     if memory_limit and 'nan' in memory_limit.lower():
-        raise BadRequest("'%s' is an invalid value for memory limit" % memory_limit)
+        raise BadRequest("Invalid value for memory limit: %s" % memory_limit)
 
     limit_factor = utils.load_spawner_ui_config()["memory"].get("limitFactor")
     if not memory_limit and limit_factor != "none":


### PR DESCRIPTION
This PR fixes an issue with the Jupyter Web App creating invalid notebook configuration with CPU and Memory set as:

- CPU: NaN
- Memory: NaNGI.

This happens with jupyter-web-app-config when limit factor is set to None and non-default resource value is set.

```yaml
limitFactor: "none"
```
I am not familiar with npm used in the frontend so I am not sure if this is the best way to fix it, hence I sent in a patch to the backend which should fix the issue.

fixes #5985 