### PR TITLE
Adding web apps to istio service mesh

### DIFF
--- a/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   replicas: 1
   template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: jupyter-web-app

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/authorization-policy.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/authorization-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: jupyter-web-app
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+  selector:
+    matchLabels:
+      app: jupyter-web-app

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/destination-rule.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/destination-rule.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: jupyter-web-app
+spec:
+  host: jupyter-web-app-service.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base
 - virtual-service.yaml
 - authorization-policy.yaml
+- destination-rule.yaml
 namespace: kubeflow
 commonLabels:
   app: jupyter-web-app

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - virtual-service.yaml
+- authorization-policy.yaml
 namespace: kubeflow
 commonLabels:
   app: jupyter-web-app

--- a/components/crud-web-apps/tensorboards/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/deployment.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   replicas: 1
   template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: tensorboards-web-app

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/authorization-policy.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/authorization-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: tensorboards-web-app
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+  selector:
+    matchLabels:
+      app: tensorboards-web-app

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/destination-rule.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/destination-rule.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: tensorboards-web-app
+spec:
+  host: tensorboards-web-app-service.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - virtual-service.yaml
+- authorization-policy.yaml
 namespace: kubeflow
 commonLabels:
   app: tensorboards-web-app

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base
 - virtual-service.yaml
 - authorization-policy.yaml
+- destination-rule.yaml
 namespace: kubeflow
 commonLabels:
   app: tensorboards-web-app

--- a/components/crud-web-apps/volumes/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/deployment.yaml
@@ -5,9 +5,6 @@ metadata:
 spec:
   replicas: 1
   template:
-    metadata:
-      annotations:
-        sidecar.istio.io/inject: "false"
     spec:
       containers:
       - name: volumes-web-app

--- a/components/crud-web-apps/volumes/manifests/overlays/istio/authorization-policy.yaml
+++ b/components/crud-web-apps/volumes/manifests/overlays/istio/authorization-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: volumes-web-app
+spec:
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            principals:
+              - cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account
+  selector:
+    matchLabels:
+      app: volumes-web-app

--- a/components/crud-web-apps/volumes/manifests/overlays/istio/destination-rule.yaml
+++ b/components/crud-web-apps/volumes/manifests/overlays/istio/destination-rule.yaml
@@ -1,0 +1,9 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: volumes-web-app
+spec:
+  host: volumes-web-app-service.kubeflow.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: ISTIO_MUTUAL

--- a/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
 - ../../base
 - virtual-service.yaml
+- authorization-policy.yaml
 namespace: kubeflow
 commonLabels:
   app: volumes-web-app

--- a/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
 - ../../base
 - virtual-service.yaml
 - authorization-policy.yaml
+- destination-rule.yaml
 namespace: kubeflow
 commonLabels:
   app: volumes-web-app


### PR DESCRIPTION
This PR fixes #6702.

# Summary
The volumes, tensorboards and jupyter web app are vulnerable to user impersonation attacks, as any user can send HTTP requests to these services while freely setting the `kubeflow-userid` header. A malicious user may exploit this to impersonate any other user and create notebooks, tensorboard etc. on their behalf. 
Since the web apps are currently not part of the istio mesh, there is no instance overwriting or validating this header.

# Solution
Remove the disable sidecar annotations and configure istio using authorizationpolicies.
