### PR TITLE
fix dashboard sending malformed headers to kfam

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -118,7 +118,8 @@ export class WorkgroupApi {
     constructor(
         private profilesService: DefaultApi,
         private k8sService: KubernetesService,
-        private registrationFlowAllowed: boolean) {}
+        private registrationFlowAllowed: boolean,
+        private userIdHeader: string) {}
     /** Retrieves and memoizes the PlatformInfo. */
     private async getPlatformInfo(): Promise<PlatformInfo> {
         if (!this.platformInfo) {
@@ -214,8 +215,12 @@ export class WorkgroupApi {
                 namespace,
                 role: 'contributor',
             });
+            // only pass the auth-related headers from the user's request on to kfam
+            const authHeaders = ['authorization', 'cookie', this.userIdHeader];
             const {headers} = req;
-            delete headers['content-length'];
+            Object.keys(headers).forEach(
+                (key) => authHeaders.includes(key) || delete headers[key]
+            );
             const actionAPI = action === 'create' ? 'createBinding' : 'deleteBinding';
             await profilesService[actionAPI](binding, {headers});
             errIndex++;

--- a/components/centraldashboard/app/server.ts
+++ b/components/centraldashboard/app/server.ts
@@ -67,7 +67,7 @@ async function main() {
     });
   });
   app.use('/api', new Api(k8sService, metricsService).routes());
-  app.use('/api/workgroup', new WorkgroupApi(profilesService, k8sService, registrationFlowAllowed).routes());
+  app.use('/api/workgroup', new WorkgroupApi(profilesService, k8sService, registrationFlowAllowed, USERID_HEADER).routes());
   app.use('/api', (req: Request, res: Response) =>
     apiError({
       res,


### PR DESCRIPTION
Currently, the central-dashboard sends EVERY client header passed to its `/add-contributor/xxx` and `/remove-contributor/xxx` APIs on to kfam's `/kfam/v1/bindings` API. 
_(NOTE: these APIs are used in the "manage contributor" page to add/remove contributors)_

This means central-dashboard sends requests to `/kfam/v1/bindings` with invalid `:authority` headers (with the hostname of the istio gateway, rather than the internal kfam Service). 

This causes significant issues when you enable istio-sidecars on the kfam Pods, as istio will reject the "invalid" HTTP request, preventing you from adding/removing contributors.

---

This PR is very simple, it defines a list of "auth headers" which are safe to pass on, and deletes all others before forwarding to `/kfam/v1/bindings`.

_(NOTE: The only "auth header" that kfam actually reads is `USERID_HEADER`, however, I have included `cookie` and `authorization` in case users are validating these with their istio configs.)_