### PR TITLE
Fix UI to support poddefault with match expressions

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -29,7 +29,14 @@ def get_poddefaults(namespace):
     # Return a list of (label, desc) with the pod defaults
     contents = []
     for pd in pod_defaults["items"]:
-        label = list(pd["spec"]["selector"]["matchLabels"].keys())[0]
+        if "matchLabels" in pd["spec"]["selector"]:
+            label = list(pd["spec"]["selector"]["matchLabels"].keys())[0] # get the first label key
+        elif "matchExpressions" in pd["spec"]["selector"]:
+            label = list(pd["spec"]["selector"]["matchExpressions"])[0]["key"] # get the first expr key
+ 	else:
+	    log.error("poddefault %s with no matchLabels  nor matchExpressions set",pd);
+            # ignore the error
+            continue
         if "desc" in pd["spec"]:
             desc = pd["spec"]["desc"]
         else:

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -30,19 +30,21 @@ def get_poddefaults(namespace):
     contents = []
     for pd in pod_defaults["items"]:
         if "matchLabels" in pd["spec"]["selector"]:
-            label = list(pd["spec"]["selector"]["matchLabels"].keys())[0] # get the first label key
+            # get the first label key
+            label = list(pd["spec"]["selector"]["matchLabels"].keys())[0] 
         elif "matchExpressions" in pd["spec"]["selector"]:
-            label = list(pd["spec"]["selector"]["matchExpressions"])[0]["key"] # get the first expr key
- 	else:
-	    log.error("poddefault %s with no matchLabels  nor matchExpressions set",pd);
+            # get the first expr key
+            label = list(pd["spec"]["selector"]["matchExpressions"])[0]["key"] 
+        else:
+            log.error("poddefault %s with no matchLabels  nor matchExpressions set",pd)
             # ignore the error
             continue
-        if "desc" in pd["spec"]:
-            desc = pd["spec"]["desc"]
-        else:
-            desc = pd["metadata"]["name"]
+    if "desc" in pd["spec"]:
+        desc = pd["spec"]["desc"]
+    else:
+        desc = pd["metadata"]["name"]
 
-        contents.append({"label": label, "desc": desc})
+    contents.append({"label": label, "desc": desc})
 
     log.info("Found poddefaults: %s", contents)
     return api.success_response("poddefaults", contents)


### PR DESCRIPTION


PodDefaults , as defined in the [sample](https://github.com/kubeflow/kubeflow/tree/master/components/admission-webhook#how-this-works), with matchLabels work fine, **but** if we create a pod default with matchExpressions instead of using matchLabels, the backing API behind the UI, http://localhost:8080/jupyter/api/namespaces/kubeflow-user-example-com/poddefaults,  complains since API only supports/expects matchLabel selectors. 

Having said that the backing [admission webhooks label selector with matchExpressions works just fine](https://github.com/kubeflow/kubeflow/blob/master/components/admission-webhook/main.go#L73) so this PR tries to fix the issue with the API behind the UI

Sample PodDefault that will cause the create notebook server to throw an error

```
apiVersion: "kubeflow.org/v1alpha1"
kind: PodDefault
metadata:
  name: add-env
  namespace: kubeflow
spec:
 selector:
  matchExpressions:
   - key: add_env
       operation: Exists
 desc: "add env"
 env:
  - name: TEST_ENV
    value: "TEST_VAR"
```