### PR TITLE
jwa(front): Create distinct notebook details page

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
@@ -2,12 +2,14 @@ from .. import authz
 from . import v1_core
 
 
-def list_pods(namespace, auth=True):
+def list_pods(namespace, auth=True, label_selector = None):
     if auth:
         authz.ensure_authorized("list", "", "v1", "pods", namespace)
 
-    return v1_core.list_namespaced_pod(namespace)
-
+    if label_selector is None:
+        return v1_core.list_namespaced_pod(namespace)
+    else:
+        return v1_core.list_namespaced_pod(namespace = namespace, label_selector = label_selector)
 
 def get_pod_logs(namespace, pod, container, auth=True):
     if auth:

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
@@ -6,10 +6,7 @@ def list_pods(namespace, auth=True, label_selector = None):
     if auth:
         authz.ensure_authorized("list", "", "v1", "pods", namespace)
 
-    if label_selector is None:
-        return v1_core.list_namespaced_pod(namespace)
-    else:
-        return v1_core.list_namespaced_pod(namespace = namespace, label_selector = label_selector)
+    return v1_core.list_namespaced_pod(namespace = namespace, label_selector = label_selector)
 
 def get_pod_logs(namespace, pod, container, auth=True):
     if auth:

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
@@ -4010,15 +4010,15 @@
       "dev": true
     },
     "array-includes": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
-      "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.6.tgz",
+      "integrity": "sha512-sgTbLvL6cNnw24FnbaDyjmvddQ2ML8arZsgaJhoABMoplz/4QRhtrYS+alr1BUM1Bwp6dhx8vVCBSLG+StwOFw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5",
-        "get-intrinsic": "^1.1.1",
+        "es-abstract": "^1.20.4",
+        "get-intrinsic": "^1.1.3",
         "is-string": "^1.0.7"
       },
       "dependencies": {
@@ -4031,6 +4031,23 @@
             "has-property-descriptors": "^1.0.0",
             "object-keys": "^1.1.1"
           }
+        },
+        "get-intrinsic": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+          "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+          "dev": true,
+          "requires": {
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.3"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+          "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+          "dev": true
         }
       }
     },
@@ -4053,15 +4070,27 @@
       "dev": true
     },
     "array.prototype.flat": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.0.tgz",
-      "integrity": "sha512-12IUEkHsAhA4DY5s0FPgNXIdc8VRSqD9Zp78a5au9abH/SOBrsp082JOWFNTjkMozh8mqcdiKuaLGhPeYztxSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
         "es-shim-unscopables": "^1.0.0"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "arrify": {
@@ -10669,14 +10698,26 @@
       }
     },
     "object.values": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.5.tgz",
