### PR TITLE
feat: Authenticate to kubeflow pipelines by default

### DIFF
--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -211,5 +211,6 @@ spawnerFormDefaults:
     # value:
     #   - add-gcp-secret
     #   - default-editor
-    value: []
+    value:
+    - access-ml-pipeline
     readOnly: false


### PR DESCRIPTION
Authenticate to kubeflow pipelines by default according to https://github.com/kubeflow/pipelines/issues/5138

depends on https://github.com/kubeflow/pipelines/pull/6629

@Bobgy 