### PR TITLE
Add '--reload_multifile' argument to tensorboard

### DIFF
--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -267,6 +267,7 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 							Args: []string{
 								"--logdir=" + mountpath,
 								"--bind_all",
+								"--reload_multifile",
 							},
 							Ports: []corev1.ContainerPort{
 								{


### PR DESCRIPTION
- Problem
If the log directory has several event files, tensorboard could not load all logs immediately. 

- Solution
The "--reload_multifile" argument can be used to poll all "active" files in a directory for new data, rather than the most recent one as mentioned at [related docs of tensorboard repository](https://github.com/tensorflow/tensorboard/blob/master/README.md#tensorboard-is-showing-only-some-of-my-data-or-isnt-properly-updating). All of the logs are loaded well after applying that argument.