### PR TITLE
AIP-6075: Add terminal activity to notebook controller culler

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -263,7 +263,7 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if !podFound {
 		// Delete LAST_ACTIVITY_ANNOTATION annotations for CR objects
 		// that do not have a pod.
-		log.Info("Notebook has not Pod running. Will remove last-activity annotation")
+		log.Info("Notebook has no Pod running. Will remove last-activity annotation")
 		meta := instance.ObjectMeta
 		if meta.GetAnnotations() == nil {
 			log.Info("No annotations found")

--- a/components/notebook-controller/pkg/culler/culler.go
+++ b/components/notebook-controller/pkg/culler/culler.go
@@ -184,6 +184,9 @@ func getNotebookApiKernels(nm, ns string) []KernelStatus {
 	// Get the Kernels' status from the Server's `/api/kernels` endpoint
 
 	resp := getNotebookResourceResponse(nm, ns, "kernels")
+	if resp == nil {
+		return nil
+	}
 
 	var kernels []KernelStatus
 
@@ -201,6 +204,9 @@ func getNotebookApiKernels(nm, ns string) []KernelStatus {
 func getNotebookApiTerminals(nm, ns string) []TerminalStatus {
 	// Get the Terminals' status from the Server's `/api/terminals` endpoint
 	resp := getNotebookResourceResponse(nm, ns, "terminals")
+	if resp == nil {
+		return nil
+	}
 
 	var terminals []TerminalStatus
 


### PR DESCRIPTION
Adds `last_activity` of the jupyter server `api/terminals` endpoint. 

Our team needed the ability to also take into account terminal activity for culling, current culler logic only takes into account kernel activity. We are checking to see if the kubeflow community would like this contribution to be added to open-source culler logic.