### PR TITLE
Remove virtualservice timeout to prevent websocket disconnect

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -482,7 +482,6 @@ func generateVirtualService(instance *v1beta1.Notebook) (*unstructured.Unstructu
 					},
 				},
 			},
-			"timeout": "300s",
 		},
 	}
 


### PR DESCRIPTION
In the existing version, the 'timeout: 300s' added to the notebook's virtual service would cause websockets to disconnect at the 5 minute mark, causing the Jupyter Notebook web terminal function to hang. This is described in https://github.com/kubeflow/kubeflow/issues/6124.