### PR TITLE
fix APP_SECURE_COOKIES manifest parameters

### DIFF
--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -76,3 +76,10 @@ vars:
     apiVersion: v1
     kind: ConfigMap
     name: parameters
+- name: JWA_APP_SECURE_COOKIES
+  fieldref:
+    fieldPath: data.JWA_APP_SECURE_COOKIES
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters

--- a/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
@@ -57,3 +57,10 @@ vars:
     apiVersion: v1
     kind: ConfigMap
     name: parameters
+- fieldref:
+    fieldPath: data.TWA_APP_SECURE_COOKIES
+  name: TWA_APP_SECURE_COOKIES
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters

--- a/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
@@ -57,3 +57,10 @@ vars:
     apiVersion: v1
     kind: ConfigMap
     name: parameters
+- name: VWA_APP_SECURE_COOKIES
+  fieldref:
+    fieldPath: data.VWA_APP_SECURE_COOKIES
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters


### PR DESCRIPTION
This PR fixes the change made in https://github.com/kubeflow/kubeflow/pull/6395, because it did not tell the Kustomize manifests to treat `TWA_APP_SECURE_COOKIES` as a variable in `ConfigMap/parameters`.

This causes the current manifests for Kubeflow 1.6.1 to set the [`APP_SECURE_COOKIES` env-var](https://github.com/kubeflow/kubeflow/blob/17740d765223ef054229631ea327dfee87956f99/components/crud-web-apps/tensorboards/manifests/base/deployment.yaml#L24-L25) as the literal value `"$(TWA_APP_SECURE_COOKIES)"`, rather than `"true"` or `"false"`. 