### PR TITLE
add(web-apps): i18n Fr translations

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/i18n/fr/messages.fr.xlf
+++ b/components/crud-web-apps/jupyter/frontend/i18n/fr/messages.fr.xlf
@@ -4,6 +4,7 @@
     <body>
       <trans-unit id="1eede69e18c5ac9c0b0295b72cabb7e64e029e74" datatype="html">
         <source>Hide</source>
+        <target>Cacher</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/advanced-options/advanced-options.component.html</context>
           <context context-type="linenumber">5</context>
@@ -11,6 +12,7 @@
       </trans-unit>
       <trans-unit id="6358767024326715915" datatype="html">
         <source>Advanced Options</source>
+        <target>Options avancées</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/advanced-options/advanced-options.component.ts</context>
           <context context-type="linenumber">19</context>
@@ -18,6 +20,7 @@
       </trans-unit>
       <trans-unit id="cff1428d10d59d14e45edec3c735a27b5482db59" datatype="html">
         <source>Name</source>
+        <target>Nom</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/name-namespace-inputs/name-input/name-input.component.html</context>
           <context context-type="linenumber">2</context>
@@ -29,6 +32,7 @@
       </trans-unit>
       <trans-unit id="130fd872c78271a8f86b1ab16a76e823969c47d9" datatype="html">
         <source>Namespace</source>
+        <target>Espace de noms</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/name-namespace-inputs/name-namespace-inputs.component.html</context>
           <context context-type="linenumber">11</context>
@@ -40,6 +44,7 @@
       </trans-unit>
       <trans-unit id="7824eb0fc97826f3919ba20317db1f8fb7926fcf" datatype="html">
         <source> Cannot be negative. </source>
+        <target> Ne peut pas être négative. </target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/positive-number-input/positive-number-input.component.html</context>
           <context context-type="linenumber">11,12</context>
@@ -48,6 +53,7 @@
       <trans-unit id="6259832288014753417" datatype="html">
         <source>Name must consist of lowercase alphanumeric characters or &apos;-&apos;,
     start with an alphabetic character, and end with an alphanumeric character.</source>
+        <target>Le nom doit être des caractères minuscules alphanumériques ou '-' et doit commencer et terminer par des caractères alphanumériques.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/validators.ts</context>
           <context context-type="linenumber">32,33</context>
@@ -55,6 +61,7 @@
       </trans-unit>
       <trans-unit id="824282508845786476" datatype="html">
         <source>Name is too long</source>
+        <target>Le nom est trop long</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/validators.ts</context>
           <context context-type="linenumber">105</context>
@@ -62,6 +69,7 @@
       </trans-unit>
       <trans-unit id="5302945586275093972" datatype="html">
         <source>Name cannot be empty</source>
+        <target>Nom ne peut pas être vide</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/form/validators.ts</context>
           <context context-type="linenumber">107</context>
@@ -69,6 +77,7 @@
       </trans-unit>
       <trans-unit id="2061ce2524f31b7754bd310c6b0ad194b563767c" datatype="html">
         <source>Select Namespace</source>
+        <target>Sélectionner l'espace de noms</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/namespace-select/namespace-select.component.html</context>
           <context context-type="linenumber">4</context>
@@ -76,6 +85,7 @@
       </trans-unit>
       <trans-unit id="3862207452684082108" datatype="html">
         <source>An error occurred: <x id="PH" equiv-text="error"/></source>
+        <target>Une erreur est survenue: <x id="PH" equiv-text="error"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/services/backend/backend.service.ts</context>
           <context context-type="linenumber">108</context>
@@ -83,6 +93,7 @@
       </trans-unit>
       <trans-unit id="1292256390007124036" datatype="html">
         <source>Client error: <x id="PH" equiv-text="error.error.message"/></source>
+        <target>Erreur client : <x id="PH" equiv-text="error.error.message"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/services/backend/backend.service.ts</context>
           <context context-type="linenumber">112</context>
