### PR TITLE
[vwa-datetime] Showing dates in main page uniformly in VWA

### DIFF
--- a/components/crud-web-apps/volumes/backend/apps/common/utils.py
+++ b/components/crud-web-apps/volumes/backend/apps/common/utils.py
@@ -18,12 +18,7 @@ def parse_pvc(pvc):
         "name": pvc.metadata.name,
         "namespace": pvc.metadata.namespace,
         "status": status.pvc_status(pvc),
-        "age": {
-            "uptime": helpers.get_uptime(pvc.metadata.creation_timestamp),
-            "timestamp": pvc.metadata.creation_timestamp.strftime(
-                "%d/%m/%Y, %H:%M:%S"
-            ),
-        },
+        "age": pvc.metadata.creation_timestamp,
         "capacity": capacity,
         "modes": pvc.spec.access_modes,
         "class": pvc.spec.storage_class_name,

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
@@ -4,6 +4,7 @@ import {
   ActionListValue,
   ActionIconValue,
   TableConfig,
+  DateTimeValue,
 } from 'kubeflow';
 
 export const tableConfig: TableConfig = {
@@ -29,9 +30,8 @@ export const tableConfig: TableConfig = {
       matColumnDef: 'age',
       textAlignment: 'right',
       style: { width: '10%' },
-      value: new PropertyValue({
-        field: 'age.uptime',
-        tooltipField: 'age.timestamp',
+      value: new DateTimeValue({
+        field: 'age',
       }),
     },
     {


### PR DESCRIPTION
In this PR:

* Modify the VWA's backend to send a timestamp as is without doing any formatting.
* Use `DateTimeValue` class in VWA's config for age column instead of `PropertyValue` one.

Signed-off-by: Elena Zioga <elena@arrikto.com>