### PR TITLE
Allow adding extra headers to rstudio notebook

### DIFF
--- a/components/crud-web-apps/jupyter/README.md
+++ b/components/crud-web-apps/jupyter/README.md
@@ -21,6 +21,10 @@ The annotation `notebooks.kubeflow.org/http-headers-request-set:`
 `'{"X-RStudio-Root-Path":"/notebook/<namespace>/<name>/"}'` is added to
 Notebook resources belonging to Group 2. This configures Istio to add
 this header to requests, which is necessary for images from Group 2 to work.
+IF you need to add extra headers to RStudio notebooks you may provide them
+by setting environment variable `RSTUDIO_EXTRA_HEADERS`
+to `'{"X-Custom-Header":"custom-header-value"}'`
+**Example:** `RSTUDIO_EXTRA_HEADERS='{"X-Forwarded-Proto":"https"}'`
 
 The Jupyter Web App displays the logos for each Notebook Server group
 in a button toggle in the Spawner UI. To easily identify the group of

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -42,6 +42,10 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
+    # IF you need to add extra headers to RStudio notebooks
+    # you may provide them by setting environment variable `RSTUDIO_EXTRA_HEADERS`
+    # to `'{"X-Custom-Header":"custom-header-value"}'`
+    # Example: `RSTUDIO_EXTRA_HEADERS='{"X-Forwarded-Proto":"https"}'`
     value: kubeflownotebookswg/rstudio-tidyverse:master-e9324d39
     # The list of available standard container Images
     options:

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -42,6 +42,10 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
+    # IF you need to add extra headers to RStudio notebooks
+    # you may provide them by setting environment variable `RSTUDIO_EXTRA_HEADERS`
+    # to `'{"X-Custom-Header":"custom-header-value"}'`
+    # Example: `RSTUDIO_EXTRA_HEADERS='{"X-Forwarded-Proto":"https"}'`
     value: kubeflownotebookswg/rstudio-tidyverse:latest
     # The list of available standard container Images
     options:


### PR DESCRIPTION
I'm currently experiencing issue stated here: https://serverfault.com/questions/985253/istio-https-traffic-converted-to-http-with-port-set-as-443 but only when creating `rstudio` notebooks

I was able to solve this problem by adding Header `"X-Forwarded-Proto":"https"` which ends up looking like this:

```yaml
apiVersion: kubeflow.org/v1
kind: Notebook
metadata:
  annotations:
    notebooks.kubeflow.org/http-headers-request-set: >-
      {"X-RStudio-Root-Path":"/notebook/my-namespace/my-rstudio-notebook/",
      "X-Forwarded-Proto":"https"}
    notebooks.kubeflow.org/http-rewrite-uri: /
    notebooks.kubeflow.org/server-type: group-two
```


### POC of this code

```python
import os
import json

def get_rstudio_header():
    nb_name = "my-rstudio-notebook"
    nb_ns = "my-namespace"
    rstudio_header = {
        "X-RStudio-Root-Path": f"/notebook/{nb_ns}/{nb_name}/"
    }
    if os.environ.get("RSTUDIO_EXTRA_HEADERS"):
        extra_headers = json.loads(os.environ.get("RSTUDIO_EXTRA_HEADERS"))
        rstudio_header = {**rstudio_header, **extra_headers}
    return json.dumps(rstudio_header)


rstudio_header = get_rstudio_header()

print(f"rstudio_header is of type {type(rstudio_header)}")
print(f"rstudio_header content is {rstudio_header}")
```

Running it on a shell

```shell
$ python -V
Python 3.7.12
$ python test.py
rstudio_header is of type <class 'str'>
rstudio_header content is {"X-RStudio-Root-Path": "/notebook/my-namespace/my-rstudio-notebook/"}
$ RSTUDIO_EXTRA_HEADERS='{"X-Forwarded-Proto":"https"}' python test.py
rstudio_header is of type <class 'str'>
rstudio_header content is {"X-RStudio-Root-Path": "/notebook/my-namespace/my-rstudio-notebook/", "X-Forwarded-Proto": "https"}
```