### PR TITLE
fix(volume name): update formCtrl.get()

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.html
@@ -52,7 +52,7 @@
       <app-form-data-volumes
         [volsArray]="formCtrl.get('datavols')"
         [readonly]="config?.dataVolumes?.readOnly"
-        [externalName]="formCtrl.get('name')"
+        [externalName]="formCtrl.get('name').value"
       >
       </app-form-data-volumes>
 


### PR DESCRIPTION
The Angular code for `<app-form-data-volumes>` was missing `.value`.

This error resulted in the name of new data volumes being injected with `[object Object]` instead of the corresponding notebook server name.

![image](https://user-images.githubusercontent.com/8212170/197050117-ef5e6a76-b03c-412e-89e9-a28648bdd94e.png)

More information can be found here: https://github.com/StatCan/jupyter-apis/issues/168.