### PR TITLE
centraldashboard: Add support for apps in new windows

### DIFF
--- a/components/centraldashboard/public/components/iframe-container.js
+++ b/components/centraldashboard/public/components/iframe-container.js
@@ -4,7 +4,7 @@
 import {html, PolymerElement} from '@polymer/polymer';
 
 import {
-    IFRAME_CONNECTED_EVENT,
+    APP_CONNECTED_EVENT,
     MESSAGE,
     NAMESPACE_SELECTED_EVENT,
     PARENT_CONNECTED_EVENT,
@@ -116,7 +116,7 @@ export class IframeContainer extends PolymerElement {
         const {data, origin} = event;
         this._iframeOrigin = origin;
         switch (data.type) {
-        case IFRAME_CONNECTED_EVENT:
+        case APP_CONNECTED_EVENT:
             this.$.iframe.contentWindow.postMessage({
                 type: PARENT_CONNECTED_EVENT,
                 value: null,

--- a/components/centraldashboard/public/components/iframe-container_test.js
+++ b/components/centraldashboard/public/components/iframe-container_test.js
@@ -1,7 +1,7 @@
 import '@polymer/test-fixture/test-fixture';
 
 import {
-    IFRAME_CONNECTED_EVENT,
+    APP_CONNECTED_EVENT,
     NAMESPACE_SELECTED_EVENT,
     PARENT_CONNECTED_EVENT,
 } from '../library.js';
@@ -96,7 +96,7 @@ describe('Iframe Container', () => {
     it('Should send messages to iframed page', async () => {
         const origin = window.location.origin;
         // Simulate message being sent from iframe
-        window.postMessage({type: IFRAME_CONNECTED_EVENT});
+        window.postMessage({type: APP_CONNECTED_EVENT});
         await sleep(1);
         expect(postMessageSpy.calls.count()).toBe(1);
         expect(postMessageSpy.calls.argsFor(0)).toEqual([

--- a/components/centraldashboard/public/library.js
+++ b/components/centraldashboard/public/library.js
@@ -3,7 +3,7 @@
  * Central Dashboard.
  */
 export const PARENT_CONNECTED_EVENT = 'parent-connected';
-export const IFRAME_CONNECTED_EVENT = 'iframe-connected';
+export const APP_CONNECTED_EVENT = 'iframe-connected';
 export const NAMESPACE_SELECTED_EVENT = 'namespace-selected';
 export const ALL_NAMESPACES_EVENT = 'all-namespaces';
 export const MESSAGE = 'message';
@@ -17,6 +17,7 @@ class CentralDashboardEventHandler_ {
     constructor() {
         this.window = window;
         this.parent = window.parent;
+        this.opener = window.opener;
         this._messageEventListener = null;
         this._onParentConnected = null;
         this._onNamespaceSelected = null;
@@ -32,14 +33,13 @@ class CentralDashboardEventHandler_ {
      *  is set to true, forcing every app to be iframed, set this flag to avoid
      *  the redirection.
      */
-    init(callback, disableForceIframe=false) {
-        const isIframed = this.window.location !== this.parent.location;
-        callback(this, isIframed);
-        if (isIframed) {
-            this._messageEventListener = this._onMessageReceived.bind(this);
-            this.window.addEventListener(MESSAGE, this._messageEventListener);
-            this.parent.postMessage({type: IFRAME_CONNECTED_EVENT},
-                this.parent.origin);
+    init(callback, disableForceIframe = false) {
+        callback(this, this.isIframed || this.isOpenedByApp);
+
+        if (this.isOpenedByApp) {
+            this._attachListenerToIframe();
+        } else if (this.isIframed) {
+            this._attachListenerToDashboard();
         } else if (!disableForceIframe) {
             fetch('/api/dashboard-settings')
                 .then((res) => res.json())
@@ -61,7 +61,16 @@ class CentralDashboardEventHandler_ {
      * Removes the message event listener.
      */
     detach() {
-        if (this._messageEventListener) {
+        if (!this._messageEventListener) {
+            return;
+        }
+
+        if (this.isOpenedByApp) {
+            this.opener.removeEventListener(MESSAGE,
+                this._messageEventListener);
+        }
+
+        if (this.isIframed) {
             this.window.removeEventListener(MESSAGE,
                 this._messageEventListener);
         }
@@ -103,6 +112,14 @@ class CentralDashboardEventHandler_ {
         }
     }
 
+    get isIframed() {
+        return this.window.location !== this.parent.location;
+    }
+
+    get isOpenedByApp() {
+        return this.opener !== null;
+    }
+
     /**
      * Handle the receipt of a message and dispatch to any added callbacks.
      * @param {MessageEvent} event
@@ -126,6 +143,41 @@ class CentralDashboardEventHandler_ {
             }
             break;
         }
+    }
+
+    /**
+     * If the app is iframed then it should add an eventListener on its own
+     * window. The CentralDashboard will be sending NAMESPACE_SELECTED_EVENT
+     * events to the iframed window.
+     */
+    _attachListenerToDashboard() {
+        this._messageEventListener = this._onMessageReceived.bind(this);
+        this.window.addEventListener(MESSAGE, this._messageEventListener);
+        this.parent.postMessage({type: APP_CONNECTED_EVENT},
+            this.parent.origin);
+    }
+
+    /**
+     * If the app is opened by another app, then it should add an eventListener
+     * to its opener window. We expect the opener window to be iframed in the
+     * CentralDashboard.
+     */
+    _attachListenerToIframe() {
+        this._messageEventListener = this._onMessageReceived.bind(this);
+        this.opener.addEventListener(MESSAGE,
+            this._messageEventListener);
+
+        // Notify the Dashboard that an app connected, in order for Dashboard
+        // to propagate the selected namespace. We expect the dasbhoard to be
+        // in the opener's parent window.
+        this.opener.parent.postMessage({type: APP_CONNECTED_EVENT},
+            this.opener.parent.origin);
+
+        // Remove event listener when the window closes in order to avoid
+        // being called with wrong context.
+        this.window.addEventListener('beforeunload', (evt) => {
+            this.detach();
+        });
     }
 }
 

--- a/components/centraldashboard/public/library_test.js
+++ b/components/centraldashboard/public/library_test.js
@@ -1,5 +1,5 @@
 import {
-    IFRAME_CONNECTED_EVENT, PARENT_CONNECTED_EVENT,
+    APP_CONNECTED_EVENT, PARENT_CONNECTED_EVENT,
     NAMESPACE_SELECTED_EVENT, CentralDashboardEventHandler,
 } from './library';
 
@@ -18,34 +18,6 @@ describe('CentralDashboardEventHandler', () => {
     afterEach(() => {
         CentralDashboardEventHandler.detach();
         CentralDashboardEventHandler.parent = oldParent;
-    });
-
-    it('Should not post message when outside of iframe', () => {
-        parentSpy.location = window.location;
-        const initSpy = jasmine.createSpy();
-        CentralDashboardEventHandler.init(initSpy);
-
-        expect(window.addEventListener).not.toHaveBeenCalled();
-        expect(CentralDashboardEventHandler.parent.postMessage)
-            .not.toHaveBeenCalled();
-        expect(initSpy).toHaveBeenCalledWith(CentralDashboardEventHandler,
-            false);
-    });
-
-    it('Should bind listener and send message to parent when in iframe', () => {
-        parentSpy.origin = 'http://testpage.com';
-        const initSpy = jasmine.createSpy();
-        CentralDashboardEventHandler.init(initSpy);
-
-        expect(window.addEventListener).toHaveBeenCalled();
-        expect(CentralDashboardEventHandler.parent.postMessage)
-            .toHaveBeenCalledWith(
-                {
-                    type: IFRAME_CONNECTED_EVENT,
-                }, 'http://testpage.com'
-            );
-        expect(initSpy).toHaveBeenCalledWith(CentralDashboardEventHandler,
-            true);
     });
 
     it('Should invoke callbacks when messages are received', () => {
@@ -70,5 +42,33 @@ describe('CentralDashboardEventHandler', () => {
         CentralDashboardEventHandler._onMessageReceived(message2);
         expect(callbacksSpy.onNamespaceSelected)
             .toHaveBeenCalledWith(message2.data.value);
+    });
+
+    it('Should not post message when outside of iframe', () => {
+        parentSpy.location = window.location;
+        const initSpy = jasmine.createSpy();
+        CentralDashboardEventHandler.init(initSpy);
+
+        expect(window.addEventListener).not.toHaveBeenCalled();
+        expect(CentralDashboardEventHandler.parent.postMessage)
+            .not.toHaveBeenCalled();
+        expect(initSpy).toHaveBeenCalledWith(CentralDashboardEventHandler,
+            false);
+    });
+
+    it('Should bind listener and send message to parent when in iframe', () => {
+        parentSpy.origin = 'http://testpage.com';
+        const initSpy = jasmine.createSpy();
+        CentralDashboardEventHandler.init(initSpy);
+
+        expect(window.addEventListener).toHaveBeenCalled();
+        expect(CentralDashboardEventHandler.parent.postMessage)
+            .toHaveBeenCalledWith(
+                {
+                    type: APP_CONNECTED_EVENT,
+                }, 'http://testpage.com'
+            );
+        expect(initSpy).toHaveBeenCalledWith(CentralDashboardEventHandler,
+            true);
     });
 });


### PR DESCRIPTION
A Kubeflow app can communicate with the dashboard using a Pub/Sub mechanism. In order for this to work, the app should live in the dashboard's `iframe`. 
But if we want to open a Kubeflow app [programmatically](https://developer.mozilla.org/en-US/docs/Web/API/Window/open) from the dashboard or from another app, the communication does not work. The current implementation requires an `iframe` to bridge the communication and in this PR we extend it and use the dashboard's window as an alternative bridge. 