### PR TITLE
Make GH actions build images on PR and push only on merge

### DIFF
--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -6,6 +6,12 @@ on:
       - v*-branch
     paths:
       - components/centraldashboard/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/centraldashboard/**
 
 jobs:
   push_to_registry:
@@ -16,15 +22,23 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run CentralDashboard build and push
+    - name: Run CentralDashboard build
       run: |
         cd components/centraldashboard
         export IMG=docker.io/kubeflownotebookswg/centraldashboard
         export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        docker build -t ${IMG}:${TAG} -f Dockerfile .
+
+    - name: Run CentralDashboard push
+      if: github.event_name == 'push'
+      run: |
+        cd components/centraldashboard
+        export IMG=docker.io/kubeflownotebookswg/centraldashboard
+        export TAG=$(git describe --tags --always);
         docker push ${IMG}:${TAG}

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -7,6 +7,13 @@ on:
     paths:
       - components/crud-web-apps/jupyter/**
       - components/crud-web-apps/common/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/crud-web-apps/jupyter/**
+      - components/crud-web-apps/common/**
 
 jobs:
   push_to_registry:
@@ -17,13 +24,21 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run JWA build and push
+    - name: Run JWA build
       run: |
         cd components/crud-web-apps/jupyter
         export IMG=docker.io/kubeflownotebookswg/jupyter-web-app
-        make image
+        make docker-build
+
+    - name: Run JWA push
+      if: github.event_name == 'push'
+      run: |
+        cd components/crud-web-apps/jupyter
+        export IMG=docker.io/kubeflownotebookswg/jupyter-web-app
+        make docker-push

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -6,6 +6,12 @@ on:
       - v*-branch
     paths:
       - components/access-management/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/access-management/**
 
 jobs:
   push_to_registry:
@@ -16,12 +22,20 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run KFAM build and push
+    - name: Run KFAM build
+      run: |
+        cd components/access-management
+        export IMG=docker.io/kubeflownotebookswg/kfam
+        make build
+
+    - name: Run KFAM push
+      if: github.event_name == 'push'
       run: |
         cd components/access-management
         export IMG=docker.io/kubeflownotebookswg/kfam

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -7,6 +7,13 @@ on:
     paths:
       - components/notebook-controller/**
       - components/common/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/notebook-controller/**
+      - components/common/**
 
 jobs:
   push_to_registry:
@@ -17,15 +24,23 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run Notebook Controller build and push
+    - name: Run Notebook Controller build
       run: |
         cd components
         export IMG=docker.io/kubeflownotebookswg/notebook-controller
         export TAG=$(git describe --tags --always)
         docker build . -t ${IMG}:${TAG} -f ./notebook-controller/Dockerfile
+
+    - name: Run Notebook Controller push
+      if: github.event_name == 'push'
+      run: |
+        cd components
+        export IMG=docker.io/kubeflownotebookswg/notebook-controller
+        export TAG=$(git describe --tags --always)
         docker push ${IMG}:${TAG}

--- a/.github/workflows/nb_server_docker_publish.yaml
+++ b/.github/workflows/nb_server_docker_publish.yaml
@@ -6,6 +6,12 @@ on:
       - v*-branch
     paths:
       - components/example-notebook-servers/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/example-notebook-servers/**
 
 jobs:
   push_to_registry:
@@ -16,63 +22,113 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run codeserver-python Notebook Server build and push
+    - name: Run codeserver-python Notebook Server build
       run: |
         cd components/example-notebook-servers/codeserver-python
         export IMG=docker.io/kubeflownotebookswg/notebook-servers/codeserver-python
-        export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        export TAG=$(git describe --tags --always)
+        docker build -t ${IMG}:${TAG} -f Dockerfile .
+
+    - name: Run codeserver-python Notebook Server push
+      if: github.event_name == 'push'
+      run: |
+        cd components/example-notebook-servers/codeserver-python
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/codeserver-python
+        export TAG=$(git describe --tags --always)
         docker push ${IMG}:${TAG}
 
-    - name: Run jupyter-scipy Notebook Server build and push
+    - name: Run jupyter-scipy Notebook Server build
       run: |
         cd components/example-notebook-servers/jupyter-scipy
         export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-scipy
-        export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        export TAG=$(git describe --tags --always)
+        docker build -t ${IMG}:${TAG} -f Dockerfile .
+
+    - name: Run jupyter-scipy Notebook Server push
+      if: github.event_name == 'push'
+      run: |
+        cd components/example-notebook-servers/jupyter-scipy
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-scipy
+        export TAG=$(git describe --tags --always)
         docker push ${IMG}:${TAG}
 
-    - name: Run jupyter-pytorch-full Notebook Server build and push
+    - name: Run jupyter-pytorch-full Notebook Server build
       run: |
         cd components/example-notebook-servers/jupyter-pytorch-full
         export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-pytorch-full
-        export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f cpu.Dockerfile . 
+        export TAG=$(git describe --tags --always)
+        docker build -t ${IMG}:${TAG} -f cpu.Dockerfile .
+
+    - name: Run jupyter-pytorch-full Notebook Server push
+      if: github.event_name == 'push'
+      run: |
+        cd components/example-notebook-servers/jupyter-pytorch-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-pytorch-full
+        export TAG=$(git describe --tags --always)
         docker push ${IMG}:${TAG}
 
-    - name: Run jupyter-pytorch-cuda-full Notebook Server build and push
+    - name: Run jupyter-pytorch-cuda-full Notebook Server build
       run: |
         cd components/example-notebook-servers/jupyter-pytorch-full
         export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-pytorch-cuda-full
-        export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f cuda.Dockerfile . 
+        export TAG=$(git describe --tags --always)
+        docker build -t ${IMG}:${TAG} -f cuda.Dockerfile .
+
+    - name: Run jupyter-pytorch-cuda-full Notebook Server push
+      if: github.event_name == 'push'
+      run: |
+        cd components/example-notebook-servers/jupyter-pytorch-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-pytorch-cuda-full
+        export TAG=$(git describe --tags --always)
         docker push ${IMG}:${TAG}
 
-    - name: Run jupyter-tensorflow-full Notebook Server build and push
+    - name: Run jupyter-tensorflow-full Notebook Server build
       run: |
         cd components/example-notebook-servers/jupyter-tensorflow-full
         export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-tensorflow-full
-        export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f cpu.Dockerfile . 
+        export TAG=$(git describe --tags --always)
+        docker build -t ${IMG}:${TAG} -f cpu.Dockerfile .
+
+    - name: Run jupyter-tensorflow-full Notebook Server push
+      if: github.event_name == 'push'
+      run: |
+        cd components/example-notebook-servers/jupyter-tensorflow-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-tensorflow-full
+        export TAG=$(git describe --tags --always)
         docker push ${IMG}:${TAG}
-        
-    - name: Run jupyter-tensorflow-cuda-full Notebook Server build and push
+
+    - name: Run jupyter-tensorflow-cuda-full Notebook Server build
       run: |
         cd components/example-notebook-servers/jupyter-tensorflow-full
         export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-tensorflow-cuda-full
-        export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f cuda.Dockerfile . 
+        export TAG=$(git describe --tags --always)
+        docker build -t ${IMG}:${TAG} -f cuda.Dockerfile .
+
+    - name: Run jupyter-tensorflow-cuda-full Notebook Server push
+      if: github.event_name == 'push'
+      run: |
+        cd components/example-notebook-servers/jupyter-tensorflow-full
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/jupyter-tensorflow-cuda-full
+        export TAG=$(git describe --tags --always) 
         docker push ${IMG}:${TAG}
 
-    - name: Run rstudio-tidyverse Notebook Server build and push
+    - name: Run rstudio-tidyverse Notebook Server build
       run: |
         cd components/example-notebook-servers/rstudio-tidyverse
         export IMG=docker.io/kubeflownotebookswg/notebook-servers/rstudio-tidyverse
-        export TAG=$(git describe --tags --always);
-        docker build -t ${IMG}:${TAG} -f Dockerfile . 
+        export TAG=$(git describe --tags --always)
+        docker build -t ${IMG}:${TAG} -f Dockerfile .
+
+    - name: Run rstudio-tidyverse Notebook Server push
+      if: github.event_name == 'push'
+      run: |
+        cd components/example-notebook-servers/rstudio-tidyverse
+        export IMG=docker.io/kubeflownotebookswg/notebook-servers/rstudio-tidyverse
+        export TAG=$(git describe --tags --always) 
         docker push ${IMG}:${TAG}

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -6,6 +6,12 @@ on:
       - v*-branch
     paths:
       - components/admission-webhook/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/admission-webhook/**
 
 jobs:
   push_to_registry:
@@ -16,13 +22,21 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run PodDefaults build and push
+    - name: Run PodDefaults build
       run: |
         cd components/admission-webhook
         export IMG=docker.io/kubeflownotebookswg/poddefaults-webhook
-        make docker-build && make docker-push
+        make docker-build
+
+    - name: Run PodDefaults push
+      if: github.event_name == 'push'
+      run: |
+        cd components/admission-webhook
+        export IMG=docker.io/kubeflownotebookswg/poddefaults-webhook
+        make docker-push

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -6,6 +6,12 @@ on:
       - v*-branch
     paths:
       - components/profile-controller/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/profile-controller/**
 
 jobs:
   push_to_registry:
@@ -16,15 +22,23 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run Profile Controller build and push
+    - name: Run Profile Controller build
       run: |
         cd components/profile-controller
         export IMG=docker.io/kubeflownotebookswg/profile-controller
         export TAG=$(git describe --tags --always)
         make build
+
+    - name: Run Profile Controller push
+      if: github.event_name == 'push'
+      run: |
+        cd components/profile-controller
+        export IMG=docker.io/kubeflownotebookswg/profile-controller
+        export TAG=$(git describe --tags --always)
         make push

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -6,6 +6,12 @@ on:
       - v*-branch
     paths:
       - components/tensorboard-controller/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/tensorboard-controller/**
 
 jobs:
   push_to_registry:
@@ -16,14 +22,21 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run Tensorboard Controller build and push
+    - name: Run Tensorboard Controller build
       run: |
         cd components/tensorboard-controller
         export IMG=docker.io/kubeflownotebookswg/tensorboard-controller:$(git describe --tags --always)
         make docker-build
+
+    - name: Run Tensorboard Controller push
+      if: github.event_name == 'push'
+      run: |
+        cd components/tensorboard-controller
+        export IMG=docker.io/kubeflownotebookswg/tensorboard-controller:$(git describe --tags --always)
         make docker-push

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -7,6 +7,13 @@ on:
     paths:
       - components/crud-web-apps/tensorboards/**
       - components/crud-web-apps/common/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/crud-web-apps/tensorboards/**
+      - components/crud-web-apps/common/**
 
 jobs:
   push_to_registry:
@@ -17,13 +24,21 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run TWA build and push
+    - name: Run TWA build
       run: |
         cd components/crud-web-apps/tensorboards
         export IMG=docker.io/kubeflownotebookswg/tensorboard-web-app
-        make image
+        make docker-build
+
+    - name: Run TWA push
+      if: github.event_name == 'push'
+      run: |
+        cd components/crud-web-apps/tensorboards
+        export IMG=docker.io/kubeflownotebookswg/tensorboard-web-app
+        make docker-push

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -30,7 +30,7 @@ jobs:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run VWA build and push
+    - name: Run VWA build
       run: |
         cd components/volumes-web-app
         export IMG=docker.io/kubeflownotebookswg/volumes-web-app

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -7,6 +7,13 @@ on:
     paths:
       - components/crud-web-apps/volumes/**
       - components/crud-web-apps/common/**
+  pull_request:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/crud-web-apps/volumes/**
+      - components/crud-web-apps/common/**
 
 jobs:
   push_to_registry:
@@ -17,6 +24,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Login to DockerHub
+      if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
         username: kubeflownotebookswg
@@ -26,4 +34,11 @@ jobs:
       run: |
         cd components/volumes-web-app
         export IMG=docker.io/kubeflownotebookswg/volumes-web-app
-        make image
+        make docker-build
+
+    - name: Run VWA push
+      if: github.event_name == 'push'
+      run: |
+        cd components/volumes-web-app
+        export IMG=docker.io/kubeflownotebookswg/volumes-web-app
+        make docker-push


### PR DESCRIPTION
In existing GH actions for building and pushing Docker images we separate the build and push steps in order to run build & push only when a PR is merged. In any other case, when a PR is opened or re-opened we only build the images.