### PR TITLE
Fix typo in notebook_controller.go

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -177,7 +177,7 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		}
 	} else if err != nil {
-		log.Error(err, "error getting Statefulset")
+		log.Error(err, "error getting Service")
 		return ctrl.Result{}, err
 	}
 	// Update the foundService object and write the result back if there are any changes


### PR DESCRIPTION
### Description
Fix typo in error msg at `notebook-controller/controller/notebook_controller.go`
`Statefulset` -> `Service`