### PR TITLE
JWA(front): Fix image group one and two not showing

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-image/form-image.component.html
@@ -27,7 +27,7 @@
 
       <mat-button-toggle
         value="group-one"
-        *ngIf="parentForm.get('imageGroupOne')?.options?.length > 0"
+        *ngIf="!parentForm.get('imageGroupOne')?.disabled"
         attr.aria-label="Use Group One based server"
         i18n-aria-label="Aria label for Group One server"
       >
@@ -35,7 +35,7 @@
       </mat-button-toggle>
       <mat-button-toggle
         value="group-two"
-        *ngIf="parentForm.get('imageGroupTwo')?.options?.length > 0"
+        *ngIf="!parentForm.get('imageGroupTwo')?.disabled"
         attr.aria-label="Use Group Two based server"
         i18n-aria-label="Aria label for Group Two server"
       >

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/utils.ts
@@ -120,9 +120,17 @@ export function initFormControls(formCtrl: FormGroup, config: Config) {
 
   formCtrl.controls.image.setValue(config.image.value);
 
-  formCtrl.controls.imageGroupOne.setValue(config.imageGroupOne.value);
+  if (config.imageGroupOne?.value) {
+    formCtrl.controls.imageGroupOne.setValue(config.imageGroupOne.value);
+  } else {
+    formCtrl.controls.imageGroupOne.disable();
+  }
 
-  formCtrl.controls.imageGroupTwo.setValue(config.imageGroupTwo.value);
+  if (config.imageGroupTwo?.value) {
+    formCtrl.controls.imageGroupTwo.setValue(config.imageGroupTwo.value);
+  } else {
+    formCtrl.controls.imageGroupTwo.disable();
+  }
 
   formCtrl.controls.imagePullPolicy.setValue(config.imagePullPolicy.value);
   if (config.imagePullPolicy.readOnly) {


### PR DESCRIPTION
This PR is a fix for images groups one and two not showing in JWA's New notebook page.

**Context**
The issue was created by this PR https://github.com/kubeflow/kubeflow/pull/6482/ , which was attempted to be fixed also by this later PR https://github.com/kubeflow/kubeflow/pull/6596 . Also currently, this PR-fix is under review https://github.com/kubeflow/kubeflow/pull/6599/ .

**Solution**
The fix proposes a straightforward solution utilising the `FormControl`'s `.disabled` attribute and `disable()` function.