-      "integrity": "sha512-QUZRW0ilQ3PnPpbNtgdNV1PDbEqLIiSFB3l+EnGtBQ/8SUTLj1PZwtQHABZtLgwpJZTSZhuGLOGk57Drx2IvYg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.6.tgz",
+      "integrity": "sha512-FVVTkD1vENCsAcwNs9k6jea2uHC/X0+JcjG8YA60FN5CMaJmG95wT9jek/xX9nornqGRrBkKtzuAu2wuHpKqvw==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "dependencies": {
+        "define-properties": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+          "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+          "dev": true,
+          "requires": {
+            "has-property-descriptors": "^1.0.0",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "obuf": {
@@ -14734,14 +14775,14 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
-      "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "dependencies": {
         "define-properties": {
@@ -14757,14 +14798,14 @@
       }
     },
     "string.prototype.trimstart": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
-      "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
-        "es-abstract": "^1.19.5"
+        "es-abstract": "^1.20.4"
       },
       "dependencies": {
         "define-properties": {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.html
@@ -1,0 +1,19 @@
+<mat-divider *ngIf="topDivider"></mat-divider>
+
+<div class="list-entry-row">
+  <!--Key-Title Row-->
+  <div
+    class="list-entry-key vertical-align"
+    [matTooltip]="keyTooltip"
+    [style.min-width]="keyMinWidth"
+  >
+    {{ key }}
+  </div>
+
+  <!--Values-Subtable Row-->
+  <div class="container">
+    <ng-content class="vertical-align"> </ng-content>
+  </div>
+</div>
+
+<mat-divider *ngIf="bottomDivider"></mat-divider>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.scss
@@ -1,0 +1,26 @@
+:host {
+  display: block;
+}
+
+.list-entry-row {
+  padding: 0.4rem 0;
+  display: flex;
+}
+
+.list-entry-key {
+  font-weight: 500;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  color: rgba(0, 0, 0, 0.66);
+}
+
+.vertical-align {
+  margin-bottom: auto;
+}
+
+.mat-divider {
+  margin: 4px 0;
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ContentListItemComponent } from './content-list-item.component';
+
+describe('ContentListItemComponent', () => {
+  let component: ContentListItemComponent;
+  let fixture: ComponentFixture<ContentListItemComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ContentListItemComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ContentListItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'lib-content-list-item',
+  templateUrl: './content-list-item.component.html',
+  styleUrls: ['./content-list-item.component.scss'],
+})
+export class ContentListItemComponent implements OnInit {
+  @Input() key: string;
+  @Input() keyTooltip: string;
+  @Input() topDivider = false;
+  @Input() bottomDivider = true;
+  @Input() keyMinWidth = '250px';
+  @Input() loadErrorMsg = 'Resources not available';
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ContentListItemComponent } from './content-list-item.component';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+@NgModule({
+  declarations: [ContentListItemComponent],
+  imports: [CommonModule, MatDividerModule, MatTooltipModule],
+  exports: [ContentListItemComponent],
+})
+export class ContentListItemModule {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list-item/details-list-item.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list-item/details-list-item.component.scss
@@ -22,7 +22,7 @@
 
 .chip-list-wa .list-chip {
   min-height: 24px;
-  margin: 0 4px;
+  margin: 4 4px;
 }
 
 .warning {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/kubeflow.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/kubeflow.module.ts
@@ -22,6 +22,7 @@ import { LoadingSpinnerModule } from './loading-spinner/loading-spinner.module';
 import { ConfirmDialogModule } from './confirm-dialog/confirm-dialog.module';
 import { EditorModule } from './editor/editor.module';
 import { HelpPopoverModule } from './help-popover/help-popover.module';
+import { StatusIconModule } from './status-icon/status-icon.module';
 
 @NgModule({
   declarations: [],
@@ -42,6 +43,7 @@ import { HelpPopoverModule } from './help-popover/help-popover.module';
     LoadingSpinnerModule,
     EditorModule,
     HelpPopoverModule,
+    StatusIconModule,
   ],
   imports: [CommonModule, HttpClientModule, HttpClientXsrfModule],
   providers: [

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.html
@@ -1,0 +1,18 @@
+<mat-icon
+  *ngIf="!stateChanging"
+  class="small-padding-right"
+  [class.warning]="statusIcon === 'warning'"
+  [class.check-circle]="statusIcon === 'check_circle'"
+  [class.stop-circle]="statusIcon === 'stop_circle'"
+>
+  {{ statusIcon }}
+</mat-icon>
+
+<mat-progress-spinner
+  *ngIf="stateChanging"
+  class="small-padding-right"
+  mode="indeterminate"
+  diameter="25"
+>
+  {{ statusIcon }}
+</mat-progress-spinner>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.scss
@@ -1,0 +1,15 @@
+.small-padding-right {
+  padding-right: 8px;
+}
+
+.warning {
+  color: orange;
+}
+
+.check-circle {
+  color: green;
+}
+
+.stop-circle {
+  color: grey;
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StatusIconComponent } from './status-icon.component';
+
+describe('StatusIconComponent', () => {
+  let component: StatusIconComponent;
+  let fixture: ComponentFixture<StatusIconComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StatusIconComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StatusIconComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { STATUS_TYPE } from '../resource-table/status/types';
+
+@Component({
+  selector: 'lib-status-icon',
+  templateUrl: './status-icon.component.html',
+  styleUrls: ['./status-icon.component.scss'],
+})
+export class StatusIconComponent implements OnInit {
+  @Input() status: STATUS_TYPE;
+  @Input() stateChanging: boolean;
+
+  get statusIcon(): string {
+    if (this.status === STATUS_TYPE.WARNING) {
+      return 'warning';
+    }
+    if (
+      this.status === STATUS_TYPE.WAITING ||
+      this.status === STATUS_TYPE.TERMINATING
+    ) {
+      return 'timelapse';
+    } else if (this.status === STATUS_TYPE.READY) {
+      return 'check_circle';
+    } else if (this.status === STATUS_TYPE.STOPPED) {
+      return 'stop_circle';
+    } else {
+      return STATUS_TYPE.UNINITIALIZED;
+    }
+  }
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatIconModule } from '@angular/material/icon';
+import { StatusIconComponent } from './status-icon.component';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+
+@NgModule({
+  declarations: [StatusIconComponent],
+  imports: [CommonModule, MatIconModule, MatProgressSpinnerModule],
+  exports: [StatusIconComponent],
+})
+export class StatusIconModule {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/types.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/types.ts
@@ -1,0 +1,6 @@
+import { ChipDescriptor } from '../details-list/types';
+
+export interface VariablesGroup {
+  name: string;
+  chipsList?: ChipDescriptor[];
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.html
@@ -1,0 +1,13 @@
+<div class="env-group-container" *ngFor="let envGroup of envGroups">
+  <div class="group-key">{{ envGroup.name }}</div>
+  <mat-chip-list class="chip-list-wa">
+    <div *ngFor="let chip of envGroup.chipsList">
+      <mat-chip color="primary" class="list-chip">
+        {{ chip.value }}
+      </mat-chip>
+    </div>
+  </mat-chip-list>
+</div>
+
+<ng-content class="vertical-align"> </ng-content>
+<div *ngIf="envGroupsEmpty() && loadCompleted">{{ loadErrorMsg }}</div>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.scss
@@ -1,0 +1,14 @@
+.env-group-container {
+  padding: 0.6rem 0;
+  margin-bottom: 16px;
+}
+
+.group-key {
+  margin-bottom: 0.6rem;
+  font-weight: 450;
+}
+
+.chip-list-wa .list-chip {
+  min-height: 28px;
+  margin: 4px 4px;
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { VariablesGroupsTableComponent } from './variables-groups-table.component';
+
+describe('VariablesGroupsTableComponent', () => {
+  let component: VariablesGroupsTableComponent;
+  let fixture: ComponentFixture<VariablesGroupsTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ VariablesGroupsTableComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VariablesGroupsTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.ts
@@ -1,0 +1,28 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { VariablesGroup } from './types';
+
+@Component({
+  selector: 'lib-variables-group-table',
+  templateUrl: './variables-groups-table.component.html',
+  styleUrls: ['./variables-groups-table.component.scss'],
+})
+export class VariablesGroupsTableComponent implements OnInit {
+  private prvEnvGroups: VariablesGroup[];
+  @Input()
+  set envGroups(groups: VariablesGroup[]) {
+    this.prvEnvGroups = groups;
+  }
+  get envGroups() {
+    return this.prvEnvGroups;
+  }
+  @Input() loadErrorMsg = 'Resources not available';
+  @Input() loadCompleted = false;
+
+  envGroupsEmpty(): boolean {
+    return this.envGroups?.length === 0;
+  }
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { VariablesGroupsTableComponent } from './variables-groups-table.component';
+import { MatChipsModule } from '@angular/material/chips';
+
+@NgModule({
+  declarations: [VariablesGroupsTableComponent],
+  imports: [CommonModule, MatChipsModule],
+  exports: [VariablesGroupsTableComponent],
+})
+export class VariablesGroupsTableModule {}

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/public-api.ts
@@ -91,3 +91,13 @@ export * from './lib/logs-viewer/logs-viewer.module';
 export * from './lib/logs-viewer/logs-viewer.component';
 export * from './lib/help-popover/help-popover.component';
 export * from './lib/help-popover/help-popover.module';
+
+export * from './lib/content-list-item/content-list-item.component';
+export * from './lib/content-list-item/content-list-item.module';
+
+export * from './lib/variables-groups-table/variables-groups-table.component';
+export * from './lib/variables-groups-table/variables-groups-table.module';
+export * from './lib/variables-groups-table/types';
+
+export * from './lib/status-icon/status-icon.component';
+export * from './lib/status-icon/status-icon.module';

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles.scss
@@ -177,6 +177,18 @@ body {
   white-space: pre-line;
 }
 
+// Strip button from all default styles
+.reset-button-to-text {
+  background-color: transparent;
+  border-width: 0;
+  font-family: inherit;
+  font-size: inherit;
+  font-style: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  padding: 0;
+}
+
 /*
  * padding for the page
  */
@@ -230,5 +242,34 @@ body {
     .mat-icon {
       color: white;
     }
+  }
+}
+
+/*
+* Classes for showing an object's details page in web apps
+*/
+.details-page {
+  .details-page-outer {
+    padding-top: 1.5rem;
+    flex-grow: 1;
+    overflow: auto;
+    padding-left: $page-space-left;
+    padding-right: $page-space-right;
+  }
+
+  .details-page-inner {
+    margin-bottom: 1rem;
+    padding-left: $page-space-left;
+    padding-right: $page-space-right;
+  }
+
+  .details-page-inner-2 {
+    display: flex;
+    align-items: center;
+  }
+
+  .title {
+    font-weight: 500;
+    font-size: 20px;
   }
 }

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -1,4 +1,9 @@
+"""GET request handlers."""
+from flask import request
+
 from kubeflow.kubeflow.crud_backend import api, logging
+
+from werkzeug.exceptions import NotFound
 
 from .. import utils
 from . import bp
@@ -26,7 +31,7 @@ def get_pvcs(namespace):
 def get_poddefaults(namespace):
     pod_defaults = api.list_poddefaults(namespace)
 
-    # Return a list of (label, desc) with the pod defaults
+    # Return a list of pod defaults adding custom fields (label, desc) for forms
     contents = []
     for pd in pod_defaults["items"]:
         label = list(pd["spec"]["selector"]["matchLabels"].keys())[0]
@@ -35,9 +40,12 @@ def get_poddefaults(namespace):
         else:
             desc = pd["metadata"]["name"]
 
-        contents.append({"label": label, "desc": desc})
+        pd["label"] = label
+        pd["desc"] = desc
+        contents.append(pd)
 
     log.info("Found poddefaults: %s", contents)
+
     return api.success_response("poddefaults", contents)
 
 
@@ -47,6 +55,28 @@ def get_notebooks(namespace):
     contents = [utils.notebook_dict_from_k8s_obj(nb) for nb in notebooks]
 
     return api.success_response("notebooks", contents)
+
+@bp.route("/api/namespaces/<namespace>/notebooks/<name>")
+def get_notebook(name, namespace):
+    notebook = api.get_notebook(name, namespace)
+    return api.success_response("notebook", notebook)
+
+@bp.route("/api/namespaces/<namespace>/notebooks/<notebook_name>/pod")
+def get_notebook_pod(notebook_name, namespace):
+    label_selector = "notebook-name=" + notebook_name
+    # There should be only one Pod for each Notebook,
+    # so we expect items to have length = 1
+    pods = api.list_pods(namespace = namespace, label_selector = label_selector)
+    if pods.items:
+        pod = pods.items[0]
+        return api.success_response(
+            "pod", api.serialize(pod),
+        )
+    else:
+        raise NotFound("No pod detected.")
+
+
+
 
 
 @bp.route("/api/gpus")

--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -139,4 +139,5 @@ def notebook_dict_from_k8s_obj(notebook):
         "memory": cntr["resources"]["requests"]["memory"],
         "volumes": [v["name"] for v in cntr["volumeMounts"]],
         "status": status.process_status(notebook),
+        "metadata": notebook["metadata"]
     }

--- a/components/crud-web-apps/jupyter/frontend/angular.json
+++ b/components/crud-web-apps/jupyter/frontend/angular.json
@@ -52,9 +52,7 @@
           },
           "configurations": {
             "fr": {
-              "localize": [
-                "fr"
-              ]
+              "localize": ["fr"]
             },
             "rok": {
               "budgets": [
@@ -158,23 +156,15 @@
             "polyfills": "src/polyfills.ts",
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "assets": ["src/favicon.ico", "src/assets"],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",
           "options": {
-            "lintFilePatterns": [
-              "src/**/*.ts",
-              "src/**/*.html"
-            ]
+            "lintFilePatterns": ["src/**/*.ts", "src/**/*.html"]
           }
         },
         "e2e": {

--- a/components/crud-web-apps/jupyter/frontend/src/app/app-routing.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/app-routing.module.ts
@@ -2,11 +2,16 @@ import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 
 import { IndexComponent } from './pages/index/index.component';
-import { FormComponent } from './pages/form/form.component';
+import { FormDefaultComponent } from './pages/form/form-default/form-default.component';
+import { NotebookPageComponent } from './pages/notebook-page/notebook-page.component';
 
 const routes: Routes = [
   { path: '', component: IndexComponent },
-  { path: 'new', component: FormComponent },
+  { path: 'new', component: FormDefaultComponent },
+  {
+    path: 'notebook/details/:namespace/:notebookName',
+    component: NotebookPageComponent,
+  },
 ];
 
 @NgModule({

--- a/components/crud-web-apps/jupyter/frontend/src/app/app.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { FormModule } from './pages/form/form.module';
 import { KubeflowModule } from 'kubeflow';
 
 import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { NotebookPageModule } from './pages/notebook-page/notebook-page.module';
 
 @NgModule({
   declarations: [AppComponent],
@@ -21,6 +22,7 @@ import { HttpClientModule, HttpClient } from '@angular/common/http';
     KubeflowModule,
     IndexModule,
     FormModule,
+    NotebookPageModule,
   ],
   providers: [],
   bootstrap: [AppComponent],

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -58,6 +58,7 @@ export const defaultConfig: TableConfig = {
       style: { width: '25%' },
       value: new PropertyValue({
         field: 'name',
+        isLink: true,
         tooltipField: 'name',
         truncate: true,
       }),

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.ts
@@ -99,6 +99,23 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
       case 'start-stop':
         this.startStopClicked(a.data);
         break;
+      case 'name:link':
+        if (a.data.metadata.deletionTimestamp) {
+          this.snackBar.open(
+            'Notebook is being deleted, cannot show details.',
+            SnackType.Info,
+            4000,
+          );
+          return;
+        }
+        this.router.navigate(
+          [`/notebook/details/${a.data.namespace}/${a.data.name}`],
+          {
+            queryParams: { tab: 'overview' },
+            queryParamsHandling: '',
+          },
+        );
+        break;
     }
   }
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
@@ -28,7 +28,6 @@
               [notebook]="notebook"
               [pod]="notebookPod"
               [podRequestCompleted]="podRequestCompleted"
-              [error]="podRequestError"
               [notebookStatus]="status"
             ></app-overview>
           </ng-template>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
@@ -1,0 +1,39 @@
+<div class="lib-content-wrapper details-page">
+  <lib-title-actions-toolbar
+    title="Notebook details"
+    [buttons]="buttonsConfig"
+    [backButton]="true"
+    (back)="navigateBack()"
+  >
+  </lib-title-actions-toolbar>
+
+  <div class="details-page-outer">
+    <lib-loading-spinner *ngIf="!notebookInfoLoaded"></lib-loading-spinner>
+
+    <ng-container *ngIf="notebookInfoLoaded">
+      <div class="details-page-inner">
+        <div class="details-page-inner-2">
+          <lib-status-icon
+            [stateChanging]="notebookStateChanging"
+            [status]="status"
+          ></lib-status-icon>
+          <div class="title">{{ notebookName }}</div>
+        </div>
+      </div>
+      <mat-tab-group dynamicHeight animationDuration="0ms">
+        <mat-tab label="OVERVIEW">
+          <ng-template matTabContent>
+            <app-overview
+              *ngIf="notebookInfoLoaded"
+              [notebook]="notebook"
+              [pod]="notebookPod"
+              [podRequestCompleted]="podRequestCompleted"
+              [error]="podRequestError"
+              [notebookStatus]="status"
+            ></app-overview>
+          </ng-template>
+        </mat-tab>
+      </mat-tab-group>
+    </ng-container>
+  </div>
+</div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.spec.ts
@@ -1,0 +1,52 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { JWABackendService } from 'src/app/services/backend.service';
+import { of } from 'rxjs';
+
+import { NotebookPageComponent } from './notebook-page.component';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ActionsService } from 'src/app/services/actions.service';
+import { NamespaceService } from 'kubeflow';
+let JWABackendServiceStub: Partial<JWABackendService>;
+let ActionsServiceStub: Partial<ActionsService>;
+let NamespaceServiceStub: Partial<NamespaceService>;
+
+JWABackendServiceStub = {
+  getNotebook: () => of(),
+  getNotebookPod: () => of(),
+};
+ActionsServiceStub = {
+  connectToNotebook: () => {},
+  deleteNotebook: () => of(),
+  startNotebook: () => of(),
+  stopNotebook: () => of(),
+};
+NamespaceServiceStub = {
+  updateSelectedNamespace: () => {},
+};
+
+describe('NotebookInfoComponent', () => {
+  let component: NotebookPageComponent;
+  let fixture: ComponentFixture<NotebookPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [NotebookPageComponent],
+      providers: [
+        { provide: JWABackendService, useValue: JWABackendServiceStub },
+        { provide: ActionsService, useValue: ActionsServiceStub },
+        { provide: NamespaceService, useValue: NamespaceServiceStub },
+      ],
+      imports: [RouterTestingModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(NotebookPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.spec.ts
@@ -4,23 +4,12 @@ import { of } from 'rxjs';
 
 import { NotebookPageComponent } from './notebook-page.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { ActionsService } from 'src/app/services/actions.service';
 import { NamespaceService } from 'kubeflow';
-let JWABackendServiceStub: Partial<JWABackendService>;
-let ActionsServiceStub: Partial<ActionsService>;
-let NamespaceServiceStub: Partial<NamespaceService>;
-
-JWABackendServiceStub = {
+const JWABackendServiceStub: Partial<JWABackendService> = {
   getNotebook: () => of(),
   getNotebookPod: () => of(),
 };
-ActionsServiceStub = {
-  connectToNotebook: () => {},
-  deleteNotebook: () => of(),
-  startNotebook: () => of(),
-  stopNotebook: () => of(),
-};
-NamespaceServiceStub = {
+const NamespaceServiceStub: Partial<NamespaceService> = {
   updateSelectedNamespace: () => {},
 };
 
@@ -33,7 +22,6 @@ describe('NotebookInfoComponent', () => {
       declarations: [NotebookPageComponent],
       providers: [
         { provide: JWABackendService, useValue: JWABackendServiceStub },
-        { provide: ActionsService, useValue: ActionsServiceStub },
         { provide: NamespaceService, useValue: NamespaceServiceStub },
       ],
       imports: [RouterTestingModule],

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.ts
@@ -1,0 +1,164 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  NamespaceService,
+  STATUS_TYPE,
+  ToolbarButton,
+  PollerService,
+} from 'kubeflow';
+import { JWABackendService } from 'src/app/services/backend.service';
+import { Subscription } from 'rxjs';
+import { NotebookRawObject } from 'src/app/types';
+import { ActivatedRoute, Router } from '@angular/router';
+import { V1Pod } from '@kubernetes/client-node';
+
+@Component({
+  selector: 'app-notebook-page',
+  templateUrl: './notebook-page.component.html',
+  styleUrls: ['./notebook-page.component.scss'],
+})
+export class NotebookPageComponent implements OnInit, OnDestroy {
+  public notebookName: string;
+  public namespace: string;
+  public notebook: NotebookRawObject;
+  public notebookPod: V1Pod;
+  public notebookInfoLoaded = false;
+  public notebookStateChanging = false;
+  public podRequestCompleted = false;
+  public podRequestError = '';
+  public buttonsConfig: ToolbarButton[] = [];
+
+  pollSubNotebook = new Subscription();
+  pollSubPod = new Subscription();
+
+  constructor(
+    public ns: NamespaceService,
+    public backend: JWABackendService,
+    public poller: PollerService,
+    public router: Router,
+
+    private route: ActivatedRoute,
+  ) {}
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      this.ns.updateSelectedNamespace(params.namespace);
+
+      this.notebookName = params.notebookName;
+      this.namespace = params.namespace;
+
+      this.poll(this.namespace, this.notebookName);
+    });
+  }
+
+  ngOnDestroy() {
+    this.pollSubNotebook.unsubscribe();
+    this.pollSubPod.unsubscribe();
+  }
+
+  private poll(namespace: string, notebook: string) {
+    this.pollSubNotebook.unsubscribe();
+
+    const request = this.backend.getNotebook(namespace, notebook);
+
+    this.pollSubNotebook = this.poller.exponential(request).subscribe(nb => {
+      this.notebook = this.processIncomingData(nb);
+      this.getNotebookPod(nb);
+      this.notebookInfoLoaded = true;
+    });
+  }
+
+  private processIncomingData(notebook: NotebookRawObject) {
+    const notebookCopy = JSON.parse(
+      JSON.stringify(notebook),
+    ) as NotebookRawObject;
+
+    return notebookCopy;
+  }
+
+  private getNotebookPod(notebook: NotebookRawObject) {
+    this.pollSubPod.unsubscribe();
+
+    const request = this.backend.getNotebookPod(notebook);
+
+    this.pollSubPod = this.poller.exponential(request).subscribe(
+      pod => {
+        this.notebookPod = pod;
+        this.podRequestCompleted = true;
+      },
+      error => {
+        this.podRequestError = error;
+        this.notebookPod = null;
+        this.podRequestCompleted = true;
+      },
+    );
+  }
+
+  navigateBack() {
+    this.router.navigate(['/']);
+  }
+
+  get status(): STATUS_TYPE {
+    const [status, state] = this.getStatusAndState(this.notebook);
+    this.notebookStateChanging = state;
+    return status;
+  }
+
+  getStatusAndState(
+    notebook: NotebookRawObject,
+  ): [status: STATUS_TYPE, state: boolean] {
+    if (!notebook) {
+      console.warn('warning');
+      return [STATUS_TYPE.WARNING, null];
+    }
+    // Although containerState has a field called terminated,
+    // field Waiting is set even when the Notebook is stopped.
+    // and we need to check in the .annotations too
+
+    // Check if the Notebook is terminating right now
+    if (
+      'kubeflow-resource-stopped' in notebook.metadata.annotations &&
+      notebook.status.readyReplicas > 0
+    ) {
+      this.notebookStateChanging = true;
+      return [STATUS_TYPE.TERMINATING, true];
+    }
+
+    // Check if the Notebook is stopped
+    if ('kubeflow-resource-stopped' in notebook.metadata.annotations) {
+      this.notebookStateChanging = false;
+      return [STATUS_TYPE.STOPPED, false];
+    }
+
+    // Check if the Notebook is running
+    if (notebook.status?.containerState?.running) {
+      this.notebookStateChanging = false;
+      return [STATUS_TYPE.READY, false];
+    }
+
+    if (notebook.status?.containerState?.waiting) {
+      this.notebookStateChanging = true;
+      return [STATUS_TYPE.WAITING, true];
+    }
+
+    return [STATUS_TYPE.UNINITIALIZED, true];
+  }
+
+  get statusIcon(): string {
+    return this.getStatusIcon(this.status);
+  }
+
+  getStatusIcon(status: STATUS_TYPE): string {
+    if (status === STATUS_TYPE.WARNING) {
+      return 'warning';
+    }
+    if (status === STATUS_TYPE.WAITING || status === STATUS_TYPE.TERMINATING) {
+      return 'timelapse';
+    } else if (status === STATUS_TYPE.READY) {
+      return 'check_circle';
+    } else if (status === STATUS_TYPE.STOPPED) {
+      return 'stop_circle';
+    } else {
+      return STATUS_TYPE.UNINITIALIZED;
+    }
+  }
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.module.ts
@@ -1,0 +1,25 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { KubeflowModule } from 'kubeflow';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatIconModule } from '@angular/material/icon';
+import { MatDividerModule } from '@angular/material/divider';
+import { NotebookPageComponent } from './notebook-page.component';
+import { OverviewModule } from './overview/overview.module';
+import { RouterModule } from '@angular/router';
+
+@NgModule({
+  declarations: [NotebookPageComponent],
+  imports: [
+    CommonModule,
+    KubeflowModule,
+    MatIconModule,
+    MatDividerModule,
+    MatTabsModule,
+    OverviewModule,
+    MatProgressSpinnerModule,
+    RouterModule,
+  ],
+})
+export class NotebookPageModule {}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configuration-info-dialog/configuration-info-dialog.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configuration-info-dialog/configuration-info-dialog.component.html
@@ -1,0 +1,21 @@
+<div>
+  <lib-heading-row
+    mat-dialog-title
+    heading="{{ data.config.name }}: "
+    subHeading="{{ data.config.Description }}"
+  ></lib-heading-row>
+  <div mat-dialog-content>
+    <lib-monaco-editor
+      [text]="yaml(data.config)"
+      language="yaml"
+      [readOnly]="true"
+      [height]="280"
+    >
+    </lib-monaco-editor>
+  </div>
+  <div mat-dialog-actions>
+    <button mat-button [mat-dialog-close]="'cancel'" cdkFocusInitial>
+      CLOSE
+    </button>
+  </div>
+</div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configuration-info-dialog/configuration-info-dialog.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configuration-info-dialog/configuration-info-dialog.component.spec.ts
@@ -1,0 +1,35 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { EditorModule, HeadingSubheadingRowModule } from 'kubeflow';
+
+import {
+  ConfigurationInfoDialogComponent,
+  DialogData,
+} from './configuration-info-dialog.component';
+const data: DialogData = {
+  config: {},
+};
+
+describe('ConfigurationInfoDialogComponent', () => {
+  let component: ConfigurationInfoDialogComponent;
+  let fixture: ComponentFixture<ConfigurationInfoDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ConfigurationInfoDialogComponent],
+      providers: [{ provide: MAT_DIALOG_DATA, useValue: data }],
+      imports: [EditorModule, HeadingSubheadingRowModule, MatDialogModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfigurationInfoDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', async () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configuration-info-dialog/configuration-info-dialog.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configuration-info-dialog/configuration-info-dialog.component.ts
@@ -1,0 +1,30 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { Configuration } from 'src/app/types/configuration';
+import { dump } from 'js-yaml';
+export interface DialogData {
+  config: Configuration;
+}
+
+@Component({
+  selector: 'app-configuration-info-dialog',
+  templateUrl: './configuration-info-dialog.component.html',
+  styleUrls: ['./configuration-info-dialog.component.scss'],
+})
+export class ConfigurationInfoDialogComponent implements OnInit {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: DialogData) {}
+
+  ngOnInit(): void {}
+
+  yaml(configuration: Configuration) {
+    if (!configuration) {
+      return 'No information available about the configuration';
+    }
+
+    // Keep original configuration unaffected
+    const config = { ...configuration };
+    delete config.name;
+
+    return dump(config);
+  }
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.html
@@ -1,0 +1,16 @@
+<div>
+  <ng-container *ngIf="configurations && configurations.length > 0">
+    <div class="config-container">
+      <button
+        *ngFor="let config of configurations"
+        class="config-item reset-button-to-text"
+        (click)="openDialog(config)"
+      >
+        {{ config.name }}
+      </button>
+    </div>
+  </ng-container>
+</div>
+<div>
+  <ng-content> </ng-content>
+</div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.scss
@@ -1,0 +1,14 @@
+.config-container {
+  display: flex;
+}
+
+.config-item {
+  margin-right: 14px;
+  color: #1a73e8;
+  text-decoration: none;
+}
+
+.config-item:hover {
+  cursor: pointer;
+  text-decoration: underline;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+
+import { ConfigurationsComponent } from './configurations.component';
+
+describe('ConfigurationsComponent', () => {
+  let component: ConfigurationsComponent;
+  let fixture: ComponentFixture<ConfigurationsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ConfigurationsComponent],
+      imports: [MatDialogModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfigurationsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.component.ts
@@ -1,0 +1,24 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { Configuration } from 'src/app/types/configuration';
+import { ConfigurationInfoDialogComponent } from './configuration-info-dialog/configuration-info-dialog.component';
+
+@Component({
+  selector: 'app-configurations',
+  templateUrl: './configurations.component.html',
+  styleUrls: ['./configurations.component.scss'],
+})
+export class ConfigurationsComponent implements OnInit {
+  @Input() configurations: Configuration[];
+
+  constructor(private dialog: MatDialog) {}
+
+  ngOnInit(): void {}
+
+  openDialog(config: Configuration) {
+    this.dialog.open(ConfigurationInfoDialogComponent, {
+      data: { config },
+      width: '600px',
+    });
+  }
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/configurations/configurations.module.ts
@@ -1,0 +1,27 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ConfigurationsComponent } from './configurations.component';
+import { MatDialogModule } from '@angular/material/dialog';
+import {
+  ContentListItemModule,
+  DetailsListModule,
+  HeadingSubheadingRowModule,
+  EditorModule,
+} from 'kubeflow';
+import { ConfigurationInfoDialogComponent } from './configuration-info-dialog/configuration-info-dialog.component';
+import { MatButtonModule } from '@angular/material/button';
+
+@NgModule({
+  declarations: [ConfigurationsComponent, ConfigurationInfoDialogComponent],
+  imports: [
+    CommonModule,
+    DetailsListModule,
+    ContentListItemModule,
+    EditorModule,
+    MatDialogModule,
+    HeadingSubheadingRowModule,
+    MatButtonModule,
+  ],
+  exports: [ConfigurationsComponent],
+})
+export class ConfigurationsModule {}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.html
@@ -1,0 +1,74 @@
+<lib-details-list-item key="Volumes" [chipsList]="volumes">
+</lib-details-list-item>
+
+<lib-details-list-item key="Shared memory enabled">
+  {{ sharedMemory }}
+</lib-details-list-item>
+
+<lib-content-list-item class="configurations" key="Configurations">
+  <app-configurations [configurations]="configurations">
+    {{ podDefaultsMessage }}
+  </app-configurations>
+</lib-content-list-item>
+
+<lib-details-list-item key="Type">
+  {{ notebookType }}
+</lib-details-list-item>
+
+<lib-details-list-item *ngIf="cpuRequests" key="Minimum CPU">
+  {{ cpuRequests }}
+</lib-details-list-item>
+
+<lib-details-list-item *ngIf="cpuLimits" key="Maximum CPU">
+  {{ cpuLimits }}
+</lib-details-list-item>
+
+<lib-details-list-item *ngIf="memoryRequests" key="Minimum memory">
+  {{ memoryRequests }}
+</lib-details-list-item>
+
+<lib-details-list-item *ngIf="memoryLimits" key="Maximum memory">
+  {{ memoryLimits }}
+</lib-details-list-item>
+
+<lib-details-list-item key="Image" [copyValue]="dockerImage">
+  {{ dockerImage }}
+</lib-details-list-item>
+
+<lib-content-list-item key="Environment">
+  <lib-variables-group-table
+    [envGroups]="envGroups"
+    [loadCompleted]="podRequestCompleted"
+    [loadErrorMsg]="'No environment variables available for this notebook.'"
+  ></lib-variables-group-table>
+</lib-content-list-item>
+
+<!-- Show spinner while pod is being fetched -->
+<ng-container *ngIf="!podRequestCompleted">
+  <lib-heading-row
+    class="heading-row"
+    heading="Pod Conditions"
+  ></lib-heading-row>
+  <lib-loading-spinner></lib-loading-spinner>
+</ng-container>
+
+<!--Show adequate message when no pod is available for this notebook-->
+<ng-container *ngIf="podRequestCompleted && !pod">
+  <lib-heading-row
+    class="heading-row"
+    heading="Pod Conditions"
+  ></lib-heading-row>
+  <lib-panel class="page-padding">
+    {{ podConditionsMessage }}
+  </lib-panel>
+</ng-container>
+
+<!--Show Pod Conditions-->
+<ng-container *ngIf="podRequestCompleted && pod">
+  <lib-conditions-table
+    *ngIf="pod?.status"
+    [conditions]="pod.status?.conditions"
+    title="Pod Conditions"
+    class="page-padding"
+  ></lib-conditions-table>
+</ng-container>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.html
@@ -43,32 +43,16 @@
   ></lib-variables-group-table>
 </lib-content-list-item>
 
-<!-- Show spinner while pod is being fetched -->
-<ng-container *ngIf="!podRequestCompleted">
-  <lib-heading-row
-    class="heading-row"
-    heading="Pod Conditions"
-  ></lib-heading-row>
+<!-- Show spinner while notebooks status is being fetched -->
+<ng-container *ngIf="!notebook?.status">
+  <lib-heading-row class="heading-row" heading="Conditions"></lib-heading-row>
   <lib-loading-spinner></lib-loading-spinner>
 </ng-container>
 
-<!--Show adequate message when no pod is available for this notebook-->
-<ng-container *ngIf="podRequestCompleted && !pod">
-  <lib-heading-row
-    class="heading-row"
-    heading="Pod Conditions"
-  ></lib-heading-row>
-  <lib-panel class="page-padding">
-    {{ podConditionsMessage }}
-  </lib-panel>
-</ng-container>
-
-<!--Show Pod Conditions-->
-<ng-container *ngIf="podRequestCompleted && pod">
-  <lib-conditions-table
-    *ngIf="pod?.status"
-    [conditions]="pod.status?.conditions"
-    title="Pod Conditions"
-    class="page-padding"
-  ></lib-conditions-table>
-</ng-container>
+<!--Show Notebook's Conditions-->
+<lib-conditions-table
+  *ngIf="notebook?.status"
+  [conditions]="notebook.status?.conditions"
+  title="Conditions"
+  class="page-padding"
+></lib-conditions-table>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.scss
@@ -1,0 +1,7 @@
+.configurations {
+  margin-top: 5px;
+}
+
+.heading-row {
+  margin-top: 35px;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.spec.ts
@@ -1,0 +1,58 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import {
+  ContentListItemModule,
+  DetailsListModule,
+  HeadingSubheadingRowModule,
+  LoadingSpinnerModule,
+  PollerService,
+  SnackBarModule,
+  VariablesGroupsTableModule,
+} from 'kubeflow';
+import { JWABackendService } from 'src/app/services/backend.service';
+import { ConfigurationsModule } from './configurations/configurations.module';
+import { OverviewComponent } from './overview.component';
+import { of } from 'rxjs';
+let JWABackendServiceStub: Partial<JWABackendService>;
+let PollerServiceStub: Partial<PollerService>;
+
+JWABackendServiceStub = {
+  getPodDefaults: () => of(),
+};
+PollerServiceStub = {
+  exponential: () => of(),
+};
+
+describe('OverviewComponent', () => {
+  let component: OverviewComponent;
+  let fixture: ComponentFixture<OverviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OverviewComponent],
+      providers: [
+        { provide: JWABackendService, useValue: JWABackendServiceStub },
+        { provide: PollerService, useValue: PollerServiceStub },
+      ],
+      imports: [
+        SnackBarModule,
+        DetailsListModule,
+        ContentListItemModule,
+        ConfigurationsModule,
+        VariablesGroupsTableModule,
+        HeadingSubheadingRowModule,
+        LoadingSpinnerModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.spec.ts
@@ -13,13 +13,10 @@ import { JWABackendService } from 'src/app/services/backend.service';
 import { ConfigurationsModule } from './configurations/configurations.module';
 import { OverviewComponent } from './overview.component';
 import { of } from 'rxjs';
-let JWABackendServiceStub: Partial<JWABackendService>;
-let PollerServiceStub: Partial<PollerService>;
-
-JWABackendServiceStub = {
+const JWABackendServiceStub: Partial<JWABackendService> = {
   getPodDefaults: () => of(),
 };
-PollerServiceStub = {
+const PollerServiceStub: Partial<PollerService> = {
   exponential: () => of(),
 };
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.ts
@@ -1,0 +1,453 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { V1EnvVar, V1Pod } from '@kubernetes/client-node';
+import { ChipDescriptor, PollerService, STATUS_TYPE } from 'kubeflow';
+import { Subscription } from 'rxjs';
+import { JWABackendService } from 'src/app/services/backend.service';
+import { NotebookRawObject, PodDefault } from 'src/app/types';
+import { EnvironmentVariablesGroup } from '../../../types/environmentVariablesGroup';
+import { Configuration } from 'src/app/types/configuration';
+import { isEqual, get } from 'lodash-es';
+import { getErrorCode } from 'src/app/shared/utils/error';
+
+@Component({
+  selector: 'app-overview',
+  templateUrl: './overview.component.html',
+  styleUrls: ['./overview.component.scss'],
+})
+export class OverviewComponent implements OnInit, OnDestroy {
+  public volumes: ChipDescriptor[];
+  private notebookEnv: ChipDescriptor[];
+  public configurations: Configuration[] = [];
+  private podDefaults: PodDefault[];
+  public envGroups: EnvironmentVariablesGroup[] = [];
+
+  private prvNotebook: NotebookRawObject;
+  private prvPod: V1Pod;
+  private pollSub = new Subscription();
+
+  @Input() error = '';
+  @Input() notebookStatus: STATUS_TYPE;
+
+  @Input()
+  set notebook(nb: NotebookRawObject) {
+    this.prvNotebook = nb;
+
+    this.volumes = this.generateVolumes(nb);
+    this.generatePodDefaults(nb);
+    this.notebookEnv = this.generateEnv(nb);
+  }
+  get notebook(): NotebookRawObject {
+    return this.prvNotebook;
+  }
+
+  @Input()
+  set pod(pod: V1Pod) {
+    if (!pod) {
+      this.prvPod = pod;
+      this.removePodEnvGroups();
+      return;
+    }
+
+    this.prvPod = pod;
+    this.generatePodEnv(pod);
+  }
+  get pod(): V1Pod {
+    return this.prvPod;
+  }
+
+  @Input() podRequestCompleted = false;
+
+  get podDefaultsMessage() {
+    return this.getPodDefaultsMessage(
+      this.podRequestCompleted,
+      this.configurations,
+    );
+  }
+
+  getPodDefaultsMessage(
+    podRequestCompleted: boolean,
+    configurations: Configuration[],
+  ) {
+    if (podRequestCompleted === true && configurations.length === 0) {
+      return 'No configurations available for this notebook.';
+    }
+  }
+
+  get notebookType(): string {
+    return this.getNotebookType(this.notebook);
+  }
+
+  getNotebookType(notebook: NotebookRawObject): string {
+    if (
+      !notebook?.metadata?.annotations['notebooks.kubeflow.org/server-type']
+    ) {
+      return 'empty';
+    }
+    const type =
+      notebook.metadata.annotations['notebooks.kubeflow.org/server-type'];
+    if (type === 'group-two') {
+      return 'RStudio';
+    } else if (type === 'group-one') {
+      return 'VSCode';
+    } else if (type === 'jupyter') {
+      return 'JupyterLab';
+    } else {
+      return type;
+    }
+  }
+
+  get podDefaultsNotEmpty() {
+    return this.getPodDefaultsNotEmpty(this.podDefaults);
+  }
+
+  getPodDefaultsNotEmpty(podDefaults: PodDefault[]) {
+    if (podDefaults?.length === 0) {
+      return false;
+    }
+    return true;
+  }
+
+  get sharedMemory(): string {
+    return this.getSharedMemory(this.notebook);
+  }
+
+  getSharedMemory(notebook: NotebookRawObject): string {
+    if (!notebook?.spec?.template?.spec?.volumes) {
+      return 'null';
+    }
+    for (const volume of notebook.spec.template.spec.volumes) {
+      if (volume.name === 'dshm') {
+        return 'Yes';
+      }
+    }
+    return 'No';
+  }
+
+  get cpuLimits(): string {
+    return this.getCpuLimits(this.notebook);
+  }
+
+  getCpuLimits(notebook: NotebookRawObject): string {
+    if (!notebook?.spec?.template?.spec?.containers) {
+      return null;
+    }
+    for (const cn of notebook.spec.template.spec.containers) {
+      if (cn.name !== notebook.metadata.name) {
+        continue;
+      }
+      if (!cn.resources.limits) {
+        return null;
+      }
+      return cn.resources.limits?.cpu;
+    }
+  }
+
+  get cpuRequests(): string {
+    return this.getCpuRequest(this.notebook);
+  }
+
+  getCpuRequest(notebook: NotebookRawObject): string {
+    if (!notebook?.spec?.template?.spec?.containers) {
+      return null;
+    }
+    for (const cn of notebook.spec.template.spec.containers) {
+      if (cn.name !== notebook.metadata.name) {
+        continue;
+      }
+      if (!cn.resources.requests) {
+        return null;
+      }
+      return cn.resources.requests?.cpu;
+    }
+  }
+
+  get memoryRequests(): string {
+    return this.getMemoryRequests(this.notebook);
+  }
+
+  getMemoryRequests(notebook: NotebookRawObject): string {
+    if (!notebook?.spec?.template?.spec?.containers) {
+      return null;
+    }
+    for (const cn of notebook.spec.template.spec.containers) {
+      if (cn.name !== notebook.metadata.name) {
+        continue;
+      }
+      if (!cn.resources.requests) {
+        return null;
+      }
+      return cn.resources.requests?.memory;
+    }
+  }
+
+  get memoryLimits(): string {
+    return this.getMemoryLimits(this.notebook);
+  }
+
+  getMemoryLimits(notebook: NotebookRawObject): string {
+    if (!notebook?.spec?.template?.spec?.containers) {
+      return null;
+    }
+    for (const cn of notebook.spec.template.spec.containers) {
+      if (cn.name !== notebook.metadata.name) {
+        continue;
+      }
+      if (!cn.resources.requests) {
+        return null;
+      }
+      return cn.resources.limits?.memory;
+    }
+  }
+
+  get dockerImage(): string {
+    return this.getDockerImage(this.notebook);
+  }
+
+  getDockerImage(notebook: NotebookRawObject): string {
+    if (!notebook?.spec?.template?.spec?.containers) {
+      return null;
+    }
+    for (const container of notebook.spec.template.spec.containers) {
+      if (container.name === notebook.metadata.name) {
+        return container.image;
+      }
+    }
+  }
+
+  get podConditionsMessage(): string {
+    return this.getPodConditionsMessage(this.error, this.notebookStatus);
+  }
+
+  getPodConditionsMessage(error: string, notebookStatus: STATUS_TYPE): string {
+    const errorCode = getErrorCode(error);
+    if (errorCode === 404 && notebookStatus === STATUS_TYPE.STOPPED) {
+      return 'This notebook is paused so its Pod was deleted. Click on ‘Start’ to resume your development environment.';
+    } else if (errorCode === 404) {
+      return `The notebook is ${notebookStatus} at the moment so its pod is not available.`;
+    } else {
+      return 'Error: The backend failed to fetch the Pod.';
+    }
+  }
+
+  constructor(
+    public backend: JWABackendService,
+    public poller: PollerService,
+  ) {}
+
+  ngOnInit(): void {}
+
+  ngOnDestroy(): void {
+    if (this.pollSub) {
+      this.pollSub.unsubscribe();
+    }
+  }
+
+  private generatePodDefaults(nb: NotebookRawObject) {
+    const configurations = [];
+
+    this.pollSub.unsubscribe();
+
+    const request = this.backend.getPodDefaults(nb.metadata.namespace);
+
+    this.pollSub = this.poller.exponential(request).subscribe(podDefaults => {
+      for (const pd of podDefaults) {
+        for (const label in nb.metadata.labels) {
+          if (label === Object.keys(pd.spec.selector.matchLabels)[0]) {
+            configurations.push(this.getPodDefaultConfiguration(pd));
+          }
+        }
+      }
+      this.configurations = configurations;
+      this.podDefaults = podDefaults;
+      this.generatePodEnv(this.pod);
+    });
+  }
+
+  private getPodDefaultConfiguration(pd: PodDefault) {
+    const configuration = {
+      name: pd.metadata.name,
+      Description: pd.spec.desc,
+      Selector: pd.spec.selector,
+      Env: pd.spec.env,
+      Volumes: pd.spec.volumes,
+      VolumeMounts: pd.spec.volumeMounts,
+      ServiceAccountName: pd.spec.serviceAccountName,
+    };
+
+    return configuration;
+  }
+
+  private generateVolumes(nb: NotebookRawObject): ChipDescriptor[] {
+    const chips = [];
+    for (const volume of nb.spec.template.spec.volumes) {
+      if (volume.persistentVolumeClaim) {
+        chips.push({
+          value: volume.persistentVolumeClaim.claimName,
+          color: 'primary',
+        });
+      }
+    }
+    return chips;
+  }
+
+  private generateEnv(nb: NotebookRawObject): ChipDescriptor[] {
+    for (const cn of nb.spec.template.spec.containers) {
+      if (cn.name !== nb.metadata.name) {
+        continue;
+      }
+
+      if (!cn.env) {
+        return null;
+      }
+
+      const envGroup: EnvironmentVariablesGroup = {
+        name: 'Notebook CR',
+        chipsList: [],
+      };
+      for (const envVar of cn.env) {
+        envGroup.chipsList.push(this.getEnvVarChip(envVar));
+      }
+
+      this.addEnvGroup(envGroup);
+
+      return envGroup.chipsList;
+    }
+  }
+
+  private generatePodEnv(pod: V1Pod): ChipDescriptor[] {
+    if (!this.podDefaults || !pod) {
+      return;
+    }
+    for (const cn of pod.spec.containers) {
+      if (cn.name !== pod.metadata.labels['notebook-name']) {
+        continue;
+      }
+
+      if (!cn.env) {
+        return null;
+      }
+
+      this.initializePodEnvGroups();
+
+      envLoop: for (const envVar of cn.env) {
+        // Skip EnvVars set from Notebook CR
+        const envChip = `${envVar.name}: ${envVar.value}`;
+        if (this.notebookEnv?.map(env => env.value).includes(envChip)) {
+          continue envLoop;
+        }
+
+        // Classify Enviornment Variable according to Configurations - Pod Defaults
+        for (const envGroup of this.envGroups) {
+          if (!envGroup.configuration) {
+            continue;
+          }
+
+          if (this.envExistsInGroupConfiguration(envVar, envGroup)) {
+            this.addEnvToGroup(envVar, envGroup);
+            continue envLoop;
+          }
+        }
+
+        const other = this.envGroups.filter(
+          envGroup => envGroup.name === 'Other',
+        )[0];
+        this.addEnvToGroup(envVar, other);
+      }
+
+      this.cleanEmptyEnvGroups();
+    }
+  }
+
+  private initializePodEnvGroups() {
+    // Initialize Environment Variables Groups
+    for (const configuration of this.podDefaults) {
+      const envVarGroup: EnvironmentVariablesGroup = {
+        name: `${configuration.metadata.name} (Configuration)`,
+        configuration,
+        chipsList: [],
+      };
+      this.addEnvGroup(envVarGroup);
+    }
+    const envGroup: EnvironmentVariablesGroup = {
+      name: 'Other',
+      chipsList: [],
+    };
+    this.addEnvGroup(envGroup);
+  }
+
+  private removePodEnvGroups() {
+    if (!this.podDefaults) {
+      return;
+    }
+    for (const group of this.envGroups) {
+      const name = group.name.replace(' (Configuration)', '');
+      if (
+        this.podDefaults.map(pd => pd.metadata.name).includes(name) ||
+        name === 'Other'
+      ) {
+        this.envGroups = this.envGroups.filter(
+          envGroup => envGroup.name !== group.name,
+        );
+      }
+    }
+  }
+
+  private cleanEmptyEnvGroups() {
+    this.envGroups = this.envGroups.filter(
+      envGroup => envGroup.chipsList.length !== 0,
+    );
+  }
+
+  private addEnvGroup(envGroup: EnvironmentVariablesGroup) {
+    const index = this.envGroups.findIndex(
+      group => group.name === envGroup.name,
+    );
+    if (index < 0) {
+      this.envGroups.push(envGroup);
+    } else if (isEqual(this.envGroups[index], envGroup)) {
+      return;
+    } else {
+      this.envGroups[index] = envGroup;
+    }
+  }
+
+  private envExistsInGroupConfiguration(
+    envVar: V1EnvVar,
+    envGroup: EnvironmentVariablesGroup,
+  ): boolean {
+    if (
+      envGroup.configuration?.spec.env
+        .map(env => env.name)
+        .includes(envVar.name)
+    ) {
+      return true;
+    }
+    return false;
+  }
+
+  private addEnvToGroup(env: V1EnvVar, group: EnvironmentVariablesGroup) {
+    const envValue = this.getEnvVarChip(env);
+    if (group.chipsList.map(chip => chip.value).includes(envValue.value)) {
+      return;
+    } else {
+      group.chipsList.push(envValue);
+      return;
+    }
+  }
+
+  private getEnvVarChip(envVar: V1EnvVar): ChipDescriptor {
+    if (envVar.value) {
+      return {
+        value: `${envVar.name}: ${envVar.value}`,
+        color: 'primary',
+      };
+    } else if (envVar.valueFrom) {
+      const path = envVar.valueFrom.fieldRef.fieldPath;
+      const envValue = get(this.pod, path);
+      return {
+        value: `${envVar.name}: ${envValue}`,
+        color: 'primary',
+      };
+    }
+  }
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.ts
@@ -7,7 +7,6 @@ import { NotebookRawObject, PodDefault } from 'src/app/types';
 import { EnvironmentVariablesGroup } from '../../../types/environmentVariablesGroup';
 import { Configuration } from 'src/app/types/configuration';
 import { isEqual, get } from 'lodash-es';
-import { getErrorCode } from 'src/app/shared/utils/error';
 
 @Component({
   selector: 'app-overview',
@@ -25,7 +24,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
   private prvPod: V1Pod;
   private pollSub = new Subscription();
 
-  @Input() error = '';
   @Input() notebookStatus: STATUS_TYPE;
 
   @Input()
@@ -211,21 +209,6 @@ export class OverviewComponent implements OnInit, OnDestroy {
       if (container.name === notebook.metadata.name) {
         return container.image;
       }
-    }
-  }
-
-  get podConditionsMessage(): string {
-    return this.getPodConditionsMessage(this.error, this.notebookStatus);
-  }
-
-  getPodConditionsMessage(error: string, notebookStatus: STATUS_TYPE): string {
-    const errorCode = getErrorCode(error);
-    if (errorCode === 404 && notebookStatus === STATUS_TYPE.STOPPED) {
-      return 'This notebook is paused so its Pod was deleted. Click on ‘Start’ to resume your development environment.';
-    } else if (errorCode === 404) {
-      return `The notebook is ${notebookStatus} at the moment so its pod is not available.`;
-    } else {
-      return 'Error: The backend failed to fetch the Pod.';
     }
   }
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.module.ts
@@ -1,0 +1,28 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OverviewComponent } from './overview.component';
+import {
+  KubeflowModule,
+  ConditionsTableModule,
+  DetailsListModule,
+  HeadingSubheadingRowModule,
+  ContentListItemModule,
+  VariablesGroupsTableModule,
+} from 'kubeflow';
+import { ConfigurationsModule } from './configurations/configurations.module';
+
+@NgModule({
+  declarations: [OverviewComponent],
+  imports: [
+    CommonModule,
+    DetailsListModule,
+    ConditionsTableModule,
+    HeadingSubheadingRowModule,
+    KubeflowModule,
+    ContentListItemModule,
+    VariablesGroupsTableModule,
+    ConfigurationsModule,
+  ],
+  exports: [OverviewComponent],
+})
+export class OverviewModule {}

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
@@ -61,9 +61,7 @@ export class JWABackendService extends BackendService {
 
     return this.http.get<JWABackendResponse>(url).pipe(
       catchError(error => this.handleError(error)),
-      map((resp: JWABackendResponse) => {
-        return resp.notebook;
-      }),
+      map((resp: JWABackendResponse) => resp.notebook),
     );
   }
 
@@ -74,9 +72,7 @@ export class JWABackendService extends BackendService {
 
     return this.http.get<JWABackendResponse>(url).pipe(
       catchError(error => this.handleErrorExtended(error, [404])),
-      map((resp: JWABackendResponse) => {
-        return resp.pod;
-      }),
+      map((resp: JWABackendResponse) => resp.pod),
     );
   }
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/error.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/error.ts
@@ -1,0 +1,7 @@
+export function getErrorCode(error: string): number {
+  // Extract error code from the first square brackets
+  // [] of the string
+  const matches = error.match(/\[(.*?)\]/);
+  const code = parseInt(matches[1], 10);
+  return code;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/condition.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/condition.ts
@@ -1,0 +1,6 @@
+export interface Condition {
+  type?: string;
+  lastProbeTime?: string;
+  reason?: string;
+  message?: string;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/configuration.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/configuration.ts
@@ -1,0 +1,9 @@
+export interface Configuration {
+  name?: string;
+  Description?: string;
+  Selector?: string;
+  Env?: string;
+  Volumes?: string;
+  VolumeMounts?: string;
+  ServiceAccountName?: string;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/environmentVariablesGroup.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/environmentVariablesGroup.ts
@@ -1,0 +1,6 @@
+import { PodDefault } from 'src/app/types';
+import { VariablesGroup } from 'kubeflow';
+
+export interface EnvironmentVariablesGroup extends VariablesGroup {
+  configuration?: PodDefault;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
@@ -1,6 +1,12 @@
 import { Status } from 'kubeflow';
 import { PodDefault } from './poddefault';
 import { GPU } from './gpu';
+import {
+  V1ContainerState,
+  V1ObjectMeta,
+  V1PodSpec,
+} from '@kubernetes/client-node';
+import { Condition } from './condition';
 
 export type ServerType = 'jupyter' | 'group-one' | 'group-two';
 
@@ -51,4 +57,20 @@ export interface NotebookFormObject {
   datavols: any[];
   shm: boolean;
   configurations: PodDefault[];
+}
+
+export interface NotebookRawObject {
+  apiVersion: string;
+  kind: string;
+  metadata: V1ObjectMeta;
+  spec: {
+    template: {
+      spec: V1PodSpec;
+    };
+  };
+  status: {
+    conditions: Condition[];
+    containerState: V1ContainerState;
+    readyReplicas: number;
+  };
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/poddefault.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/poddefault.ts
@@ -1,4 +1,33 @@
+import {
+  V1EnvFromSource,
+  V1EnvVar,
+  V1LabelSelector,
+  V1ObjectMeta,
+  V1Toleration,
+  V1Volume,
+  V1VolumeMount,
+} from '@kubernetes/client-node';
+
 export interface PodDefault {
-  label: string;
-  desc: string;
+  label?: string;
+  desc?: string;
+  apiVersion?: string;
+  kind?: string;
+  metadata?: V1ObjectMeta;
+  spec?: PodDefaultSpec;
+}
+
+export interface PodDefaultSpec {
+  annotations?: { [key: string]: string };
+  labels?: Record<string, string>;
+
+  automountServiceAccountToken?: boolean;
+  desc?: string;
+  env?: Array<V1EnvVar>;
+  envFrom?: Array<V1EnvFromSource>;
+  selector: V1LabelSelector;
+  serviceAccountName?: string;
+  volumeMounts?: Array<V1VolumeMount>;
+  volumes?: Array<V1Volume>;
+  tolerations?: Array<V1Toleration>;
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/responses.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/responses.ts
@@ -1,13 +1,16 @@
+import { V1Pod } from '@kubernetes/client-node';
 import { BackendResponse } from 'kubeflow';
 import { Config } from './config';
-import { NotebookResponseObject } from './notebook';
+import { NotebookRawObject, NotebookResponseObject } from './notebook';
 import { PodDefault } from './poddefault';
 import { PvcResponseObject } from './volume';
 
 export interface JWABackendResponse extends BackendResponse {
+  notebook?: NotebookRawObject;
   notebooks?: NotebookResponseObject[];
   pvcs?: PvcResponseObject[];
   config?: Config;
   poddefaults?: PodDefault[];
   vendors?: string[];
+  pod?: V1Pod;
 }


### PR DESCRIPTION
This PR is part of the effort to add [details pages for objects in our WAs](https://github.com/kubeflow/kubeflow/issues/6707). It creates **a new notebook details page where a user can navigate and see key information about each notebook**. More specifically, this tab contains an overview of the `.status` of the object plus a selection of the most important fields from the spec. These are _Volumes, Applied Configurations from PodDefaults, Notebook type, ENV Vars, Minimum/Maximum CPU/RAM, Docker image, Conditions_. We will also introduce soon `LOGS`, `EVENTS` and `YAML` tab.

### Route
Regarding **the link** that this page will be served on, we need to be able to extract from the link information about the **notebook's name** we 're currently viewing and the **current namespace**.  Thus, we ended up with `notebook/details/namespace/notebook-name?ns=namespace` .

### Notebook's Conditions
Our plan here was to add a Conditions table inside the `OVERVIEW` tab in order to show the `.status.conditions` of the notebook. 

**Problem**
However, we found out that the notebook’s `.status.conditions` are fundamentally broken. Right now the Notebook Controller is blindly appending Pod conditions on the Notebook's conditions https://github.com/kubeflow/kubeflow/blob/master/components/notebook-controller/controllers/notebook_controller.go#L247. 
The conditions are expected to provide a summary of the state of an object for a specific point in time, not use the list to combine the conditions to get to the final state. https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#typical-status-properties

**Workaround**
Since currently, there is no point in exposing the notebook `.status.conditions`, we decided, as a temporary workaround, to show the Notebook’s underlying Pod  conditions and to be explicit about which conditions the table refers to.

### Sidenote
For **clickable items - links**, we followed the style and what we do in general in KFP (e.g. Output Artifacts)

### Screenshots 
![image](https://user-images.githubusercontent.com/44405072/203787746-50b047d5-994a-4391-a189-e911cbee12b0.png)
![image](https://user-images.githubusercontent.com/44405072/203787789-6839450c-6f6f-4c15-be46-32f42f639fbb.png)
![image](https://user-images.githubusercontent.com/44405072/203787767-dcf377b5-278a-4f31-97e0-b74d47499e2a.png)

cc @kimwnasptd 