### PR TITLE
web-apps(front): Introduce Logs Viewer component

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.html
@@ -1,0 +1,9 @@
+<lib-heading-row [heading]="[heading]" [subHeading]="[subHeading]">
+</lib-heading-row>
+
+<cdk-virtual-scroll-viewport itemSize="18" class="logs-viewer">
+  <div *cdkVirtualFor="let entry of logs; let index = index" class="log-entry">
+    <span class="number">{{ index }}</span>
+    {{ entry }}
+  </div>
+</cdk-virtual-scroll-viewport>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.scss
@@ -1,0 +1,32 @@
+:host {
+  display: block;
+}
+
+.logs-viewer {
+  background-color: #222;
+  color: #fff;
+  font-family: 'Source Code Pro', monospace;
+  font-size: 12px;
+  overflow: auto !important;
+  white-space: pre;
+}
+
+.log-entry {
+  width: 100%;
+  display: flex;
+  height: 18px;
+}
+
+.log-entry:hover {
+  width: 100%;
+  display: flex;
+  background-color: #333;
+}
+
+.number {
+  color: #999;
+  flex: 40px 0 0;
+  padding-right: 10px;
+  text-align: right;
+  user-select: none;
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.spec.ts
@@ -1,0 +1,28 @@
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HeadingSubheadingRowModule } from '../heading-subheading-row/heading-subheading-row.module';
+
+import { LogsViewerComponent } from './logs-viewer.component';
+
+describe('LogsViewerComponent', () => {
+  let component: LogsViewerComponent;
+  let fixture: ComponentFixture<LogsViewerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LogsViewerComponent],
+      imports: [CommonModule, HeadingSubheadingRowModule, ScrollingModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LogsViewerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.component.ts
@@ -1,0 +1,49 @@
+import {
+  Component,
+  Input,
+  ViewChild,
+  HostBinding,
+  AfterViewInit,
+} from '@angular/core';
+import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+
+@Component({
+  selector: 'lib-logs-viewer',
+  templateUrl: './logs-viewer.component.html',
+  styleUrls: ['./logs-viewer.component.scss'],
+})
+export class LogsViewerComponent implements AfterViewInit {
+  @HostBinding('class.lib-logs-viewer') selfClass = true;
+  @ViewChild(CdkVirtualScrollViewport, { static: true })
+  viewPort: CdkVirtualScrollViewport;
+
+  @Input() heading = 'Logs';
+  @Input() subHeading = 'tit';
+  @Input() height = '400px';
+  @Input()
+  set logs(newLogs: string[]) {
+    const currLogsLength = this.logs.length;
+
+    this.logsPrv = newLogs;
+
+    if (!this.logs) {
+      return;
+    }
+
+    if (currLogsLength === 0) {
+      setTimeout(() => {
+        const scrollIndex = this.logsPrv.length - 1;
+        this.viewPort.scrollToIndex(scrollIndex, 'smooth');
+      }, 350);
+    }
+  }
+  get logs(): string[] {
+    return this.logsPrv;
+  }
+
+  private logsPrv: string[] = [];
+
+  ngAfterViewInit() {
+    this.viewPort.elementRef.nativeElement.style.height = this.height;
+  }
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/logs-viewer/logs-viewer.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ScrollingModule } from '@angular/cdk/scrolling';
+import { LogsViewerComponent } from './logs-viewer.component';
+import { HeadingSubheadingRowModule } from '../heading-subheading-row/heading-subheading-row.module';
+
+@NgModule({
+  declarations: [LogsViewerComponent],
+  imports: [CommonModule, ScrollingModule, HeadingSubheadingRowModule],
+  exports: [LogsViewerComponent],
+})
+export class LogsViewerModule {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
@@ -83,3 +83,6 @@ export * from './lib/form/step-info/step-info.component';
 export * from './lib/form/submit-bar/submit-bar.component';
 export * from './lib/form/step-info/step-info.component';
 export * from './lib/resource-table/table/table.component';
+
+export * from './lib/logs-viewer/logs-viewer.module';
+export * from './lib/logs-viewer/logs-viewer.component';


### PR DESCRIPTION
This PR introduces a Logs Viewer component in order to be able to **show an object's logs in our WAs**. This component is identical to the one we use in Models Web app.

This PR is required for efforts that are going to introduce a Details page for Notebooks, Volumes and TensorBoards  https://github.com/kubeflow/kubeflow/issues/6707, since an essential part of the Details page will be the `LOGS` tab.