### PR TITLE
notebooks: Don't reconcile on Events deletion

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -710,6 +710,9 @@ func (r *NotebookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		CreateFunc: func(e event.CreateEvent) bool {
 			return checkEvent(e.Object, e.Meta)
 		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
 		GenericFunc: func(e event.GenericEvent) bool {
 			return checkEvent(e.Object, e.Meta)
 		},


### PR DESCRIPTION
Refs https://github.com/kubeflow/kubeflow/issues/6382

The PR updates the controller to never trigger the `Reconcile()` function when any K8s Event gets deleted, whether it belonged to a Notebook or not.

This should resolve logs we saw in #6382 like:
```
2022-03-01T14:08:50.378Z	ERROR	controllers.Notebook	unable to fetch Notebook	{"notebook": "kube-system/istio-cni-node-854fq.16d83d225eab3a57", "error": "Notebook.kubeflow.org \"istio-cni-node-854fq.16d83d225eab3a57\" not found"}
github.com/go-logr/zapr.(*zapLogger).Error
	/go/pkg/mod/github.com/go-logr/zapr@v0.1.0/zapr.go:128
github.com/kubeflow/kubeflow/components/notebook-controller/controllers.(*NotebookReconciler).Reconcile
	/workspace/notebook-controller/controllers/notebook_controller.go:125
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/internal/controller/controller.go:216
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/internal/controller/controller.go:192
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.2.0/pkg/internal/controller/controller.go:171
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:152
k8s.io/apimachinery/pkg/util/wait.JitterUntil
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:153
k8s.io/apimachinery/pkg/util/wait.Until
	/go/pkg/mod/k8s.io/apimachinery@v0.0.0-20190404173353-6a84e37a896d/pkg/util/wait/wait.go:88
```

This means that the Controller won't be doing anything to the mirrored/emitted Notebook events, if one of the underlying Pod Events gets deleted. But this is already the case, so we are not changing any functionality.

I've also built an image for this code, for trying it out `gcr.io/arrikto/notebook-controller:v1.5.0-rc.0-13-g459c3bdaf`

/cc @juliusvonkohout @elikatsis 