### PR TITLE
Add support for `command` and `args` in `PodDefault`

### DIFF
--- a/components/admission-webhook/manifests/base/crd.yaml
+++ b/components/admission-webhook/manifests/base/crd.yaml
@@ -58,9 +58,6 @@ spec:
                     x-kubernetes-preserve-unknown-fields: true
                   type: array
                   x-kubernetes-preserve-unknown-fields: true
-                securityContext:
-                  type: object
-                  x-kubernetes-preserve-unknown-fields: true
                 command:
                   items:
                     type: string

--- a/components/admission-webhook/manifests/base/crd.yaml
+++ b/components/admission-webhook/manifests/base/crd.yaml
@@ -10,7 +10,7 @@ spec:
     singular: poddefault
   preserveUnknownFields: false
   scope: Namespaced
-  versions: 
+  versions:
     - name: v1alpha1
       served: true
       storage: true
@@ -55,6 +55,21 @@ spec:
                 volumes:
                   items:
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                securityContext:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                command:
+                  items:
+                    type: string
+                    x-kubernetes-preserve-unknown-fields: true
+                  type: array
+                  x-kubernetes-preserve-unknown-fields: true
+                args:
+                  items:
+                    type: string
                     x-kubernetes-preserve-unknown-fields: true
                   type: array
                   x-kubernetes-preserve-unknown-fields: true

--- a/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
+++ b/components/admission-webhook/pkg/apis/settings/v1alpha1/poddefault_types.go
@@ -69,6 +69,12 @@ type PodDefaultSpec struct {
 	Labels map[string]string `json:"labels,omitempty"`
 
 	Tolerations []v1.Toleration `json:"tolerations,omitempty"`
+
+	// Entrypoint array.
+	Command []string `json:"command,omitempty" protobuf:"bytes,3,rep,name=command"`
+
+	// Arguments to the entrypoint.
+	Args []string `json:"args,omitempty" protobuf:"bytes,4,rep,name=args"`
 }
 
 // PodDefaultStatus defines the observed state of PodDefault


### PR DESCRIPTION
#### What changes were proposed in this pull request?
Closes #2208, closes #3838.
This PR extends `PodDefault` to provide a capability to set a custom `command` and `args` for Notebook servers.

#### Example
- Create the following PodDefaut in the user's namespace:
```
apiVersion: "kubeflow.org/v1alpha1"
kind: PodDefault
metadata:
  name: custom-entrypoint
spec:
  selector:
    matchLabels:
      custom-entrypoint: "true"
  desc: "Lauch as Jupyter Lab"
  command:
  - jupyter
  args:
  - lab
  - --notebook-dir=/workspace
  - --ip=0.0.0.0
  - --no-browser
  - --allow-root
  - --port=8888
  - --NotebookApp.token=''
  - --NotebookApp.password=''
  - --NotebookApp.allow_origin='*'
  - --NotebookApp.base_url=$(NB_PREFIX)
```
- In notebook form, select "Custom image" and set the image you want to run (e.g. nvcr.io/nvidia/tensorflow:22.05-tf1-py3.)
- Under configuration, select "Launch as Jupyter Lab" and click "Launch"
Notebook server pod should be create with the specified command and arguments.
