### PR TITLE
profiles: Update the permissions for notebook idleness

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -466,7 +466,8 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 				},
 			},
 			{
-				// allow the notebook-controller in the kubeflow namespace to access the api/status endpoint of the notebook servers.
+				// allow the notebook-controller in the kubeflow namespace to
+				// access the api/kernels endpoint of the notebook servers.
 				From: []*istioSecurity.Rule_From{
 					{
 						Source: &istioSecurity.Source{
@@ -478,7 +479,7 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 					{
 						Operation: &istioSecurity.Operation{
 							Methods: []string{"GET"},
-							Paths:   []string{"*/api/status"}, // wildcard for the name of the notebook server
+							Paths:   []string{"*/api/kernels"}, // wildcard for the name of the notebook server
 						},
 					},
 				},


### PR DESCRIPTION
Follow up for #6297 
Design in: https://github.com/kubeflow/kubeflow/blob/master/components/proposals/20220121-jupyter-notebook-idleness.md

Extend the Profiles Controller to create an AuthorizationPolicy for allowing Notebooks Controller to talk to the Notebooks' `/api/kernels` endpoint. Without it the Notebooks Controller will be getting 403 RBAC errors by Istio, since it won't be allowed to talk to Notebooks in other namespaces