### PR TITLE
fix: stop unnecessary updates of profiles

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -710,9 +710,10 @@ func (r *ProfileReconciler) PatchDefaultPluginSpec(ctx context.Context, profileI
 				},
 			})
 		}
-	}
-	if err := r.Update(ctx, profileIns); err != nil {
-		return err
+		if err := r.Update(ctx, profileIns); err != nil {
+			return err
+		}
+
 	}
 	return nil
 }

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -709,11 +709,10 @@ func (r *ProfileReconciler) PatchDefaultPluginSpec(ctx context.Context, profileI
 					Raw: []byte(fmt.Sprintf(`{"gcpServiceAccount": "%v"}`, r.WorkloadIdentity)),
 				},
 			})
+			if err := r.Update(ctx, profileIns); err != nil {
+				return err
+			}
 		}
-		if err := r.Update(ctx, profileIns); err != nil {
-			return err
-		}
-
 	}
 	return nil
 }


### PR DESCRIPTION
Currently, profiles are always updated although they are not changed.

- https://github.com/kubeflow/kubeflow/blob/master/components/profile-controller/controllers/profile_controller.go#L270
- https://github.com/kubeflow/kubeflow/blob/master/components/profile-controller/controllers/profile_controller.go#L714

If `WorkloadIdentity` is empty, profiles are not changed, so we don't need to update profiles.