### PR TITLE
Ability to add annotations to PVCs in Volumes web app

### DIFF
--- a/components/crud-web-apps/volumes/backend/apps/common/form.py
+++ b/components/crud-web-apps/volumes/backend/apps/common/form.py
@@ -26,8 +26,17 @@ def pvc_from_dict(body, namespace):
     Convert the PVC json object that is sent from the backend to a python
     client PVC instance.
     """
+
+    annotations = {}
+    for annotation in body["annotations"]:
+        annotations[annotation["key"]] = annotation["value"]
+
     return client.V1PersistentVolumeClaim(
-        metadata=client.V1ObjectMeta(name=body["name"], namespace=namespace),
+        metadata=client.V1ObjectMeta(
+            name=body["name"],
+            namespace=namespace,
+            annotations=annotations,
+        ),
         spec=client.V1PersistentVolumeClaimSpec(
             access_modes=[body["mode"]],
             storage_class_name=handle_storage_class(body),

--- a/components/crud-web-apps/volumes/frontend/src/app/app.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/app.module.ts
@@ -19,6 +19,7 @@ import {
 import { IndexComponent } from './pages/index/index.component';
 import { FormDefaultComponent } from './pages/form/form-default/form-default.component';
 import { FormRokComponent } from './pages/form/form-rok/form-rok.component';
+import { AnnotationComponent} from './pages/form/form-default/annotation/annotation.component';
 import { IndexDefaultComponent } from './pages/index/index-default/index-default.component';
 import { IndexRokComponent } from './pages/index/index-rok/index-rok.component';
 
@@ -28,6 +29,7 @@ import { HttpClientModule, HttpClient } from '@angular/common/http';
   declarations: [
     AppComponent,
     IndexComponent,
+    AnnotationComponent,
     FormDefaultComponent,
     FormRokComponent,
     IndexDefaultComponent,

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.html
@@ -1,0 +1,11 @@
+<div *ngIf="annotation" [formGroup]="annotation" class="row">
+  <mat-form-field class="column" appearance="outline" id="key">
+    <mat-label i18n>Key</mat-label>
+    <input matInput formControlName="key" />
+  </mat-form-field>
+
+  <mat-form-field class="column" appearance="outline" id="value">
+    <mat-label i18n>Value</mat-label>
+    <input matInput formControlName="value" />
+  </mat-form-field>
+</div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+
+import { AnnotationComponent } from './annotation.component';
+
+describe('AnnotationComponent', () => {
+  let component: AnnotationComponent;
+  let fixture: ComponentFixture<AnnotationComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [AnnotationComponent],
+      }).compileComponents();
+    }),
+  );
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AnnotationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.ts
@@ -1,0 +1,16 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-annotation',
+  templateUrl: './annotation.component.html',
+  styleUrls: ['./annotation.component.scss'],
+})
+export class AnnotationComponent {
+  annotationKey = '';
+  annotationValue = '';
+
+  @Input() annotation: FormGroup;
+
+  constructor() {}
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/annotation/annotation.component.ts
@@ -7,9 +7,6 @@ import { FormGroup } from '@angular/forms';
   styleUrls: ['./annotation.component.scss'],
 })
 export class AnnotationComponent {
-  annotationKey = '';
-  annotationValue = '';
-
   @Input() annotation: FormGroup;
 
   constructor() {}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.html
@@ -58,6 +58,41 @@
       </mat-select>
     </mat-form-field>
 
+    <!--Annotations-->
+    <lib-form-section>
+      <button
+        mat-stroked-button
+        class="add-annotation-button"
+        color="accent"
+        (click)="addAnnotation()"
+        type="button"
+        i18n="Add annotation button text"
+      >
+        <mat-icon>add</mat-icon>
+        ADD ANNOTATION
+      </button>
+    </lib-form-section>
+
+    <div class="annotations">
+      <div *ngFor="let annotation of annotations; let i = index" class="annotation-wrapper">
+        <app-annotation
+          [annotation]="annotation"
+        >
+        </app-annotation>
+
+        <div class="del-btn">
+          <button
+            mat-icon-button
+            color="warn"
+            (click)="deleteAnnotation(i)"
+            type="button"
+          >
+            <mat-icon>delete</mat-icon>
+          </button>
+        </div>
+      </div>
+    </div>
+
     <button
       mat-raised-button
       color="primary"

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.scss
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.scss
@@ -1,0 +1,25 @@
+.annotations {
+  margin-top: 1rem;
+}
+
+.annotation-wrapper {
+  display: flex;
+  width: 100%;
+}
+
+.annotation-wrapper > app-annotation {
+  flex: 1 1 0px;
+  min-width: initial;
+  max-width: 93%;
+}
+
+.annotation-wrapper > .del-btn {
+  margin-top: 0.8rem;
+  margin-left: 1rem;
+  width: 7%;
+  text-align: center;
+}
+
+.form--button-margin {
+  margin-top: 2rem;
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -1,17 +1,13 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import {
+  FormArray,
   FormBuilder,
   FormGroup,
   Validators,
-  FormControl,
-  ValidatorFn,
 } from '@angular/forms';
 import { Subscription } from 'rxjs';
 import {
   NamespaceService,
-  getExistingNameValidator,
-  dns1035Validator,
-  getNameError,
   DIALOG_RESP,
 } from 'kubeflow';
 import { VWABackendService } from 'src/app/services/backend.service';
@@ -49,6 +45,7 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
       size: [10, []],
       class: ['$empty', [Validators.required]],
       mode: ['ReadWriteOnce', [Validators.required]],
+      annotations: fb.array([]),
     });
   }
 
@@ -100,5 +97,27 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
 
   public onCancel() {
     this.dialog.close(DIALOG_RESP.CANCEL);
+  }
+
+  get annotations() {
+    const annotations = this.formCtrl.get('annotations') as FormArray;
+    return annotations.controls;
+  }
+
+  addAnnotation() {
+    const fb = new FormBuilder();
+    const ctrl = fb.group({
+      key: ['', [Validators.required]],
+      value: ['', [Validators.required]],
+    });
+
+    const annotations = this.formCtrl.get('annotations') as FormArray;
+    annotations.push(ctrl);
+  }
+
+  deleteAnnotation(idx: number) {
+    const annotations = this.formCtrl.get('annotations') as FormArray;
+    annotations.removeAt(idx);
+    this.formCtrl.updateValueAndValidity();
   }
 }


### PR DESCRIPTION
I've added the ability to add annotations to a PVC while creating them in the Volumes web app.

We use alluxio storageclass and annotations to create PVCs that connect to HDFS so we needed this functionality for ease-of-use.

I think this will be useful for others as well so I'm sharing the code.

FYI I don't know Angular (but I know Vue), so if there's anything weird in the Angular code please let me know!

![Screenshot 2021-10-08 at 15 52 28](https://user-images.githubusercontent.com/4998112/136511501-3482b4c1-bcd1-4db8-948d-db9e5456165a.jpg)

![Screenshot 2021-10-08 at 15 50 51](https://user-images.githubusercontent.com/4998112/136511423-31277b2e-abb0-4cf0-ae2e-0892dbf75129.jpg)


After submitting the form, PVC is created correctly.

```
kubectl describe pvc test-annotations -n markwinter
Name:          test-annotations
Namespace:     markwinter
StorageClass:  nfs-client2
Status:        Bound
Volume:        pvc-8b5a71f0-6cab-4311-9c12-3e1260d44ea3
Labels:        <none>
Annotations:   myAnnotationKey: myAnnotationValue
               pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: cluster.local/storage2-nfs-client-provisioner
```