### PR TITLE
web-apps: Common code for all-namespaces

### DIFF
--- a/.github/workflows/frontend_lint.yaml
+++ b/.github/workflows/frontend_lint.yaml
@@ -11,8 +11,8 @@ on:
       - components/crud-web-apps/volumes/frontend/**
 
 jobs:
-  lint:
-    name: Lint frontend code
+  lint-common-code:
+    name: Common code
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -24,17 +24,44 @@ jobs:
         cd components/crud-web-apps/common/frontend/kubeflow-common-lib
         npm i
         npm run lint-check
-    - name: Lint jupyter
+
+  lint-jwa-code:
+    name: Jupyter web app
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 12
+    - name: Lint jupyter web app
       run: |
         cd components/crud-web-apps/jupyter/frontend
         npm i
         npm run lint-check
+
+  lint-twa-code:
+    name: TensorBoards web app
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 12
     - name: Lint tensorboards
       run: |
         cd components/crud-web-apps/tensorboards/frontend
         npm i
         npm run lint-check
-    - name: Lint volumes
+
+  lint-vwa-code:
+    name: Volumes web app
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
+      with:
+        node-version: 12
+    - name: Lint Volumes web app
       run: |
         cd components/crud-web-apps/volumes/frontend
         npm i

--- a/.github/workflows/frontend_lint.yaml
+++ b/.github/workflows/frontend_lint.yaml
@@ -23,19 +23,19 @@ jobs:
       run: |
         cd components/crud-web-apps/common/frontend/kubeflow-common-lib
         npm i
-        npm run lint
+        npm run lint-check
     - name: Lint jupyter
       run: |
         cd components/crud-web-apps/jupyter/frontend
         npm i
-        npm run lint
+        npm run lint-check
     - name: Lint tensorboards
       run: |
         cd components/crud-web-apps/tensorboards/frontend
         npm i
-        npm run lint
+        npm run lint-check
     - name: Lint volumes
       run: |
         cd components/crud-web-apps/volumes/frontend
         npm i
-        npm run lint
+        npm run lint-check

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -8,6 +8,7 @@
     "test": "ng test",
     "test-ci": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test-docker": "docker run -v $(pwd):/usr/src/app browserless/chrome:1.44-chrome-stable npm run test-ci",
+    "lint-check": "ng lint",
     "lint": "ng lint --fix",
     "e2e": "ng e2e",
     "copyCSS": "cp ./projects/kubeflow/src/kubeflow.css ./dist/kubeflow && cp ./projects/kubeflow/src/styles.scss ./dist/kubeflow && cp ./projects/kubeflow/src/lib/variables.scss ./dist/kubeflow/lib && cp ./projects/kubeflow/src/lib/fonts.scss ./dist/kubeflow/lib",

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
@@ -1,17 +1,17 @@
 import { PropertyValue, TableColumn, TableConfig } from '../types';
 
-export function createNamespaceColumn(field: string): TableColumn {
-  return {
-    matHeaderCellDef: $localize`Namespace`,
-    matColumnDef: 'namespace',
-    style: { width: '20%' },
-    value: new PropertyValue({
-      field,
-      tooltipField: 'namespace',
-      truncate: true,
-    }),
-  };
-}
+export const NAMESPACE_COLUMN: TableColumn = {
+  matHeaderCellDef: $localize`Namespace`,
+  matColumnDef: 'namespace',
+  style: { width: '20%' },
+  value: new PropertyValue({
+    valueFn: (obj: any) => {
+      return obj?.namespace || obj?.metadata?.namespace;
+    },
+    tooltipField: 'namespace',
+    truncate: true,
+  }),
+};
 
 export function removeColumn(config: TableConfig, name: string) {
   const index = findColumnIndex(config, name);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
@@ -5,9 +5,7 @@ export const NAMESPACE_COLUMN: TableColumn = {
   matColumnDef: 'namespace',
   style: { width: '20%' },
   value: new PropertyValue({
-    valueFn: (obj: any) => {
-      return obj?.namespace || obj?.metadata?.namespace;
-    },
+    valueFn: (obj: any) => obj?.namespace || obj?.metadata?.namespace,
     tooltipField: 'namespace',
     truncate: true,
   }),

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/table.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/table.ts
@@ -33,6 +33,7 @@ export interface TableConfig {
   newButtonText?: string;
   width?: string;
   theme?: TABLE_THEME;
+  dynamicNamespaceColumn?: boolean;
 }
 
 export enum TABLE_THEME {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.html
@@ -23,34 +23,38 @@
     <ng-container *ngFor="let button of buttons">
       <!--raised button-->
       <ng-container *ngIf="button.raised">
-        <button
-          mat-button
-          [color]="button.color"
-          [disabled]="button.disabled"
-          (click)="button.fn()"
-          class="toolbar-button"
-        >
-          <mat-icon *ngIf="button.icon" class="button-icon">
-            {{ button.icon }}
-          </mat-icon>
-          {{ button.text }}
-        </button>
+        <div [matTooltip]="button.tooltip">
+          <button
+            mat-button
+            [color]="button.color"
+            [disabled]="button.disabled"
+            (click)="button.fn()"
+            class="toolbar-button"
+          >
+            <mat-icon *ngIf="button.icon" class="button-icon">
+              {{ button.icon }}
+            </mat-icon>
+            {{ button.text }}
+          </button>
+        </div>
       </ng-container>
 
       <!--stroked button-->
       <ng-container *ngIf="button.stroked">
-        <button
-          mat-stroked-button
-          [color]="button.color"
-          [disabled]="button.disabled"
-          (click)="button.fn()"
-          class="toolbar-button"
-        >
-          <mat-icon *ngIf="button.icon" class="button-icon">
-            {{ button.icon }}
-          </mat-icon>
-          {{ button.text }}
-        </button>
+        <div [matTooltip]="button.tooltip">
+          <button
+            mat-stroked-button
+            [color]="button.color"
+            [disabled]="button.disabled"
+            (click)="button.fn()"
+            class="toolbar-button"
+          >
+            <mat-icon *ngIf="button.icon" class="button-icon">
+              {{ button.icon }}
+            </mat-icon>
+            {{ button.text }}
+          </button>
+        </div>
       </ng-container>
     </ng-container>
   </div>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.module.ts
@@ -4,10 +4,17 @@ import { TitleActionsToolbarComponent } from './title-actions-toolbar.component'
 import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 @NgModule({
   declarations: [TitleActionsToolbarComponent],
-  imports: [CommonModule, MatIconModule, MatDividerModule, MatButtonModule],
+  imports: [
+    CommonModule,
+    MatIconModule,
+    MatDividerModule,
+    MatButtonModule,
+    MatTooltipModule,
+  ],
   exports: [TitleActionsToolbarComponent],
 })
 export class TitleActionsToolbarModule {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/types.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/types.ts
@@ -17,7 +17,7 @@ export class ToolbarButton {
   raised: boolean;
   stroked: boolean;
   tooltip: string;
-  fn: () => {};
+  fn: () => any;
 
   private defaults: ToolbarButtonConfig = {
     icon: '',

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/types.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/types.ts
@@ -5,6 +5,7 @@ export interface ToolbarButtonConfig {
   color?: string;
   raised?: boolean;
   stroked?: boolean;
+  tooltip?: string;
   fn: () => any;
 }
 
@@ -15,7 +16,8 @@ export class ToolbarButton {
   color: string;
   raised: boolean;
   stroked: boolean;
-  fn: () => any;
+  tooltip: string;
+  fn: () => {};
 
   private defaults: ToolbarButtonConfig = {
     icon: '',
@@ -23,11 +25,12 @@ export class ToolbarButton {
     disabled: false,
     color: 'primary',
     raised: true,
+    tooltip: '',
     fn: () => {},
   };
 
   constructor(config: ToolbarButtonConfig) {
-    const { icon, text, disabled, color, stroked, raised, fn } = {
+    const { icon, text, disabled, color, stroked, raised, tooltip, fn } = {
       ...this.defaults,
       ...config,
     };
@@ -37,11 +40,25 @@ export class ToolbarButton {
     this.disabled = disabled;
     this.color = color;
     this.raised = raised;
+    this.tooltip = tooltip;
     this.fn = fn;
 
     if (stroked) {
       this.raised = false;
       this.stroked = true;
     }
+  }
+
+  public namespaceChanged(ns: string | string[], resourceName: string) {
+    // enable the button on single namespace
+    if (!Array.isArray(ns)) {
+      this.disabled = false;
+      this.tooltip = '';
+      return;
+    }
+
+    // all-namespaces was selected
+    this.disabled = true;
+    this.tooltip = $localize`Select a namespace in which to create a new ${resourceName}.`;
   }
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/tsconfig.lib.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/tsconfig.lib.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "inlineSources": true,
     "types": [],
-    "lib": ["dom", "es2018"]
+    "lib": ["dom", "es2018", "es2019"]
   },
   "angularCompilerOptions": {
     "skipTemplateCodegen": true,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/tsconfig.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/tsconfig.json
@@ -11,8 +11,14 @@
     "moduleResolution": "node",
     "importHelpers": true,
     "target": "es2015",
-    "typeRoots": ["node_modules/@types"],
-    "lib": ["es2018", "dom"],
+    "typeRoots": [
+      "node_modules/@types"
+    ],
+    "lib": [
+      "es2018",
+      "dom",
+      "es2019"
+    ],
     "paths": {
       "kubeflow": ["dist/kubeflow"],
       "kubeflow/*": ["dist/kubeflow/*"]

--- a/components/crud-web-apps/jupyter/frontend/package-lock.json
+++ b/components/crud-web-apps/jupyter/frontend/package-lock.json
@@ -3685,15 +3685,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "dependencies": {
@@ -3706,6 +3706,23 @@
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
           }
+        },
+        "get-intrinsic": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
         }
       }
     },
@@ -3731,15 +3748,27 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "arrify": {
@@ -4220,7 +4249,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true
     },
     "buffer-from": {
@@ -4244,7 +4273,7 @@
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
     },
     "bytes": {
       "version": "3.0.0",
@@ -4399,7 +4428,7 @@
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
+      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
       "dev": true
     },
     "chokidar": {
@@ -7409,7 +7438,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -9661,7 +9690,7 @@
     "lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
+      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
       "dev": true
     },
     "less": {
@@ -9915,7 +9944,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "dev": true
     },
     "lodash.truncate": {
@@ -10997,14 +11026,26 @@
       }
     },
     "object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "obuf": {
@@ -11206,7 +11247,7 @@
     "ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
-      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
+      "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
       "dev": true
     },
     "p-cancelable": {
@@ -11423,7 +11464,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true
     },
     "performance-now": {
@@ -13658,7 +13699,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -13822,7 +13863,7 @@
     "request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
       "dev": true,
       "requires": {
         "throttleit": "^1.0.0"
@@ -15049,14 +15090,14 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "dependencies": {
         "define-properties": {
@@ -15072,14 +15113,14 @@
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "dependencies": {
         "define-properties": {
@@ -15562,7 +15603,7 @@
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
+      "integrity": "sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==",
       "dev": true
     },
     "through": {
@@ -16884,7 +16925,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/components/crud-web-apps/jupyter/frontend/package.json
+++ b/components/crud-web-apps/jupyter/frontend/package.json
@@ -17,6 +17,7 @@
     "test": "ng test",
     "e2e": "cypress open .",
     "e2e-ci": "cypress run .",
+    "lint-check": "ng lint",
     "lint": "ng lint --fix"
   },
   "private": true,

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -11,7 +11,6 @@ import {
   TableColumn,
   TABLE_THEME,
   DateTimeValue,
-  createNamespaceColumn,
 } from 'kubeflow';
 import { ServerTypeComponent } from './server-type/server-type.component';
 
@@ -45,9 +44,8 @@ export function getStopDialogConfig(name: string): DialogConfig {
 }
 
 // --- Config for the Resource Table ---
-export const NAMESPACE_COLUMN: TableColumn = createNamespaceColumn('namespace');
-
 export const defaultConfig: TableConfig = {
+  dynamicNamespaceColumn: true,
   columns: [
     {
       matHeaderCellDef: $localize`Status`,

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
@@ -21,13 +21,34 @@ export class JWABackendService extends BackendService {
   }
 
   // GET
-  public getNotebooks(namespace: string): Observable<NotebookResponseObject[]> {
+  private getNotebooksSingleNamespace(
+    namespace: string,
+  ): Observable<NotebookResponseObject[]> {
     const url = `api/namespaces/${namespace}/notebooks`;
 
     return this.http.get<JWABackendResponse>(url).pipe(
       catchError(error => this.handleError(error)),
       map((resp: JWABackendResponse) => resp.notebooks),
     );
+  }
+
+  private getNotebooksAllNamespaces(
+    namespaces: string[],
+  ): Observable<NotebookResponseObject[]> {
+    return this.getObjectsAllNamespaces(
+      this.getNotebooksSingleNamespace.bind(this),
+      namespaces,
+    );
+  }
+
+  public getNotebooks(
+    ns: string | string[],
+  ): Observable<NotebookResponseObject[]> {
+    if (Array.isArray(ns)) {
+      return this.getNotebooksAllNamespaces(ns);
+    }
+
+    return this.getNotebooksSingleNamespace(ns);
   }
 
   public getConfig(): Observable<Config> {

--- a/components/crud-web-apps/tensorboards/frontend/package.json
+++ b/components/crud-web-apps/tensorboards/frontend/package.json
@@ -10,6 +10,7 @@
     "copyLibAssets": "cp -r ./node_modules/kubeflow/assets/* ./src/assets/",
     "i18n:extract": "ng extract-i18n --output-path i18n",
     "test": "ng test",
+    "lint-check": "ng lint",
     "lint": "ng lint --fix",
     "e2e": "ng e2e"
   },

--- a/components/crud-web-apps/volumes/frontend/package-lock.json
+++ b/components/crud-web-apps/volumes/frontend/package-lock.json
@@ -3529,15 +3529,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "dependencies": {
@@ -3550,6 +3550,23 @@
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
           }
+        },
+        "get-intrinsic": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
         }
       }
     },
@@ -3575,15 +3592,27 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "arrify": {
@@ -4065,7 +4094,7 @@
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
     },
     "bytes": {
       "version": "3.0.0",
@@ -10087,14 +10116,26 @@
       }
     },
     "object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "obuf": {
@@ -12735,7 +12776,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "requires": {
         "resolve": "^1.1.6"
       }
@@ -14095,14 +14136,14 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "dependencies": {
         "define-properties": {
@@ -14118,14 +14159,14 @@
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "dependencies": {
         "define-properties": {

--- a/components/crud-web-apps/volumes/frontend/package.json
+++ b/components/crud-web-apps/volumes/frontend/package.json
@@ -14,6 +14,7 @@
     "format:write": "prettier --write 'src/**/*.{js,ts,html,scss,css}'",
     "i18n:extract": "ng extract-i18n --output-path i18n",
     "test": "ng test",
+    "lint-check": "ng lint",
     "lint": "ng lint --fix",
     "e2e": "ng e2e"
   },


### PR DESCRIPTION
Follow up of review comments in https://github.com/kubeflow/kubeflow/pull/6706

In this PR I've moved to the common code:
1. Dynamically showing the `Namespace` column, in the common table component, if all-namespaces is selected
2. Common handlers for creating the multiple http calls, for all namespaces
3. The logic for resetting the polling if the data received is different
    * We now always expect that the received objects are K8s objects with `.metadata.name` fields

Lastly I've modified the code of the JWA to use this common code for showing objects from all-namespaces.

/cc @tasos-ale 

if we are OK with these changes I can then send a follow-up PR for adding this functionality to the rest of the web apps