### PR TITLE
tensorboard-controller: Fix tensorboard endless restarts

### DIFF
--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -80,6 +80,14 @@ func (r *TensorboardReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
+	// tensorboards-web-app deletes objects using foreground deletion policy, Tensorboard CR will stay until all owned objects are deleted
+	// reconcile loop might keep on trying to recreate the resources that the API server tries to delete.
+	// so when Tensorboard CR is terminating, reconcile loop should do nothing
+
+	if !instance.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	// Reconcile k8s deployment.
 	deployment, err := generateDeployment(instance, logger, r)
 	if err != nil {


### PR DESCRIPTION
tensorboard-controller: Fix tensorboard endless restarts
tensorboards-web-app deletes objects using foreground deletion policy, Tensorboard CR will stay until all owned objects are deleted reconcile loop might keep on trying to recreate the resources that the API server tries to delete. so when Tensorboard CR is terminating, reconcile loop should do nothing

This commit allow manager to skip reconcile while Tensorboard CR is deleting.