### PR TITLE
Bump Jupyter web app to Python 3.8.

### DIFF
--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build the backend kubeflow-wheel ---
-FROM python:3.7-slim-buster AS backend-kubeflow-wheel
+FROM python:3.8-slim-buster AS backend-kubeflow-wheel
 
 WORKDIR /src
 
@@ -42,7 +42,7 @@ RUN npm run build -- --output-path=./dist/default --configuration=production
 RUN npm run build -- --output-path=./dist/rok --configuration=rok-prod
 
 # Web App
-FROM python:3.7-slim-buster
+FROM python:3.8-slim-buster
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .

--- a/components/crud-web-apps/jupyter/README.md
+++ b/components/crud-web-apps/jupyter/README.md
@@ -32,7 +32,7 @@ with a [configmap](./manifests/base/configs/logos-configmap.yaml) to make it eas
 
 Requirements:
 * node 12.0.0
-* python 3.7
+* python 3.8
 
 ### Frontend
 
@@ -56,8 +56,8 @@ npm run build:watch
 # create a virtual env and install deps
 # https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
 cd components/crud-web-apps/jupyter/backend
-python3.7 -m pip install --user virtualenv
-python3.7 -m venv web-apps-dev
+python3.8 -m pip install --user virtualenv
+python3.8 -m venv web-apps-dev
 source web-apps-dev/bin/activate
 
 # install the deps on the activated virtual env


### PR DESCRIPTION
1. There is no common breaking change from 3.7 to 3.8.
2. All other apps under https://github.com/kubeflow/kubeflow/tree/master/components/crud-web-apps have been upgraded and better to align with them.
