### PR TITLE
Fix invalid kustomization patch introduced for profile-controller manager

### DIFF
--- a/components/profile-controller/config/manager/manager.yaml
+++ b/components/profile-controller/config/manager/manager.yaml
@@ -33,16 +33,6 @@ spec:
         name: manager
         livenessProbe:
           httpGet:
-            path: /metrics
-            port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 30
-        ports:
-        - containerPort: 8080
-          name: manager-http
-          protocol: TCP
-        livenessProbe:
-          httpGet:
             path: /healthz
             port: 9876
           initialDelaySeconds: 15


### PR DESCRIPTION
This fixes a currently invalid, but working, on early kustomize, yaml for the profile-controller manager manifests.
In [this PR](https://github.com/kubeflow/kubeflow/pull/6491/files#diff-a6712d4f1fc4fbc5bcaa8ff94677bc6c423e6b4ef894bb9590e0c591389a5158) duplicated entries for ports and livenessProbe.
Removing the previous items makes no changes to the output so this change is no-op for early kustomize versions, but it actually allows newer kustomize versions to work, they currently break.

tests:
* Used kustomize-3.8.10 to generate template from master with and without the patch and the output is identical
* Used kustomize-4.5.5 to generate template from master and it breaks without the patch but produces identical output to 3.8.10 with the patch in

### kustomize-4.5.5 breaking...
```
❯ ( git co master && cd components/profile-controller/config/manager && ./kustomize-4.5.5 -o master.template.yaml build )
Already on 'master'
Your branch is up to date with 'origin/master'.
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 37: mapping key "livenessProbe" already defined at line 27
  line 49: mapping key "ports" already defined at line 33
```

### Identical outputs after the patch
```
❯ ( git co master && cd components/profile-controller/config/manager 
            && ./kustomize-3.8.10 -o master.template.yaml build 
            && git checkout fix-kustomize-profile-manager 
            && ./kustomize-3.8.10 -o fixed.template.yaml build 
            && ./kustomize-4.5.5  -o modern.template.yaml build 
            && diff fixed.template.yaml master.template.yaml 
            && diff modern.template.yaml master.template.yaml)
Already on 'master'
Your branch is up to date with 'origin/master'.
Switched to branch 'fix-kustomize-profile-manager'
❯ echo $?
0
```