### PR TITLE
feat: make profile controller error logs more descriptive

### DIFF
--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -109,7 +109,7 @@ const surfaceProfileControllerErrors = (info: {res: Response, msg: string, err: 
     const code = (err.response && err.response.statusCode) || 400;
     const devError = err.body || '';
     // Msg is the developer reason of what happened, devError is the technical details as to why
-    console.error(msg+(devError?` ${devError}`:''), err.stack?err:'');
+    console.error(msg + (devError ? ` ${JSON.stringify(devError)}` : ''), err.stack ?JSON.stringify(err) : '');
     apiError({res, code, error: devError || msg});
 };
 


### PR DESCRIPTION
* The current error logs look like below:

> Unable to contact Profile Controller [object Object]
