### PR TITLE
Add GH action for publishing all images when VERSION is updated

### DIFF
--- a/.github/workflows/all_components_docker_publish.yaml
+++ b/.github/workflows/all_components_docker_publish.yaml
@@ -1,0 +1,145 @@
+name: Build & Publish all Docker images
+on:
+  push:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - releasing/version/VERSION
+
+jobs:
+  push_to_registry:
+    name: Build & Push all Docker images to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: kubeflownotebookswg
+        password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
+
+    - name: Run CentralDashboard build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/centraldashboard
+        export IMG=docker.io/kubeflownotebookswg/centraldashboard
+        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        docker push ${IMG}:${TAG}
+
+    - name: Run JWA build and push
+      run: |
+        export GIT_TAG=$(cat releasing/version/VERSION)
+        cd components/crud-web-apps/jupyter
+        export IMG=docker.io/kubeflownotebookswg/jupyter-web-app
+        make image
+
+    - name: Run KFAM build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/access-management
+        export IMG=docker.io/kubeflownotebookswg/kfam
+        make push
+
+    - name: Run Notebook Controller build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components
+        export IMG=docker.io/kubeflownotebookswg/notebook-controller
+        docker build . -t ${IMG}:${TAG} -f ./notebook-controller/Dockerfile
+        docker push ${IMG}:${TAG}
+
+    - name: Run codeserver-python Notebook Server build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/codeserver-python
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/codeserver-python
+        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        docker push ${IMG}:${TAG}
+
+    - name: Run jupyter-scipy Notebook Server build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/jupyter-scipy
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-scipy
+        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        docker push ${IMG}:${TAG}
+
+    - name: Run jupyter-pytorch-full Notebook Server build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/jupyter-pytorch-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-pytorch-full
+        docker build -t ${IMG}:${TAG} -f cpu.Dockerfile . 
+        docker push ${IMG}:${TAG}
+
+    - name: Run jupyter-pytorch-cuda-full Notebook Server build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/jupyter-pytorch-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-pytorch-cuda-full
+        docker build -t ${IMG}:${TAG} -f cuda.Dockerfile . 
+        docker push ${IMG}:${TAG}
+
+    - name: Run jupyter-tensorflow-full Notebook Server build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/jupyter-tensorflow-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-tensorflow-full
+        docker build -t ${IMG}:${TAG} -f cpu.Dockerfile . 
+        docker push ${IMG}:${TAG}
+        
+    - name: Run jupyter-tensorflow-cuda-full Notebook Server build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/jupyter-tensorflow-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-tensorflow-cuda-full
+        docker build -t ${IMG}:${TAG} -f cuda.Dockerfile . 
+        docker push ${IMG}:${TAG}
+
+    - name: Run rstudio-tidyverse Notebook Server build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/rstudio-tidyverse
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/rstudio-tidyverse
+        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        docker push ${IMG}:${TAG}
+
+    - name: Run PodDefaults build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/admission-webhook
+        export IMG=docker.io/kubeflownotebookswg/poddefaults-webhook
+        make docker-build && make docker-push
+
+    - name: Run Profile Controller build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/profile-controller
+        export IMG=docker.io/kubeflownotebookswg/profile-controller
+        make build
+        make push
+
+    - name: Run Tensorboard Controller build and push
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/tensorboard-controller
+        export IMG=docker.io/kubeflownotebookswg/tensorboard-controller:${TAG}
+        make docker-build
+        make docker-push
+
+    - name: Run TWA build and push
+      run: |
+        export GIT_TAG=$(cat releasing/version/VERSION)
+        cd components/volumes-web-app
+        export IMG=docker.io/kubeflownotebookswg/volumes-web-app
+        make image
+
+    - name: Run VWA build and push
+      run: |
+        export GIT=$(cat releasing/version/VERSION)
+        cd components/volumes-web-app
+        export IMG=docker.io/kubeflownotebookswg/volumes-web-app
+        make image


### PR DESCRIPTION
Add a GH action that runs when `VERSION` file is bumped. The workflow is:
1. Gets triggered on `on.push` for the `master` and `v*-branch` branches
2. Gets triggered only when the `releasing/version/VERSION` file is changed
3. Reads the content of the VERSION file and:
    1. Builds all images (we'll need a step for each component)
    2. Pushes the images of each component