### PR TITLE
Fix notebook culling

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -208,14 +209,14 @@ func (r *NotebookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	foundPod := &corev1.Pod{}
-	podFound := false
+	podFound := true
 	err = r.Get(ctx, types.NamespacedName{Name: ss.Name + "-0", Namespace: ss.Namespace}, foundPod)
 	if err != nil && apierrs.IsNotFound(err) {
 		log.Info("Pod not found...")
+		podFound = false
 	} else if err != nil {
 		return ctrl.Result{}, err
 	}
-	podFound = true
 
 	// Update Notebook CR status
 	err = updateNotebookStatus(r, instance, foundStateful, foundPod, req)
@@ -310,8 +311,8 @@ func createNotebookStatus(r *NotebookReconciler, nb *v1beta1.Notebook,
 	}
 
 	// Update the status based on the Pod's status
-	if pod == nil {
-		log.Info("No pod found. Won't update notebook conditions and containerState")
+	if reflect.DeepEqual(pod.Status, corev1.PodStatus{}) {
+		log.Info("No pod.Status found. Won't update notebook conditions and containerState")
 		return status, nil
 	}
 


### PR DESCRIPTION
This PR fixes: kubeflow#6648

The notebook controller writes the last-activity annotation before culling the Notebook, however, doesn't remove this annotation before start. This causes the Notebook to be culled again before is has a chance to start.

Changes:
* calculate correctly the podFound variable and ensure its value its true only if the Pod is actually found. This way the culling annotation will be removed when there is no Pod.



Signed-off-by: Apostolos Gerakaris <apoger@arrikto.com>