### PR TITLE
fix(backend): tensorboard-controller does not work because of missing permissions

### DIFF
--- a/components/tensorboard-controller/config/rbac/role.yaml
+++ b/components/tensorboard-controller/config/rbac/role.yaml
@@ -56,6 +56,7 @@ rules:
   - tensorboard.kubeflow.org
   resources:
   - tensorboards
+  - tensorboards/finalizers
   verbs:
   - create
   - delete


### PR DESCRIPTION
I have added the necessary permission.

https://github.com/kubeflow/kubeflow/blob/0c6c738efb95fbd320dc425c56c91fd6bcef5418/components/tensorboard-controller/controllers/tensorboard_controller.go#L148 tries to own the deployment but tensorboards/finalizers are not in the role

So you will get an error message similar to 
```
2021-11-05T12:02:24.832Z	ERROR	controller-runtime.controller	Reconciler error	{"controller": "tensorboard", "request": "dev-1/workspace-kulius-1", "error": "deployments.apps \"workspace-kulius-1\" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>"}
```