@@ -90,6 +101,7 @@
       </trans-unit>
       <trans-unit id="8194451610848887333" datatype="html">
         <source>Could not connect to the backend.</source>
+        <target>Impossible de se connecter à l'infrastructure d'arrière plan.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/services/backend/backend.service.ts</context>
           <context context-type="linenumber">119</context>
@@ -97,6 +109,7 @@
       </trans-unit>
       <trans-unit id="4553983244211420347" datatype="html">
         <source>Unexpected error encountered</source>
+        <target>Erreur inattendue rencontrée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/services/backend/backend.service.ts</context>
           <context context-type="linenumber">131</context>
@@ -104,6 +117,7 @@
       </trans-unit>
       <trans-unit id="0c0be57aaf30414531e79157a45e0fc3fd6b637b" datatype="html">
         <source>DISMISS</source>
+        <target>REJETER</target>
         <context-group purpose="location">
           <context context-type="sourcefile">projects/kubeflow/src/lib/snack-bar/component/snack-bar.component.html</context>
           <context context-type="linenumber">4</context>
@@ -111,6 +125,7 @@
       </trans-unit>
       <trans-unit id="ac184ad5119488375c501e04e46b79dbb6079cc7" datatype="html">
         <source>Miscellaneous Settings</source>
+        <target>Paramètres divers</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-advanced-options/form-advanced-options.component.html</context>
           <context context-type="linenumber">2</context>
@@ -118,6 +133,7 @@
       </trans-unit>
       <trans-unit id="aa98eb3757f779bf6bce68192b5c93831570c9ea" datatype="html">
         <source>Other possible settings to be applied to the Notebook Server.</source>
+        <target>Autres paramètres possibles à appliquer au serveur bloc-notes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-advanced-options/form-advanced-options.component.html</context>
           <context context-type="linenumber">3</context>
@@ -125,6 +141,7 @@
       </trans-unit>
       <trans-unit id="4f9350429574d4118ef3709016039f34a0785466" datatype="html">
         <source> Enable Shared Memory </source>
+        <target>Activer la mémoire partagée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-advanced-options/form-advanced-options.component.html</context>
           <context context-type="linenumber">9,10</context>
@@ -132,6 +149,7 @@
       </trans-unit>
       <trans-unit id="e0a31a4739749d022f9c0265ef0db1779daf3bad" datatype="html">
         <source>Affinity / Tolerations</source>
+        <target>Affinité / Tolérances</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-affinity-tolerations/form-affinity-tolerations.component.html</context>
           <context context-type="linenumber">2</context>
@@ -139,6 +157,7 @@
       </trans-unit>
       <trans-unit id="d3f8def051f09bcd2b129a7cd61bb993fe206bce" datatype="html">
         <source>Configure the Notebook&apos;s Affinity and Tolerations.</source>
+        <target>Configuration de l'affinité et des tolérances du bloc-notes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-affinity-tolerations/form-affinity-tolerations.component.html</context>
           <context context-type="linenumber">3</context>
@@ -146,6 +165,7 @@
       </trans-unit>
       <trans-unit id="633ab3500af3e54a7519377f4b6e5bc100737123" datatype="html">
         <source> Affinity Config </source>
+        <target>Config d'affinité</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-affinity-tolerations/form-affinity-tolerations.component.html</context>
           <context context-type="linenumber">11</context>
@@ -153,6 +173,7 @@
       </trans-unit>
       <trans-unit id="a2f14a73f7a6e94479f67423cc51102da8d6f524" datatype="html">
         <source>None</source>
+        <target>Aucun</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-affinity-tolerations/form-affinity-tolerations.component.html</context>
           <context context-type="linenumber">13</context>
@@ -169,6 +190,7 @@
       </trans-unit>
       <trans-unit id="26316693d7df543784a554fb79d00771f79a2865" datatype="html">
         <source> Tolerations Group </source>
