### PR TITLE
Reword image name in TWA Gh action

### DIFF
--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -33,12 +33,12 @@ jobs:
     - name: Run TWA build
       run: |
         cd components/crud-web-apps/tensorboards
-        export IMG=docker.io/kubeflownotebookswg/tensorboard-web-app
+        export IMG=docker.io/kubeflownotebookswg/tensorboards-web-app
         make docker-build
 
     - name: Run TWA push
       if: github.event_name == 'push'
       run: |
         cd components/crud-web-apps/tensorboards
-        export IMG=docker.io/kubeflownotebookswg/tensorboard-web-app
+        export IMG=docker.io/kubeflownotebookswg/tensorboards-web-app
         make docker-push


### PR DESCRIPTION
When merging the initial PR for building the images we had a bug in some image names we used in the GH actions. This is a fix for the TWA image name.