### PR TITLE
Central Dashboard/Iframe: fix special characters in url

### DIFF
--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -53,7 +53,7 @@ export class IframeContainer extends PolymerElement {
         iframe.addEventListener('load', () => {
             const syncIframePage = () => {
                 const iframeLocation = iframe.contentWindow.location;
-                // This allows to the usage of URL's with special characters
+                // For Special characters within links inside iframe
                 const newIframePage = encodeURIComponent(
                     decodeURIComponent(
                         iframeLocation.href.slice(

--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -53,8 +53,13 @@ export class IframeContainer extends PolymerElement {
         iframe.addEventListener('load', () => {
             const syncIframePage = () => {
                 const iframeLocation = iframe.contentWindow.location;
-                const newIframePage = iframeLocation.href.slice(
-                    iframeLocation.origin.length);
+                // This allows to the usage of URL's with special characters
+                const newIframePage = encodeURIComponent(
+                    decodeURIComponent(
+                        iframeLocation.href.slice(
+                            iframeLocation.origin.length)))
+
+
                 if (this.page !== newIframePage) {
                     this.page = newIframePage;
                 }

--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -53,11 +53,9 @@ export class IframeContainer extends PolymerElement {
         iframe.addEventListener('load', () => {
             const syncIframePage = () => {
                 const iframeLocation = iframe.contentWindow.location;
-                // For Special characters within links inside iframe
-                const newIframePage = encodeURIComponent(
-                    decodeURIComponent(
-                        iframeLocation.href.slice(
-                            iframeLocation.origin.length)))
+                // special characters within links inside iframe
+                const newIframePage = decodeURIComponent(
+                    iframeLocation.href.slice(iframeLocation.origin.length));
 
 
                 if (this.page !== newIframePage) {
@@ -85,7 +83,7 @@ export class IframeContainer extends PolymerElement {
     _srcChanged(newSrc) {
         const iframe = this.$.iframe;
         if (iframe.contentWindow.location.toString() !== newSrc) {
-            iframe.contentWindow.location.replace(newSrc);
+            iframe.contentWindow.location.replace(decodeURIComponent(newSrc));
         }
     }
 

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -76,7 +76,7 @@ describe('Iframe Container', () => {
             .returnValue({location: fakeLocation});
         expect(iframeContainer.page).toBe(undefined);
         iframeContainer.$.iframe.contentDocument.firstChild.click();
-        expect(iframeContainer.page).toBe('%2Ffoo%2Fbar%3Fname%3Dblah');
+        expect(iframeContainer.page).toBe('/foo/bar?name=blah');
     });
 
     it('Should reflect iframe URL changes on hashchange event', async () => {
@@ -90,8 +90,7 @@ describe('Iframe Container', () => {
         fakeLocation.href = 'http://testsite.com/foo/bar?name=blah#new-hash';
         iframeContainer.$.iframe.contentDocument
             .dispatchEvent(new Event('hashchange'));
-        expect(iframeContainer.page).toBe(
-            '%2Ffoo%2Fbar%3Fname%3Dblah%23new-hash');
+        expect(iframeContainer.page).toBe('/foo/bar?name=blah#new-hash');
     });
 
     it('Should send messages to iframed page', async () => {

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -76,7 +76,7 @@ describe('Iframe Container', () => {
             .returnValue({location: fakeLocation});
         expect(iframeContainer.page).toBe(undefined);
         iframeContainer.$.iframe.contentDocument.firstChild.click();
-        expect(iframeContainer.page).toBe('/foo/bar?name=blah');
+        expect(iframeContainer.page).toBe('%2Ffoo%2Fbar%3Fname%3Dblah');
     });
 
     it('Should reflect iframe URL changes on hashchange event', async () => {
@@ -90,7 +90,8 @@ describe('Iframe Container', () => {
         fakeLocation.href = 'http://testsite.com/foo/bar?name=blah#new-hash';
         iframeContainer.$.iframe.contentDocument
             .dispatchEvent(new Event('hashchange'));
-        expect(iframeContainer.page).toBe('/foo/bar?name=blah#new-hash');
+        expect(iframeContainer.page).toBe(
+            '%2Ffoo%2Fbar%3Fname%3Dblah%23new-hash');
     });
 
     it('Should send messages to iframed page', async () => {


### PR DESCRIPTION
The Central Dashboard Iframe is currently unable to handle special characters links in the iframe. And it produces erroneous links with double encoding of special characters.

Consider the following  Condensed Examples, I.e. URL containing the following characters were incorrectly encoded breaking the application.

| ascii | correct | centraldashboard |
|-------|---------|------------------|
| ["    | %5B%22  | %5B%2522         |
| "]    | %22%5D  | %2522%5D         |

To fix this I decoded the URI recieved by CentralDashboard. I tested this on my Kubeflow Cluster, and this worked correctly without affecting existing links.

Kubeflow Central Dashboard Iframe seems to cause a Double Encoding of Browser Links, so I added a decode to prevent it. I am not familiar with Polymer/UI development, so I don't know if this would be best way to fix it, but this seems to do the trick.

## Additional Background Context

MLFlow Metric Graphs would not work when in a Central Dashboard IFrame. The link looks like the following:
https://base-url/ns/mlflow/#/metric/foo?runs=["3869cd1170fc4ae0a677b20f9159eba5"]&experiment=3&plot_metric_keys=["foo"]&plot_layout={}&x_axis=relative&y_axis_scale=linear&line_smoothness=1&show_point=false&deselected_curves=[]&last_linear_y_axis_range=[]

Correct Encoding

https://base-url/ns/mlflow/#/metric/foo?runs=[%223869cd1170fc4ae0a677b20f9159eba5%22]&experiment=3&plot_metric_keys=[%22foo%22]&plot_layout={}&x_axis=relative&y_axis_scale=linear&line_smoothness=1&show_point=false&deselected_curves=[]&last_linear_y_axis_range=[]

CentralDashboard messes up the URL, leading to the application breaking down
