### PR TITLE
Update few packages and images to fix critical CVEs in centraldashboard component

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Builds and tests
-FROM node:12.22.8-alpine AS build
+FROM node:12.22.12-alpine AS build
 
 ARG kubeflowversion
 ARG commit
@@ -40,7 +40,7 @@ RUN npm rebuild && \
     npm prune --production
 
 # Step 2: Packages assets for serving
-FROM node:12.22.8-alpine AS serve
+FROM node:12.22.12-alpine AS serve
 
 ENV NODE_ENV=production
 WORKDIR /app

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -7239,9 +7239,9 @@
             "dev": true
         },
         "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
         },
         "json-schema-traverse": {
             "version": "0.4.1",
@@ -7307,13 +7307,13 @@
             }
         },
         "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
+            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
+                "json-schema": "0.4.0",
                 "verror": "1.10.0"
             }
         },

--- a/components/centraldashboard/third_party/license.txt
+++ b/components/centraldashboard/third_party/license.txt
@@ -24876,7 +24876,7 @@ Jasmine
 http://jasmine.github.io
 Copyright (c) 2010-2017 Pivotal Labs. This software is licensed under the MIT License.
 --------------------------------------------------------------------------------
-jsprim@1.4.1  MIT  https://github.com/joyent/node-jsprim/tree/master/LICENSE
+jsprim@1.4.2  MIT  https://github.com/joyent/node-jsprim/tree/master/LICENSE
 --------------------------------------------------------------------------------
 Copyright (c) 2012, Joyent, Inc. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/components/centraldashboard/third_party/license_info.csv
+++ b/components/centraldashboard/third_party/license_info.csv
@@ -737,7 +737,7 @@ json-bigint@0.3.0,https://github.com/sidorares/json-bigint/tree/master/LICENSE,M
 json-parse-better-errors@1.0.2,https://github.com/zkat/json-parse-better-errors/tree/latest/LICENSE.md,MIT,https://raw.githubusercontent.com/zkat/json-parse-better-errors/latest/LICENSE.md
 json-schema-traverse@0.3.1,https://github.com/epoberezkin/json-schema-traverse/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/epoberezkin/json-schema-traverse/master/LICENSE
 json-schema-traverse@0.4.1,https://github.com/epoberezkin/json-schema-traverse/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/epoberezkin/json-schema-traverse/master/LICENSE
-json-schema@0.2.3,https://github.com/kriszyp/json-schema/tree/master/README.md,AFLv2.1,BSD
+json-schema@0.4.0,https://github.com/kriszyp/json-schema/tree/master/README.md,AFLv2.1,BSD
 json-stable-stringify-without-jsonify@1.0.1,https://github.com/samn/json-stable-stringify/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/samn/json-stable-stringify/master/LICENSE
 json-stringify-safe@5.0.1,https://github.com/isaacs/json-stringify-safe/tree/master/LICENSE,ISC,https://raw.githubusercontent.com/isaacs/json-stringify-safe/master/LICENSE
 json3@3.3.3,https://github.com/bestiejs/json3/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/bestiejs/json3/master/LICENSE
@@ -746,7 +746,7 @@ json5@1.0.1,https://github.com/json5/json5/tree/master/LICENSE.md,MIT,https://ra
 json5@2.1.1,https://github.com/json5/json5/tree/master/LICENSE.md,MIT,https://raw.githubusercontent.com/json5/json5/master/LICENSE.md
 jsonfile@4.0.0,https://github.com/jprichardson/node-jsonfile/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/jprichardson/node-jsonfile/master/LICENSE
 jsonpath@1.0.1,https://github.com/dchester/jsonpath/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/dchester/jsonpath/master/LICENSE
-jsprim@1.4.1,https://github.com/joyent/node-jsprim/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/joyent/node-jsprim/master/LICENSE
+jsprim@1.4.2,https://github.com/joyent/node-jsprim/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/joyent/node-jsprim/master/LICENSE
 jstransformer@1.0.0,https://github.com/jstransformers/jstransformer/tree/master/LICENSE.md,MIT,https://raw.githubusercontent.com/jstransformers/jstransformer/master/LICENSE.md
 jwa@1.4.1,https://github.com/brianloveswords/node-jwa/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/brianloveswords/node-jwa/master/LICENSE
 jws@3.2.2,https://github.com/brianloveswords/node-jws/tree/master/LICENSE,MIT,https://raw.githubusercontent.com/brianloveswords/node-jws/master/LICENSE


### PR DESCRIPTION
## Central Dashboard

- Updating json-schema version to 0.4.0 to patch/fix [this CVE](https://github.com/advisories/GHSA-896r-f27r-55mw) (had to update `jsprim` to version 1.4.2)
- Updating node linux version (in the dockerfile) to `node:12.22.12-alpine` to patch [this CVE](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-28391)