### PR TITLE
fix Profile Plugins functionality

### DIFF
--- a/.github/workflows/prof_controller_unit_test.yaml
+++ b/.github/workflows/prof_controller_unit_test.yaml
@@ -1,4 +1,4 @@
-name: Run unit tests for Profile Controller
+name: Run Profile Controller unit tests
 on:
   pull_request:
     paths:

--- a/.github/workflows/prof_controller_unit_test.yaml
+++ b/.github/workflows/prof_controller_unit_test.yaml
@@ -1,0 +1,23 @@
+name: Run unit tests for Profile Controller
+on:
+  pull_request:
+    paths:
+      - components/profile-controller/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.17'
+        check-latest: true
+
+    - name: Run unit tests
+      run: |
+        cd components/profile-controller
+        make test

--- a/components/profile-controller/README.md
+++ b/components/profile-controller/README.md
@@ -130,7 +130,7 @@ In order for the custom Notebook Controller to be functional from your local mac
 
 1. Set the number of replicas to zero:
 ```sh
-kubectl edit deployment profiles-controller-deployment -n=kubeflow
+kubectl edit deployment profiles-deployment -n=kubeflow
 ```
 
 2. Start the manager locally:

--- a/components/profile-controller/config/samples/_v1_profile.yaml
+++ b/components/profile-controller/config/samples/_v1_profile.yaml
@@ -1,6 +1,8 @@
 apiVersion: kubeflow.org/v1
 kind: Profile
 metadata:
-  name: profile-sample
+  name: test-user-profile
 spec:
-  # TODO(user): Add fields here
+  owner:
+    kind: User
+    name: test-user@kubeflow.org

--- a/components/profile-controller/config/samples/_v1_profile_aws_iam.yaml
+++ b/components/profile-controller/config/samples/_v1_profile_aws_iam.yaml
@@ -1,0 +1,12 @@
+apiVersion: kubeflow.org/v1
+kind: Profile
+metadata:
+  name: profile-aws-iam
+spec:
+  owner:
+    kind: User
+    name: test-user@kubeflow.org
+  plugins:
+  - kind: AwsIamForServiceAccount
+    spec:
+      awsIamRole: arn:aws:iam::account-id:role/s3-reader

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -656,14 +657,14 @@ func (r *ProfileReconciler) GetPluginSpec(profileIns *profilev1.Profile) ([]Plug
 
 		// To deserialize it to a specific type we need to first serialize it to bytes
 		// and then unserialize it.
-		specBytes, err := yaml.Marshal(p.Spec)
+		specBytes, err := json.Marshal(p.Spec)
 
 		if err != nil {
 			logger.Info("Could not marshal plugin ", p.Kind, "; error: ", err)
 			return nil, err
 		}
 
-		err = yaml.Unmarshal(specBytes, pluginIns)
+		err = json.Unmarshal(specBytes, pluginIns)
 		if err != nil {
 			logger.Info("Could not unmarshal plugin ", p.Kind, "; error: ", err)
 			return nil, err

--- a/components/profile-controller/controllers/profile_controller_test.go
+++ b/components/profile-controller/controllers/profile_controller_test.go
@@ -1,11 +1,17 @@
 package controllers
 
 import (
+	"encoding/json"
+	"fmt"
 	"reflect"
 	"testing"
 
+	profilev1 "github.com/kubeflow/kubeflow/components/profile-controller/api/v1"
+	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 type namespaceLabelSuite struct {
@@ -107,4 +113,88 @@ func TestEnforceNamespaceLabelsFromConfig(t *testing.T) {
 			t.Errorf("Expect:\n%v; Output:\n%v", &test.expected, &test.current)
 		}
 	}
+}
+
+type getPluginSpecSuite struct {
+	profile         *profilev1.Profile
+	expectedPlugins []Plugin
+}
+
+func TestGetPluginSpec(t *testing.T) {
+	role_arn := "arn:aws:iam::123456789012:role/test-iam-role"
+	gcp_sa := "kubeflow2@project-id.iam.gserviceaccount.com"
+	tests := []getPluginSpecSuite{
+		{
+			&profilev1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "aws-user-profile",
+					Namespace: "k8snamespace",
+				},
+				Spec: profilev1.ProfileSpec{
+					Plugins: []profilev1.Plugin{
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind: KIND_AWS_IAM_FOR_SERVICE_ACCOUNT,
+							},
+							Spec: &runtime.RawExtension{
+								Raw: []byte(fmt.Sprintf(`{"awsIamRole": "%v"}`, role_arn)),
+							},
+						},
+					},
+				},
+			},
+			[]Plugin{
+				&AwsIAMForServiceAccount{
+					AwsIAMRole: role_arn,
+				},
+			},
+		},
+		{
+			&profilev1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gcp-user-profile",
+					Namespace: "k8snamespace",
+				},
+				Spec: profilev1.ProfileSpec{
+					Plugins: []profilev1.Plugin{
+						{
+							TypeMeta: metav1.TypeMeta{
+								Kind: KIND_WORKLOAD_IDENTITY,
+							},
+							Spec: &runtime.RawExtension{
+								Raw: []byte(fmt.Sprintf(`{"gcpServiceAccount": "%v"}`, gcp_sa)),
+							},
+						},
+					},
+				},
+			},
+			[]Plugin{
+				&GcpWorkloadIdentity{
+					GcpServiceAccount: gcp_sa,
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		loadedPlugins, err := createMockReconciler().GetPluginSpec(test.profile)
+
+		assert.Nil(t, err)
+		if !reflect.DeepEqual(&test.expectedPlugins, &loadedPlugins) {
+			expected, _ := json.Marshal(test.expectedPlugins)
+			found, _ := json.Marshal(loadedPlugins)
+			t.Errorf("Test: %v. Expected:\n%v\nFound:\n%v", test.profile.Name, string(expected), string(found))
+		}
+	}
+}
+
+func createMockReconciler() *ProfileReconciler {
+	reconciler := &ProfileReconciler{
+		Scheme:                     runtime.NewScheme(),
+		Log:                        ctrl.Log,
+		UserIdHeader:               "dummy",
+		UserIdPrefix:               "dummy",
+		WorkloadIdentity:           "dummy",
+		DefaultNamespaceLabelsPath: "dummy",
+	}
+	return reconciler
 }


### PR DESCRIPTION
Resolves: #6618

Description of changes:
- As described in https://github.com/kubeflow/kubeflow/issues/6618#issuecomment-1223404464, profile plugins functionality broke when the yaml package was changed as part of #6491. Since the structs have JSON tags, we can safely serialize and deserialize the structs using Go's JSON library.
- Added unit tests to prevent this from happening in future.
- Added a validation in the plugin to error out if the role value is missing because golang json library will create the struct even if the value is missing. Since the struct is small at this point, I have added a simple validation but this solution is not great if the struct is complex.
- Added samples which were deleted.

Testing:
- Ran unit tests
- Tested with and without the AWS plugin by running the controller locally
- Tested that GCP plugin struct as well to ensure it is loaded but have not run a real e2e test. Someone using GCP will need to confirm