### PR TITLE
update stablebot configs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,19 +1,44 @@
-# Configuration for stale probot
-# https://probot.github.io/apps/stale/
-#
+## Configuration for "Probot: Stale"
+## https://github.com/probot/stale
+
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 90
+
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
+
 # Issues with these labels will never be considered stale
 exemptLabels:
   - lifecycle/frozen
+  - priority/p0
+  - priority/p1
+  - priority/p2
+  - priority/p3
+
+# Set to true to ignore issues in a project
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone
+exemptMilestones: true
+
 # Label to use when marking an issue as stale
 staleLabel: lifecycle/stale
+
 # Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  recent activity. It will be closed if no further activity occurs. Thank you
-  for your contributions.
+markComment: |
+  This issue has been automatically marked as stale because it has not had activity in __90 days__.
+  It will be closed in __7 days__ if no further activity occurs.
+  
+  Thank you for your contributions.
+  
+  ---
+  
+  Issues never become stale if any of the following is true:
+  
+  1. they are added to a GitHub __Project__
+  2. they are added to a GitHub __Milestone__
+  3. they have a priority label: `priority/p0`, `priority/p1`, `priority/p2`, `priority/p3`
+  4. they have the frozen label: `lifecycle/frozen`
+
 # Comment to post when closing a stale issue. Set to `false` to disable
 closeComment: false


### PR DESCRIPTION
This PR updates the stablebot configs to prevent active issues from being closed.

There are now 3 ways to prevent an issue from being closed (in addition to the `lifecycle/frozen` label):

1. Add them to a GitHub project board
1. Add them to a GitHub milestone
2. Apply a priority label: `priority/p0`, `priority/p1`, `priority/p2`, `priority/p3`

