### PR TITLE
fix: double URL encoding in central-dashboard links

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -345,7 +345,8 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             }
         }
         window.history.replaceState(null, null, l.toString());
-        this.set('routeHash.path', window.location.hash.substr(1));
+        this.set('routeHash.path',
+            window.decodeURIComponent(window.location.hash.substr(1)));
     }
 
     /**

--- a/components/centraldashboard/public/components/main-page_test.js
+++ b/components/centraldashboard/public/components/main-page_test.js
@@ -270,13 +270,14 @@ describe('Main Page', () => {
         const hash = '#/hash/route/fragments';
         window.location.hash = hash;
         mainPage.set('queryParams.ns', 'test');
-        mainPage.set('queryParams.foo', 'bar');
+        mainPage.set('queryParams.foo', '["bar"]');
         mainPage.subRouteData.path = '/pipeline/';
         mainPage._routePageChanged('_');
         flush();
 
-        expect(mainPage.iframeSrc).toMatch(
-            new RegExp(`${window.location.origin}/pipeline/?.*foo=bar${hash}`));
+        expect(mainPage.iframeSrc).toMatch(new RegExp(
+            `${window.location.origin}/pipeline/?.*foo=%5B%22bar%22%5D${hash}`
+        ));
     });
 
     it('Sets iframeSrc to about:blank when user navigates to non-iframe page',


### PR DESCRIPTION
Central dashboard would lead to double URL encoding characters such as quotation due to the expectation that the
underlying Iron-Location hash is already decoded, and failure to decode it when directly setting it from an iframe URL
change.

Fixes kubeflow/dashboard#34