### PR TITLE
Fix #66622: rename environment variable for dashboard configmap

### DIFF
--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -38,6 +38,6 @@ spec:
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
           value: $(CD_REGISTRATION_FLOW)
-        - name: DASHBOARD_LINKS_CONFIGMAP
+        - name: DASHBOARD_CONFIGMAP
           value: $(CD_CONFIGMAP_NAME)
       serviceAccountName: centraldashboard


### PR DESCRIPTION
Fixes #6622, where the manifests for deployment uses a deprecated name for the environment variable that specifies the dashboard's link configmap. 

As far as I can tell this is the only place where this error occurs, but I have not robustly checked for it elsewhere.  