### PR TITLE
centraldashboard: Fix how the app is ran locally

### DIFF
--- a/components/centraldashboard/README.md
+++ b/components/centraldashboard/README.md
@@ -45,8 +45,10 @@ Make sure you have the latest LTS version of `node` installed along with `npm`.
       from the front-end starting with `/api` are proxied to the Express
       server. All other requests are handled by the front-end server which
       mirrors the production configuration.
-4. To access a Kubenetes service, run `kubectl port-forward -n kubeflow svc/<service-name> <service-proxy-port>:<service-port>` e.g. `kubectl port-forward -n kubeflow svc/jupyter-web-app-service 8085:80`.
-   - This forwards requests to Kubernetes services from http://localhost:service-proxy-port. Requests from the front-end starting with `/jupyter`, `/notebook` and `/pipeline` are proxied there. See the [webpack config file](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/webpack.config.js) for more details.
+4. - To access the Jupyter Web App run: `kubectl port-forward -n kubeflow svc/jupyter-web-app-service 8085:80`.
+    - To access Pipeline Web App run: `kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8087:80`.`
+
+    This forwards requests to Kubernetes services from `http://localhost:service-proxy-port`. See the [webpack config file](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/webpack.config.js) for more details.
 
 ### Server Components
 

--- a/components/centraldashboard/README.md
+++ b/components/centraldashboard/README.md
@@ -45,8 +45,8 @@ Make sure you have the latest LTS version of `node` installed along with `npm`.
       from the front-end starting with `/api` are proxied to the Express
       server. All other requests are handled by the front-end server which
       mirrors the production configuration.
-4. To access the Kubenetes REST API, run `kubectl proxy --port=8083`.
-   - This runs [kubectl proxy](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#proxy) to create a reverse proxy at http://localhost:8083. Requests from the front-end starting with `/jupyter`, `/metadata`, `/notebook` and `/pipeline` are proxied to the [Kubenetes API server](https://kubernetes.io/docs/tasks/administer-cluster/access-cluster-api/). See the [webpack config file](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/webpack.config.js) for more details.
+4. To access a Kubenetes service, run `kubectl port-forward -n kubeflow svc/<service-name> <service-proxy-port>:<service-port>` e.g. `kubectl port-forward -n kubeflow svc/jupyter-web-app-service 8085:80`.
+   - This forwards requests to Kubernetes services from http://localhost:service-proxy-port. Requests from the front-end starting with `/jupyter`, `/notebook` and `/pipeline` are proxied there. See the [webpack config file](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/webpack.config.js) for more details.
 
 ### Server Components
 

--- a/components/centraldashboard/webpack.config.js
+++ b/components/centraldashboard/webpack.config.js
@@ -196,23 +196,29 @@ module.exports = {
         proxy: {
             '/api': 'http://localhost:8082',
             '/jupyter': {
-                target: 'http://localhost:8083/api/v1/namespaces/kubeflow/services/jupyter-web-app-service:80/proxy',
+                target: 'http://localhost:8085',
                 pathRewrite: {'^/jupyter': ''},
+                headers: {
+                    'kubeflow-userid': 'user',
+                },
             },
-            '/metadata': {
-                target: 'http://localhost:8083/api/v1/namespaces/kubeflow/services/metadata-ui:80/proxy',
-                pathRewrite: {'^/metadata': ''},
-            },
+            // Requests at /notebook currently fail with a 504 error 
             '/notebook': {
-                target: 'http://localhost:8083/api/v1/namespaces/',
+                target: 'http://localhost:8086',
                 pathRewrite: {
                     '^/notebook/(.*?)/(.*?)/(.*)':
                         '/$1/services/$2/proxy/notebook/$1/$2/$3',
                 },
+                headers: {
+                    'kubeflow-userid': 'user',
+                },
             },
             '/pipeline': {
-                target: 'http://localhost:8083/api/v1/namespaces/kubeflow/services/ml-pipeline-ui:80/proxy',
+                target: 'http://localhost:8087',
                 pathRewrite: {'^/pipeline': ''},
+                headers: {
+                    'kubeflow-userid': 'user',
+                },
             },
         },
         historyApiFallback: {


### PR DESCRIPTION
**Context**

Currently, running the Central dashboard locally and accessing  in-cluster services of K8s fails. With `kubectl proxy` and using [routes ](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/webpack.config.js#L199)like `/api/v1/namespaces/<ns>/*services*/<svc>/proxy`, what we actually do is sending our requests to the K8s service by passing via the K8s API Server (which we proxy with `kubectl proxy`). But this fails, since the K8s API Server is not allowed to talk to the services (Istio). 

**Change**

This PR fixes the proxies and instructions in order to run the app locally. What we propose essentially is to access a Kubenetes service with `kubectl port-forward -n kubeflow svc/<service-name> <service-proxy-port>:<service-port>` e.g. `kubectl port-forward -n kubeflow svc/jupyter-web-app-service 8085:80`. This forwards requests to Kubernetes services from http://localhost:service-proxy-port.