### PR TITLE
Adding multi-arch support for linux-ppc64le in CI for notebook-controller

### DIFF
--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -15,30 +15,41 @@ on:
       - components/notebook-controller/**
       - components/common/**
 
+env:
+  DOCKER_USER: kubeflownotebookswg
+  IMG: kubeflownotebookswg/notebook-controller
+  ARCH: linux/ppc64le,linux/amd64
+
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Login to DockerHub
-      if: github.event_name == 'push'
-      uses: docker/login-action@v2
-      with:
-        username: kubeflownotebookswg
-        password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
+      - name: Login to DockerHub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run Notebook Controller build
-      run: |
-        cd components/notebook-controller
-        export IMG=kubeflownotebookswg/notebook-controller
-        make docker-build
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: ppc64le
 
-    - name: Run Notebook Controller push
-      if: github.event_name == 'push'
-      run: |
-        cd components/notebook-controller
-        export IMG=kubeflownotebookswg/notebook-controller
-        make docker-push
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build multi-arch docker image
+        run: |
+          cd components/notebook-controller
+          make docker-build-multi-arch
+
+      - name: Build  and push multi-arch docker image
+        if: github.event_name == 'push'
+        run: |
+          cd components/notebook-controller
+          make docker-build-push-multi-arch

--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -1,6 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= notebook-controller
 TAG ?= $(shell git describe --tags --always --dirty)
+ARCH ?= linux/amd64
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd"
@@ -84,6 +85,16 @@ docker-build: ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}:${TAG}
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
+	cd .. && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} -f ./notebook-controller/Dockerfile .
+
+
+.PHONY: docker-build-push-multi-arch
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
+	cd .. && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push -f ./notebook-controller/Dockerfile .
+
 
 .PHONY: image
 image: docker-build docker-push ## Build and push docker image with the manager.


### PR DESCRIPTION
* the  Build & Publish Notebook Controller  github workflow only releases docker image for linux-amd64 
*  Adding linux-ppc64le arch in workflow to release the docker image for ppc64le arch 
*  Using docker buildx and qemu to build the multi-arch docker images