### PR TITLE
web-apps: Add support for all-namespaces in the Volumes and TensorBoards web apps

### DIFF
--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -8,7 +8,8 @@ import '@polymer/paper-item/paper-item.js';
 import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 
 export const ALL_NAMESPACES = 'All namespaces';
-export const ALL_NAMESPACES_ALLOWED_LIST = [];
+export const ALL_NAMESPACES_ALLOWED_LIST = ['jupyter', 'volumes',
+                                            'tensorboards'];
 
 const allNamespacesAllowedPaths = ALL_NAMESPACES_ALLOWED_LIST
     .map(( p)=>`/_/${p}/`);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/namespace-select/namespace-select.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/namespace-select/namespace-select.component.html
@@ -8,7 +8,10 @@
       (selectionChange)="namespaceChanged($event.value)"
       data-cy-namespace-selector-dropdown
     >
-      <mat-option value="{all}">All namespaces</mat-option>
+      <mat-option data-cy-all-namespaces value="{all}">
+        All namespaces
+      </mat-option>
+
       <mat-option
         *ngFor="let namespace of namespaces"
         [value]="namespace"

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.html
@@ -11,7 +11,7 @@
     <mat-icon>keyboard_backspace</mat-icon>
   </button>
 
-  <div class="title-margin title">
+  <div class="title-margin title" data-cy-toolbar-title>
     {{ title }}
   </div>
 

