### PR TITLE
Fix unnecessary updates of istio AuthorizationPolicy

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -508,7 +508,7 @@ func (r *ProfileReconciler) updateIstioAuthorizationPolicy(profileIns *profilev1
 			return err
 		}
 	} else {
-		if !reflect.DeepEqual(istioAuth, foundAuthorizationPolicy) {
+		if !reflect.DeepEqual(istioAuth.Spec, foundAuthorizationPolicy.Spec) {
 			foundAuthorizationPolicy.Spec = istioAuth.Spec
 			logger.Info("Updating Istio AuthorizationPolicy", "namespace", istioAuth.ObjectMeta.Namespace,
 				"name", istioAuth.ObjectMeta.Name)


### PR DESCRIPTION
AuthorizationPolicy is always updated although it hasn't changed. In fact, when checking if an update is needed, we need to compare the `Spec` field instead of the AuthorizationPolicy itself.