### PR TITLE
update jupyterlab to 3.4.3

### DIFF
--- a/components/example-notebook-servers/jupyter/requirements.txt
+++ b/components/example-notebook-servers/jupyter/requirements.txt
@@ -1,3 +1,3 @@
-jupyterlab==3.0.16
-notebook==6.4.10
-ipykernel==5.5.5
+jupyterlab==3.4.3
+notebook==6.4.12
+ipykernel==6.15.0


### PR DESCRIPTION
The current version of JupyterLab is VERY out of date in our example notebook images, this PR updates it to the latest version.

__NOTE:__ after this PR is merged we will have to update the other images which use the `jupyter` image as a base to use whatever `public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/jupyter:master-XXXXXXX` is created.

1. [`jupyter-pytorch`](https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch)
2. [`jupyter-scipy`](https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-scipy)
3. [`jupyter-tensorflow-full`](https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-tensorflow-full)
4. [`jupyter-tensorflow`](https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-tensorflow)