### PR TITLE
web-apps(front): Changes needed for trials table

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
@@ -3304,6 +3304,21 @@
         "keyv": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.184",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.184.tgz",
+      "integrity": "sha512-RoZphVtHbxPZizt4IcILciSWiC6dcn+eZ8oX9IWEYfDMcocdd42f7NPI6fQj+6zI8y4E0L7gu2pcZKLGTRaV9Q==",
+      "dev": true
+    },
+    "@types/lodash-es": {
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash-es/-/lodash-es-4.17.6.tgz",
+      "integrity": "sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -54,6 +54,7 @@
     "@kubernetes/client-node": "^0.16.3",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "^2.0.9",
+    "@types/lodash-es": "^4.17.6",
     "@types/node": "^12.11.1",
     "@typescript-eslint/eslint-plugin": "4.28.2",
     "@typescript-eslint/parser": "4.28.2",

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/help-popover/help-popover.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/help-popover/help-popover.component.html
@@ -33,40 +33,44 @@
       </mat-chip>
     </p>
     <mat-divider></mat-divider>
-    <p><b>Status</b></p>
-    <p>Filter based on the objects' status, by using:</p>
-    <ul>
-      <li>The value shown in the tooltip</li>
-      <li>
-        The status types (i.e.
-        <i
-          >ready, waiting, warning, error, unavailable, uninitialized,
-          terminating, stopped</i
-        >)
-      </li>
-    </ul>
+    <ng-template [ngIf]="showStatus">
+      <p><b>Status</b></p>
+      <p>Filter based on the objects' status, by using:</p>
+      <ul>
+        <li>The value shown in the tooltip</li>
+        <li>
+          The status types (i.e.
+          <i
+            >ready, waiting, warning, error, unavailable, uninitialized,
+            terminating, stopped</i
+          >)
+        </li>
+      </ul>
+    </ng-template>
     <mat-divider></mat-divider>
-    <p><b>Date</b></p>
-    <p>Filter timestamp values based on:</p>
-    <ul>
-      <li>
-        <span
-          >The "-" character for empty date values:
-          <mat-chip class="mat-chip-blue">
-            Created at: -
-            <button matChipRemove>
-              <mat-icon>cancel</mat-icon>
-            </button>
-          </mat-chip>
-        </span>
-      </li>
-      <li>
-        The relative time text, shown in the column (i.e. <i>X months ago</i>)
-      </li>
-      <li>
-        The substring of the timestamp, that is shown in the UTC part of the
-        tooltip
-      </li>
-    </ul>
+    <ng-template [ngIf]="showDate">
+      <p><b>Date</b></p>
+      <p>Filter timestamp values based on:</p>
+      <ul>
+        <li>
+          <span
+            >The "-" character for empty date values:
+            <mat-chip class="mat-chip-blue">
+              Created at: -
+              <button matChipRemove>
+                <mat-icon>cancel</mat-icon>
+              </button>
+            </mat-chip>
+          </span>
+        </li>
+        <li>
+          The relative time text, shown in the column (i.e. <i>X months ago</i>)
+        </li>
+        <li>
+          The substring of the timestamp, that is shown in the UTC part of the
+          tooltip
+        </li>
+      </ul>
+    </ng-template>
   </div>
 </ng-template>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/help-popover/help-popover.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/help-popover/help-popover.component.ts
@@ -8,6 +8,12 @@ import { Component, OnInit, Input } from '@angular/core';
 export class HelpPopoverComponent implements OnInit {
   @Input() popoverPosition = 'below';
 
+  @Input()
+  showStatus: boolean;
+
+  @Input()
+  showDate: boolean;
+
   constructor() {}
 
   ngOnInit(): void {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
@@ -41,17 +41,15 @@
     aria-label="Help"
     (click)="$event.stopPropagation()"
   >
-    <lib-help-popover></lib-help-popover>
+    <lib-help-popover [showStatus]="showStatus" [showDate]="showDate">
+    </lib-help-popover>
   </button>
   <mat-autocomplete
     #auto="matAutocomplete"
     panelWidth="270px"
     (optionSelected)="selected($event)"
   >
-    <mat-option
-      *ngFor="let header of filteredHeaders | async"
-      [value]="header.title"
-    >
+    <mat-option *ngFor="let header of filteredHeaders" [value]="header.title">
       {{ header.title }}
     </mat-option>
   </mat-autocomplete>
@@ -249,7 +247,13 @@
   </ng-container>
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  <tr
+    mat-row
+    *matRowDef="let row; let i = index; columns: displayedColumns"
+    [ngClass]="highlightRow(row, highlightedRow)"
+  >
+  {{row}}
+</tr>
 
   <!-- Row shown when there is no matching data. -->
   <tr class="mat-row" *matNoDataRow>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.scss
@@ -72,3 +72,7 @@ lib-action {
 .filter-header {
   margin-right: 8px;
 }
+
+.highlight-row {
+  background-color: #ffffcd;
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.spec.ts
@@ -2,8 +2,93 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { TableComponent } from './table.component';
 import { ResourceTableModule } from '../resource-table.module';
-import { PropertyValue, DateTimeValue } from '../types';
 import { quantityToScalar } from '@kubernetes/client-node/dist/util';
+import {
+  PropertyValue,
+  DateTimeValue,
+  StatusValue,
+  ComponentValue,
+} from '../types';
+import { MatChipInputEvent } from '@angular/material/chips';
+import { TableColumnComponent } from '../component-value/component-value.component';
+import { Component, SimpleChange } from '@angular/core';
+import subMonths from 'date-fns/sub_months';
+import { cloneDeep } from 'lodash-es';
+
+@Component({
+  selector: 'lib-server-type',
+  template: ``,
+})
+export class ServerTypeComponent implements TableColumnComponent {
+  constructor() {}
+
+  notebookServerType: string;
+
+  set element(notebook) {
+    this.notebookServerType = notebook.serverType;
+  }
+}
+
+const tableConfig = {
+  title: 'test',
+  columns: [
+    {
+      matHeaderCellDef: `Status`,
+      matColumnDef: 'status',
+      value: new StatusValue(),
+    },
+    {
+      matHeaderCellDef: `Name`,
+      matColumnDef: 'name',
+      value: new PropertyValue({
+        field: 'name',
+        tooltipField: 'name',
+        truncate: true,
+      }),
+    },
+    {
+      matHeaderCellDef: `Type`,
+      matColumnDef: 'type',
+      value: new ComponentValue({
+        component: ServerTypeComponent,
+      }),
+      filteringPreprocessorFn: element => element.serverType,
+    },
+    {
+      matHeaderCellDef: `Created at`,
+      matColumnDef: 'age',
+      value: new DateTimeValue({ field: 'age' }),
+    },
+  ],
+};
+
+const tableData = [
+  {
+    status: {
+      phase: 'ready',
+      message: 'Running',
+    },
+    name: 'a-notebook',
+    serverType: 'jupyter',
+    age: '2022-02-25T16:57:23Z',
+  },
+  {
+    status: {
+      phase: 'stopped',
+      message: 'No Pods are currently running for this Notebook Server.',
+    },
+    name: 'b-notebook',
+    serverType: 'group-one',
+    age: '2022-01-23T14:51:29Z',
+  },
+];
+
+function checkCell(compiled) {
+  const nameCell = compiled.querySelector(
+    '[data-cy-resource-table-row="Name"]',
+  );
+  expect(nameCell.textContent.replace(/\s+/g, '')).toBe('b-notebook');
+}
 
 describe('TableComponent', () => {
   let component: TableComponent;
@@ -128,5 +213,155 @@ describe('TableComponent', () => {
 
     // your assertions, i.e. expect to see the first element being sorted in the table
     expect(columnCells[0].textContent.replace(/\s+/g, '')).toBe('1');
+  });
+
+  it('should filter property values based on all columns', () => {
+    component.config = tableConfig;
+    component.data = tableData;
+
+    const compiled = fixture.debugElement.nativeElement;
+    const inputElement = compiled.querySelector('#filterInput');
+    component.add({
+      input: inputElement,
+      value: 'b-not',
+    } as MatChipInputEvent);
+
+    fixture.detectChanges();
+
+    checkCell(compiled);
+  });
+
+  it('should filter property values based on one column', () => {
+    component.config = tableConfig;
+    component.data = tableData;
+
+    const compiled = fixture.debugElement.nativeElement;
+    const inputElement = compiled.querySelector('#filterInput');
+    component.add({
+      input: inputElement,
+      value: 'Name: b-not',
+    } as MatChipInputEvent);
+
+    fixture.detectChanges();
+
+    checkCell(compiled);
+  });
+
+  it('should filter date values based on one column using UTC timestamp', () => {
+    component.config = tableConfig;
+    component.data = tableData;
+
+    const compiled = fixture.debugElement.nativeElement;
+    const inputElement = compiled.querySelector('#filterInput');
+    component.add({
+      input: inputElement,
+      value: 'Created at: 2022-01-23',
+    } as MatChipInputEvent);
+
+    fixture.detectChanges();
+
+    checkCell(compiled);
+  });
+
+  it('should filter date values based on one column using X months ago', () => {
+    component.config = tableConfig;
+    const tableDataCopy = cloneDeep(tableData);
+    tableDataCopy[1].age = subMonths(new Date(), 2).toISOString();
+    component.data = tableDataCopy;
+
+    const compiled = fixture.debugElement.nativeElement;
+    const inputElement = compiled.querySelector('#filterInput');
+    component.add({
+      input: inputElement,
+      value: 'Created at: 2 months ago',
+    } as MatChipInputEvent);
+
+    fixture.detectChanges();
+
+    checkCell(compiled);
+  });
+
+  it('should filter component values based on one column', () => {
+    component.config = tableConfig;
+    component.data = tableData;
+
+    const compiled = fixture.debugElement.nativeElement;
+    const inputElement = compiled.querySelector('#filterInput');
+    component.add({
+      input: inputElement,
+      value: 'Type: group',
+    } as MatChipInputEvent);
+
+    fixture.detectChanges();
+
+    checkCell(compiled);
+  });
+
+  it('should filter status values based on one column using status phase', () => {
+    component.config = tableConfig;
+    component.data = tableData;
+
+    const compiled = fixture.debugElement.nativeElement;
+    const inputElement = compiled.querySelector('#filterInput');
+    component.add({
+      input: inputElement,
+      value: 'Status: stopped',
+    } as MatChipInputEvent);
+
+    fixture.detectChanges();
+
+    checkCell(compiled);
+  });
+
+  it('should filter status values based on one column using status message', () => {
+    component.config = tableConfig;
+    component.data = tableData;
+
+    const compiled = fixture.debugElement.nativeElement;
+    const inputElement = compiled.querySelector('#filterInput');
+    component.add({
+      input: inputElement,
+      value: 'Status: No Pods',
+    } as MatChipInputEvent);
+
+    fixture.detectChanges();
+
+    checkCell(compiled);
+  });
+
+  it('should properly configure filter section', () => {
+    component.config = tableConfig;
+
+    expect(component.filteredHeaders).toEqual([]);
+    expect(component.showStatus).toEqual(false);
+    expect(component.showDate).toEqual(false);
+
+    fixture.detectChanges();
+    component.ngOnChanges({
+      config: new SimpleChange(null, component.config, true),
+    });
+
+    expect(component.filteredHeaders).toEqual([
+      { title: 'Status' },
+      { title: 'Name' },
+      { title: 'Type' },
+      { title: 'Created at' },
+    ]);
+    expect(component.showStatus).toEqual(true);
+    expect(component.showDate).toEqual(true);
+
+    const configCopy = cloneDeep(tableConfig);
+    configCopy.columns.pop();
+    component.ngOnChanges({
+      config: new SimpleChange(null, configCopy, false),
+    });
+
+    expect(component.filteredHeaders).toEqual([
+      { title: 'Status' },
+      { title: 'Name' },
+      { title: 'Type' },
+    ]);
+    expect(component.showStatus).toEqual(true);
+    expect(component.showDate).toEqual(false);
   });
 });


### PR DESCRIPTION
In this PR, we introduce the following changes that will be needed in a follow-up PR that makes trials table support pagination/sorting/filtering (https://github.com/kubeflow/katib/issues/1441):

- Adjust filtering tooltip to expose info only for the existing columns.
- Extend table component to be able to highlight a row.
- Fix autocomplete dropdown bug.

Signed-off-by: Elena Zioga <elena@arrikto.com>