### PR TITLE
[wa-age-column-improvements] Improvements in the web app's age column

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -77,6 +77,7 @@ export const defaultConfig: TableConfig = {
     {
       matHeaderCellDef: $localize`Last activity`,
       matColumnDef: 'last_activity',
+      textAlignment: 'right',
       value: new DateTimeValue({ field: 'last_activity' }),
     },
     {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -68,7 +68,7 @@ export const defaultConfig: TableConfig = {
       }),
     },
     {
-      matHeaderCellDef: $localize`Age`,
+      matHeaderCellDef: $localize`Created at`,
       matColumnDef: 'age',
       style: { width: '12%' },
       textAlignment: 'right',

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
@@ -28,7 +28,7 @@ const tableConfig: TableConfig = {
       }),
     },
     {
-      matHeaderCellDef: $localize`Age`,
+      matHeaderCellDef: $localize`Created at`,
       matColumnDef: 'age',
       style: { width: '15%' },
       textAlignment: 'right',

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
@@ -26,7 +26,7 @@ export const tableConfig: TableConfig = {
       }),
     },
     {
-      matHeaderCellDef: $localize`Age`,
+      matHeaderCellDef: $localize`Created at`,
       matColumnDef: 'age',
       textAlignment: 'right',
       style: { width: '10%' },


### PR DESCRIPTION
In this PR:
- Rename `Age` header to `Created at` in WAs.
- Right-align all date columns in WAs.

Here's a screenshot of how it will look like:
![image](https://user-images.githubusercontent.com/87971102/199013630-8b24de13-8abf-4ea6-b063-50849d9fd2c1.png)

Signed-off-by: Elena Zioga [elena@arrikto.com](mailto:elena@arrikto.com)