### PR TITLE
Update release due date to Aug and link to timeline

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Kubeflow Roadmap
 
-## Kubeflow 1.6 Release, Due: July 2022
-* Kubeflow 1.6 [milestones and timelines](https://github.com/kubeflow/community/pull/558)
+## Kubeflow 1.6 Release, Due: August 2022
+* Kubeflow 1.6 [milestones and timelines](https://github.com/kubeflow/community/tree/master/releases/release-1.6)
 
 #### Themes
 * Kubernetes 1.22 support

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Kubeflow Roadmap
 
-## Kubeflow 1.6 Release, Due: August 2022
+## Kubeflow 1.6 Release, Due: September 2022
 * Kubeflow 1.6 [milestones and timelines](https://github.com/kubeflow/community/tree/master/releases/release-1.6)
 
 #### Themes


### PR DESCRIPTION
Signed-off-by: Anna Jung (VMware) <antheaj@vmware.com>

- Due to the recent [delay in the release](https://groups.google.com/g/kubeflow-discuss/c/NTAxdlMj1GM/m/Jerg2ihmAgAJ), updating the due date to August
- Fixing the release timeline link to point to the correct doc (This link does not contain the modified dates yet, there is a [PR open to updated release timeline](https://github.com/kubeflow/community/pull/561). Once merged, it should reflect the correct dates)

cc @kubeflow/release-team @jbottum 