### PR TITLE
fix(web-apps): Use relative path for --deploy-url build. #5566

### DIFF
--- a/components/crud-web-apps/jupyter/README.md
+++ b/components/crud-web-apps/jupyter/README.md
@@ -55,7 +55,7 @@ npm run build:watch
 ```bash
 # create a virtual env and install deps
 # https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
-cd component/crud-web-apps/jupyter/backend
+cd components/crud-web-apps/jupyter/backend
 python3.7 -m pip install --user virtualenv
 python3.7 -m venv web-apps-dev
 source web-apps-dev/bin/activate

--- a/components/crud-web-apps/jupyter/frontend/package.json
+++ b/components/crud-web-apps/jupyter/frontend/package.json
@@ -4,8 +4,8 @@
   "scripts": {
     "ng": "ng",
     "format": "prettier --write './**/*.{ts,html,css}'",
-    "build": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url /jupyter/static/",
-    "build:fr": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url /jupyter/static/ --configuration=fr",
+    "build": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url static/",
+    "build:fr": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url static/ --configuration=fr",
     "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all",
     "build:watch:rok": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/rok/static/ --outputHashing all --configuration=rok",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",

--- a/components/crud-web-apps/volumes/frontend/package.json
+++ b/components/crud-web-apps/volumes/frontend/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "build": "npm run copyLibAssets && ng build --prod --base-href /volumes/ --deploy-url static/",
-    "build:fr": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url /static/ --configuration=fr",
+    "build:fr": "npm run copyLibAssets && ng build --prod --base-href /volumes/ --deploy-url /static/ --configuration=fr",
     "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all",
     "build:watch:rok": "npm run copyLibAssets && ng build --watch --deploy-url static/ --configuration=rok --outputPath ../backend/apps/rok/static/ --outputHashing all",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",

--- a/components/crud-web-apps/volumes/frontend/package.json
+++ b/components/crud-web-apps/volumes/frontend/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "ng": "ng",
     "build": "npm run copyLibAssets && ng build --prod --base-href /volumes/ --deploy-url static/",
-    "build:fr": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url /jupyter/static/ --configuration=fr",
+    "build:fr": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url /static/ --configuration=fr",
     "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all",
     "build:watch:rok": "npm run copyLibAssets && ng build --watch --deploy-url static/ --configuration=rok --outputPath ../backend/apps/rok/static/ --outputHashing all",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",


### PR DESCRIPTION
Partial #5566

During standalone JWA deployment, js files are referenced with `/jupyter` prefix, instead it should be relative to `--base-href` parameter.