+        <target>Groupe de tolérances</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-affinity-tolerations/form-affinity-tolerations.component.html</context>
           <context context-type="linenumber">25</context>
@@ -176,6 +198,7 @@
       </trans-unit>
       <trans-unit id="edd04e579025543c017d80558217d1e2788708df" datatype="html">
         <source>Configurations</source>
+        <target>Configurations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-configurations/form-configurations.component.html</context>
           <context context-type="linenumber">2</context>
@@ -184,6 +207,8 @@
       <trans-unit id="63220bf4b545f3ca1f7b5215f1953b95dc3645e0" datatype="html">
         <source>Extra layers of configurations that will be applied to the new Notebook. 
         (e.g. Insert credentials as Secrets, set Environment Variables.)</source>
+        <target>Couche supplémentaire de configurations qui sera appliquée au nouveau bloc-note. 
+(ex. insérer les informations d'identification en tant que secret, définir les variables d'environnement.)</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-configurations/form-configurations.component.html</context>
           <context context-type="linenumber">3,4</context>
@@ -191,6 +216,7 @@
       </trans-unit>
       <trans-unit id="a76f7ebd6eb4f4afd7109e574dc617f858cd2d80" datatype="html">
         <source> Configurations </source>
+        <target>Configurations</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-configurations/form-configurations.component.html</context>
           <context context-type="linenumber">10</context>
@@ -198,6 +224,7 @@
       </trans-unit>
       <trans-unit id="f22f0cf2e9846ef910c72864e8d5b62b36b81c86" datatype="html">
         <source>CPU / RAM</source>
+        <target>CPU / Mémoire vive</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html</context>
           <context context-type="linenumber">2</context>
@@ -207,6 +234,7 @@
       <trans-unit id="6af244dea6f7d8f929b45cd8226522d0e35d7110" datatype="html">
         <source>Specify the total amount of CPU and RAM reserved by your Notebook Server.
          For CPU-intensive workloads, you can choose more than 1 CPU (e.g. 1.5).</source>
+        <target>Spécifier le nombre total de CPU et mémoire vive reservé pour votre serveur bloc-notes. Pour les charges de travail lourde pour le CPU, vous pouvez choisir plus d'un CPU (ex. 1.5).</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html</context>
           <context context-type="linenumber">3,4</context>
@@ -215,6 +243,7 @@
       </trans-unit>
       <trans-unit id="01817bd08ce56cd2966da83498f862a5c3984cc8" datatype="html">
         <source>Requested CPUs</source>
+        <target>CPUs demandés</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html</context>
           <context context-type="linenumber">16</context>
@@ -222,6 +251,7 @@
       </trans-unit>
       <trans-unit id="c35a751936ff43637e90b7a97c69939364e32a2f" datatype="html">
         <source>Requested memory in Gi</source>
+        <target>Mémoire demandé en Gi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html</context>
           <context context-type="linenumber">26</context>
@@ -229,6 +259,7 @@
       </trans-unit>
       <trans-unit id="b236d0d38ab7c46409b041002e008f28ade48e54" datatype="html">
         <source>CPU limit</source>
+        <target>Limite du CPU</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html</context>
           <context context-type="linenumber">36</context>
@@ -236,21 +267,40 @@
       </trans-unit>
       <trans-unit id="393e204f9358a7b2bb54c23a1dd6fda2d3a20fe0" datatype="html">
         <source> Memory limit in Gi </source>
+        <target>Limite pour la mémoire, en Gi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-cpu-ram/form-cpu-ram.component.html</context>
           <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="1d41bb5873bf9a2c9cfa0176d4637258953cad24" datatype="html">
