### PR TITLE
Export notebook culling metrics

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -303,7 +303,6 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 		// Set annotations to the Notebook
 		culler.SetStopAnnotation(&instance.ObjectMeta, r.Metrics)
-		r.Metrics.NotebookCullingCount.WithLabelValues(instance.Namespace, instance.Name).Inc()
 		err = r.Update(ctx, instance)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/components/notebook-controller/pkg/metrics/metrics.go
+++ b/components/notebook-controller/pkg/metrics/metrics.go
@@ -68,6 +68,8 @@ func (m *Metrics) Describe(ch chan<- *prometheus.Desc) {
 	m.runningNotebooks.Describe(ch)
 	m.NotebookCreation.Describe(ch)
 	m.NotebookFailCreation.Describe(ch)
+	m.NotebookCullingCount.Describe(ch)
+	m.NotebookCullingTimestamp.Describe(ch)
 }
 
 // Collect implements the prometheus.Collector interface.
@@ -76,6 +78,8 @@ func (m *Metrics) Collect(ch chan<- prometheus.Metric) {
 	m.runningNotebooks.Collect(ch)
 	m.NotebookCreation.Collect(ch)
 	m.NotebookFailCreation.Collect(ch)
+	m.NotebookCullingCount.Collect(ch)
+	m.NotebookCullingTimestamp.Collect(ch)
 }
 
 // scrape gets current running notebook statefulsets.


### PR DESCRIPTION
Currently, notebook culling metrics are not exported.

This PR fixes two things
- Export culling metrics
- Remove duplicated increment of `notebook_culling_total` (incremented twice in [`SetStopAnnotation`](https://github.com/kubeflow/kubeflow/blob/master/components/notebook-controller/pkg/culler/culler.go#L125) and [`Reconcile`](https://github.com/kubeflow/kubeflow/blob/master/components/notebook-controller/controllers/notebook_controller.go#L306))