### PR TITLE
KFNBC: Build Dockerfile with -mod=mod flag

### DIFF
--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -23,9 +23,9 @@ WORKDIR /workspace/notebook-controller
 
 # Build
 RUN if [ "$(uname -m)" = "aarch64" ]; then \
-        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -a -o manager main.go; \
+        CGO_ENABLED=0 GOOS=linux GOARCH=arm64 GO111MODULE=on go build -a -mod=mod -o manager main.go; \
     else \
-        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go; \
+        CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -mod=mod -o manager main.go; \
     fi
 
 # Use distroless as minimal base image to package the manager binary


### PR DESCRIPTION
Build notebook controller explicitly using the `-mod=mod` flag.

This is the default behaviour with the current builder image. But it  possible to build this image in other CI systems too, where the base image is replaced by a private image with vendoring enabled by default (-mod=vendor).