### PR TITLE
build(central dashboard): Remove node v12 patch version numbers in the Dockerfile

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Builds and tests
-FROM node:12.22.8-alpine AS build
+FROM node:12.22-alpine AS build
 
 ARG kubeflowversion
 ARG commit
@@ -40,7 +40,7 @@ RUN npm rebuild && \
     npm prune --production
 
 # Step 2: Packages assets for serving
-FROM node:12.22.8-alpine AS serve
+FROM node:12.22-alpine AS serve
 
 ENV NODE_ENV=production
 WORKDIR /app


### PR DESCRIPTION
Refs: https://github.com/kubeflow/kubeflow/pull/6260

I think it's better to remove the patch version number for LTS Node.js versions.

See also: https://github.com/kubeflow/kubeflow/pull/6258
