### PR TITLE
frontend: Use responsive tables instead of cards

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -7,6 +7,7 @@
     "build": "ng build && npm run copyCSS && npm run copyAssets",
     "test": "ng test",
     "test-ci": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
+    "test-docker": "docker run -v $(pwd):/usr/src/app browserless/chrome:1.44-chrome-stable npm run test-ci",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "copyCSS": "cp ./projects/kubeflow/src/kubeflow.css ./dist/kubeflow && cp ./projects/kubeflow/src/styles.scss ./dist/kubeflow && cp ./projects/kubeflow/src/lib/variables.scss ./dist/kubeflow/lib && cp ./projects/kubeflow/src/lib/fonts.scss ./dist/kubeflow/lib",

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/config.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/config.ts
@@ -1,7 +1,6 @@
 import {
   PropertyValue,
   StatusValue,
-  TRUNCATE_TEXT_SIZE,
   TABLE_THEME,
   TableConfig,
 } from '../resource-table/types';
@@ -16,7 +15,7 @@ export function generateConfig(): TableConfig {
       {
         matHeaderCellDef: 'Status',
         matColumnDef: 'status',
-        width: '40px',
+        style: { width: '40px' },
         value: new StatusValue({
           fieldPhase: 'statusPhase',
           fieldMessage: 'statusMessage',
@@ -25,7 +24,7 @@ export function generateConfig(): TableConfig {
       {
         matHeaderCellDef: 'Type',
         matColumnDef: 'type',
-        width: '150px',
+        style: { width: '150px' },
         value: new PropertyValue({
           field: 'type',
         }),
@@ -33,7 +32,7 @@ export function generateConfig(): TableConfig {
       {
         matHeaderCellDef: 'Last Transition Time',
         matColumnDef: 'lastTransitionTime',
-        width: '160px',
+        style: { width: '150px' },
         value: new DateTimeValue({
           field: 'lastTransitionTime',
         }),
@@ -41,7 +40,7 @@ export function generateConfig(): TableConfig {
       {
         matHeaderCellDef: 'Reason',
         matColumnDef: 'reason',
-        width: '150px',
+        style: { width: '150px' },
         value: new PropertyValue({
           field: 'reason',
         }),
@@ -49,7 +48,7 @@ export function generateConfig(): TableConfig {
       {
         matHeaderCellDef: 'Message',
         matColumnDef: 'message',
-        minWidth: '150px',
+        style: { width: '150px' },
         value: new PropertyValue({
           field: 'message',
         }),

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.component.html
@@ -36,7 +36,7 @@
         [config]="config"
         [data]="data"
         [trackByFn]="trackByFn"
-        [emitter]="actionsEmitter"
+        (actionsEmitter)="actionTriggered($event)"
       ></lib-table>
     </mat-card-content>
   </mat-card>
@@ -71,7 +71,7 @@
       [config]="config"
       [data]="data"
       [trackByFn]="trackByFn"
-      [emitter]="actionsEmitter"
+      (actionsEmitter)="actionTriggered($event)"
     ></lib-table>
   </div>
 </div>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.module.ts
@@ -22,10 +22,12 @@ import { PopoverModule } from '../popover/popover.module';
 import { TableChipsListComponent } from './chips-list/chips-list.component';
 import { ComponentValueComponent } from './component-value/component-value.component';
 import { PortalModule } from '@angular/cdk/portal';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @NgModule({
   imports: [
     CommonModule,
+    BrowserAnimationsModule,
     MatTableModule,
     MatTooltipModule,
     MatProgressSpinnerModule,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.module.ts
@@ -49,6 +49,6 @@ import { PortalModule } from '@angular/cdk/portal';
     TableComponent,
     ComponentValueComponent,
   ],
-  exports: [ResourceTableComponent],
+  exports: [ResourceTableComponent, TableComponent],
 })
 export class ResourceTableModule {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/resource-table.module.ts
@@ -7,6 +7,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatTableModule } from '@angular/material/table';
+import { MatPaginatorModule } from '@angular/material/paginator';
 import { StatusComponent } from './status/status.component';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -33,6 +34,7 @@ import { PortalModule } from '@angular/cdk/portal';
     MatButtonModule,
     MatChipsModule,
     MatMenuModule,
+    MatPaginatorModule,
     PortalModule,
     FontAwesomeModule,
     MatIconModule,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
@@ -175,3 +175,10 @@
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
 </table>
+
+<mat-paginator
+  [pageSizeOptions]="[10, 20, 50]"
+  showFirstLastButtons
+></mat-paginator>
+
+<mat-divider></mat-divider>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
@@ -10,7 +10,7 @@
       [ngClass]="{
         grey: tableTheme === TABLE_THEME.FLAT,
         'right-align': col.textAlignment === 'right',
-        'row-right-padding': col.textAlignment === 'right'
+        'header-padding': true
       }"
     >
       {{ col.matHeaderCellDef }}
@@ -22,16 +22,17 @@
         mat-cell
         *matCellDef="let element"
         data-cy-resource-table-row
-        [ngStyle]="{ 'min-width': col.minWidth, width: col.width }"
+        [ngStyle]="col.style"
         [ngClass]="{
           'right-align': col.textAlignment === 'right',
-          'row-right-padding': col.textAlignment === 'right'
+          'mat-cell-truncate': col.value.truncate
         }"
       >
         <div
           [matTooltip]="col.value.getTooltip(element)"
           [libPopover]="col.value.getPopover(element)"
           matTooltipClass="custom-tooltip"
+          [ngStyle]="col.value.style"
           [ngClass]="col.value.getClasses()"
           (click)="linkClicked(col.matColumnDef, element)"
         >
@@ -46,7 +47,7 @@
         mat-cell
         *matCellDef="let element"
         data-cy-resource-table-row
-        [ngStyle]="{ 'min-width': col.minWidth, width: col.width }"
+        [ngStyle]="col.style"
       >
         <lib-status [row]="element" [config]="col.value"></lib-status>
       </td>
@@ -58,7 +59,8 @@
         mat-cell
         *matCellDef="let element"
         data-cy-resource-table-row
-        [ngStyle]="{ 'min-width': col.minWidth, width: col.width }"
+        [ngStyle]="col.style"
+        [ngClass]="{ 'right-align': col.textAlignment === 'right' }"
       >
         <lib-date-time [date]="col.value.getValue(element)"></lib-date-time>
       </td>
@@ -70,8 +72,8 @@
         mat-cell
         *matCellDef="let element"
         data-cy-resource-table-row
-        [ngStyle]="{ 'min-width': col.minWidth, width: col.width }"
-        [ngClass]="{ 'right-align': col.rightAlign }"
+        [ngStyle]="col.style"
+        [ngClass]="{ 'right-align': col.textAlignment === 'right' }"
       >
         <lib-component-value
           [element]="element"
@@ -86,7 +88,7 @@
         mat-cell
         *matCellDef="let element"
         data-cy-resource-table-row
-        [ngStyle]="{ 'min-width': col.minWidth, width: col.width }"
+        [ngStyle]="col.style"
         [ngClass]="{
           'right-align': col.textAlignment === 'right',
           'row-right-padding': col.textAlignment === 'right'
@@ -105,7 +107,7 @@
         mat-cell
         *matCellDef="let element"
         data-cy-resource-table-row
-        [ngStyle]="{ 'min-width': col.minWidth, width: col.width }"
+        [ngStyle]="col.style"
       >
         <lib-table-chips-list
           [element]="element"
@@ -120,7 +122,7 @@
         mat-cell
         *matCellDef="let element"
         data-cy-resource-table-row
-        [ngStyle]="{ 'min-width': col.minWidth, width: col.width }"
+        [ngStyle]="col.style"
       >
         <button mat-icon-button [matMenuTriggerFor]="menu">
           <mat-icon>{{ col.value.menuIcon }}</mat-icon>
@@ -159,6 +161,7 @@
             <lib-action
               *ngIf="isActionIconValue(action)"
               data-cy-resource-table-action-icon
+              class="action-button"
               [action]="action"
               [data]="element"
               (emitter)="actionTriggered($event)"

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.scss
@@ -1,11 +1,15 @@
-$row-right-padding: 28px;
+$row-padding: 8px;
+
+:host {
+  display: block;
+}
 
 .grey {
   background-color: rgb(245, 245, 245);
 }
 
 .row-right-padding {
-  padding-right: $row-right-padding;
+  padding-right: $row-padding;
 }
 
 tr th.right-align {
@@ -14,17 +18,26 @@ tr th.right-align {
 
 .action-list {
   display: flex;
+  width: fit-content;
+  margin: auto 0 auto auto;
 }
 
 .action-button {
-  margin: auto;
+  margin: auto 0.2rem;
 }
 
-.mat-cell {
-  min-height: auto;
-  padding-top: 2px;
-  padding-bottom: 2px;
-  padding-right: $row-right-padding;
+.mat-cell-truncate {
+  max-width: 20px;
+}
+
+th.mat-header-cell {
+  padding-right: $row-padding;
+  padding-left: $row-padding;
+}
+
+td.mat-cell {
+  padding-right: $row-padding;
+  padding-left: $row-padding;
 }
 
 .mat-row:hover {
@@ -39,18 +52,6 @@ tr th.right-align {
   text-decoration: underline;
   color: blue;
   cursor: pointer;
-}
-
-.text-small {
-  max-width: 150px;
-}
-
-.text-medium {
-  max-width: 300px;
-}
-
-.text-large {
-  max-width: 450px;
 }
 
 lib-action {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
@@ -57,7 +57,7 @@ export class TableComponent {
   // Whenever a button in a row is pressed the component will emit an event
   // with information regarding the button that was pressed as well as the
   // row's object.
-  @Input() emitter: EventEmitter<ActionEvent>;
+  @Output() actionsEmitter = new EventEmitter<ActionEvent>();
 
   public isActionListValue(obj) {
     return obj instanceof ActionListValue;
@@ -101,17 +101,17 @@ export class TableComponent {
 
   public actionTriggered(e: ActionEvent) {
     // Forward the emitted ActionEvent
-    this.emitter.emit(e);
+    this.actionsEmitter.emit(e);
   }
 
   public newButtonTriggered() {
     const ev = new ActionEvent('newResourceButton', {});
-    this.emitter.emit(ev);
+    this.actionsEmitter.emit(ev);
   }
 
   public linkClicked(col: string, data: any) {
     const ev = new ActionEvent(`${col}:link`, data);
-    this.emitter.emit(ev);
+    this.actionsEmitter.emit(ev);
   }
 
   get tableTheme(): TABLE_THEME {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
@@ -1,5 +1,14 @@
-import { Component, Input, Output, EventEmitter } from '@angular/core';
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  AfterViewInit,
+  HostBinding,
+  ViewChild,
+} from '@angular/core';
 import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
 import {
   TableConfig,
   ActionEvent,
@@ -21,12 +30,15 @@ import { TemplateValue } from '../types/template';
   templateUrl: './table.component.html',
   styleUrls: ['./table.component.scss'],
 })
-export class TableComponent {
+export class TableComponent implements AfterViewInit {
   private innerConfig: TableConfig;
   private innerData: any[] = [];
 
   public dataSource = new MatTableDataSource();
   public displayedColumns: string[] = [];
+
+  @HostBinding('class.lib-table') selfClass = true;
+  @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
 
   TABLE_THEME = TABLE_THEME;
 
@@ -58,6 +70,10 @@ export class TableComponent {
   // with information regarding the button that was pressed as well as the
   // row's object.
   @Output() actionsEmitter = new EventEmitter<ActionEvent>();
+
+  ngAfterViewInit() {
+    this.dataSource.paginator = this.paginator;
+  }
 
   public isActionListValue(obj) {
     return obj instanceof ActionListValue;

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/property-value.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/property-value.ts
@@ -1,20 +1,13 @@
 import { get as getAttributeValue } from 'lodash';
 
-// Single Text field
-export enum TRUNCATE_TEXT_SIZE {
-  NO_TRUNCATE = 'none',
-  SMALL = 'text-small',
-  MEDIUM = 'text-medium',
-  LARGE = 'text-large',
-}
-
 export interface PropertyConfig {
   field?: string;
   valueFn?: (row: any) => any;
   tooltipField?: string;
   popoverField?: string;
-  truncate?: TRUNCATE_TEXT_SIZE;
+  truncate?: boolean /* if set to true, user needs to define max-width */;
   isLink?: boolean;
+  style?: { [prop: string]: string };
 }
 
 export class PropertyValue {
@@ -22,19 +15,29 @@ export class PropertyValue {
   tooltipField: string;
   valueFn?: (row: any) => any;
   popoverField: string;
-  truncate: TRUNCATE_TEXT_SIZE;
+  truncate: boolean;
   isLink: boolean;
+  style: { [prop: string]: string };
 
   private defaultValues: PropertyConfig = {
     field: '',
     tooltipField: '',
     popoverField: '',
-    truncate: TRUNCATE_TEXT_SIZE.NO_TRUNCATE,
+    truncate: false,
     isLink: false,
+    style: {},
   };
 
   constructor(config: PropertyConfig) {
-    const { field, valueFn, tooltipField, popoverField, truncate, isLink } = {
+    const {
+      field,
+      valueFn,
+      tooltipField,
+      popoverField,
+      truncate,
+      isLink,
+      style,
+    } = {
       ...this.defaultValues,
       ...config,
     };
@@ -44,6 +47,7 @@ export class PropertyValue {
     this.popoverField = popoverField;
     this.truncate = truncate;
     this.isLink = isLink;
+    this.style = style;
   }
 
   getClasses() {
@@ -53,11 +57,11 @@ export class PropertyValue {
       classes.push('link');
     }
 
-    if (this.truncate === TRUNCATE_TEXT_SIZE.NO_TRUNCATE) {
+    if (!this.truncate) {
       return classes;
     }
 
-    classes.push(...['truncate', this.truncate]);
+    classes.push('truncate');
     return classes;
   }
 

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/table.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/table.ts
@@ -6,6 +6,7 @@ import { DateTimeValue } from './date-time';
 import { TemplateValue } from './template';
 import { ChipsListValue } from './chip-list';
 import { ComponentValue } from './component-value';
+import { MenuValue } from './menu-value';
 
 export type TextAlignment = 'left' | 'right';
 
@@ -18,17 +19,17 @@ export interface TableColumn {
     | ActionListValue
     | ActionIconValue
     | DateTimeValue
+    | MenuValue
     | ChipsListValue
     | ComponentValue
     | TemplateValue;
   textAlignment?: TextAlignment;
-  minWidth?: string;
-  width?: string;
+  style?: { [prop: string]: string };
 }
 
 export interface TableConfig {
   columns: TableColumn[];
-  title: string;
+  title?: string;
   newButtonText?: string;
   width?: string;
   theme?: TABLE_THEME;

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
@@ -21,6 +21,7 @@
 
 .title-margin {
   margin: auto 0;
+  padding: 12px 0;
 }
 
 .button-icon {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
@@ -8,7 +8,7 @@
 
 .title {
   font-weight: 400;
-  font-size: 20px;
+  font-size: 24px;
 }
 
 .back-button {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
@@ -80,3 +80,4 @@ export * from './lib/form/submit-bar/submit-bar.component';
 export * from './lib/form/step-info/step-info.component';
 export * from './lib/form/submit-bar/submit-bar.component';
 export * from './lib/form/step-info/step-info.component';
+export * from './lib/resource-table/table/table.component';

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -116,6 +116,13 @@ body {
   text-overflow: ellipsis;
 }
 
+/*
+ * common table
+ */
+.lib-table .mat-paginator-container {
+  min-height: 48px;
+}
+
 // Form global css
 .form--dialog-padding .mat-dialog-container {
   padding: 0 24px;

--- a/components/crud-web-apps/jupyter/frontend/angular.json
+++ b/components/crud-web-apps/jupyter/frontend/angular.json
@@ -157,8 +157,7 @@
           "options": {
             "tsConfig": [
               "tsconfig.app.json",
-              "tsconfig.spec.json",
-              "e2e/tsconfig.json"
+              "tsconfig.spec.json"
             ],
             "exclude": ["**/node_modules/**"]
           }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
@@ -1,79 +1,91 @@
-<div class="center-flex">
-  <div class="form-with-buttons">
-    <div class="form--card-container mat-elevation-z2">
-      <form novalidate (ngSubmit)="onSubmit()" [formGroup]="formCtrl">
-        <app-form-name-namespace
-          [parentForm]="formCtrl"
-        ></app-form-name-namespace>
+<div class="lib-content-wrapper">
+  <lib-title-actions-toolbar
+    title="New notebook"
+    [backButton]="true"
+    (back)="onCancel()"
+  >
+  </lib-title-actions-toolbar>
 
-        <app-form-image
-          [parentForm]="formCtrl"
-          [images]="config?.image?.options"
-          [imagesGroupOne]="config?.imageGroupOne?.options"
-          [imagesGroupTwo]="config?.imageGroupTwo?.options"
-          [allowCustomImage]="config?.allowCustomImage"
-          [hideRegistry]="config?.hideRegistry"
-          [hideTag]="config?.hideTag"
-        ></app-form-image>
+  <!--scrollable page content-->
+  <div class="page-padding lib-flex-grow lib-overflow-auto">
+    <div class="center-flex">
+      <div class="form-with-buttons">
+        <div class="form--card-container mat-elevation-z2">
+          <form novalidate (ngSubmit)="onSubmit()" [formGroup]="formCtrl">
+            <app-form-name-namespace
+              [parentForm]="formCtrl"
+            ></app-form-name-namespace>
 
-        <app-form-cpu-ram
-          [parentForm]="formCtrl"
-          [readonlyCPU]="config?.cpu?.readOnly"
-          [readonlyMemory]="config?.memory?.readOnly"
-          [cpuLimitFactor]="config?.cpu?.limitFactor"
-          [memoryLimitFactor]="config?.memory?.limitFactor"
-        ></app-form-cpu-ram>
+            <app-form-image
+              [parentForm]="formCtrl"
+              [images]="config?.image?.options"
+              [imagesGroupOne]="config?.imageGroupOne?.options"
+              [imagesGroupTwo]="config?.imageGroupTwo?.options"
+              [allowCustomImage]="config?.allowCustomImage"
+              [hideRegistry]="config?.hideRegistry"
+              [hideTag]="config?.hideTag"
+            ></app-form-image>
 
-        <app-form-gpus
-          [parentForm]="formCtrl"
-          [vendors]="config?.gpus?.value.vendors"
-        ></app-form-gpus>
+            <app-form-cpu-ram
+              [parentForm]="formCtrl"
+              [readonlyCPU]="config?.cpu?.readOnly"
+              [readonlyMemory]="config?.memory?.readOnly"
+              [cpuLimitFactor]="config?.cpu?.limitFactor"
+              [memoryLimitFactor]="config?.memory?.limitFactor"
+            ></app-form-cpu-ram>
 
-        <app-form-workspace-volume
-          [parentForm]="formCtrl"
-          [pvcs]="pvcs"
-          [readonly]="config?.workspaceVolume?.readOnly"
-          [defaultStorageClass]="defaultStorageclass"
+            <app-form-gpus
+              [parentForm]="formCtrl"
+              [vendors]="config?.gpus?.value.vendors"
+            ></app-form-gpus>
+
+            <app-form-workspace-volume
+              [parentForm]="formCtrl"
+              [pvcs]="pvcs"
+              [readonly]="config?.workspaceVolume?.readOnly"
+              [defaultStorageClass]="defaultStorageclass"
+            >
+            </app-form-workspace-volume>
+
+            <app-form-data-volumes
+              [parentForm]="formCtrl"
+              [pvcs]="pvcs"
+              [readonly]="config?.dataVolumes?.readOnly"
+              [defaultStorageClass]="defaultStorageclass"
+            >
+            </app-form-data-volumes>
+
+            <app-form-configurations
+              [parentForm]="formCtrl"
+            ></app-form-configurations>
+
+            <app-form-affinity-tolerations
+              [parentForm]="formCtrl"
+              [affinityConfigs]="config?.affinityConfig?.options"
+              [tolerationGroups]="config?.tolerationGroup?.options"
+            ></app-form-affinity-tolerations>
+
+            <app-form-advanced-options
+              [parentForm]="formCtrl"
+            ></app-form-advanced-options>
+          </form>
+        </div>
+
+        <button
+          mat-raised-button
+          color="primary"
+          class="form--button-margin"
+          (click)="onSubmit()"
+          [disabled]="!formCtrl.valid || blockSubmit"
+          i18n
         >
-        </app-form-workspace-volume>
+          LAUNCH
+        </button>
 
-        <app-form-data-volumes
-          [parentForm]="formCtrl"
-          [pvcs]="pvcs"
-          [readonly]="config?.dataVolumes?.readOnly"
-          [defaultStorageClass]="defaultStorageclass"
-        >
-        </app-form-data-volumes>
-
-        <app-form-configurations
-          [parentForm]="formCtrl"
-        ></app-form-configurations>
-
-        <app-form-affinity-tolerations
-          [parentForm]="formCtrl"
-          [affinityConfigs]="config?.affinityConfig?.options"
-          [tolerationGroups]="config?.tolerationGroup?.options"
-        ></app-form-affinity-tolerations>
-
-        <app-form-advanced-options
-          [parentForm]="formCtrl"
-        ></app-form-advanced-options>
-      </form>
+        <button mat-raised-button type="button" (click)="onCancel()" i18n>
+          CANCEL
+        </button>
+      </div>
     </div>
-
-    <button
-      mat-raised-button
-      color="primary"
-      class="form--button-margin"
-      (click)="onSubmit()"
-      [disabled]="!formCtrl.valid || blockSubmit"
-      i18n
-    >
-      LAUNCH
-    </button>
-
-    <button mat-raised-button type="button" (click)="onCancel()" i18n>
-      CANCEL
-    </button>
   </div>
 </div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.module.ts
@@ -16,6 +16,7 @@ import { FormAdvancedOptionsComponent } from './form-advanced-options/form-advan
 import {
   FormModule as KfFormModule,
   ImmediateErrorStateMatcher,
+  TitleActionsToolbarModule,
 } from 'kubeflow';
 import { FormWorkspaceVolumeComponent } from './form-workspace-volume/form-workspace-volume.component';
 import { VolumeComponent } from './volume/volume.component';
@@ -44,6 +45,7 @@ import { FormAffinityTolerationsComponent } from './form-affinity-tolerations/fo
     MatSlideToggleModule,
     MatIconModule,
     MatButtonToggleModule,
+    TitleActionsToolbarModule,
   ],
   exports: [
     FormDefaultComponent,

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-rok/form-rok.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-rok/form-rok.component.html
@@ -20,7 +20,7 @@
               [parentForm]="formCtrl"
             ></app-form-name-namespace>
 
-        <app-form-cpu-ram [parentForm]="formCtrl"></app-form-cpu-ram>
+            <app-form-cpu-ram [parentForm]="formCtrl"></app-form-cpu-ram>
             <app-form-image
               [parentForm]="formCtrl"
               [images]="config?.image?.options"

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-rok/form-rok.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-rok/form-rok.component.html
@@ -1,70 +1,91 @@
-<div class="center-flex">
-  <div class="form-with-buttons">
-    <div class="form--card-container mat-elevation-z2">
-      <form novalidate (ngSubmit)="onSubmit()" [formGroup]="formCtrl">
-        <app-rok-jupyter-lab-selector
-          [parentForm]="formCtrl"
-        ></app-rok-jupyter-lab-selector>
+<div class="lib-content-wrapper">
+  <lib-title-actions-toolbar
+    title="New notebook"
+    [backButton]="true"
+    (back)="onCancel()"
+  >
+  </lib-title-actions-toolbar>
 
-        <app-form-name-namespace
-          [parentForm]="formCtrl"
-        ></app-form-name-namespace>
+  <!--scrollable page content-->
+  <div class="page-padding lib-flex-grow lib-overflow-auto">
+    <div class="center-flex">
+      <div class="form-with-buttons">
+        <div class="form--card-container mat-elevation-z2">
+          <form novalidate (ngSubmit)="onSubmit()" [formGroup]="formCtrl">
+            <app-rok-jupyter-lab-selector
+              [parentForm]="formCtrl"
+            ></app-rok-jupyter-lab-selector>
 
-        <app-form-image
-          [parentForm]="formCtrl"
-          [images]="config?.image?.options"
-          [imagesGroupOne]="config?.imageGroupOne?.options"
-          [imagesGroupTwo]="config?.imageGroupTwo?.options"
-          [allowCustomImage]="config?.allowCustomImage"
-        ></app-form-image>
+            <app-form-name-namespace
+              [parentForm]="formCtrl"
+            ></app-form-name-namespace>
 
         <app-form-cpu-ram [parentForm]="formCtrl"></app-form-cpu-ram>
+            <app-form-image
+              [parentForm]="formCtrl"
+              [images]="config?.image?.options"
+              [imagesGroupOne]="config?.imageGroupOne?.options"
+              [imagesGroupTwo]="config?.imageGroupTwo?.options"
+              [allowCustomImage]="config?.allowCustomImage"
+            ></app-form-image>
 
-        <app-form-gpus
-          [parentForm]="formCtrl"
-          [vendors]="config?.gpus?.value.vendors"
-        ></app-form-gpus>
+            <app-form-cpu-ram
+              [parentForm]="formCtrl"
+              [readonlyCPU]="config?.cpu?.readOnly"
+              [readonlyMemory]="config?.memory?.readOnly"
+              [cpuLimitFactor]="config?.cpu?.limitFactor"
+              [memoryLimitFactor]="config?.memory?.limitFactor"
+            ></app-form-cpu-ram>
 
-        <app-rok-form-workspace-volume
-          [parentForm]="formCtrl"
-          [pvcs]="pvcs"
-          [readonly]="config?.workspaceVolume?.readOnly"
+            <app-form-gpus
+              [parentForm]="formCtrl"
+              [vendors]="config?.gpus?.value.vendors"
+            ></app-form-gpus>
+
+            <app-rok-form-workspace-volume
+              [parentForm]="formCtrl"
+              [pvcs]="pvcs"
+              [readonly]="config?.workspaceVolume?.readOnly"
+            >
+            </app-rok-form-workspace-volume>
+
+            <app-rok-form-data-volumes
+              [parentForm]="formCtrl"
+              [pvcs]="pvcs"
+              [readonly]="config?.dataVolumes?.readOnly"
+            >
+            </app-rok-form-data-volumes>
+
+            <app-rok-form-configurations
+              [parentForm]="formCtrl"
+            ></app-rok-form-configurations>
+
+            <app-form-affinity-tolerations
+              [parentForm]="formCtrl"
+              [affinityConfigs]="config?.affinityConfig?.options"
+              [tolerationGroups]="config?.tolerationGroup?.options"
+            ></app-form-affinity-tolerations>
+
+            <app-form-advanced-options
+              [parentForm]="formCtrl"
+            ></app-form-advanced-options>
+          </form>
+        </div>
+
+        <button
+          mat-raised-button
+          color="primary"
+          class="form--button-margin"
+          (click)="onSubmit()"
+          [disabled]="!formCtrl.valid || blockSubmit"
         >
-        </app-rok-form-workspace-volume>
+          LAUNCH
+        </button>
 
-        <app-rok-form-data-volumes
-          [parentForm]="formCtrl"
-          [pvcs]="pvcs"
-          [readonly]="config?.dataVolumes?.readOnly"
-        >
-        </app-rok-form-data-volumes>
-
-        <app-rok-form-configurations
-          [parentForm]="formCtrl"
-        ></app-rok-form-configurations>
-
-        <app-form-affinity-tolerations
-          [parentForm]="formCtrl"
-          [affinityConfigs]="config?.affinityConfig?.options"
-          [tolerationGroups]="config?.tolerationGroup?.options"
-        ></app-form-affinity-tolerations>
-
-        <app-form-advanced-options
-          [parentForm]="formCtrl"
-        ></app-form-advanced-options>
-      </form>
+        <button mat-raised-button type="button" (click)="onCancel()">
+          CANCEL
+        </button>
+      </div>
     </div>
-
-    <button
-      mat-raised-button
-      color="primary"
-      class="form--button-margin"
-      (click)="onSubmit()"
-      [disabled]="!formCtrl.valid || blockSubmit"
-    >
-      LAUNCH
-    </button>
-
-    <button mat-raised-button type="button" (click)="onCancel()">CANCEL</button>
   </div>
 </div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-rok/form-rok.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-rok/form-rok.module.ts
@@ -5,7 +5,10 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
 
-import { FormModule as KfFormModule } from 'kubeflow';
+import {
+  FormModule as KfFormModule,
+  TitleActionsToolbarModule,
+} from 'kubeflow';
 import { FormNameComponent } from '../form-default/form-name/form-name.component';
 import { FormImageComponent } from '../form-default/form-image/form-image.component';
 import { FormCpuRamComponent } from '../form-default/form-cpu-ram/form-cpu-ram.component';
@@ -40,6 +43,7 @@ import { RokFormConfigurationsComponent } from './rok-form-configurations/rok-fo
     MatSlideToggleModule,
     MatIconModule,
     FormDefaultModule,
+    TitleActionsToolbarModule,
   ],
   exports: [FormRokComponent],
 })

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -4,10 +4,11 @@ import {
   ActionListValue,
   ActionIconValue,
   ActionButtonValue,
-  TRUNCATE_TEXT_SIZE,
   MenuValue,
   DialogConfig,
   ComponentValue,
+  TableConfig,
+  TABLE_THEME,
 } from 'kubeflow';
 import { ServerTypeComponent } from './server-type/server-type.component';
 
@@ -41,9 +42,7 @@ export function getStopDialogConfig(name: string): DialogConfig {
 }
 
 // --- Config for the Resource Table ---
-export const defaultConfig = {
-  title: $localize`Notebooks`,
-  newButtonText: $localize`NEW NOTEBOOK`,
+export const defaultConfig: TableConfig = {
   columns: [
     {
       matHeaderCellDef: $localize`Status`,
@@ -53,10 +52,11 @@ export const defaultConfig = {
     {
       matHeaderCellDef: $localize`Name`,
       matColumnDef: 'name',
+      style: { width: '25%' },
       value: new PropertyValue({
         field: 'name',
-        truncate: TRUNCATE_TEXT_SIZE.SMALL,
         tooltipField: 'name',
+        truncate: true,
       }),
     },
     {
@@ -69,20 +69,26 @@ export const defaultConfig = {
     {
       matHeaderCellDef: $localize`Age`,
       matColumnDef: 'age',
-      value: new PropertyValue({ field: 'age' }),
+      style: { width: '12%' },
+      textAlignment: 'right',
+      value: new PropertyValue({ field: 'age', truncate: true }),
     },
     {
       matHeaderCellDef: $localize`Image`,
       matColumnDef: 'image',
+      style: { width: '30%' },
       value: new PropertyValue({
         field: 'shortImage',
-        tooltipField: 'image',
-        truncate: TRUNCATE_TEXT_SIZE.MEDIUM,
+        popoverField: 'image',
+        truncate: true,
+        style: { maxWidth: '300px' },
       }),
     },
     {
       matHeaderCellDef: $localize`GPUs`,
       matColumnDef: 'gpus',
+      style: { width: '8%' },
+      textAlignment: 'right',
       value: new PropertyValue({
         field: 'gpus.count',
         tooltipField: 'gpus.message',
@@ -91,11 +97,15 @@ export const defaultConfig = {
     {
       matHeaderCellDef: $localize`CPUs`,
       matColumnDef: 'cpu',
+      style: { width: '8%' },
+      textAlignment: 'right',
       value: new PropertyValue({ field: 'cpu' }),
     },
     {
       matHeaderCellDef: $localize`Memory`,
       matColumnDef: 'memory',
+      style: { width: '8%' },
+      textAlignment: 'right',
       value: new PropertyValue({ field: 'memory' }),
     },
     {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.html
@@ -1,8 +1,15 @@
-<lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+<div class="lib-content-wrapper">
+  <lib-title-actions-toolbar title="Notebooks" [buttons]="buttons" i18n-title>
+    <lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+  </lib-title-actions-toolbar>
 
-<lib-resource-table
-  [config]="config"
-  [data]="processedData"
-  [trackByFn]="notebookTrackByFn"
-  (actionsEmitter)="reactToAction($event)"
-></lib-resource-table>
+  <!--scrollable page content-->
+  <div class="page-padding lib-flex-grow lib-overflow-auto">
+    <lib-table
+      [config]="config"
+      [data]="processedData"
+      [trackByFn]="notebookTrackByFn"
+      (actionsEmitter)="reactToAction($event)"
+    ></lib-table>
+  </div>
+</div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.ts
@@ -10,6 +10,7 @@ import {
   SnackBarService,
   DIALOG_RESP,
   SnackType,
+  ToolbarButton,
 } from 'kubeflow';
 import { JWABackendService } from 'src/app/services/backend.service';
 import { Subscription } from 'rxjs';
@@ -37,6 +38,17 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
   config = defaultConfig;
   rawData: NotebookResponseObject[] = [];
   processedData: NotebookProcessedObject[] = [];
+
+  buttons: ToolbarButton[] = [
+    new ToolbarButton({
+      text: `New Notebook`,
+      icon: 'add',
+      stroked: true,
+      fn: () => {
+        this.router.navigate(['/new']);
+      },
+    }),
+  ];
 
   constructor(
     public ns: NamespaceService,
@@ -85,9 +97,6 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
   // Event handling functions
   reactToAction(a: ActionEvent) {
     switch (a.action) {
-      case 'newResourceButton': // TODO: could also use enums here
-        this.newResourceClicked();
-        break;
       case 'delete':
         this.deleteVolumeClicked(a.data);
         break;
@@ -98,11 +107,6 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
         this.startStopClicked(a.data);
         break;
     }
-  }
-
-  public newResourceClicked() {
-    // Redirect to form page
-    this.router.navigate(['/new']);
   }
 
   public deleteVolumeClicked(notebook: NotebookProcessedObject) {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.module.ts
@@ -1,20 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IndexDefaultComponent } from './index-default.component';
-import {
-  ResourceTableModule,
-  NamespaceSelectModule,
-  ConfirmDialogModule,
-} from 'kubeflow';
+import { KubeflowModule } from 'kubeflow';
 
 @NgModule({
   declarations: [IndexDefaultComponent],
-  imports: [
-    CommonModule,
-    ResourceTableModule,
-    NamespaceSelectModule,
-    ConfirmDialogModule,
-  ],
+  imports: [CommonModule, KubeflowModule],
   exports: [IndexDefaultComponent],
 })
 export class IndexDefaultModule {}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-rok/index-rok.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-rok/index-rok.module.ts
@@ -2,22 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { IndexRokComponent } from './index-rok.component';
 import { IndexDefaultComponent } from '../index-default/index-default.component';
-import {
-  ResourceTableModule,
-  NamespaceSelectModule,
-  ConfirmDialogModule,
-} from 'kubeflow';
+import { KubeflowModule } from 'kubeflow';
 import { IndexDefaultModule } from '../index-default/index-default.module';
 
 @NgModule({
   declarations: [IndexRokComponent],
-  imports: [
-    CommonModule,
-    ResourceTableModule,
-    NamespaceSelectModule,
-    ConfirmDialogModule,
-    IndexDefaultModule,
-  ],
+  imports: [CommonModule, KubeflowModule, IndexDefaultModule],
   exports: [IndexRokComponent],
 })
 export class IndexRokModule {}

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
@@ -5,32 +5,33 @@ import {
   ActionIconValue,
   ActionButtonValue,
   TableColumn,
-  TRUNCATE_TEXT_SIZE,
   TableConfig,
   DateTimeValue,
 } from 'kubeflow';
 
 const tableConfig: TableConfig = {
-  title: $localize`Tensorboards`,
-  newButtonText: $localize`NEW TENSORBOARD`,
   columns: [
     {
       matHeaderCellDef: $localize`Status`,
       matColumnDef: 'status',
+      style: { width: '1%' },
       value: new StatusValue(),
     },
     {
       matHeaderCellDef: $localize`Name`,
       matColumnDef: 'name',
+      style: { width: '25%' },
       value: new PropertyValue({
         field: 'name',
         tooltipField: 'name',
-        truncate: TRUNCATE_TEXT_SIZE.SMALL,
+        truncate: true,
       }),
     },
     {
       matHeaderCellDef: $localize`Age`,
       matColumnDef: 'age',
+      style: { width: '15%' },
+      textAlignment: 'right',
       value: new DateTimeValue({
         field: 'age',
       }),
@@ -38,10 +39,11 @@ const tableConfig: TableConfig = {
     {
       matHeaderCellDef: $localize`Logspath`,
       matColumnDef: 'logspath',
+      style: { width: '40%%' },
       value: new PropertyValue({
         field: 'logspath',
         tooltipField: 'logspath',
-        truncate: TRUNCATE_TEXT_SIZE.SMALL,
+        truncate: true,
       }),
     },
   ],

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.html
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.html
@@ -1,8 +1,19 @@
-<lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+<div class="lib-content-wrapper">
+  <lib-title-actions-toolbar
+    title="TensorBoards"
+    [buttons]="buttons"
+    i18n-title
+  >
+    <lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+  </lib-title-actions-toolbar>
 
-<lib-resource-table
-  [config]="config"
-  [data]="processedData"
-  [trackByFn]="tensorboardTrackByFn"
-  (actionsEmitter)="reactToAction($event)"
-></lib-resource-table>
+  <!--scrollable page content-->
+  <div class="page-padding lib-flex-grow lib-overflow-auto">
+    <lib-table
+      [config]="config"
+      [data]="processedData"
+      [trackByFn]="tensorboardTrackByFn"
+      (actionsEmitter)="reactToAction($event)"
+    ></lib-table>
+  </div>
+</div>

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.ts
@@ -10,6 +10,7 @@ import {
   DialogConfig,
   SnackBarService,
   SnackType,
+  ToolbarButton,
 } from 'kubeflow';
 import { defaultConfig } from './config';
 import { environment } from '@app/environment';
@@ -37,6 +38,17 @@ export class IndexComponent implements OnInit {
   public config = defaultConfig;
   public rawData: TensorboardResponseObject[] = [];
   public processedData: TensorboardProcessedObject[] = [];
+
+  buttons: ToolbarButton[] = [
+    new ToolbarButton({
+      text: `New TensorBoard`,
+      icon: 'add',
+      stroked: true,
+      fn: () => {
+        this.newResourceClicked();
+      },
+    }),
+  ];
 
   constructor(
     public ns: NamespaceService,
@@ -81,9 +93,6 @@ export class IndexComponent implements OnInit {
 
   public reactToAction(a: ActionEvent) {
     switch (a.action) {
-      case 'newResourceButton':
-        this.newResourceClicked();
-        break;
       case 'delete':
         this.deleteTensorboardClicked(a.data);
         break;
@@ -164,7 +173,7 @@ export class IndexComponent implements OnInit {
     window.open(`/tensorboard/${tensorboard.namespace}/${tensorboard.name}/`);
   }
 
-  //Utility functions
+  // Utility functions
   public processIncomingData(
     tensorboards: TensorboardResponseObject[],
   ): TensorboardProcessedObject[] {

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
@@ -3,31 +3,32 @@ import {
   StatusValue,
   ActionListValue,
   ActionIconValue,
-  TRUNCATE_TEXT_SIZE,
   TableConfig,
 } from 'kubeflow';
 
 export const tableConfig: TableConfig = {
-  title: $localize`Volumes`,
-  newButtonText: $localize`NEW VOLUME`,
   columns: [
     {
       matHeaderCellDef: $localize`Status`,
       matColumnDef: 'status',
+      style: { width: '1%' },
       value: new StatusValue(),
     },
     {
       matHeaderCellDef: $localize`Name`,
       matColumnDef: 'name',
+      style: { width: '25%' },
       value: new PropertyValue({
         field: 'name',
         tooltipField: 'name',
-        truncate: TRUNCATE_TEXT_SIZE.SMALL,
+        truncate: true,
       }),
     },
     {
       matHeaderCellDef: $localize`Age`,
       matColumnDef: 'age',
+      textAlignment: 'right',
+      style: { width: '10%' },
       value: new PropertyValue({
         field: 'age.uptime',
         tooltipField: 'age.timestamp',
@@ -36,17 +37,21 @@ export const tableConfig: TableConfig = {
     {
       matHeaderCellDef: $localize`Size`,
       matColumnDef: 'size',
-      value: new PropertyValue({ field: 'capacity' }),
+      textAlignment: 'right',
+      style: { width: '10%' },
+      value: new PropertyValue({ field: 'capacity', truncate: true }),
     },
     {
       matHeaderCellDef: $localize`Access Mode`,
       matColumnDef: 'modes',
-      value: new PropertyValue({ field: 'modes' }),
+      style: { width: '15%' },
+      value: new PropertyValue({ field: 'modes', truncate: true }),
     },
     {
       matHeaderCellDef: $localize`Storage Class`,
       matColumnDef: 'class',
-      value: new PropertyValue({ field: 'class' }),
+      style: { width: '10%' },
+      value: new PropertyValue({ field: 'class', truncate: true }),
     },
 
     // the apps should import the actions they want

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.html
@@ -1,8 +1,15 @@
-<lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+<div class="lib-content-wrapper">
+  <lib-title-actions-toolbar title="Volumes" [buttons]="buttons" i18n-title>
+    <lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+  </lib-title-actions-toolbar>
 
-<lib-resource-table
-  [config]="config"
-  [data]="processedData"
-  [trackByFn]="pvcTrackByFn"
-  (actionsEmitter)="reactToAction($event)"
-></lib-resource-table>
+  <!--scrollable page content-->
+  <div class="page-padding lib-flex-grow lib-overflow-auto">
+    <lib-table
+      [config]="config"
+      [data]="processedData"
+      [trackByFn]="pvcTrackByFn"
+      (actionsEmitter)="reactToAction($event)"
+    ></lib-table>
+  </div>
+</div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
@@ -10,6 +10,7 @@ import {
   DialogConfig,
   SnackBarService,
   SnackType,
+  ToolbarButton,
 } from 'kubeflow';
 import { defaultConfig } from './config';
 import { environment } from '@app/environment';
@@ -35,6 +36,17 @@ export class IndexDefaultComponent implements OnInit {
   public rawData: PVCResponseObject[] = [];
   public processedData: PVCProcessedObject[] = [];
   public pvcsWaitingViewer = new Set<string>();
+
+  buttons: ToolbarButton[] = [
+    new ToolbarButton({
+      text: `New Volume`,
+      icon: 'add',
+      stroked: true,
+      fn: () => {
+        this.newResourceClicked();
+      },
+    }),
+  ];
 
   constructor(
     public ns: NamespaceService,
@@ -78,9 +90,6 @@ export class IndexDefaultComponent implements OnInit {
 
   public reactToAction(a: ActionEvent) {
     switch (a.action) {
-      case 'newResourceButton': // TODO: could also use enums here
-        this.newResourceClicked();
-        break;
       case 'delete':
         this.deleteVolumeClicked(a.data);
         break;


### PR DESCRIPTION
A first step for https://github.com/kubeflow/kubeflow/issues/6315

Extend the frontends of our web apps to instead use responsive tables, to be more inline with what Pipelines are doing.

Here the new look of the apps
![twa](https://user-images.githubusercontent.com/11134742/150978000-e25d32fc-e32d-4ba0-a9c7-0207537ea040.png)

![jwa](https://user-images.githubusercontent.com/11134742/150978046-2c36d283-07e9-4784-ba0a-ba5b6b1e4fdc.png)


