### PR TITLE
jwa(front): Don't disable vendors with no GPUs

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-gpus/form-gpus.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-gpus/form-gpus.component.html
@@ -25,7 +25,6 @@
         <mat-option
           *ngFor="let v of vendors"
           [value]="v.limitsKey"
-          [disabled]="vendorIsDisabled(v)"
           [matTooltip]="vendorTooltip(v)"
         >
           {{ v.uiName }}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-gpus/form-gpus.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-gpus/form-gpus.component.ts
@@ -47,13 +47,9 @@ export class FormGpusComponent implements OnInit {
   }
 
   // Vendor handling
-  public vendorIsDisabled(vendor: GPUVendor) {
-    return !this.installedVendors.has(vendor.limitsKey);
-  }
-
   public vendorTooltip(vendor: GPUVendor) {
     return !this.installedVendors.has(vendor.limitsKey)
-      ? $localize`No ${vendor.uiName} GPU found installed in the cluster.`
+      ? $localize`There are currently no ${vendor.uiName} GPUs in you cluster.`
       : '';
   }
 


### PR DESCRIPTION
closes #6161 

JWA should not block users from selecting GPUs if the current cluster nodes do not have any GPUs attached to them. 

We've seen users that have autoscaled nodegroups for GPUs, so a GPU node will be added to the cluster once a Pod has requested it.

cc @vinayan3
/cc @elikatsis 
/assign @kimwnasptd 