### PR TITLE
Pin alpine repository version

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -10,8 +10,8 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
 # Installs latest-stable Chromium package and configures environment for testing
 RUN apk update && apk upgrade && \
-    echo @stable http://nl.alpinelinux.org/alpine/latest-stable/community >> /etc/apk/repositories && \
-    echo @stable http://nl.alpinelinux.org/alpine/latest-stable/main >> /etc/apk/repositories
+    echo @stable http://nl.alpinelinux.org/alpine/v3.15/community >> /etc/apk/repositories && \
+    echo @stable http://nl.alpinelinux.org/alpine/v3.15/main >> /etc/apk/repositories
 
 RUN apk add --no-cache bash chromium@stable nss@stable \
     freetype@stable \


### PR DESCRIPTION
With the current `latest-stable` `v3.16` version of the alpine package repository, an attempt to build a central dashboard image fails with:
```
 => ERROR [build 3/7] RUN apk add --no-cache bash@stable chromium@stable nss@stable     freetype@stable     harfbuzz@stable     ttf-freefont@stable     libstdc++@stable                                        4.4s
------
 > [build 3/7] RUN apk add --no-cache bash@stable chromium@stable nss@stable     freetype@stable     harfbuzz@stable     ttf-freefont@stable     libstdc++@stable:
#7 0.940 fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/main/x86_64/APKINDEX.tar.gz
#7 1.239 fetch https://dl-cdn.alpinelinux.org/alpine/v3.15/community/x86_64/APKINDEX.tar.gz
#7 1.803 fetch http://nl.alpinelinux.org/alpine/latest-stable/community/x86_64/APKINDEX.tar.gz
#7 2.701 fetch http://nl.alpinelinux.org/alpine/latest-stable/main/x86_64/APKINDEX.tar.gz
#7 3.630 ERROR: unable to select packages:
#7 4.065   so:libmbedcrypto.so.7 (no such package):
#7 4.065     required by: librist-0.2.6-r1[so:libmbedcrypto.so.7]
------
executor failed running [/bin/sh -c apk add --no-cache bash@stable chromium@stable nss@stable     freetype@stable     harfbuzz@stable     ttf-freefont@stable     libstdc++@stable]: exit code: 4
make: *** [Makefile:42: build] Error 1
```