### PR TITLE
Fix kubernetes python client to v22.6.0

### DIFF
--- a/components/crud-web-apps/common/backend/setup.py
+++ b/components/crud-web-apps/common/backend/setup.py
@@ -3,7 +3,7 @@ import setuptools
 REQUIRES = [
     "Flask >= 1.1.1",
     "Flask-API >= 2.0",
-    "kubernetes >= 11.0.1",
+    "kubernetes == 22.6.0",
     "requests >= 2.22.0",
     "urllib3 >= 1.25.7",
     "Werkzeug >= 0.16.0",


### PR DESCRIPTION
We've just upgraded Kubeflow 1.5 (from 1.3) and have seen a similar issue raised by https://github.com/kubeflow/kubeflow/issues/6419.

On inspecting the error message:

```
Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:98.0) Gecko/20100101 Firefox/98.0"
2022-03-29 03:03:18,481 | apps.common.utils | INFO | Using config file: /etc/config/spawner_ui_config.yaml
2022-03-29 03:03:18,492 | kubeflow.kubeflow.crud_backend.errors.handlers | ERROR | Caught and unhandled Exception!
2022-03-29 03:03:18,498 | apps.common.utils | INFO | Using config file: /etc/config/spawner_ui_config.yaml
2022-03-29 03:03:18,492 | kubeflow.kubeflow.crud_backend.errors.handlers | ERROR | Invalid value for `type` (FrequentContainerdRestart), must be one of ['DiskPressure', 'MemoryPressure', 'NetworkUnavailable', 'PIDPressure', 'Ready']
Traceback (most recent call last):
```

I've checked that the Jupyter Webapp uses `kubernetes==v23.3.0`. The source of the error is this line: https://github.com/kubernetes-client/python/blob/v23.3.0/kubernetes/client/models/v1_node_condition.py#L217.

## The Fix

I've pinned the version of the Python Kubernetes client to use v22.6.0. I've rebuilt the image and tested this on my Kubeflow installation and the error goes away.