### PR TITLE
Tell user to select a namespace to access namespaced menu item

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -35,6 +35,7 @@ import './namespace-selector.js';
 import './dashboard-view.js';
 import './activity-view.js';
 import './not-found-view.js';
+import './namespace-needed-view.js';
 import './manage-users-view.js';
 import './resources/kubeflow-icons.js';
 import './iframe-container.js';
@@ -265,12 +266,18 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             this._setActiveLink(this.$.home);
             break;
         default:
-            this.page = 'not_found';
             // Handles case when an iframed page requests an invalid route
             if (this._isInsideOfIframe()) {
                 notFoundInIframe = true;
+                hideSidebar = true;
+            }
+            if (path && path.includes('{ns}')) {
+                this.page = 'namespace_needed'
+            } else {
+                this.page = 'not_found';
             }
         }
+
         this._setNotFoundInIframe(notFoundInIframe);
         this._setHideTabs(hideTabs);
         this._setAllNamespaces(allNamespaces);

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -104,6 +104,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         src='[[iframeSrc]]', page="{{iframePage}}")
                 neon-animatable(page='not_found')
                     not-found-view(path="[[route.path]]")
+                neon-animatable(page='namespace_needed')
+                    namespace-needed-view()
     iron-media-query(query='(max-width: 900px)', query-matches='{{sidebarBleed}}')
     iron-media-query(query='(max-width: 1270px)', query-matches='{{thinView}}')
 paper-toast#welcomeUser(duration=5000) Welcome, [[_extractLdap(user)]]!

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -157,6 +157,21 @@ describe('Main Page', () => {
                 .hasAttribute('hidden')).toBe(true);
         });
 
+    it('Sets view state when the namespace is not specified for ' +
+       'a namespaced item', () => {
+            spyOn(mainPage, '_isInsideOfIframe').and.returnValue(true);
+            mainPage._routePageChanged('iframe', '/myapp/{ns}');
+            flush();
+
+            expect(mainPage.page).toBe('namespace_needed');
+            expect(mainPage.notFoundInIframe).toBe(true);
+            expect(mainPage.shadowRoot.getElementById('ViewTabs')
+                .hasAttribute('hidden')).toBe(true);
+            expect(mainPage.shadowRoot.getElementById('ViewTabs')
+                .hasAttribute('hidden')).toBe(true);
+
+        });
+
     it('Appends query string when building links', () => {
         const sidebarLinkSelector = '#MainDrawer iron-selector iframe-link';
         const headerLinkSelector = '#ViewTabs paper-tabs a';

--- a/components/centraldashboard/public/components/namespace-needed-view.js
+++ b/components/centraldashboard/public/components/namespace-needed-view.js
@@ -1,0 +1,26 @@
+import {html, PolymerElement} from '@polymer/polymer';
+
+export class NamespaceNeededView extends PolymerElement {
+    static get template() {
+        return html`
+            <style>
+                :host {
+                    background: #f1f3f4;
+                    color: var(--google-grey-500);
+                    font-style: italic;
+                    font-size: 2em;
+                    font-family: Google Sans;
+                    padding: 1em;
+                    text-align: center;
+                    align-self: center;
+                    position: absolute;
+                    top: 50%;
+                    transform: translateY(-50%);
+                }
+            </style>
+            <p>Please select a <strong>namespace</strong> from the top bar</p>
+        `;
+    }
+}
+
+window.customElements.define('namespace-needed-view', NamespaceNeededView);


### PR DESCRIPTION
Fix
#6118

Although namespaced menus items will be available for KF1.4 (#5871), there is room for improvement.
@munagekar pointed out the message that is shown for the user when he tries to access the namespaced item without  namespace selection.

This PR makes it possible to show the user-friendly message "Please select a namespace from the top bar" for such users.

@munagekar I appreciate if you help discussions for this PR.

/cc @kimwnasptd @jbottum @munagekar 