### PR TITLE
jwa: Use common date component for age

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -130,7 +130,7 @@ def notebook_dict_from_k8s_obj(notebook):
         "name": notebook["metadata"]["name"],
         "namespace": notebook["metadata"]["namespace"],
         "serverType": server_type,
-        "age": helpers.get_uptime(notebook["metadata"]["creationTimestamp"]),
+        "age": notebook["metadata"]["creationTimestamp"],
         "last_activity": get_notebook_last_activity(notebook),
         "image": cntr["image"],
         "shortImage": cntr["image"].split("/")[-1],

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -76,7 +76,7 @@ export const defaultConfig: TableConfig = {
       matColumnDef: 'age',
       style: { width: '12%' },
       textAlignment: 'right',
-      value: new PropertyValue({ field: 'age', truncate: true }),
+      value: new DateTimeValue({ field: 'age' }),
     },
     {
       matHeaderCellDef: $localize`Last activity`,


### PR DESCRIPTION
Instead of parsing the date in the backend we should use our common UI date component, in order to show dates in a uniform way.

Relevant PR https://github.com/kubeflow/katib/pull/1989

/cc @elenzio9 @tasos-ale 