### PR TITLE
Readiness Probe for Central dashboard

### DIFF
--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -66,6 +66,12 @@ async function main() {
       message: `I tick, therfore I am!`,
     });
   });
+  app.get('/readyz', (req: Request, res: Response) => {
+    res.json({
+      codeEnvironment,
+      message: `I am ready to serve traffic`,
+    });
+  });
   app.use('/api', new Api(k8sService, metricsService).routes());
   app.use('/api/workgroup', new WorkgroupApi(profilesService, k8sService, registrationFlowAllowed).routes());
   app.use('/api', (req: Request, res: Response) => 


### PR DESCRIPTION
changed server.ts file to include /readyz endpoint for readiness probe

Could have used /healthz endpoint, but considering future development and
to distinguish probes have added a new endpoint.

Signed-off-by: Vijay Nag B S <vijay.bs@rakuten.com>

**Resolves**
https://github.com/kubeflow/kubeflow/issues/6154