-        <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/> ADD VOLUME </source>
+      <trans-unit id="cbe5b11222992396a96e6d3d8ba3e9af4cbbdd92" datatype="html">
+        <source>Data Volumes</source>
+        <target>Volumes de données</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html</context>
-          <context context-type="linenumber">16,18</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f586fa68fde13b574cf55682962b36884e507d21" datatype="html">
+        <source>Configure the Volumes to be mounted as your Datasets.</source>
+        <target>Configurer le volume qui sera monter comme base de données.</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="1d41bb5873bf9a2c9cfa0176d4637258953cad24" datatype="html">
+        <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/> ADD VOLUME </source>
+        <target><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/> AJOUTER UN VOLUME</target>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html</context>
+          <context context-type="linenumber">18,20</context>
         </context-group>
         <note priority="1" from="description">Add data volume button text</note>
       </trans-unit>
       <trans-unit id="f90b91d2308a85dd1f7b6139f8822d7659e0e6f6" datatype="html">
         <source> LAUNCH </source>
+        <target> LANCER</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-default.component.html</context>
           <context context-type="linenumber">72,73</context>
@@ -258,6 +308,7 @@
       </trans-unit>
       <trans-unit id="ae582a9312e4bcbb32a62d84e47e6b1b73ffd06a" datatype="html">
         <source> CANCEL </source>
+        <target>ANNULER</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-default.component.html</context>
           <context context-type="linenumber">76,77</context>
@@ -265,6 +316,7 @@
       </trans-unit>
       <trans-unit id="7110584923376845969" datatype="html">
         <source>No default Storage Class is set. Can&apos;t create new Disks for the new Notebook. Please use an Existing Disk.</source>
+        <target>Aucune classe de stockage par défaut n'est définie. Impossible de créer un nouveau disque pour le nouveau bloc-notes. Veuillez utiliser un disque existant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-default.component.ts</context>
           <context context-type="linenumber">77</context>
@@ -272,6 +324,7 @@
       </trans-unit>
       <trans-unit id="126c1d5ce9129e10a0328764227f045806ab0e50" datatype="html">
         <source>GPUs</source>
+        <target>GPUs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-gpus/form-gpus.component.html</context>
           <context context-type="linenumber">2</context>
@@ -280,6 +333,7 @@
       <trans-unit id="9e62d063b88fdd89761c29f791e7655ce93e0aef" datatype="html">
         <source>Specify the number and Vendor of GPUs that will be assigned to the 
         Notebook Server&apos;s Container.</source>
+        <target>Spécifier le nombre et le vendeur de GPUs qui sera assigné au containeur du serveur bloc-notes.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-gpus/form-gpus.component.html</context>
           <context context-type="linenumber">3,4</context>
@@ -287,6 +341,7 @@
       </trans-unit>
       <trans-unit id="6bc1c2ef4d2045c6f6a152e10bb00365a381c804" datatype="html">
         <source>Number of GPUs</source>
+        <target>Nombre de GPUs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-gpus/form-gpus.component.html</context>
           <context context-type="linenumber">12</context>
@@ -294,6 +349,7 @@
       </trans-unit>
       <trans-unit id="f49d3e9fe3286f0f5d07d5323db3cd6333331489" datatype="html">
         <source>GPU Vendor</source>
+        <target>Vendeur de GPU</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-gpus/form-gpus.component.html</context>
           <context context-type="linenumber">23</context>
@@ -301,6 +357,7 @@
       </trans-unit>
       <trans-unit id="2704250739785727999" datatype="html">
         <source>No <x id="PH" equiv-text="vendor.uiName"/> GPU found installed in the cluster.</source>
+        <target>Aucun GPU <x id="PH" equiv-text="vendor.uiName"/>  n’a été trouvé installé dans le cluster.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-gpus/form-gpus.component.ts</context>
           <context context-type="linenumber">56</context>
@@ -308,6 +365,7 @@
       </trans-unit>
       <trans-unit id="6063824952991640049" datatype="html">
         <source>You must also specify the GPU Vendor for the assigned GPUs</source>
