### PR TITLE
fix setting readOnly on gpus

### DIFF
--- a/components/crud-web-apps/jupyter/README.md
+++ b/components/crud-web-apps/jupyter/README.md
@@ -36,26 +36,34 @@ Requirements:
 
 ### Frontend
 
+__Build the common library:__
+
 ```bash
-# build the common library
 cd components/crud-web-apps/common/frontend/kubeflow-common-lib
 npm i
 npm run build
 cd dist/kubeflow
 npm link
+```
 
-# build the app frontend
-cd ../../../jupyter/frontend
+__Build the app frontend:__
+
+```bash
+cd components/crud-web-apps/jupyter/frontend
 npm i
 npm link kubeflow
 npm run build:watch
 ```
 
 ### Backend
+
+__Build the app backend:__
+
 ```bash
+cd components/crud-web-apps/jupyter
+
 # create a virtual env and install deps
 # https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/
-cd components/crud-web-apps/jupyter/backend
 python3.8 -m pip install --user virtualenv
 python3.8 -m venv web-apps-dev
 source web-apps-dev/bin/activate
@@ -64,10 +72,13 @@ source web-apps-dev/bin/activate
 make -C backend install-deps
 
 # run the backend
+# NOTE: if your on MacOS, you might need to disable "AirPlay Receiver" as this uses port 5000
+#       https://developer.apple.com/forums/thread/682332
 make -C backend run-dev
 ```
 
 ### Internationalization
+
 Support for non-English languages is only supported in a best effort way.
 
 Internationalization(i18n) was implemented using [Angular's i18n](https://angular.io/guide/i18n)

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/form-default.component.ts
@@ -122,7 +122,7 @@ export class FormDefaultComponent implements OnInit, OnDestroy {
     }
 
     // Ensure GPU input is a string
-    if (typeof notebook.gpus.num === 'number') {
+    if (notebook.gpus && typeof notebook.gpus.num === 'number') {
       notebook.gpus.num = notebook.gpus.num.toString();
     }
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
@@ -44,7 +44,7 @@ export interface NotebookFormObject {
   cpuLimit: number | string;
   memory: number | string;
   memoryLimit: number | string;
-  gpus: GPU;
+  gpus?: GPU;
   environment?: string;
   noWorkspace: boolean;
   workspace: any;


### PR DESCRIPTION
This PR resolves https://github.com/kubeflow/kubeflow/issues/6182.

Previously, the JWA UI threw an error when when `gpus.readOnly` was true, because of trying to access `num` when `gpus` was undefined in `NotebookFormObject`.

It also fixes the README for the JWA to show the correct build commands for local development. 