### PR TITLE
Fix #6616: Typo on New Notebook page

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-workspace-volume/form-workspace-volume.component.html
@@ -1,7 +1,7 @@
 <lib-form-section
   title="Workspace Volume"
   i18n-title
-  text="Volume that will be mounted in you home directory."
+  text="Volume that will be mounted in your home directory."
   i18n-text
 >
   <mat-accordion>


### PR DESCRIPTION
Fix a typo on the new notebook page

“Volume that will be mounted in you home directory” -> “Volume that will be mounted in your home directory”

First kubeflow PR!