### PR TITLE
centraldashboard: Add KServe overlay

### DIFF
--- a/components/centraldashboard/manifests/overlays/kserve/kustomization.yaml
+++ b/components/centraldashboard/manifests/overlays/kserve/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../istio
+
+commonLabels:
+  kustomize.component: centraldashboard
+  app: centraldashboard
+  app.kubernetes.io/component: centraldashboard
+  app.kubernetes.io/name: centraldashboard
+
+patchesStrategicMerge:
+- patches/configmap.yaml

--- a/components/centraldashboard/manifests/overlays/kserve/patches/configmap.yaml
+++ b/components/centraldashboard/manifests/overlays/kserve/patches/configmap.yaml
@@ -1,0 +1,135 @@
+apiVersion: v1
+data:
+  settings: |-
+    {
+      "DASHBOARD_FORCE_IFRAME": true
+    }
+  links: |-
+    {
+      "menuLinks": [
+        {
+          "type": "item",
+          "link": "/jupyter/",
+          "text": "Notebooks",
+          "icon": "book"
+        },
+        {
+          "type": "item",
+          "link": "/tensorboards/",
+          "text": "Tensorboards",
+          "icon": "assessment"
+        },
+        {
+          "type": "item",
+          "link": "/volumes/",
+          "text": "Volumes",
+          "icon": "device:storage"
+        },
+        {
+          "type": "item",
+          "link": "/kserve-endpoints/",
+          "text": "Models",
+          "icon": "kubeflow:models"
+        },
+        {
+          "type": "item",
+          "link": "/katib/",
+          "text": "Experiments (AutoML)",
+          "icon": "kubeflow:katib"
+        },
+        {
+          "type": "item",
+          "text": "Experiments (KFP)",
+          "link": "/pipeline/#/experiments",
+          "icon": "done-all"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/pipelines",
+          "text": "Pipelines",
+          "icon": "kubeflow:pipeline-centered"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/runs",
+          "text": "Runs",
+          "icon": "maps:directions-run"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/recurringruns",
+          "text": "Recurring Runs",
+          "icon": "device:access-alarm"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/artifacts",
+          "text": "Artifacts",
+          "icon": "editor:bubble-chart"
+        },
+        {
+          "type": "item",
+          "link": "/pipeline/#/executions",
+          "text": "Executions",
+          "icon": "av:play-arrow"
+        }
+      ],
+      "externalLinks": [ ],
+        "quickLinks": [
+          {
+            "text": "Upload a pipeline",
+            "desc": "Pipelines",
+            "link": "/pipeline/"
+          },
+          {
+            "text": "View all pipeline runs",
+            "desc": "Pipelines",
+            "link": "/pipeline/#/runs"
+          },
+          {
+            "text": "Create a new Notebook server",
+            "desc": "Notebook Servers",
+            "link": "/jupyter/new?namespace=kubeflow"
+          },
+          {
+            "text": "View Katib Experiments",
+            "desc": "Katib",
+            "link": "/katib/"
+          }
+        ],
+        "documentationItems": [
+          {
+            "text": "Getting Started with Kubeflow",
+            "desc": "Get your machine-learning workflow up and running on Kubeflow",
+            "link": "https://www.kubeflow.org/docs/started/getting-started/"
+          },
+          {
+            "text": "MiniKF",
+            "desc": "A fast and easy way to deploy Kubeflow locally",
+            "link": "https://www.kubeflow.org/docs/distributions/minikf/"
+          },
+          {
+            "text": "Microk8s for Kubeflow",
+            "desc": "Quickly get Kubeflow running locally on native hypervisors",
+            "link": "https://www.kubeflow.org/docs/distributions/microk8s/kubeflow-on-microk8s/"
+          },
+          {
+            "text": "Kubeflow on GCP",
+            "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+            "link": "https://www.kubeflow.org/docs/gke/"
+          },
+          {
+            "text": "Kubeflow on AWS",
+            "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+            "link": "https://www.kubeflow.org/docs/aws/"
+          },
+          {
+            "text": "Requirements for Kubeflow",
+            "desc": "Get more detailed information about using Kubeflow and its components",
+            "link": "https://www.kubeflow.org/docs/started/requirements/"
+          }
+        ]
+    }
+kind: ConfigMap
+metadata:
+  name: centraldashboard-config


### PR DESCRIPTION
Refs https://github.com/kubeflow/manifests/issues/2112#issuecomment-1055693752

Add an overlay in the dashboard for using the KServe models web app, instead of the KFServing one. The KServe app is using a different prefix https://github.com/kserve/models-web-app/pull/27.