### PR TITLE
Add quotes to notebook_template.yaml namespace field.

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -2,7 +2,7 @@ apiVersion: kubeflow.org/v1beta1
 kind: Notebook
 metadata:
   name: {name}
-  namespace: {namespace}
+  namespace: "{namespace}"
   labels:
     app: {name}
   annotations:


### PR DESCRIPTION
We have a problem, when creating notebooks with namepace name, which include only numbers like "6132435". But this commit should solve this problem.