+        <target>Vous devez spécifier le vendeur des GPUs assignés</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-gpus/form-gpus.component.ts</context>
           <context context-type="linenumber">65</context>
@@ -315,6 +373,7 @@
       </trans-unit>
       <trans-unit id="a5f9ba9bb9faa8284bcadb1cdbc6aaf969e9c4bb" datatype="html">
         <source>Image</source>
+        <target>Image</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">2</context>
@@ -336,6 +395,7 @@
       <trans-unit id="1e8059172dc79be0273478003dd2e2ae465fd41b" datatype="html">
         <source>A starter Jupyter Docker Image with a baseline deployment and typical
         ML packages</source>
+        <target>Une image Jupyter Docker de démarrage avec un déploiement de base et les paquets ML typiques</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">3,4</context>
@@ -344,6 +404,7 @@
       </trans-unit>
       <trans-unit id="059242c0f52aaeff3ed373739d818de15acc9751" datatype="html">
         <source> Custom Image </source>
+        <target> Image personnalisée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">15,16</context>
@@ -351,6 +412,7 @@
       </trans-unit>
       <trans-unit id="1f35754236a77f283c76f144f8ca55a2590b2897" datatype="html">
         <source>Docker Image</source>
+        <target>Image Docker</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">60</context>
@@ -366,6 +428,7 @@
       </trans-unit>
       <trans-unit id="817830b30c16a82f008858d8f7a6d64e7826a2b2" datatype="html">
         <source>Please provide an Image to use</source>
+        <target>Veuillez fournir une image à utiliser</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">68</context>
@@ -385,6 +448,7 @@
       </trans-unit>
       <trans-unit id="2f0e016d5caf4e42f1b6f60dc9fe80e2b98f5287" datatype="html">
         <source>Custom Image</source>
+        <target>Image personnalisée</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">128</context>
@@ -392,6 +456,7 @@
       </trans-unit>
       <trans-unit id="d8aa5559daf4007f0eff2ea4e5ea28d1ac49e105" datatype="html">
         <source>Image pull policy</source>
+        <target>Politique de téléchargement de l'image</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">141</context>
@@ -399,6 +464,7 @@
       </trans-unit>
       <trans-unit id="6408a210e22cb458fc925aad796666f5a1198662" datatype="html">
         <source> Always </source>
+        <target>Toujours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">144,145</context>
@@ -407,6 +473,7 @@
       </trans-unit>
       <trans-unit id="7a084ea40b1b4313d812cfc6c7f41333f5021c45" datatype="html">
         <source> IfNotPresent </source>
+        <target> Si elle n'est pas présente </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">147,148</context>
@@ -415,6 +482,7 @@
       </trans-unit>
       <trans-unit id="414e175f751673aebbcac9ac0ee64fb16c508e8d" datatype="html">
         <source> Never </source>
+        <target>Jamais</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-image/form-image.component.html</context>
           <context context-type="linenumber">150,151</context>
@@ -423,6 +491,7 @@
       </trans-unit>
       <trans-unit id="cee8a23f48b6c7ae06f53a349a12744d3f3d0096" datatype="html">
         <source>Specify the name of the Notebook Server and the Namespace it will belong to.</source>
+        <target>Spécifier le nom du serveur bloc-notes et l'espace de noms dont il fera partie.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-name/form-name.component.html</context>
           <context context-type="linenumber">3</context>
@@ -430,6 +499,7 @@
       </trans-unit>
       <trans-unit id="5f02a6412cf09bf5dd273aeb77215ce0ef343716" datatype="html">
         <source>Workspace Volume</source>
+        <target>Volume d'espace de travail</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.html</context>
           <context context-type="linenumber">2</context>
@@ -437,6 +507,7 @@
       </trans-unit>
       <trans-unit id="752dfb855b4c8a9210e3d24477995a2371eab64f" datatype="html">
         <source>Configure the Volume to be mounted as your personal Workspace.</source>
