### PR TITLE
Fix #6056: Update Notebook status properly

### DIFF
--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -1,0 +1,23 @@
+name: Run Notebook Controller unit tests
+on:
+  pull_request:
+    paths:
+      - components/notebook-controller/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.17'
+        check-latest: true
+
+    - name: Run unit tests
+      run: |
+        cd components/notebook-controller
+        make test

--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -65,7 +65,8 @@ vet: ## Run go vet against code.
 
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./controllers/... -coverprofile cover.out
 
 .PHONY: manager
 manager: generate fmt vet ## Build manager binary.

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -206,8 +206,18 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 	}
 
+	foundPod := &corev1.Pod{}
+	podFound := false
+	err = r.Get(ctx, types.NamespacedName{Name: ss.Name + "-0", Namespace: ss.Namespace}, foundPod)
+	if err != nil && apierrs.IsNotFound(err) {
+		log.Info("Pod not found...")
+	} else if err != nil {
+		return ctrl.Result{}, err
+	}
+	podFound = true
+
 	// Update Notebook CR status
-	podFound, err := updateNotebookStatus(r, instance, foundStateful, req)
+	err = updateNotebookStatus(r, instance, foundStateful, foundPod, req)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -270,99 +280,80 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func updateNotebookStatus(r *NotebookReconciler, nb *v1beta1.Notebook,
-	sts *appsv1.StatefulSet, req ctrl.Request) (bool, error) {
+	sts *appsv1.StatefulSet, pod *corev1.Pod, req ctrl.Request) error {
 
 	log := r.Log.WithValues("notebook", req.NamespacedName)
 	ctx := context.Background()
 
-	statusUpdate := false
-	// Initialize Notebook CR Status
-	if nb.Status.Conditions == nil {
-		log.Info("Initializing Notebook CR Status", "namespace", nb.Namespace, "name", nb.Name)
-		newStatus := initializeStatus()
-		nb.Status = newStatus
-		statusUpdate = true
+	status, err := createNotebookStatus(r, nb, sts, pod, req)
+	if err != nil {
+		return err
 	}
 
-	// Update the Notebook CR status.readyReplicas if the status is changed
-	if sts.Status.ReadyReplicas != nb.Status.ReadyReplicas {
-		log.Info("Updating status.ReadyReplicas", "namespace", nb.Namespace, "name", nb.Name)
-		nb.Status.ReadyReplicas = sts.Status.ReadyReplicas
-		statusUpdate = true
-	}
-
-	// Check the pod status
-	pod := &corev1.Pod{}
-	podFound := false
-	err := r.Get(ctx, types.NamespacedName{Name: sts.Name + "-0", Namespace: sts.Namespace}, pod)
-	if err != nil && apierrs.IsNotFound(err) {
-		// This should be reconciled by the StatefulSet
-		log.Info("Pod not found...")
-		return podFound, nil
-	} else if err != nil {
-		return podFound, err
-	} else {
-		podFound = true
-		// Update status of the CR using the ContainerState of
-		// the container that has the same name as the CR.
-		// If no container of same name is found, the state of the CR is not updated.
-		if len(pod.Status.ContainerStatuses) > 0 {
-			notebookContainerFound := false
-			for i := range pod.Status.ContainerStatuses {
-				if pod.Status.ContainerStatuses[i].Name != nb.Name {
-					continue
-				}
-				if pod.Status.ContainerStatuses[i].State == nb.Status.ContainerState {
-					continue
-				}
-				// Update Notebook CR's status.ContainerState
-				log.Info("Updating Notebook CR state: ", "namespace", nb.Namespace, "name", nb.Name)
-				cs := pod.Status.ContainerStatuses[i].State
-				nb.Status.ContainerState = cs
-				// Mirroring pod condition
-				notebookConditions := []v1beta1.NotebookCondition{}
-				for i := range pod.Status.Conditions {
-					condition := PodCondToNotebookCond(pod.Status.Conditions[i])
-					log.Info("Mirroring pod condition: ", "namespace", nb.Namespace, "name", nb.Name, "type", condition.Type,
-						"status", condition.Status, "reason", condition.Reason, "message", condition.Message)
-					notebookConditions = append(notebookConditions, condition)
-				}
-				nb.Status.Conditions = notebookConditions
-
-				statusUpdate = true
-				notebookContainerFound = true
-				break
-
-			}
-			if !notebookContainerFound {
-				log.Error(nil, "Could not find the Notebook container, will not update the status of the CR. No container has the same name as the CR.", "CR name:", nb.Name)
-			}
-		}
-	}
-
-	if statusUpdate {
-		log.Info("Updating Notebook CR Status", "namespace", nb.Namespace, "name", nb.Name)
-		err = r.Status().Update(ctx, nb)
-		if err != nil {
-			return podFound, err
-		}
-	}
-
-	return podFound, nil
+	log.Info("Updating Notebook CR Status", "status", status)
+	nb.Status = status
+	return r.Status().Update(ctx, nb)
 }
 
-func initializeStatus() v1beta1.NotebookStatus {
-	var conditions = make([]v1beta1.NotebookCondition, 0)
-	var readyReplicas = int32(0)
-	var containerState = corev1.ContainerState{}
+func createNotebookStatus(r *NotebookReconciler, nb *v1beta1.Notebook,
+	sts *appsv1.StatefulSet, pod *corev1.Pod, req ctrl.Request) (v1beta1.NotebookStatus, error) {
 
-	newStatus := v1beta1.NotebookStatus{
-		Conditions:     conditions,
-		ReadyReplicas:  readyReplicas,
-		ContainerState: containerState,
+	log := r.Log.WithValues("notebook", req.NamespacedName)
+
+	// Initialize Notebook CR Status
+	log.Info("Initializing Notebook CR Status")
+	status := v1beta1.NotebookStatus{
+		Conditions:     make([]v1beta1.NotebookCondition, 0),
+		ReadyReplicas:  sts.Status.ReadyReplicas,
+		ContainerState: corev1.ContainerState{},
 	}
 
-	return newStatus
+	// Update the status based on the Pod's status
+	if pod == nil {
+		log.Info("No pod found. Won't update notebook conditions and containerState")
+		return status, nil
+	}
+
+	// Update status of the CR using the ContainerState of
+	// the container that has the same name as the CR.
+	// If no container of same name is found, the state of the CR is not updated.
+	notebookContainerFound := false
+	log.Info("Calculating Notebook's  containerState")
+	for i := range pod.Status.ContainerStatuses {
+		if pod.Status.ContainerStatuses[i].Name != nb.Name {
+			continue
+		}
+
+		if pod.Status.ContainerStatuses[i].State == nb.Status.ContainerState {
+			continue
+		}
+
+		// Update Notebook CR's status.ContainerState
+		cs := pod.Status.ContainerStatuses[i].State
+		log.Info("Updating Notebook CR state: ", "state", cs)
+
+		status.ContainerState = cs
+		notebookContainerFound = true
+		break
+	}
+
+	if !notebookContainerFound {
+		log.Error(nil, "Could not find container with the same name as Notebook "+
+			"in containerStates of Pod. Will not update notebook's "+
+			"status.containerState ")
+	}
+
+	// Mirroring pod condition
+	notebookConditions := []v1beta1.NotebookCondition{}
+	log.Info("Calculating Notebook's Conditions")
+	for i := range pod.Status.Conditions {
+		condition := PodCondToNotebookCond(pod.Status.Conditions[i])
+		notebookConditions = append(notebookConditions, condition)
+	}
+
+	status.Conditions = notebookConditions
+
+	return status, nil
 }
 
 func PodCondToNotebookCond(podc corev1.PodCondition) v1beta1.NotebookCondition {

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	reconcilehelper "github.com/kubeflow/kubeflow/components/common/reconcilehelper"
@@ -376,12 +377,22 @@ func PodCondToNotebookCond(podc corev1.PodCondition) v1beta1.NotebookCondition {
 		condition.Reason = podc.Reason
 	}
 
-	if !(podc.LastProbeTime.IsZero()) {
+	// check if podc.LastProbeTime is null. If so initialize
+	// the field with metav1.Now()
+	check := podc.LastProbeTime.Time.Equal(time.Time{})
+	if !check {
 		condition.LastProbeTime = podc.LastProbeTime
+	} else {
+		condition.LastProbeTime = metav1.Now()
 	}
 
-	if !(podc.LastTransitionTime.IsZero()) {
+	// check if podc.LastTransitionTime is null. If so initialize
+	// the field with metav1.Now()
+	check = podc.LastTransitionTime.Time.Equal(time.Time{})
+	if !check {
 		condition.LastTransitionTime = podc.LastTransitionTime
+	} else {
+		condition.LastTransitionTime = metav1.Now()
 	}
 
 	return condition

--- a/components/notebook-controller/controllers/notebook_controller_test.go
+++ b/components/notebook-controller/controllers/notebook_controller_test.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"reflect"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -11,6 +12,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
+
+	nbv1beta1 "github.com/kubeflow/kubeflow/components/notebook-controller/api/v1beta1"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 func TestNbNameFromInvolvedObject(t *testing.T) {
@@ -83,4 +87,166 @@ func TestNbNameFromInvolvedObject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCreateNotebookStatus(t *testing.T) {
+
+	tests := []struct {
+		name             string
+		currentNb        nbv1beta1.Notebook
+		pod              corev1.Pod
+		sts              appsv1.StatefulSet
+		expectedNbStatus nbv1beta1.NotebookStatus
+	}{
+		{
+			name: "NotebookStatusInitialization",
+			currentNb: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			pod: corev1.Pod{},
+			sts: appsv1.StatefulSet{},
+			expectedNbStatus: nbv1beta1.NotebookStatus{
+				Conditions:     []nbv1beta1.NotebookCondition{},
+				ReadyReplicas:  int32(0),
+				ContainerState: corev1.ContainerState{},
+			},
+		},
+		{
+			name: "NotebookStatusReadyReplicas",
+			currentNb: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			pod: corev1.Pod{},
+			sts: appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: appsv1.StatefulSetStatus{
+					ReadyReplicas: int32(1),
+				},
+			},
+			expectedNbStatus: nbv1beta1.NotebookStatus{
+				Conditions:     []nbv1beta1.NotebookCondition{},
+				ReadyReplicas:  int32(1),
+				ContainerState: corev1.ContainerState{},
+			},
+		},
+		{
+			name: "NotebookContainerState",
+			currentNb: nbv1beta1.Notebook{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: nbv1beta1.NotebookStatus{},
+			},
+			pod: corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name: "test",
+							State: corev1.ContainerState{
+								Running: &corev1.ContainerStateRunning{
+									StartedAt: v1.Time{},
+								},
+							},
+						},
+					},
+				},
+			},
+			sts: appsv1.StatefulSet{},
+			expectedNbStatus: nbv1beta1.NotebookStatus{
+				Conditions:    []nbv1beta1.NotebookCondition{},
+				ReadyReplicas: int32(0),
+				ContainerState: corev1.ContainerState{
+					Running: &corev1.ContainerStateRunning{
+						StartedAt: v1.Time{},
+					},
+				},
+			},
+		},
+		{
+			name: "mirroringPodConditions",
+			pod: corev1.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:          "Running",
+							LastProbeTime: v1.Time{},
+						},
+						{
+							Type:          "Waiting",
+							LastProbeTime: v1.Time{},
+							Reason:        "PodInitializing",
+						},
+					},
+				},
+			},
+			sts: appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test",
+					Namespace: "kubeflow-user",
+				},
+				Status: appsv1.StatefulSetStatus{
+					ReadyReplicas: int32(1),
+				},
+			},
+			expectedNbStatus: nbv1beta1.NotebookStatus{
+				Conditions: []nbv1beta1.NotebookCondition{
+					{
+						Type:          "Running",
+						LastProbeTime: v1.Time{},
+					},
+					{
+						Type:          "Waiting",
+						LastProbeTime: v1.Time{},
+						Reason:        "PodInitializing",
+					},
+				},
+				ReadyReplicas:  int32(1),
+				ContainerState: corev1.ContainerState{},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			r := createMockReconciler()
+			req := ctrl.Request{}
+			status, err := createNotebookStatus(r, &test.currentNb, &test.sts, &test.pod, req)
+			if err != nil {
+				t.Errorf("Unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(status, test.expectedNbStatus) {
+				t.Errorf("Expect:\n%v; Output:\n%v", test.expectedNbStatus, status)
+			}
+			// t.Logf("Success:%v\n", status)
+		})
+	}
+
+}
+
+func createMockReconciler() *NotebookReconciler {
+	reconciler := &NotebookReconciler{
+		Scheme: runtime.NewScheme(),
+		Log:    ctrl.Log,
+	}
+	return reconciler
 }


### PR DESCRIPTION
The root cause of this error is race conditions when updating the various status fields of a Notebook CR.

More specifically, I found that it is possible for the reconciliation loop to be slow enough so that both the `ContainerState` in the Pod has changed (i.e waiting, running) and the `status.ReadyReplicas` field of the STS has also changed (from 0 to 1) and so a `Status().Update()` (from this [code line](https://github.com/kubeflow/kubeflow/blob/806d32bd1252a59d8ae13e6dc4ab0143c7525fdc/components/notebook-controller/controllers/notebook_controller.go#L213)) is performed before the controller being able to update the Notebook CR's `Status.Conditions` field accordingly, which remains with the default null value. Thus, the controller ends up applying an instance with `nil` conditions and the error occurs.

Fixes:
1. Add an initialization function for the status of a Notebook CR
    - Having undefined fields makes troubleshooting of error situations more difficult.
2. Include all the status update logic into an `updateNotebookStatus` function and perform a single `Status().Update()` at the end of this function.

Branch: feature-apoger-fix-notebook-status

Signed-off-by: Apostolos Gerakaris apoger@arrikto.com