### PR TITLE
web-apps(front): Enable sorting in namespace column

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/utils.ts
@@ -9,6 +9,7 @@ export const NAMESPACE_COLUMN: TableColumn = {
     tooltipField: 'namespace',
     truncate: true,
   }),
+  sort: true,
 };
 
 export function removeColumn(config: TableConfig, name: string) {


### PR DESCRIPTION
This PR enables sorting in namespace column when displayed.

![image](https://user-images.githubusercontent.com/87971102/203533087-69463f23-73ef-48bf-b10b-417d543a8b27.png)

Related issue: https://github.com/kubeflow/kubeflow/issues/6460

Related PRs: https://github.com/kubeflow/kubeflow/pull/6742, https://github.com/kubeflow/kubeflow/pull/6743

Signed-off-by: Elena Zioga <elena@arrikto.com>