### PR TITLE
jwa: Expose a last-activity column

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -16,6 +16,7 @@ FILE_ABS_PATH = os.path.abspath(os.path.dirname(__file__))
 NOTEBOOK_TEMPLATE_YAML = os.path.join(
     FILE_ABS_PATH, "yaml/notebook_template.yaml"
 )
+LAST_ACTIVITY_ANNOTATION = "notebooks.kubeflow.org/last-activity"
 
 # The production configuration is mounted on the app's pod via a configmap
 DEV_CONFIG = os.path.join(FILE_ABS_PATH, "yaml/spawner_ui_config.yaml")
@@ -113,6 +114,11 @@ def get_storage_class(vol):
 
 
 # Functions for transforming the data from k8s api
+def get_notebook_last_activity(notebook):
+    annotations = notebook["metadata"].get("annotations", {})
+    return annotations.get(LAST_ACTIVITY_ANNOTATION, "")
+
+
 def notebook_dict_from_k8s_obj(notebook):
     cntr = notebook["spec"]["template"]["spec"]["containers"][0]
     server_type = None
@@ -125,6 +131,7 @@ def notebook_dict_from_k8s_obj(notebook):
         "namespace": notebook["metadata"]["namespace"],
         "serverType": server_type,
         "age": helpers.get_uptime(notebook["metadata"]["creationTimestamp"]),
+        "last_activity": get_notebook_last_activity(notebook),
         "image": cntr["image"],
         "shortImage": cntr["image"].split("/")[-1],
         "cpu": cntr["resources"]["requests"]["cpu"],

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -9,6 +9,7 @@ import {
   ComponentValue,
   TableConfig,
   TABLE_THEME,
+  DateTimeValue,
 } from 'kubeflow';
 import { ServerTypeComponent } from './server-type/server-type.component';
 
@@ -72,6 +73,11 @@ export const defaultConfig: TableConfig = {
       style: { width: '12%' },
       textAlignment: 'right',
       value: new PropertyValue({ field: 'age', truncate: true }),
+    },
+    {
+      matHeaderCellDef: $localize`Last activity`,
+      matColumnDef: 'last_activity',
+      value: new DateTimeValue({ field: 'last_activity' }),
     },
     {
       matHeaderCellDef: $localize`Image`,


### PR DESCRIPTION
We want to extend JWA to have a column for showing the `Last activity` of a Notebook CR. This is the last piece for making the changes from the [idleness proposal](https://github.com/kubeflow/kubeflow/blob/master/components/proposals/20220121-jupyter-notebook-idleness.md) visible to users.

Refs #6463 
Refs https://github.com/kubeflow/kubeflow/issues/6461

cc @athamark 

![image](https://user-images.githubusercontent.com/11134742/175570502-e6115099-6d14-41e4-8d49-640b932ffc6f.png)
