### PR TITLE
change pull policy from always to ifNotPresent

### DIFF
--- a/components/notebook-controller/config/manager/manager.yaml
+++ b/components/notebook-controller/config/manager/manager.yaml
@@ -52,7 +52,7 @@ spec:
               configMapKeyRef:
                 name: config
                 key: IDLENESS_CHECK_PERIOD
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
             path: /healthz

--- a/components/profile-controller/config/manager/manager.yaml
+++ b/components/profile-controller/config/manager/manager.yaml
@@ -29,7 +29,7 @@ spec:
           - configMapRef:
               name: config
         image: public.ecr.aws/j1r0q0g6/notebooks/profile-controller
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: manager
         livenessProbe:
           httpGet:

--- a/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
@@ -21,7 +21,7 @@ spec:
           - configMapRef:
               name: config
         image: public.ecr.aws/j1r0q0g6/notebooks/access-management
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: kfam
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Mirror PR created in https://github.com/kubeflow/manifests/pull/2310
Address issue https://github.com/kubeflow/kubeflow/issues/6704
-change docker image pull policy to IfNotPresent so images can be cached to avoid [docker pull rate limit](https://aws.amazon.com/premiumsupport/knowledge-center/ecs-pull-container-error-rate-limit/#:~:text=Docker%20Hub%20uses%20IP%20addresses,pulls%20per%206%2Dhour%20period)