+        <target>Configurer le volume qui sera monté en tant que votre espace de travail personnel.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.html</context>
           <context context-type="linenumber">3</context>
@@ -444,6 +515,7 @@
       </trans-unit>
       <trans-unit id="3fcd8eaf3f795a406ca8d2418b7c0251b5ba4f31" datatype="html">
         <source> Don&apos;t use Persistent Storage for User&apos;s home </source>
+        <target>Ne pas utiliser le stockage persistant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.html</context>
           <context context-type="linenumber">10,11</context>
@@ -451,6 +523,7 @@
       </trans-unit>
       <trans-unit id="2959471737957986113" datatype="html">
         <source>Your workspace will not be persistent. You will lose all data in it, if your notebook is terminated for any reason.</source>
+        <target>Votre espace de travail ne sera pas persistant. Toutes les données seront perdues si le bloc-notes prend fin, pour quelque raison que ce soit.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.ts</context>
           <context context-type="linenumber">40</context>
@@ -458,6 +531,7 @@
       </trans-unit>
       <trans-unit id="f61c6867295f3b53d23557021f2f4e0aa1d0b8fc" datatype="html">
         <source>Type</source>
+        <target>Type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">3</context>
@@ -465,6 +539,7 @@
       </trans-unit>
       <trans-unit id="6aa0944e1e88f326f92278269c69175ca0b8683e" datatype="html">
         <source> New </source>
+        <target>Nouveau</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">6,7</context>
@@ -472,6 +547,7 @@
       </trans-unit>
       <trans-unit id="694e11ff8cc8b070c82c65b5eaa118b4e4f3f169" datatype="html">
         <source> Existing </source>
+        <target>Existant</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">8</context>
@@ -479,6 +555,7 @@
       </trans-unit>
       <trans-unit id="e1b3e1dca04b54d87b5a7ff9593676dacaf6dce0" datatype="html">
         <source>Size in Gi</source>
+        <target>Taille en Gi</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">26</context>
@@ -486,6 +563,7 @@
       </trans-unit>
       <trans-unit id="37e10df2d9c0c25ef04ac112c9c9a7723e8efae0" datatype="html">
         <source>Mode</source>
+        <target>Mode</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">32</context>
@@ -493,6 +571,7 @@
       </trans-unit>
       <trans-unit id="3ecda4b04c618776ed92e6436ff5f0fc8a58b17a" datatype="html">
         <source>ReadWriteOnce</source>
+        <target>ReadWriteOnce</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">34</context>
@@ -500,6 +579,7 @@
       </trans-unit>
       <trans-unit id="134b8b6d344324352f2e3c4c6cd37c0a69f13294" datatype="html">
         <source>ReadOnlyMany </source>
+        <target>ReadOnlyMany </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">35</context>
@@ -507,6 +587,7 @@
       </trans-unit>
       <trans-unit id="5b20b7812eb6056ee343b25ecc21dd87da6cc261" datatype="html">
         <source>ReadWriteMany </source>
+        <target>ReadWriteMany </target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">36</context>
@@ -514,6 +595,7 @@
       </trans-unit>
       <trans-unit id="145eca4aa8d12853efaf9a1e27004e3238232eff" datatype="html">
         <source>Mount Point</source>
+        <target>Point de montage</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/volume/volume.component.html</context>
           <context context-type="linenumber">42</context>
@@ -521,6 +603,7 @@
       </trans-unit>
       <trans-unit id="3496981118988770473" datatype="html">
         <source>Are you sure you want to delete this notebook server? <x id="PH" equiv-text="name"/></source>
+        <target>Êtes-vous sûr de vouloir supprimer ce serveur bloc-notes? <x id="PH" equiv-text="name"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">17</context>
@@ -529,6 +612,7 @@
       <trans-unit id="6971434231050877464" datatype="html">
         <source>Warning: Your data might be lost if the notebook server
                        is not backed by persistent storage</source>
