### PR TITLE
fix: giant div overlay in main page

### DIFF
--- a/components/centraldashboard/public/styles.css
+++ b/components/centraldashboard/public/styles.css
@@ -16,7 +16,7 @@ html, body {
     box-sizing: border-box;
 }
 
-body>* {
+body > main-page {
     flex: 1
 }
 


### PR DESCRIPTION
## Overview
Fix div overlay on main page https://github.com/kubeflow/kubeflow/issues/6610

## Implementation details
- Only set `flex: 1` on main-page component

## How to test
Run on local
**Before**
![Screen Shot 2022-10-03 at 0 00 38](https://user-images.githubusercontent.com/5120965/193461167-793c9113-606c-436b-b50c-d520a471cf7e.png)




**After**
![Screen Shot 2022-10-03 at 0 01 24](https://user-images.githubusercontent.com/5120965/193461171-1128603b-3e55-4b7a-9fa6-6e71a8be16f2.png)

## Alternative ways
Removing overlay div directly

```css
body > iron-a11y-announcer + div {
    display: none;
}
```

