### PR TITLE
(Draft) KF conformance test framework

### DIFF
--- a/conformance/1.0/Makefile
+++ b/conformance/1.0/Makefile
@@ -1,0 +1,27 @@
+TEST_PROFILE ?= kf-conformance-test
+KUBEFLOW_NAMESPACE ?= kubeflow
+
+setup:
+	# Create the conformance report directory
+	mkdir -p /tmp/kf-conformance
+
+	kubectl apply -f ./setup.yaml
+
+run: setup run-kfp
+
+report: report-kfp
+
+clean:
+	kubectl delete -f ./setup.yaml
+	rm -rf /tmp/kf-conformance
+
+# Component specific tasks
+
+run-kfp:
+	kubectl apply -f ./kfp-conformance.yaml
+
+report-kfp:
+	./report-pod.sh \
+		$(shell kubectl get pod -n kf-conformance --selector=app=kfp-conformance -o jsonpath='{.items[*].metadata.name}') \
+		/tmp/kfp-conformance.done \
+		/tmp/kfp-conformance.log

--- a/conformance/1.0/README.md
+++ b/conformance/1.0/README.md
@@ -1,0 +1,27 @@
+# Kubeflow conformance program (WIP)
+
+Before running the conformance tests, you need to configure kubectl default context to point to the k8s cluster that is hosting Kubeflow.
+
+TODO: Make the kubeflow namespace configurable.
+
+To run version <x.y> of the conformance test.
+
+`cd kubeflow/conformance/<x.y>`
+
+**Run conformance test**
+
+`make run`
+
+**Download test report**
+
+`make report`
+
+The reports are downloaded to /tmp/kf-conformance
+
+**Submit the test report to Kubeflow conformance body for review**
+
+TBD
+
+**Clean up test resources**
+
+`make clean`

--- a/conformance/1.0/kfp-conformance.yaml
+++ b/conformance/1.0/kfp-conformance.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kfp-conformance
+  namespace: kf-conformance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kfp-conformance
+  template:
+    metadata:
+      labels:
+        app: kfp-conformance
+      annotations:
+        proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
+    spec:
+      terminationGracePeriodSeconds: 0
+      serviceAccountName: kf-conformance
+      containers:
+      - name: kfp-conformance
+      # TODO: update the image version to 1.0
+        image: gcr.io/ml-pipeline/kfp-conformance:0.1
+        resources:
+          limits:
+            memory: "128Mi"
+            cpu: "1"
+          requests:
+            memory: "64Mi"
+            cpu: "0.5"
+        imagePullPolicy: Always
+        volumeMounts:
+        - mountPath: /var/run/secrets/kubeflow/pipelines
+          name: volume-kf-pipeline-token
+          readOnly: true
+        env:
+        - name: KF_PIPELINES_SA_TOKEN_PATH
+          value: /var/run/secrets/kubeflow/pipelines/token
+      volumes:
+      - name: volume-kf-pipeline-token
+        projected:
+          sources:
+            - serviceAccountToken:
+                path: token
+                expirationSeconds: 7200
+                audience: pipelines.kubeflow.org
+---

--- a/conformance/1.0/report-pod.sh
+++ b/conformance/1.0/report-pod.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# Wait for the pod to generate a done file.
+until kubectl exec $1 -n kf-conformance -- ls $2
+do
+    sleep 30
+    echo Waiting for $1 to finish ...
+done
+
+KFP_REPORT_PATH=/tmp/kf-conformance/$(basename $3)
+kubectl cp kf-conformance/$1:$3 $KFP_REPORT_PATH
+
+echo KFP test report copied to $KFP_REPORT_PATH

--- a/conformance/1.0/setup.yaml
+++ b/conformance/1.0/setup.yaml
@@ -1,0 +1,59 @@
+# Conformance test profile
+apiVersion: kubeflow.org/v1beta1
+kind: Profile
+metadata:
+  name: kf-conformance
+spec:
+  owner:
+    kind: User
+    name: test@kf-conformance.com
+  resourceQuotaSpec:
+   hard:
+     cpu: "2"
+     memory: 2Gi
+     requests.storage: "5Gi"
+---
+# Service account used by conformance test
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kf-conformance
+  namespace: kf-conformance
+---
+# Bind service account to kubeflow-admin role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kf-conformance
+  namespace: kf-conformance
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubeflow-admin
+subjects:
+- kind: ServiceAccount
+  name: kf-conformance
+  namespace: kf-conformance
+---
+# TODO: workaround until this issue can be fixed: https://github.com/kubeflow/pipelines/issues/7657
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kfp-conformance-patch
+rules:
+- apiGroups: [""]
+  resources: ["pipelines"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kfp-conformance-patch
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kfp-conformance-patch
+subjects:
+- kind: ServiceAccount
+  name: kf-conformance
+  namespace: kf-conformance


### PR DESCRIPTION
This is a PR for illustration, and getting feedback. This PR is the [test driver](https://docs.google.com/document/d/1_til1HkVBFQ1wCgyUpWuMlKRYI4zP1YPmNxr75mzcps/edit#bookmark=id.miv9odawagc8) for running KFP's implementation of conformance test ([design](https://docs.google.com/document/d/1_til1HkVBFQ1wCgyUpWuMlKRYI4zP1YPmNxr75mzcps/edit#heading=h.3jexna4u6o8s)). 

Please start with the README.md file to review the workflow for conformance verification. Then look at the Makefile which is the test driver. The KFP tests can be used as a template for REST API-based tests. I think components like training will want to write CRD based tests. The Makefile has extension points to accommodate that.