+        <target>Attention: Vos données pourraient être perdues si le serveur n'est pas sauvegardé par un stockage persistant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">18,19</context>
@@ -536,6 +620,7 @@
       </trans-unit>
       <trans-unit id="841311519047609428" datatype="html">
         <source>DELETE</source>
+        <target>SUPPRIMER</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">20</context>
@@ -543,6 +628,7 @@
       </trans-unit>
       <trans-unit id="6943486270557756671" datatype="html">
         <source>CANCEL</source>
+        <target>ANNULER</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">22</context>
@@ -554,6 +640,7 @@
       </trans-unit>
       <trans-unit id="3271166475979376691" datatype="html">
         <source>DELETING</source>
+        <target>Supression en cours</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">24</context>
@@ -561,6 +648,7 @@
       </trans-unit>
       <trans-unit id="2683684114180894925" datatype="html">
         <source>Are you sure you want to stop this notebook server? <x id="PH" equiv-text="name"/></source>
+        <target>Êtes-vous sûr de vouloir arrêter ce serveur bloc-notes? <x id="PH" equiv-text="name"/></target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">31</context>
@@ -569,6 +657,7 @@
       <trans-unit id="1374919527500826150" datatype="html">
         <source>Warning: Your data might be lost if the notebook server
                        is not backed by persistent storage.</source>
+        <target>Attention: Vos données pourraient être perdues si le serveur n'est pas sauvegardé par un stockage persistant.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">32,33</context>
@@ -576,6 +665,7 @@
       </trans-unit>
       <trans-unit id="2616985041535023317" datatype="html">
         <source>STOP</source>
+        <target>ARRÊTER</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">34</context>
@@ -583,6 +673,7 @@
       </trans-unit>
       <trans-unit id="3806796620052804699" datatype="html">
         <source>STOPPING</source>
+        <target>En cours d'arrêt</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">38</context>
@@ -590,6 +681,7 @@
       </trans-unit>
       <trans-unit id="5114128994255248149" datatype="html">
         <source>Notebooks</source>
+        <target>Bloc-notes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">45</context>
@@ -597,6 +689,7 @@
       </trans-unit>
       <trans-unit id="6503351501628765557" datatype="html">
         <source>NEW NOTEBOOK</source>
+        <target>Nouveau bloc-note</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">46</context>
@@ -604,6 +697,7 @@
       </trans-unit>
       <trans-unit id="5611592591303869712" datatype="html">
         <source>Status</source>
+        <target>Statut</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">49</context>
@@ -611,6 +705,7 @@
       </trans-unit>
       <trans-unit id="8953033926734869941" datatype="html">
         <source>Name</source>
+        <target>Nom</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">54</context>
@@ -618,6 +713,7 @@
       </trans-unit>
       <trans-unit id="8650499415827640724" datatype="html">
         <source>Type</source>
+        <target>Type</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">63</context>
@@ -625,6 +721,7 @@
       </trans-unit>
       <trans-unit id="1130652265542107236" datatype="html">
         <source>Age</source>
+        <target>Âge</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">70</context>
@@ -632,6 +729,7 @@
       </trans-unit>
       <trans-unit id="3012906865384504293" datatype="html">
         <source>Image</source>
+        <target>Image</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">75</context>
@@ -639,6 +737,7 @@
       </trans-unit>
       <trans-unit id="3840111939816305457" datatype="html">
         <source>GPUs</source>
+        <target>GPUs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">84</context>
@@ -646,6 +745,7 @@
       </trans-unit>
       <trans-unit id="4027647877328291519" datatype="html">
         <source>CPUs</source>
+        <target>CPUs</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">92</context>
@@ -653,6 +753,7 @@
       </trans-unit>
       <trans-unit id="1548129644093494406" datatype="html">
         <source>Memory</source>
+        <target>Mémoire</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">97</context>
@@ -660,6 +761,7 @@
       </trans-unit>
       <trans-unit id="2823783345206414517" datatype="html">
         <source>Volumes</source>
