### PR TITLE
Adding support for linux-ppc64le in CI for kfam multi-arch docker image

### DIFF
--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -13,30 +13,39 @@ on:
     paths:
       - components/access-management/**
 
+env:
+  DOCKER_USER: kubeflownotebookswg
+  IMG: kubeflownotebookswg/kfam
+  ARCH: linux/ppc64le,linux/amd64
+
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Login to DockerHub
-      if: github.event_name == 'push'
-      uses: docker/login-action@v2
-      with:
-        username: kubeflownotebookswg
-        password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
+      - name: Login to DockerHub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run KFAM build
-      run: |
-        cd components/access-management
-        export IMG=kubeflownotebookswg/kfam
-        make docker-build
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
 
-    - name: Run KFAM push
-      if: github.event_name == 'push'
-      run: |
-        cd components/access-management
-        export IMG=kubeflownotebookswg/kfam
-        make docker-push
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build multi-arch docker image
+        run: |
+          cd components/access-management
+          make docker-build-multi-arch
+
+      - name: Build  and push multi-arch docker image
+        if: github.event_name == 'push'
+        run: |
+          cd components/access-management
+          make docker-build-push-multi-arch

--- a/components/access-management/Makefile
+++ b/components/access-management/Makefile
@@ -6,7 +6,7 @@ GIT_VERSION := $(shell git describe --tags --always --dirty)
 
 IMG ?= kfam
 TAG ?= $(GIT_VERSION)
-
+ARCH ?= linux/amd64
 generate-go-client: bin/swagger
 	bin/swagger generate client -f api/swagger.yaml -t api/go_client
 
@@ -20,5 +20,13 @@ docker-build:
 
 docker-push: 
 	docker push $(IMG):$(TAG)
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} .
+
+.PHONY: docker-build-push-multi-arch
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push .
 
 image: docker-build docker-push 


### PR DESCRIPTION
* the workflow "Build & Publish KFAM Docker" releases docker image for linux-amd64 
*  Added docker-build-multi-arch and build-push-multi-arch targets in Makefile  of access-management component 
*  Dropping docker-build and docker-push from workflow 
*  Keeping these steps will increase the workflow runtime 
*  docker-build-push-multi-arch builds and pushes the images for linux-amd64 and linux-ppc64le 

