### PR TITLE
jwa: Support for showing Notebooks from all namespaces

### DIFF
--- a/components/crud-web-apps/common/backend/setup.py
+++ b/components/crud-web-apps/common/backend/setup.py
@@ -8,6 +8,7 @@ REQUIRES = [
     "urllib3 >= 1.25.7",
     "Werkzeug >= 0.16.0",
     "Flask-Cors >= 3.0.8",
+    "gevent",
 ]
 
 setuptools.setup(

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/namespace-select/namespace-select.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/namespace-select/namespace-select.component.html
@@ -3,11 +3,12 @@
   <mat-form-field>
     <mat-label i18n>Select Namespace</mat-label>
     <mat-select
-      [(ngModel)]="currNamespace"
       name="namespacesSelect"
+      [value]="currNamespace"
       (selectionChange)="namespaceChanged($event.value)"
       data-cy-namespace-selector-dropdown
     >
+      <mat-option value="{all}">All namespaces</mat-option>
       <mat-option
         *ngFor="let namespace of namespaces"
         [value]="namespace"

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
@@ -35,7 +35,18 @@ export class TableComponent implements AfterViewInit {
   private innerData: any[] = [];
 
   public dataSource = new MatTableDataSource();
-  public displayedColumns: string[] = [];
+  public get displayedColumns(): string[] {
+    if (!this.config) {
+      return [];
+    }
+
+    const cols = [];
+    for (const col of this.config.columns) {
+      cols.push(col.matColumnDef);
+    }
+
+    return cols;
+  }
 
   @HostBinding('class.lib-table') selfClass = true;
   @ViewChild(MatPaginator, { static: true }) paginator: MatPaginator;
@@ -43,17 +54,7 @@ export class TableComponent implements AfterViewInit {
   TABLE_THEME = TABLE_THEME;
 
   @Input()
-  set config(config: TableConfig) {
-    this.innerConfig = config;
-
-    this.displayedColumns = [];
-    for (const col of config.columns) {
-      this.displayedColumns.push(col.matColumnDef);
-    }
-  }
-  get config(): TableConfig {
-    return this.innerConfig;
-  }
+  config: TableConfig;
 
   @Input()
   trackByFn: (index: number, r: any) => string;

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
@@ -1,0 +1,38 @@
+import { PropertyValue, TableColumn, TableConfig } from '../types';
+
+export function createNamespaceColumn(field: string): TableColumn {
+  return {
+    matHeaderCellDef: $localize`Namespace`,
+    matColumnDef: 'namespace',
+    style: { width: '20%' },
+    value: new PropertyValue({
+      field,
+      tooltipField: 'namespace',
+      truncate: true,
+    }),
+  };
+}
+
+export function removeColumn(config: TableConfig, name: string) {
+  const index = findColumnIndex(config, name);
+
+  if (index !== -1) {
+    config.columns.splice(index, 1);
+  }
+}
+
+export function addColumn(
+  config: TableConfig,
+  column: TableColumn,
+  after: string,
+) {
+  const index = findColumnIndex(config, after);
+
+  if (index !== -1) {
+    config.columns.splice(index + 1, 0, column);
+  }
+}
+
+function findColumnIndex(config: TableConfig, name: string) {
+  return config.columns.findIndex(col => col.matColumnDef === name);
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
@@ -1,5 +1,13 @@
 import { Injectable } from '@angular/core';
-import { ReplaySubject, Subscription, fromEvent, BehaviorSubject } from 'rxjs';
+import {
+  ReplaySubject,
+  Subscription,
+  fromEvent,
+  BehaviorSubject,
+  Observable,
+  Subject,
+  merge,
+} from 'rxjs';
 import { DashboardState } from '../enums/dashboard';
 
 declare global {
@@ -13,6 +21,7 @@ declare global {
 })
 export class NamespaceService {
   private currNamespace: string;
+  private allNamespaces: string[];
 
   // Observable string sources
   private selectedNamespaceSource = new ReplaySubject<string>(1);
@@ -22,6 +31,7 @@ export class NamespaceService {
 
   // Observable string streams
   selectedNamespace$ = this.selectedNamespaceSource.asObservable();
+  selectedNamespace2$ = new ReplaySubject<string | string[]>(1);
   dashboardConnected$ = this.dashboardConnectedSource.asObservable();
 
   constructor() {
@@ -37,6 +47,9 @@ export class NamespaceService {
             // Binds a callback that gets invoked anytime the Dashboard's
             // namespace is changed
             cdeh.onNamespaceSelected = this.updateSelectedNamespace.bind(this);
+            cdeh.onAllNamespacesSelected = this.updateAllSelectedNamespaces.bind(
+              this,
+            );
           },
         );
 
@@ -53,8 +66,12 @@ export class NamespaceService {
   }
 
   // GETers
-  getSelectedNamespace() {
+  getSelectedNamespace(): Observable<string> {
     return this.selectedNamespace$;
+  }
+
+  getSelectedNamespace2(): Observable<string | string[]> {
+    return this.selectedNamespace2$;
   }
 
   // Service message commands
@@ -62,7 +79,13 @@ export class NamespaceService {
     if (namespace.length !== 0) {
       this.currNamespace = namespace;
       this.selectedNamespaceSource.next(namespace);
+      this.selectedNamespace2$.next(namespace);
     }
+  }
+
+  updateAllSelectedNamespaces(namespaces: string[]) {
+    this.allNamespaces = namespaces;
+    this.selectedNamespace2$.next(namespaces);
   }
 
   dashboardConnected() {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
@@ -48,6 +48,7 @@ export * from './lib/form/rok-url-input/rok-url-input.component';
 
 export * from './lib/resource-table/types';
 export * from './lib/resource-table/status/types';
+export * from './lib/resource-table/table/utils';
 export * from './lib/snack-bar/types';
 export * from './lib/services/backend/types';
 export * from './lib/services/rok/types';

--- a/components/crud-web-apps/jupyter/backend/Makefile
+++ b/components/crud-web-apps/jupyter/backend/Makefile
@@ -12,23 +12,35 @@ unittest:
 run:
 	APP_PREFIX=/jupyter \
 	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+	gunicorn \
+		-w 3 \
+		--worker-class=gevent \
+		--bind 0.0.0.0:5000 \
+		--access-logfile - entrypoint:app
 
 run-rok:
 	UI_FLAVOR=rok \
 	APP_PREFIX=/jupyter \
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
 
 run-dev:
 	UI_FLAVOR=default \
 	BACKEND_MODE=dev \
-	APP_PREFIX=/ \
 	APP_SECURE_COOKIES=False \
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+	APP_PREFIX=/ \
+	gunicorn \
+		-w 3 \
+		--worker-class=gevent \
+		--bind 0.0.0.0:5000 \
+		--access-logfile - entrypoint:app
 
 run-dev-rok:
 	UI_FLAVOR=rok \
 	BACKEND_MODE=dev \
 	ROK_URL=http://10.10.10.10:8080/rok \
-	APP_PREFIX=/ \
 	APP_SECURE_COOKIES=False \
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+	APP_PREFIX=/ \
+	gunicorn \
+		-w 3 \
+		--worker-class=gevent \
+		--bind 0.0.0.0:5000 \
+		--access-logfile - entrypoint:app

--- a/components/crud-web-apps/jupyter/frontend/package.json
+++ b/components/crud-web-apps/jupyter/frontend/package.json
@@ -8,6 +8,7 @@
     "build:fr": "npm run copyLibAssets && ng build --prod --base-href /jupyter/ --deploy-url static/ --configuration=fr",
     "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all",
     "build:watch:rok": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/rok/static/ --outputHashing all --configuration=rok",
+    "serve": "npm run copyLibAssets && ng serve --proxy-config=src/proxy.conf.json",
     "serve:rok": "npm run copyLibAssets && ng serve --configuration=rok --proxy-config=src/proxy.conf.rok.json",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "format:check": "prettier --check 'src/**/*.{js,ts,html,scss,css}' || node scripts/check-format-error.js",

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -57,9 +57,13 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
 
     // Keep track of the selected namespace
     this.subscriptions.add(
-      this.namespaceService.getSelectedNamespace().subscribe(namespace => {
-        this.currNamespace = namespace;
-        this.formCtrl.controls.namespace.setValue(this.currNamespace);
+      this.namespaceService.getSelectedNamespace2().subscribe(namespace => {
+        if (Array.isArray(namespace)) {
+          this.goToNotebooks();
+        } else {
+          this.currNamespace = namespace;
+          this.formCtrl.controls.namespace.setValue(this.currNamespace);
+        }
       }),
     );
 
@@ -163,11 +167,15 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
         SnackType.Success,
         3000,
       );
-      this.router.navigate(['/']);
+      this.goToNotebooks();
     });
   }
 
   onCancel() {
+    this.goToNotebooks();
+  }
+
+  goToNotebooks() {
     this.router.navigate(['/']);
   }
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -8,8 +8,10 @@ import {
   DialogConfig,
   ComponentValue,
   TableConfig,
+  TableColumn,
   TABLE_THEME,
   DateTimeValue,
+  createNamespaceColumn,
 } from 'kubeflow';
 import { ServerTypeComponent } from './server-type/server-type.component';
 
@@ -43,6 +45,8 @@ export function getStopDialogConfig(name: string): DialogConfig {
 }
 
 // --- Config for the Resource Table ---
+export const NAMESPACE_COLUMN: TableColumn = createNamespaceColumn('namespace');
+
 export const defaultConfig: TableConfig = {
   columns: [
     {

--- a/components/crud-web-apps/jupyter/frontend/tsconfig.json
+++ b/components/crud-web-apps/jupyter/frontend/tsconfig.json
@@ -17,7 +17,7 @@
     },
 
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2018", "dom"],
+    "lib": ["es2018", "dom", "es2019"],
     "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Extend the JWA to be able to show Notebooks from all namespaces, when selected from the CentralDashboard. This requires the CentralDashboard work #6674. 

Notable **performance** changes in this PR:
* The frontend will be polling requests for each namespace
* The backend will be using `gevent` workers, for being able to handle a lot of concurrent requests

Notable **UX** changes in this PR:
* When all-namespaces is selected in the dashboard then a new `Namespaces` column will be added
* When all-namespaces is selected the users won't be able to create new notebooks. They'll need to select a namespace first

/cc @tasos-ale 
/cc @elikatsis 

![image](https://user-images.githubusercontent.com/11134742/199691958-5225add8-a596-4c9f-92f4-de8811dd2b0f.png)
