### PR TITLE
[bugfix]: update unsupported links to latest pages

### DIFF
--- a/components/centraldashboard/config/centraldashboard-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-config.yaml
@@ -64,17 +64,12 @@ data:
         {
           "text": "MiniKF",
           "desc": "A fast and easy way to deploy Kubeflow locally",
-          "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+          "link": "https://www.kubeflow.org/docs/distributions/minikf/"
         },
         {
           "text": "Microk8s for Kubeflow",
           "desc": "Quickly get Kubeflow running locally on native hypervisors",
-          "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
-        },
-        {
-          "text": "Minikube for Kubeflow",
-          "desc": "Quickly get Kubeflow running locally",
-          "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+          "link": "https://www.kubeflow.org/docs/distributions/microk8s/kubeflow-on-microk8s/"
         },
         {
           "text": "Kubeflow on GCP",

--- a/components/centraldashboard/manifests/base/configmap.yaml
+++ b/components/centraldashboard/manifests/base/configmap.yaml
@@ -106,17 +106,12 @@ data:
           {
             "text": "MiniKF",
             "desc": "A fast and easy way to deploy Kubeflow locally",
-            "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+            "link": "https://www.kubeflow.org/docs/distributions/minikf/"
           },
           {
             "text": "Microk8s for Kubeflow",
             "desc": "Quickly get Kubeflow running locally on native hypervisors",
-            "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
-          },
-          {
-            "text": "Minikube for Kubeflow",
-            "desc": "Quickly get Kubeflow running locally",
-            "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+            "link": "https://www.kubeflow.org/docs/distributions/microk8s/kubeflow-on-microk8s/"
           },
           {
             "text": "Kubeflow on GCP",


### PR DESCRIPTION
The main page of central dashboard have some usefule document links such as:
![link 잘못되어있음](https://user-images.githubusercontent.com/37469330/137585416-c1a969e1-2c3f-4a82-bac9-7abf2ea2a96a.png)

But there were no longer supported links

So I changed the URL for minikf and microk8s.

Also, I couldn't find the official docs about minikube in kubeflow page, So I removed such item.

Please let me know If there was an official page for minikube getting-started. Thanks in advance.