### PR TITLE
Fix(Profile controller): Add cluster role and role binding for some resources

### DIFF
--- a/components/profile-controller/config/rbac/kustomization.yaml
+++ b/components/profile-controller/config/rbac/kustomization.yaml
@@ -5,7 +5,7 @@ resources:
 # runtime. Be sure to update RoleBinding and ClusterRoleBinding
 # subjects if changing service account names.
 # - service_account.yaml
-# - role.yaml
+- role.yaml
 - role_binding.yaml
 - leader_election_role.yaml
 - leader_election_role_binding.yaml

--- a/components/profile-controller/config/rbac/role_binding.yaml
+++ b/components/profile-controller/config/rbac/role_binding.yaml
@@ -9,3 +9,15 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: controller-service-account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-role-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: controller-service-account


### PR DESCRIPTION
### Background

I met some problems when I deploy Kubeflow in the cluster with built-in security policies.
The errors will look like

```
... don't have the permissions to list resource "profiles" in the API group "kubeflow.org" in the cluster scope
```

```
... don't have the permissions to list resource "rolebindings" in the API group "rbac.authorization.k8s.io" in the cluster scope
```

Add the new role and rolebinding should fix the issue.
