### PR TITLE
fix(jupyter-web-app-fronted)fixed bug where imagename with port not rendered correctly

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.ts
@@ -81,7 +81,15 @@ export class FormImageComponent implements OnInit, OnDestroy {
     this.subs.unsubscribe();
   }
   imageDisplayName(image: string): string {
-    const [name, tag = null] = image.split(':');
+    const nameTagRegex = /(.*):([^:]*)$/;
+    let name, tag;
+
+    if (!image.includes(':')){
+      name = image, tag = null;
+    } else {
+      [name, tag] = image.match(nameTagRegex).splice(1);
+    }
+
     let tokens = name.split('/');
 
     if (this.hideRegistry && tokens.length > 1 && tokens[0].includes('.')) {


### PR DESCRIPTION
A bug where an image name with a port in it did not render correctly has been fixed. E.g. previously the image name `public.ecr.aws:443/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-6e4ad3b4` would have been rendered as `public.ecr.aws:443/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy`, that is the tag (`:master-6e4ad3b4`) would have been effectively removed. The new regex correctly renders the displayname as `public.ecr.aws:443/j1r0q0g6/notebooks/notebook-servers/jupyter-scipy:master-6e4ad3b4` with tag working as intended. I have tested the solution with image names without ports, with ports, as well as images without both port and tag and all cases work as intended.