### PR TITLE
Make admission-webhook port number configurable

### DIFF
--- a/components/admission-webhook/main.go
+++ b/components/admission-webhook/main.go
@@ -684,15 +684,17 @@ func serveMutatePods(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	var config Config
+	var port int
 	flag.StringVar(&config.CertFile, "tlsCertFile", "/etc/webhook/certs/cert.pem", "File containing the x509 Certificate for HTTPS.")
 	flag.StringVar(&config.KeyFile, "tlsKeyFile", "/etc/webhook/certs/key.pem", "File containing the x509 private key to --tlsCertFile.")
+	flag.IntVar(&port, "webhookPort", 4443, "Port number on which the webhook listens.")
 	flag.Parse()
 	klog.InitFlags(nil)
 
 	http.HandleFunc("/apply-poddefault", serveMutatePods)
 
 	server := &http.Server{
-		Addr:      ":4443",
+		Addr:      fmt.Sprintf(":%d", port),
 		TLSConfig: configTLS(config),
 	}
 	klog.Info(fmt.Sprintf("About to start serving webhooks: %#v", server))


### PR DESCRIPTION
Previously the webhook listened on a fixed port, 4443, which can clash
with other services when the webhook is run on the host network in
Kubernetes, which is required when using some CNI implementations,
notably Calico on EKS [1].

Enable configuration of the webhook listen port via the program flags.

[1] https://projectcalico.docs.tigera.io/getting-started/kubernetes/managed-public-cloud/eks#install-eks-with-calico-networking

Signed-off-by: Steve Larkin <steve.larkin@gmail.com>