+        <target>Volumes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">102</context>
@@ -667,6 +769,7 @@
       </trans-unit>
       <trans-unit id="2074758921664227900" datatype="html">
         <source>Connect to this notebook server</source>
+        <target>Connecter à ce serveur bloc-notes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">113</context>
@@ -674,6 +777,7 @@
       </trans-unit>
       <trans-unit id="8966109024004058984" datatype="html">
         <source>CONNECT</source>
+        <target>CONNECTER</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">116</context>
@@ -681,6 +785,7 @@
       </trans-unit>
       <trans-unit id="8453883859090217683" datatype="html">
         <source>Stop this notebook server</source>
+        <target>Arrêter ce serveur bloc-notes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">120</context>
@@ -688,6 +793,7 @@
       </trans-unit>
       <trans-unit id="1580383878043741894" datatype="html">
         <source>Start this notebook server</source>
+        <target>Démarer ce serveur bloc-notes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">121</context>
@@ -695,6 +801,7 @@
       </trans-unit>
       <trans-unit id="7490997651991943628" datatype="html">
         <source>Delete this notebook server</source>
+        <target>Supprimer ce serveur bloc-notes</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/config.ts</context>
           <context context-type="linenumber">129</context>
@@ -702,6 +809,7 @@
       </trans-unit>
       <trans-unit id="4872314094100927318" datatype="html">
         <source>Starting Notebook server &apos;<x id="PH" equiv-text="notebook.name"/>&apos;...</source>
+        <target>Démarer le serveur bloc-notes  '<x id="PH" equiv-text="notebook.name"/>'...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/index-default.component.ts</context>
           <context context-type="linenumber">159</context>
@@ -709,6 +817,7 @@
       </trans-unit>
       <trans-unit id="9162667715823767475" datatype="html">
         <source>Stopping Notebook server &apos;<x id="PH" equiv-text="notebook.name"/>&apos;...</source>
+        <target>Arrêter le serveur bloc-notes  '<x id="PH" equiv-text="notebook.name"/>'...</target>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/index/index-default/index-default.component.ts</context>
           <context context-type="linenumber">202</context>

--- a/components/crud-web-apps/jupyter/frontend/i18n/messages.xlf
+++ b/components/crud-web-apps/jupyter/frontend/i18n/messages.xlf
@@ -241,11 +241,25 @@
           <context context-type="linenumber">50</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="cbe5b11222992396a96e6d3d8ba3e9af4cbbdd92" datatype="html">
+        <source>Data Volumes</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html</context>
+          <context context-type="linenumber">2</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="f586fa68fde13b574cf55682962b36884e507d21" datatype="html">
+        <source>Configure the Volumes to be mounted as your Datasets.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html</context>
+          <context context-type="linenumber">3</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="1d41bb5873bf9a2c9cfa0176d4637258953cad24" datatype="html">
         <source><x id="START_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;mat-icon&gt;"/>add<x id="CLOSE_TAG_MAT_ICON" ctype="x-mat_icon" equiv-text="&lt;/mat-icon&gt;"/> ADD VOLUME </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html</context>
-          <context context-type="linenumber">16,18</context>
+          <context context-type="linenumber">18,20</context>
         </context-group>
         <note priority="1" from="description">Add data volume button text</note>
       </trans-unit>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-data-volumes/form-data-volumes.component.html
@@ -2,6 +2,8 @@
   title="Data Volumes"
   text="Configure the Volumes to be mounted as your Datasets."
   icon="fa:fas:hdd"
+  i18n-title
+  i18n-text
 >
   <div [formGroup]="parentForm">
     <button


### PR DESCRIPTION
This PR adds i18n localize FR translations.
Related to #6042

Translates all crud-web-apps/jupyter/frontend literals in French.
To test this feature:
`ng serve --configuration=fr`