### PR TITLE
web-apps: Ensure in-flight requests are cancelled 

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/angular.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/poller.service.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/poller.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PollerService } from './poller.service';
+
+describe('PollerService', () => {
+  let service: PollerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PollerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/poller.service.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/poller.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+import { never, Observable, of } from 'rxjs';
+import { expand, delay, tap, concatMap, filter } from 'rxjs/operators';
+import { isEqual } from 'lodash';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PollerService {
+  constructor() {}
+
+  public exponential<T>(obs: Observable<T>): Observable<T> {
+    let period = 1;
+    let currData: any;
+
+    /*
+    * The poller$ observable is pushing values in an exponential manner.
+    * The `expand` operator is emitting values by using the value from the
+    * previous emit. In our case we also use delay with a dynamic period
+    * to achieve resetable exponential delay.
+    */
+    const poller$ = of(1).pipe(expand(x => of(period).pipe(delay(x * 1000))));
+
+    const request$ = poller$.pipe(
+      concatMap(() => obs),
+      tap(() => (period = Math.min(period * 2, 8))),
+      filter(data => !isEqual(data, currData)),
+      tap(data => {
+        // new data detected
+        if (currData) {
+          period = 1;
+        }
+
+        currData = data;
+      }),
+    );
+
+    return request$;
+  }
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
@@ -8,6 +8,7 @@ export * from './lib/snack-bar/snack-bar.module';
 export * from './lib/snack-bar/snack-bar.service';
 
 export * from './lib/services/namespace.service';
+export * from './lib/services/poller.service';
 export * from './lib/services/backend/backend.service';
 export * from './lib/services/rok/rok.service';
 

--- a/components/crud-web-apps/jupyter/frontend/angular.json
+++ b/components/crud-web-apps/jupyter/frontend/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-rok/index-rok.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-rok/index-rok.component.ts
@@ -5,6 +5,7 @@ import {
   NamespaceService,
   SnackBarService,
   ConfirmDialogService,
+  PollerService,
 } from 'kubeflow';
 import { JWABackendService } from 'src/app/services/backend.service';
 import { Router } from '@angular/router';
@@ -23,8 +24,9 @@ export class IndexRokComponent extends IndexDefaultComponent implements OnInit {
     public confirmDialog: ConfirmDialogService,
     public popup: SnackBarService,
     public router: Router,
+    public poller: PollerService,
   ) {
-    super(ns, backend, confirmDialog, popup, router);
+    super(ns, backend, confirmDialog, popup, router, poller);
 
     this.rok.initCSRF();
   }

--- a/components/crud-web-apps/tensorboards/frontend/angular.json
+++ b/components/crud-web-apps/tensorboards/frontend/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/components/crud-web-apps/tensorboards/frontend/package.json
+++ b/components/crud-web-apps/tensorboards/frontend/package.json
@@ -6,6 +6,7 @@
     "build": "npm run copyLibAssets && ng build --prod  --deploy-url static/",
     "build:fr": "npm run copyLibAssets && ng build --prod --deploy-url static/ --configuration=fr",
     "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/app/static/ --outputHashing all",
+    "serve": "npm run copyLibAssets && ng serve --proxy-config=src/proxy.conf.json",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "i18n:extract": "ng extract-i18n --output-path i18n",
     "test": "ng test",

--- a/components/crud-web-apps/tensorboards/frontend/src/proxy.conf.json
+++ b/components/crud-web-apps/tensorboards/frontend/src/proxy.conf.json
@@ -2,5 +2,10 @@
   "/api": {
     "target": "http://localhost:5000",
     "secure": false
+  },
+  "/static": {
+    "target": "http://localhost:4200",
+    "pathRewrite": { "^/static": "" },
+    "secure": false
   }
 }

--- a/components/crud-web-apps/volumes/backend/Makefile
+++ b/components/crud-web-apps/volumes/backend/Makefile
@@ -1,7 +1,7 @@
 SHELL=bash
 
 install-deps:
-	pushd ../../../py && \
+	pushd ../../common/backend && \
 	pip install -e . && \
 	popd
 	pip install -r requirements.txt

--- a/components/crud-web-apps/volumes/frontend/angular.json
+++ b/components/crud-web-apps/volumes/frontend/angular.json
@@ -1,5 +1,8 @@
 {
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {

--- a/components/crud-web-apps/volumes/frontend/package.json
+++ b/components/crud-web-apps/volumes/frontend/package.json
@@ -7,6 +7,8 @@
     "build:fr": "npm run copyLibAssets && ng build --prod --base-href /volumes/ --deploy-url /static/ --configuration=fr",
     "build:watch": "npm run copyLibAssets && ng build --watch --deploy-url static/ --outputPath ../backend/apps/default/static/ --outputHashing all",
     "build:watch:rok": "npm run copyLibAssets && ng build --watch --deploy-url static/ --configuration=rok --outputPath ../backend/apps/rok/static/ --outputHashing all",
+    "serve": "npm run copyLibAssets && ng serve --proxy-config=src/proxy.conf.json",
+    "serve:rok": "npm run copyLibAssets && ng serve --configuration=rok --proxy-config=src/proxy.conf.rok.json",
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "format:check": "prettier --check 'src/**/*.{js,ts,html,scss,css}' || node scripts/check-format-error.js",
     "format:write": "prettier --write 'src/**/*.{js,ts,html,scss,css}'",

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
@@ -1,23 +1,22 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import {
   NamespaceService,
   ActionEvent,
   ConfirmDialogService,
-  ExponentialBackoff,
   STATUS_TYPE,
   DIALOG_RESP,
   DialogConfig,
   SnackBarService,
   SnackType,
   ToolbarButton,
+  PollerService,
 } from 'kubeflow';
 import { defaultConfig } from './config';
 import { environment } from '@app/environment';
 import { VWABackendService } from 'src/app/services/backend.service';
 import { PVCResponseObject, PVCProcessedObject } from 'src/app/types';
-import { Subscription, Observable, Subject } from 'rxjs';
-import { isEqual } from 'lodash';
+import { Subscription } from 'rxjs';
 import { FormDefaultComponent } from '../../form/form-default/form-default.component';
 
 @Component({
@@ -25,15 +24,13 @@ import { FormDefaultComponent } from '../../form/form-default/form-default.compo
   templateUrl: './index-default.component.html',
   styleUrls: ['./index-default.component.scss'],
 })
-export class IndexDefaultComponent implements OnInit {
+export class IndexDefaultComponent implements OnInit, OnDestroy {
+  private nsSub = new Subscription();
+  private pollSub = new Subscription();
+
   public env = environment;
-  public poller: ExponentialBackoff;
-
-  public currNamespace = '';
-  public subs = new Subscription();
-
   public config = defaultConfig;
-  public rawData: PVCResponseObject[] = [];
+  public currNamespace: string;
   public processedData: PVCProcessedObject[] = [];
   public pvcsWaitingViewer = new Set<string>();
 
@@ -54,38 +51,31 @@ export class IndexDefaultComponent implements OnInit {
     public backend: VWABackendService,
     public dialog: MatDialog,
     public snackBar: SnackBarService,
+    public poller: PollerService,
   ) {}
 
   ngOnInit() {
-    this.poller = new ExponentialBackoff({ interval: 1000, retries: 3 });
+    this.nsSub = this.ns.getSelectedNamespace().subscribe(ns => {
+      this.currNamespace = ns;
+      this.pvcsWaitingViewer = new Set<string>();
+      this.poll(ns);
+    });
+  }
 
-    // Poll for new data and reset the poller if different data is found
-    this.subs.add(
-      this.poller.start().subscribe(() => {
-        if (!this.currNamespace) {
-          return;
-        }
+  ngOnDestroy() {
+    this.nsSub.unsubscribe();
+    this.pollSub.unsubscribe();
+  }
 
-        this.backend.getPVCs(this.currNamespace).subscribe(pvcs => {
-          if (!isEqual(this.rawData, pvcs)) {
-            this.rawData = pvcs;
+  public poll(ns: string) {
+    this.pollSub.unsubscribe();
+    this.processedData = [];
 
-            // Update the frontend's state
-            this.processedData = this.parseIncomingData(pvcs);
-            this.poller.reset();
-          }
-        });
-      }),
-    );
+    const request = this.backend.getPVCs(ns);
 
-    // Reset the poller whenever the selected namespace changes
-    this.subs.add(
-      this.ns.getSelectedNamespace().subscribe(ns => {
-        this.currNamespace = ns;
-        this.pvcsWaitingViewer = new Set<string>();
-        this.poller.reset();
-      }),
-    );
+    this.pollSub = this.poller.exponential(request).subscribe(pvcs => {
+      this.processedData = this.parseIncomingData(pvcs);
+    });
   }
 
   public reactToAction(a: ActionEvent) {
@@ -110,7 +100,7 @@ export class IndexDefaultComponent implements OnInit {
           SnackType.Success,
           2000,
         );
-        this.poller.reset();
+        this.poll(this.currNamespace);
       }
     });
   }
@@ -134,9 +124,9 @@ export class IndexDefaultComponent implements OnInit {
       }
 
       // Close the open dialog only if the DELETE request succeeded
-      this.backend.deletePVC(this.currNamespace, pvc.name).subscribe({
+      this.backend.deletePVC(pvc.namespace, pvc.name).subscribe({
         next: _ => {
-          this.poller.reset();
+          this.poll(pvc.namespace);
           ref.close(DIALOG_RESP.ACCEPT);
         },
         error: err => {

--- a/components/crud-web-apps/volumes/frontend/src/proxy.conf.json
+++ b/components/crud-web-apps/volumes/frontend/src/proxy.conf.json
@@ -2,5 +2,10 @@
   "/api": {
     "target": "http://localhost:5000",
     "secure": false
+  },
+  "/static": {
+    "target": "http://localhost:4200",
+    "pathRewrite": { "^/static": "" },
+    "secure": false
   }
 }

--- a/components/crud-web-apps/volumes/frontend/src/proxy.conf.rok.json
+++ b/components/crud-web-apps/volumes/frontend/src/proxy.conf.rok.json
@@ -1,0 +1,23 @@
+{
+  "/api": {
+    "target": "http://localhost:5000",
+    "secure": false
+  },
+  "/static": {
+    "target": "http://localhost:4200",
+    "pathRewrite": { "^/static": "" },
+    "secure": false
+  },
+  "/rok": {
+    "target": "http://localhost:8000",
+    "secure": false,
+    "pathRewrite": {
+      "^/rok": ""
+    },
+    "headers": {
+      "kubeflow-userid": "user",
+      "x-forwarded-prefix": "/rok/",
+      "x-forwarded-host": "localhost:4200"
+    }
+  }
+}


### PR DESCRIPTION
While working on the [all-namespaces support](https://github.com/kubeflow/kubeflow/blob/master/components/proposals/20220621-all-namespaces.md), follow up of https://github.com/kubeflow/kubeflow/pull/6706, I noticed that we currently don't cancel inflight requests.

This means that if a user changes the namespace, and there's delay in the requests, then they will keep seeing objects from the previous namespace. Then once new requests succeed the data will be updated accordingly.

To reproduce this you can set a `2s latency` in the DevTools and try to switch namespace. 

This PR creates a common Angular Service for polling that:
1. Handles exponential polling
2. Uses RxJS observables to handle the requests. This way when we unsubscribe the requests get cancelled

/cc @tasos-ale 