### PR TITLE
Create separate workflows for each notebook server

### DIFF
--- a/.github/workflows/nb_server_codeserver_python_docker_publish.yaml
+++ b/.github/workflows/nb_server_codeserver_python_docker_publish.yaml
@@ -6,12 +6,16 @@ on:
       - v*-branch
     paths:
       - components/example-notebook-servers/codeserver-python/**
+      - components/example-notebook-servers/codeserver/**
+      - components/example-notebook-servers/base/**
   pull_request:
     branches:
       - master
       - v*-branch
     paths:
       - components/example-notebook-servers/codeserver-python/**
+      - components/example-notebook-servers/codeserver/**
+      - components/example-notebook-servers/base/**
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_server_jupyter_pytorch_full_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_pytorch_full_docker_publish.yaml
@@ -6,12 +6,18 @@ on:
       - v*-branch
     paths:
       - components/example-notebook-servers/jupyter-pytorch-full/**
+      - components/example-notebook-servers/jupyter-pytorch/**
+      - components/example-notebook-servers/jupyter/**
+      - components/example-notebook-servers/base/**
   pull_request:
     branches:
       - master
       - v*-branch
     paths:
       - components/example-notebook-servers/jupyter-pytorch-full/**
+      - components/example-notebook-servers/jupyter-pytorch/**
+      - components/example-notebook-servers/jupyter/**
+      - components/example-notebook-servers/base/**
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_server_jupyter_scipy_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_scipy_docker_publish.yaml
@@ -6,12 +6,16 @@ on:
       - v*-branch
     paths:
       - components/example-notebook-servers/jupyter-scipy/**
+      - components/example-notebook-servers/jupyter/**
+      - components/example-notebook-servers/base/**
   pull_request:
     branches:
       - master
       - v*-branch
     paths:
       - components/example-notebook-servers/jupyter-scipy/**
+      - components/example-notebook-servers/jupyter/**
+      - components/example-notebook-servers/base/**
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_server_jupyter_tf_full_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_tf_full_docker_publish.yaml
@@ -6,12 +6,18 @@ on:
       - v*-branch
     paths:
       - components/example-notebook-servers/jupyter-tensorflow-full/**
+      - components/example-notebook-servers/jupyter-tensorflow/**
+      - components/example-notebook-servers/jupyter/**
+      - components/example-notebook-servers/base/**
   pull_request:
     branches:
       - master
       - v*-branch
     paths:
       - components/example-notebook-servers/jupyter-tensorflow-full/**
+      - components/example-notebook-servers/jupyter-tensorflow/**
+      - components/example-notebook-servers/jupyter/**
+      - components/example-notebook-servers/base/**
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_server_rstudio_tidyverse_docker_publish.yaml
+++ b/.github/workflows/nb_server_rstudio_tidyverse_docker_publish.yaml
@@ -6,12 +6,16 @@ on:
       - v*-branch
     paths:
       - components/example-notebook-servers/rstudio-tidyverse/**
+      - components/example-notebook-servers/rstudio/**
+      - components/example-notebook-servers/base/**
   pull_request:
     branches:
       - master
       - v*-branch
     paths:
       - components/example-notebook-servers/rstudio-tidyverse/**
+      - components/example-notebook-servers/rstudio/**
+      - components/example-notebook-servers/base/**
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
Until now we had one workflow that builds all the notebooks. We now add a different workflow for each notebook server and only for the ones that appear in JWA's Config Map: https://github.com/kubeflow/kubeflow/blob/bb9fb467c85d495b2af12dfc26e71f17f9ec857c/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml#L17-L48