### PR TITLE
Use the workspace volume path from spanner_ui_config, rather than harcodecode

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -105,6 +105,14 @@ def get_storage_class(vol):
         return vol["class"]
 
 
+def workspace_volume_from_config(config):
+    """
+    return the mountPath specified as specified in the spawner_ui configuration
+    :param config: loaded spawner_ui configuration
+    """
+    return config["workspaceVolume"]["value"]["mountPath"]["value"]
+
+
 # Functions for transforming the data from k8s api
 def pvc_dict_from_k8s_obj(pvc):
     return {

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -48,7 +48,7 @@ def post_pvc(namespace):
             notebook,
             workspace_vol["name"],
             workspace_vol["name"],
-            workspace_vol["templatedPath"],
+            utils.workspace_volume_from_config(defaults),
         )
 
     # Add the Data Volumes


### PR DESCRIPTION
The workspace volume path of "/home/jovyan" was previously hardcoded. This is problematic for configurations which customize this value in the spanner_ui_config and created a disconnect in which the presented workspace path in the UI did not match what is actually used on the backend.

With this fix, the workspace path presented to the user in the UI is the same that is used when creating the statefulset for the notebook.

A previous fix was to use the `templatedPath` parameter passed back from the UI, but it seems semantically incorrect to treat a template as a materialized value.