### PR TITLE
Remember the most recently selected namespace

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -307,7 +307,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         if (namespace) {
             // Save the user's choice so we are able to restore it, 
             // when re-loading the page without a queryParam
-            const localStorageKey = "selectedNamespace" + 
+            const localStorageKey = "/centraldashboard/selectedNamespace/" +
                 (this.user && "." + this.user || "");
             localStorage.setItem(localStorageKey, namespace);
         }

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -307,7 +307,9 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         if (namespace) {
             // Save the user's choice so we are able to restore it, 
             // when re-loading the page without a queryParam
-            localStorage.setItem("selectedNamespace", namespace);
+            const localStorageKey = "selectedNamespace" + 
+                (this.user && "." + this.user || "");
+            localStorage.setItem(localStorageKey, namespace);
         }
 
         if (this.namespacedItemTemplete &&

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -303,6 +303,13 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
     _namespaceChanged(namespace) {
         // update namespaced menu item when namespace is changed
         // by namespace selector
+
+        if (namespace) {
+            // Save the user's choice so we are able to restore it, 
+            // when re-loading the page without a queryParam
+            localStorage.setItem("selectedNamespace", namespace);
+        }
+
         if (this.namespacedItemTemplete &&
             this.namespacedItemTemplete.includes('{ns}')) {
             this.set('subRouteData.path',

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -79,7 +79,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     query-params='{{queryParams}}', route='{{route}}',
                     namespaces='[[namespaces]]', selected='{{namespace}}',
                     hides, hidden$='[[hideNamespaces]]'
-                    all-namespaces='[[allNamespaces]]')
+                    all-namespaces='[[allNamespaces]]', 
+                    user='[[user]]')
                 footer#User-Badge
                     a(target="_top", href="/logout")
                         iron-icon.icon(icon='kubeflow:logout' title="Logout")

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -198,7 +198,7 @@ export class NamespaceSelector extends PolymerElement {
      */
     getDefaultNamespace() {
         // Restore the user's previous namespace choice
-        const localStorageKey = "selectedNamespace" + 
+        const localStorageKey = "/centraldashboard/selectedNamespace/" +
             (this.user && "." + this.user || "");
         const previousNamespaceName = localStorage.getItem(localStorageKey);
         if (previousNamespaceName) {

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -196,6 +196,16 @@ export class NamespaceSelector extends PolymerElement {
      * @return {string}
      */
     getDefaultNamespace() {
+        // Restore the user's previous namespace choice
+        const previousNamespaceName = localStorage.getItem("selectedNamespace");
+        if (previousNamespaceName) {
+            const previousNamespace = this.namespaces.find(
+                (n) => n.namespace === previousNamespaceName);
+            if (previousNamespace) {
+                return previousNamespace;
+            }
+        }
+
         return this.namespaces.find(
             (n) => n.role == 'owner');
     }

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -118,6 +118,7 @@ export class NamespaceSelector extends PolymerElement {
                 notify: true,
             },
             allNamespaces: {type: Boolean, value: false},
+            user: String,
             selectedNamespaceIsOwned: {
                 type: Boolean,
                 readOnly: true,
@@ -197,7 +198,9 @@ export class NamespaceSelector extends PolymerElement {
      */
     getDefaultNamespace() {
         // Restore the user's previous namespace choice
-        const previousNamespaceName = localStorage.getItem("selectedNamespace");
+        const localStorageKey = "selectedNamespace" + 
+            (this.user && "." + this.user || "");
+        const previousNamespaceName = localStorage.getItem(localStorageKey);
         if (previousNamespaceName) {
             const previousNamespace = this.namespaces.find(
                 (n) => n.namespace === previousNamespaceName);


### PR DESCRIPTION
# The Problem 

When visiting Kubeflow, [the first owned namespace is selected automatically](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/public/components/namespace-selector.js#L168).

As a user, this annoys me when: 
- I don't own a namespace and am only a contributor to namespaces. In this case, no namespace is selected, and I need to make a selection each time I visit Kubeflow.
- There are multiple namespaces available, as a "random" selection will be made for me.

# My Proposal

In this PR, I've integrated the local storage to save the user's last selection. When visiting Kubeflow without the namespace being part of the URL, the local storage is prompted, and - if possible - the user's previous selection restored.