### PR TITLE
jwa(front): Use new Editor component

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/angular.json
+++ b/components/crud-web-apps/jupyter/frontend/angular.json
@@ -34,16 +34,14 @@
             "tsConfig": "tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor",
+                "output": "assets/monaco-editor"
+              }
             ],
-            "styles": [
-              "src/styles.scss"
-            ],
-            "scripts": [
-              "node_modules/ace-builds/src-min/ace.js",
-              "node_modules/ace-builds/src-min/mode-yaml.js",
-              "node_modules/ace-builds/src-min/theme-xcode.js"
-            ],
+            "styles": ["src/styles.scss"],
             "crossOrigin": "use-credentials",
             "vendorChunk": true,
             "extractLicenses": false,

--- a/components/crud-web-apps/jupyter/frontend/package-lock.json
+++ b/components/crud-web-apps/jupyter/frontend/package-lock.json
@@ -3398,11 +3398,6 @@
         "negotiator": "0.6.2"
       }
     },
-    "ace-builds": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.12.tgz",
-      "integrity": "sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg=="
-    },
     "acorn": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
@@ -4165,11 +4160,6 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
     },
-    "brace": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/brace/-/brace-0.11.1.tgz",
-      "integrity": "sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4223,7 +4213,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
       "dev": true
     },
     "buffer-from": {
@@ -4402,7 +4392,7 @@
     "check-more-types": {
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/check-more-types/-/check-more-types-2.24.0.tgz",
-      "integrity": "sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==",
+      "integrity": "sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=",
       "dev": true
     },
     "chokidar": {
@@ -7399,7 +7389,7 @@
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "~1.2.0"
@@ -9651,7 +9641,7 @@
     "lazy-ass": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
-      "integrity": "sha512-cc8oEVoctTvsFZ/Oje/kGnHbpWHYBe8IAJe4C0QNc3t8uM/0Y8+erSz/7Y1ALuXTEZTMvxXwO6YbX1ey3ujiZw==",
+      "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
       "dev": true
     },
     "less": {
@@ -9902,7 +9892,7 @@
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
       "dev": true
     },
     "lodash.truncate": {
@@ -10514,6 +10504,11 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
     },
+    "monaco-editor": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
+      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -10614,15 +10609,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "ng2-ace-editor": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/ng2-ace-editor/-/ng2-ace-editor-0.3.9.tgz",
-      "integrity": "sha512-e8Q4YCirlL/OEiekewmzupG+zV3prYsiYmQnRzQzd0wNgsPjOLOdb0it7cCbzFfIXKGyIIHKTW5584WxPr2LnQ==",
-      "requires": {
-        "ace-builds": "^1.4.2",
-        "brace": "^0.11.1"
-      }
     },
     "nice-try": {
       "version": "1.0.5",
@@ -11192,7 +11178,7 @@
     "ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
-      "integrity": "sha512-o6E5qJV5zkAbIDNhGSIlyOhScKXgQrSRMilfph0clDfM0nEnBOlKlH4sWDmG95BW/CvwNz0vmm7dJVtU2KlMiA==",
+      "integrity": "sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=",
       "dev": true
     },
     "p-cancelable": {
@@ -11409,7 +11395,7 @@
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
     "performance-now": {
@@ -13808,7 +13794,7 @@
     "request-progress": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-      "integrity": "sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==",
+      "integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
       "dev": true,
       "requires": {
         "throttleit": "^1.0.0"
@@ -15522,7 +15508,7 @@
     "throttleit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-      "integrity": "sha512-rkTVqu6IjfQ/6+uNuuc3sZek4CEYxTJom3IktzgdSxcZqdARuebbA/f4QmAxMQIxqq9ZLEUkSYqvuk1I6VKq4g==",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=",
       "dev": true
     },
     "through": {
@@ -16844,7 +16830,7 @@
     "yauzl": {
       "version": "2.10.0",
       "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
         "buffer-crc32": "~0.2.3",

--- a/components/crud-web-apps/jupyter/frontend/package.json
+++ b/components/crud-web-apps/jupyter/frontend/package.json
@@ -44,7 +44,7 @@
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.11",
     "material-icons": "^0.7.3",
-    "ng2-ace-editor": "^0.3.9",
+    "monaco-editor": "^0.33.0",
     "raw-loader": "^4.0.2",
     "rxjs": "~6.6.7",
     "tslib": "^2.0.0",

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/existing/existing-volume.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/existing/existing-volume.component.html
@@ -32,6 +32,13 @@
   >
   <ng-container i18n> for the supported volumes and their specs</ng-container>
 
-  <div ace-editor mode="yaml" theme="xcode" [(text)]="yaml"></div>
+  <lib-monaco-editor
+    [(text)]="yaml"
+    language="yaml"
+    [readOnly]="false"
+    [height]="250"
+    class="editor"
+  ></lib-monaco-editor>
+
   <mat-error *ngIf="errorParsingYaml">{{ errorParsingYaml }}</mat-error>
 </ng-template>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/existing/existing-volume.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/existing/existing-volume.component.scss
@@ -2,9 +2,7 @@
   display: block;
 }
 
-[ace-editor] {
-  width: auto;
-  height: 250px;
+.editor {
   margin-top: 0.5rem;
   margin-bottom: 1rem;
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/existing/existing-volume.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/existing/existing-volume.module.ts
@@ -8,7 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 
 import { ExistingPvcModule } from './pvc/pvc.module';
-import { AceEditorModule } from 'ng2-ace-editor';
+import { EditorModule } from 'kubeflow';
 
 @NgModule({
   declarations: [ExistingVolumeComponent],
@@ -19,7 +19,7 @@ import { AceEditorModule } from 'ng2-ace-editor';
     MatInputModule,
     MatSelectModule,
     ExistingPvcModule,
-    AceEditorModule,
+    EditorModule,
   ],
   exports: [ExistingVolumeComponent],
 })

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/new/new.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/new/new.component.html
@@ -41,7 +41,13 @@
     >
     <ng-container i18n> for the supported volumes and their specs</ng-container>
 
-    <div ace-editor mode="yaml" theme="xcode" [(text)]="yaml"></div>
+    <lib-monaco-editor
+      [(text)]="yaml"
+      language="yaml"
+      [readOnly]="false"
+      [height]="250"
+      class="editor"
+    ></lib-monaco-editor>
 
     <mat-error *ngIf="errorParsingYaml">{{ errorParsingYaml }}</mat-error>
   </ng-container>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/new/new.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/new/new.component.scss
@@ -2,9 +2,7 @@
   display: block;
 }
 
-[ace-editor] {
-  width: auto;
-  height: 250px;
+.editor {
   margin-top: 0.5rem;
   margin-bottom: 1rem;
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/new/new.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-default/volume/new/new.module.ts
@@ -5,12 +5,12 @@ import { VolumeNameModule } from './name/name.module';
 import { StorageClassModule } from './storage-class/storage-class.module';
 import { VolumeAccessModesModule } from './access-modes/access-modes.module';
 import { VolumeSizeModule } from './size/size.module';
-import { AceEditorModule } from 'ng2-ace-editor';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { RokUrlModule } from './rok-url/rok-url.module';
+import { EditorModule } from 'kubeflow';
 
 @NgModule({
   declarations: [NewVolumeComponent],
@@ -20,12 +20,12 @@ import { RokUrlModule } from './rok-url/rok-url.module';
     StorageClassModule,
     VolumeAccessModesModule,
     VolumeSizeModule,
-    AceEditorModule,
     MatInputModule,
     MatSelectModule,
     ReactiveFormsModule,
     MatFormFieldModule,
     RokUrlModule,
+    EditorModule,
   ],
   exports: [NewVolumeComponent],
 })


### PR DESCRIPTION
This PR imports new Editor component from Kubeflow Common Library in JWA and replaces all instances of the previous Ace Editor. It is a follow up PR to this one https://github.com/kubeflow/kubeflow/pull/6733.