--- a/components/crud-web-apps/jupyter/frontend/cypress/fixtures/notebook.ts
+++ b/components/crud-web-apps/jupyter/frontend/cypress/fixtures/notebook.ts
@@ -13,8 +13,6 @@ export const notebook = {
   memory: '1Gi',
   memoryLimit: '',
   gpus: { num: 'none' },
-  noWorkspace: true,
-  workspace: {},
   affinityConfig: '',
   tolerationGroup: '',
   datavols: [],

--- a/components/crud-web-apps/jupyter/frontend/cypress/fixtures/settings.ts
+++ b/components/crud-web-apps/jupyter/frontend/cypress/fixtures/settings.ts
@@ -1,5 +1,5 @@
 export const settings = {
-  // namespace to create test InferenceServices in
+  // namespace to create test Notebooks in
   namespace: 'default',
 
   // POST/PATCH/PUT/DELETE requests will need these headers since we are

--- a/components/crud-web-apps/jupyter/frontend/cypress/integration/main-page.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/cypress/integration/main-page.spec.ts
@@ -3,11 +3,9 @@ import { settings } from '../fixtures/settings';
 describe('Main table', () => {
   beforeEach(() => {});
 
-  it('should have a "Notebook Servers" title', () => {
+  it('should have a "Notebook" title', () => {
     cy.visit('/');
-    cy.get('[data-cy-table-title]')
-      .contains('Notebook Servers')
-      .should('exist');
+    cy.get('[data-cy-toolbar-title]').contains('Notebooks').should('exist');
   });
 
   it('should list Notebooks without errors', () => {
@@ -23,5 +21,15 @@ describe('Main table', () => {
 
     // after fetching the data the page should not have an error snackbar
     cy.get('[data-cy-snack-status=ERROR]').should('not.exist');
+  });
+
+  it('should have a `Namespace` column, when showing all-namespaces', () => {
+    cy.selectAllNamespaces();
+
+    // ensure there's at least one Notebook
+    cy.createNotebook().then(nb => {
+      cy.log(nb);
+      cy.get('[data-cy-table-header-row="Namespace"]').should('exist');
+    });
   });
 });

--- a/components/crud-web-apps/jupyter/frontend/cypress/support/commands.ts
+++ b/components/crud-web-apps/jupyter/frontend/cypress/support/commands.ts
@@ -13,6 +13,18 @@ Cypress.Commands.add('selectNamespace', ns => {
   cy.get(`[data-cy-namespace=${ns}]`).click();
 });
 
+Cypress.Commands.add('selectAllNamespaces', () => {
+  cy.intercept('GET', '/api/namespaces').as('getNamespaces');
+  cy.visit('/');
+
+  cy.log(`Selecting all namespaces`);
+  cy.wait('@getNamespaces');
+
+  // click and select the provided namespace
+  cy.get('[data-cy-namespace-selector-dropdown]').click();
+  cy.get(`[data-cy-all-namespaces]`).click();
+});
+
 Cypress.Commands.add('createNotebook', () => {
   const randomSubfix = Math.random().toString(36).substring(4);
 

--- a/components/crud-web-apps/jupyter/frontend/cypress/support/index.ts
+++ b/components/crud-web-apps/jupyter/frontend/cypress/support/index.ts
@@ -13,6 +13,11 @@ declare global {
       selectNamespace(ns: string): Chainable;
 
       /**
+       * Custom command to select all-namespaces option from the dropdown
+       */
+      selectAllNamespaces(): Chainable;
+
+      /**
        * Custom command to create a Notebook with random suffixed name
        */
       createNotebook(): Chainable;

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/form/form.component.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/form/form.component.ts
@@ -50,7 +50,7 @@ export class FormComponent implements OnInit, OnDestroy {
         this.currNamespace = ns;
         this.formCtrl.controls.namespace.setValue(ns);
 
-        this.backend.getTensorboards(ns).subscribe(tensorboards => {
+        this.backend.getTensorBoards(ns).subscribe(tensorboards => {
           this.tensorboardNames.clear();
           tensorboards.forEach(tensorboard =>
             this.tensorboardNames.add(tensorboard.name),

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
@@ -74,8 +74,9 @@ const actionsCol: TableColumn = {
   ]),
 };
 
-export const defaultConfig = {
+export const defaultConfig: TableConfig = {
   title: tableConfig.title,
+  dynamicNamespaceColumn: true,
   newButtonText: tableConfig.newButtonText,
   columns: tableConfig.columns.concat(actionsCol),
 };

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.ts
@@ -12,6 +12,7 @@ import {
   SnackType,
   ToolbarButton,
   PollerService,
+  ToolbarButtonConfig,
 } from 'kubeflow';
 import { defaultConfig } from './config';
 import { environment } from '@app/environment';
@@ -29,7 +30,7 @@ import { FormComponent } from '../form/form.component';
   styleUrls: ['./index.component.scss'],
 })
 export class IndexComponent implements OnInit, OnDestroy {
-  public currNamespace = '';
+  public currNamespace: string | string[];
   public nsSub = new Subscription();
   public pollSub = new Subscription();
 
@@ -37,16 +38,16 @@ export class IndexComponent implements OnInit, OnDestroy {
   public config = defaultConfig;
   public processedData: TensorboardProcessedObject[] = [];
 
-  buttons: ToolbarButton[] = [
-    new ToolbarButton({
-      text: `New TensorBoard`,
-      icon: 'add',
-      stroked: true,
-      fn: () => {
-        this.newResourceClicked();
-      },
-    }),
-  ];
+  private newTensorBoardButton = new ToolbarButton({
+    text: $localize`New TensorBoard`,
+    icon: 'add',
+    stroked: true,
+    fn: () => {
+      this.newResourceClicked();
+    },
+  });
+
+  buttons: ToolbarButton[] = [this.newTensorBoardButton];
 
   constructor(
     public ns: NamespaceService,
@@ -58,9 +59,10 @@ export class IndexComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.nsSub = this.ns.getSelectedNamespace().subscribe(ns => {
+    this.nsSub = this.ns.getSelectedNamespace2().subscribe(ns => {
       this.currNamespace = ns;
       this.poll(ns);
+      this.newTensorBoardButton.namespaceChanged(ns, $localize`TensorBoard`);
     });
   }
 
@@ -69,11 +71,11 @@ export class IndexComponent implements OnInit, OnDestroy {
     this.pollSub.unsubscribe();
   }
 
-  public poll(ns: string) {
+  public poll(ns: string | string[]) {
     this.pollSub.unsubscribe();
     this.processedData = [];
 
-    const request = this.backend.getTensorboards(ns);
+    const request = this.backend.getTensorBoards(ns);
 
     this.pollSub = this.poller.exponential(request).subscribe(tensorboards => {
       this.processedData = this.processIncomingData(tensorboards);
@@ -132,7 +134,9 @@ export class IndexComponent implements OnInit, OnDestroy {
         .deleteTensorboard(tensorboard.namespace, tensorboard.name)
         .subscribe({
           next: _ => {
-            this.poll(tensorboard.namespace);
+            // We don't want to use the namespace of the deleted object since
+            // it might override the selected all-namespaces
+            this.poll(this.currNamespace);
             ref.close(DIALOG_RESP.ACCEPT);
           },
           error: err => {

--- a/components/crud-web-apps/tensorboards/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/services/backend.service.ts
@@ -17,7 +17,7 @@ export class TWABackendService extends BackendService {
     super(http, snackBar);
   }
   // GET Tensorboards
-  public getTensorboards(
+  private getNamespacedTensorboards(
     namespace: string,
   ): Observable<TensorboardResponseObject[]> {
     const url = `api/namespaces/${namespace}/tensorboards`;
@@ -26,6 +26,25 @@ export class TWABackendService extends BackendService {
       catchError(error => this.handleError(error)),
       map((resp: TWABackendResponse) => resp.tensorboards),
     );
+  }
+
+  private getTensorBoardsAllNamespaces(
+    namespaces: string[],
+  ): Observable<TensorboardResponseObject[]> {
+    return this.getObjectsAllNamespaces(
+      this.getNamespacedTensorboards.bind(this),
+      namespaces,
+    );
+  }
+
+  public getTensorBoards(
+    ns: string | string[],
+  ): Observable<TensorboardResponseObject[]> {
+    if (Array.isArray(ns)) {
+      return this.getTensorBoardsAllNamespaces(ns);
+    }
+
+    return this.getNamespacedTensorboards(ns);
   }
 
   // GET PVC names

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/config.ts
@@ -22,6 +22,7 @@ const actionsCol: TableColumn = {
 
 export const defaultConfig: TableConfig = {
   title: tableConfig.title,
+  dynamicNamespaceColumn: true,
   newButtonText: tableConfig.newButtonText,
   columns: tableConfig.columns.concat(actionsCol),
 };

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/config.ts
@@ -30,6 +30,7 @@ const actionsCol: TableColumn = {
 
 export const rokConfig: TableConfig = {
   title: tableConfig.title,
+  dynamicNamespaceColumn: true,
   newButtonText: tableConfig.newButtonText,
   columns: tableConfig.columns.concat([actionsCol]),
 };

--- a/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.ts
@@ -13,13 +13,32 @@ export class VWABackendService extends BackendService {
     super(http, snackBar);
   }
 
-  public getPVCs(namespace: string): Observable<PVCResponseObject[]> {
+  private getNamespacedPVCs(
+    namespace: string,
+  ): Observable<PVCResponseObject[]> {
     const url = `api/namespaces/${namespace}/pvcs`;
 
     return this.http.get<VWABackendResponse>(url).pipe(
       catchError(error => this.handleError(error)),
       map((resp: VWABackendResponse) => resp.pvcs),
     );
+  }
+
+  private getPVCsAllNamespaces(
+    namespaces: string[],
+  ): Observable<PVCResponseObject[]> {
+    return this.getObjectsAllNamespaces(
+      this.getNamespacedPVCs.bind(this),
+      namespaces,
+    );
+  }
+
+  public getPVCs(ns: string | string[]): Observable<PVCResponseObject[]> {
+    if (!Array.isArray(ns)) {
+      return this.getNamespacedPVCs(ns);
+    }
+
+    return this.getPVCsAllNamespaces(ns);
   }
 
   // POST


### PR DESCRIPTION
This should be the last work item for supporting all-namespaces for the web apps https://github.com/kubeflow/kubeflow/blob/master/components/proposals/20220621-all-namespaces.md

This PR:
* Adds support to the Volumes web app for all namespaces
* Adds support to the TensorBoards web app for all namespaces
* Updates the CentralDashboard to have the `All namespaces` option for the JWA, VWA and TWA
* Adds some e2e helpers (attribute selectors) and tests