### PR TITLE
jwa: Update manifests to access Pods and Pods/log

### DIFF
--- a/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/cluster-role.yaml
@@ -46,6 +46,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/log
+  verbs:
+  - list
+  - get
 
 ---
 


### PR DESCRIPTION
As part of the effort for the new Notebook details page in JWA, update the manifests for jwa's cluster role in order for JWA's service account to be able to **list pods and get pods/log** resources . This is part of [this effort](https://github.com/kubeflow/kubeflow/issues/6707).