### PR TITLE
Fix legacy of Python version information in README files.

### DIFF
--- a/components/crud-web-apps/tensorboards/README.md
+++ b/components/crud-web-apps/tensorboards/README.md
@@ -13,7 +13,7 @@ This web app is responsible for allowing the user to manipulate Tensorboard inst
 
 Requirements:
 * node 12.0.0
-* python 3.7
+* python 3.8
 
 ### Frontend
 
@@ -37,8 +37,8 @@ npm run build:watch
 # create a virtual env and install deps
 # https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
 cd component/crud-web-apps/tensorboards/backend
-python3.7 -m pip install --user virtualenv
-python3.7 -m venv web-apps-dev
+python3.8 -m pip install --user virtualenv
+python3.8 -m venv web-apps-dev
 source web-apps-dev/bin/activate
 
 # install the deps on the activated virtual env

--- a/components/crud-web-apps/volumes/README.md
+++ b/components/crud-web-apps/volumes/README.md
@@ -6,7 +6,7 @@ This web app is responsible for allowing the user to manipulate PVCs in their Ku
 
 Requirements:
 * node 12.0.0
-* python 3.7
+* python 3.8
 
 ### Frontend
 
@@ -30,8 +30,8 @@ npm run build:watch
 # create a virtual env and install deps
 # https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
 cd component/crud-web-apps/volumes/backend
-python3.7 -m pip install --user virtualenv
-python3.7 -m venv web-apps-dev
+python3.8 -m pip install --user virtualenv
+python3.8 -m venv web-apps-dev
 source web-apps-dev/bin/activate
 
 # install the deps on the activated virtual env


### PR DESCRIPTION
The code has upgraded to Python 3.8 while the doc keeps legacy information.
https://github.com/kubeflow/kubeflow/blob/master/components/crud-web-apps/tensorboards/Dockerfile#L2
https://github.com/kubeflow/kubeflow/blob/master/components/crud-web-apps/volumes/Dockerfile#L2
