### PR TITLE
Trim the custom Jupyter image string

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.ts
@@ -99,7 +99,7 @@ export class FormNewComponent implements OnInit, OnDestroy {
 
     // Use the custom image instead
     if (notebook.customImageCheck) {
-      notebook.image = notebook.customImage;
+      notebook.image = notebook.customImage?.trim();
     } else if (notebook.serverType === 'group-one') {
       // Set notebook image from imageGroupOne
       notebook.image = notebook.imageGroupOne;


### PR DESCRIPTION
If the custom image has extra white space, the status is always pending on the web page.