### PR TITLE
VWA: Create Volume details page

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
@@ -24,6 +24,11 @@ def list_pvcs(namespace):
     )
     return v1_core.list_namespaced_persistent_volume_claim(namespace)
 
+def get_pvc(pvc, namespace):
+    authz.ensure_authorized(
+        "get", "", "v1", "persistentvolumeclaims", namespace
+    )
+    return v1_core.read_namespaced_persistent_volume_claim(pvc, namespace)
 
 def patch_pvc(name, namespace, pvc, auth=True):
     if auth:

--- a/components/crud-web-apps/volumes/backend/apps/default/routes/get.py
+++ b/components/crud-web-apps/volumes/backend/apps/default/routes/get.py
@@ -13,3 +13,14 @@ def get_pvcs(namespace):
     content = [utils.parse_pvc(pvc) for pvc in pvcs.items]
 
     return api.success_response("pvcs", content)
+
+@bp.route("/api/namespaces/<namespace>/pvcs/<pvc_name>")
+def get_pvc(namespace, pvc_name):
+    pvc = api.get_pvc(pvc_name, namespace)
+    return api.success_response("pvc", api.serialize(pvc))
+
+@bp.route("/api/namespaces/<namespace>/pvcs/<pvc_name>/pods")
+def get_pvc_pods(namespace, pvc_name):
+    pods = utils.get_pods_using_pvc(pvc_name, namespace)
+
+    return api.success_response("pods", api.serialize(pods))

--- a/components/crud-web-apps/volumes/backend/apps/rok/routes/get.py
+++ b/components/crud-web-apps/volumes/backend/apps/rok/routes/get.py
@@ -1,6 +1,7 @@
 from kubeflow.kubeflow.crud_backend import api, logging
 
 from ...common import status
+from ...common.utils import get_pods_using_pvc
 from .. import utils
 from . import bp
 
@@ -23,3 +24,14 @@ def get_pvcs(namespace):
     content = [utils.parse_pvc(pvc, viewers) for pvc in pvcs.items]
 
     return api.success_response("pvcs", content)
+
+@bp.route("/api/namespaces/<namespace>/pvcs/<pvc_name>")
+def get_pvc(namespace, pvc_name):
+    pvc = api.get_pvc(pvc_name, namespace)
+    return api.success_response("pvc", api.serialize(pvc))
+
+@bp.route("/api/namespaces/<namespace>/pvcs/<pvc_name>/pods")
+def get_pvc_pods(namespace, pvc_name):
+    pods = get_pods_using_pvc(pvc_name, namespace)
+
+    return api.success_response("pods", api.serialize(pods))

--- a/components/crud-web-apps/volumes/frontend/src/app/app-routing.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/app-routing.module.ts
@@ -1,8 +1,15 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { IndexComponent } from './pages/index/index.component';
+import { VolumeDetailsPageComponent } from './pages/volume-details-page/volume-details-page.component';
 
-const routes: Routes = [{ path: '', component: IndexComponent }];
+const routes: Routes = [
+  { path: '', component: IndexComponent },
+  {
+    path: 'volume/details/:namespace/:pvcName',
+    component: VolumeDetailsPageComponent,
+  },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes, { relativeLinkResolution: 'legacy' })],

--- a/components/crud-web-apps/volumes/frontend/src/app/app.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { IndexDefaultComponent } from './pages/index/index-default/index-default
 import { IndexRokComponent } from './pages/index/index-rok/index-rok.component';
 
 import { HttpClientModule, HttpClient } from '@angular/common/http';
+import { VolumeDetailsPageModule } from './pages/volume-details-page/volume-details-page.module';
 
 @NgModule({
   declarations: [
@@ -43,6 +44,7 @@ import { HttpClientModule, HttpClient } from '@angular/common/http';
     FormModule,
     KubeflowModule,
     HttpClientModule,
+    VolumeDetailsPageModule,
   ],
   providers: [
     { provide: ErrorStateMatcher, useClass: ImmediateErrorStateMatcher },

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/config.ts
@@ -24,6 +24,7 @@ export const tableConfig: TableConfig = {
       value: new PropertyValue({
         field: 'name',
         tooltipField: 'name',
+        isLink: true,
         truncate: true,
       }),
       sort: true,

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
@@ -18,6 +18,7 @@ import { VWABackendService } from 'src/app/services/backend.service';
 import { PVCResponseObject, PVCProcessedObject } from 'src/app/types';
 import { Subscription } from 'rxjs';
 import { FormDefaultComponent } from '../../form/form-default/form-default.component';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-index-default',
@@ -52,6 +53,7 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
     public dialog: MatDialog,
     public snackBar: SnackBarService,
     public poller: PollerService,
+    public router: Router,
   ) {}
 
   ngOnInit() {
@@ -83,6 +85,19 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
     switch (a.action) {
       case 'delete':
         this.deleteVolumeClicked(a.data);
+        break;
+      case 'name:link':
+        if (a.data.status.phase === STATUS_TYPE.TERMINATING) {
+          this.snackBar.open(
+            'PVC is unavailable now.',
+            SnackType.Warning,
+            3000,
+          );
+          return;
+        }
+        this.router.navigate([
+          `/volume/details/${a.data.namespace}/${a.data.name}`,
+        ]);
         break;
     }
   }

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.ts
@@ -17,6 +17,7 @@ import { IndexDefaultComponent } from '../index-default/index-default.component'
 import { FormRokComponent } from '../../form/form-rok/form-rok.component';
 import { rokConfig } from './config';
 import { PVCProcessedObjectRok, PVCResponseObjectRok } from 'src/app/types';
+import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-index-rok',
@@ -25,7 +26,8 @@ import { PVCProcessedObjectRok, PVCResponseObjectRok } from 'src/app/types';
 })
 export class IndexRokComponent
   extends IndexDefaultComponent
-  implements OnInit, OnDestroy {
+  implements OnInit, OnDestroy
+{
   config = rokConfig;
 
   constructor(
@@ -36,8 +38,17 @@ export class IndexRokComponent
     public snackBar: SnackBarService,
     public rok: RokService,
     public poller: PollerService,
+    public router: Router,
   ) {
-    super(ns, confirmDialog, backend, dialog, snackBar, poller);
+    super(
+      ns,
+      confirmDialog,
+      backend,
+      dialog,
+      snackBar,
+      poller,
+      router,
+    );
   }
 
   ngOnInit() {

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.ts
@@ -26,8 +26,7 @@ import { Router } from '@angular/router';
 })
 export class IndexRokComponent
   extends IndexDefaultComponent
-  implements OnInit, OnDestroy
-{
+  implements OnInit, OnDestroy {
   config = rokConfig;
 
   constructor(
@@ -40,15 +39,7 @@ export class IndexRokComponent
     public poller: PollerService,
     public router: Router,
   ) {
-    super(
-      ns,
-      confirmDialog,
-      backend,
-      dialog,
-      snackBar,
-      poller,
-      router,
-    );
+    super(ns, confirmDialog, backend, dialog, snackBar, poller, router);
   }
 
   ngOnInit() {

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.html
@@ -1,0 +1,17 @@
+<div
+  class="link-groups"
+  *ngFor="let linkGroup of linkGroups; trackBy: groupTrackByFn"
+>
+  <div class="group-key">{{ linkGroup.name }}</div>
+  <div class="link-group-container" [ngSwitch]="linkGroup.name">
+    <a
+      [href]="link.url"
+      *ngFor="let link of linkGroup.links; trackBy: linkTrackByFn"
+      class="link-item"
+    >
+      {{ link.name }}
+    </a>
+  </div>
+</div>
+
+<div *ngIf="linkGroupsEmpty() && loadCompleted">{{ loadErrorMsg }}</div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.scss
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.scss
@@ -1,0 +1,32 @@
+.link-groups {
+  padding: 0.6rem 0;
+  margin-bottom: 16px;
+}
+
+.link-groups:last-of-type {
+  margin-bottom: 0;
+}
+
+.group-key {
+  margin-bottom: 0.6rem;
+  font-weight: 500;
+}
+
+.link-group-container {
+  display: flex;
+}
+
+.link-item {
+  margin-right: 14px;
+  color: #1a73e8;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.link-item:visited {
+  color: #1a73e8;
+}
+
+.link-item:hover {
+  text-decoration: underline;
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LinkGroupsTableComponent } from './link-groups-table.component';
+
+describe('LinkGroupsTableComponent', () => {
+  let component: LinkGroupsTableComponent;
+  let fixture: ComponentFixture<LinkGroupsTableComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [LinkGroupsTableComponent],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LinkGroupsTableComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.component.ts
@@ -1,0 +1,46 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { LinkGroup, LinkObject } from './types';
+
+@Component({
+  selector: 'app-link-groups-table',
+  templateUrl: './link-groups-table.component.html',
+  styleUrls: ['./link-groups-table.component.scss'],
+})
+export class LinkGroupsTableComponent implements OnInit {
+  private prvLinkGroups: LinkGroup[];
+  @Input()
+  set linkGroups(groups: LinkGroup[]) {
+    this.prvLinkGroups = groups;
+  }
+  get linkGroups() {
+    return this.prvLinkGroups;
+  }
+
+  @Input() loadErrorMsg = 'Resources not available';
+  @Input() loadCompleted = false;
+
+  linkGroupsEmpty() {
+    if (this.linkGroups?.length === 0) {
+      return true;
+    }
+    return false;
+  }
+
+  buttonNavigate(url: string) {
+    const directories = url.split('/');
+    const pvcName = directories[directories.length - 2];
+    window.open(url, `${pvcName}: Edit file contents`, 'height=600,width=800');
+  }
+
+  constructor() {}
+
+  ngOnInit(): void {}
+
+  groupTrackByFn(group: LinkGroup) {
+    return JSON.stringify(group);
+  }
+
+  linkTrackByFn(link: LinkObject) {
+    return link.name;
+  }
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/link-groups-table.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LinkGroupsTableComponent } from './link-groups-table.component';
+
+@NgModule({
+  declarations: [LinkGroupsTableComponent],
+  imports: [CommonModule],
+  exports: [LinkGroupsTableComponent],
+})
+export class LinkGroupsTableModule {}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/types.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/link-groups-table/types.ts
@@ -1,0 +1,9 @@
+export interface LinkObject {
+  name: string;
+  url?: string;
+}
+
+export interface LinkGroup {
+  name: string;
+  links: LinkObject[];
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.html
@@ -1,0 +1,40 @@
+<lib-details-list-item key="Access modes" [chipsList]="accessModes">
+</lib-details-list-item>
+
+<lib-details-list-item key="Size">
+  {{ size }}
+</lib-details-list-item>
+
+<lib-details-list-item key="Storage class">
+  {{ storageClass }}
+</lib-details-list-item>
+
+<lib-details-list-item key="Volume mode">
+  {{ volumeMode }}
+</lib-details-list-item>
+
+<lib-details-list-item key="Volume name" *ngIf="volumeName">
+  {{ volumeName }}
+</lib-details-list-item>
+
+<lib-details-list-item
+  key="Owned by"
+  keyTooltip="The pvc is owned by the objects in this list. If all objects in the list get deleted, then the PVC itself will be deleted"
+  *ngIf="ownerReferencesNotEmpty"
+  [chipsList]="ownerRefs"
+>
+</lib-details-list-item>
+
+<lib-content-list-item key="Pods Mounted">
+  <ng-container *ngIf="!podGroupsLoaded">
+    <lib-loading-spinner></lib-loading-spinner>
+  </ng-container>
+
+  <app-link-groups-table
+    *ngIf="podGroupsLoaded"
+    [linkGroups]="podGroups"
+    [loadCompleted]="podGroupsLoaded"
+    [loadErrorMsg]="podsMountedMessage"
+  >
+  </app-link-groups-table>
+</lib-content-list-item>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.scss
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.scss
@@ -1,0 +1,14 @@
+.link-item {
+  margin-right: 14px;
+  color: #1a73e8;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.link-item:visited {
+  color: #1a73e8;
+}
+
+.link-item:hover {
+  text-decoration: underline;
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ContentListItemModule,
+  DetailsListModule,
+  KubeflowModule,
+  LoadingSpinnerModule,
+  PollerService,
+  SnackBarModule,
+} from 'kubeflow';
+import { VWABackendService } from 'src/app/services/backend.service';
+import { of } from 'rxjs';
+
+import { OverviewComponent } from './overview.component';
+
+const VWABackendServiceStub: Partial<VWABackendService> = {
+  getPodsUsingPVC: () => of(),
+};
+const PollerServiceStub: Partial<PollerService> = {
+  exponential: () => of(),
+};
+
+describe('OverviewComponent', () => {
+  let component: OverviewComponent;
+  let fixture: ComponentFixture<OverviewComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [OverviewComponent],
+      providers: [
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: PollerService, useValue: PollerServiceStub },
+      ],
+      imports: [
+        DetailsListModule,
+        LoadingSpinnerModule,
+        SnackBarModule,
+        ContentListItemModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(OverviewComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.component.ts
@@ -1,0 +1,235 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { environment } from '@app/environment';
+import { V1PersistentVolumeClaim, V1Pod } from '@kubernetes/client-node';
+import { ChipDescriptor, PollerService } from 'kubeflow';
+import { Subscription } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
+import { LinkGroup, LinkObject } from './link-groups-table/types';
+
+@Component({
+  selector: 'app-overview',
+  templateUrl: './overview.component.html',
+  styleUrls: ['./overview.component.scss'],
+})
+export class OverviewComponent implements OnInit, OnDestroy {
+  public accessModes: ChipDescriptor[];
+  public ownerRefs: ChipDescriptor[];
+  public podGroups: LinkGroup[] = [];
+  public podGroupsLoaded = false;
+  public env = environment;
+  public podsMountedError: string;
+
+  pollSub = new Subscription();
+
+  private prvPvc: V1PersistentVolumeClaim;
+
+  @Input()
+  set pvc(pvc: V1PersistentVolumeClaim) {
+    this.prvPvc = pvc;
+
+    if (!pvc) {
+      return;
+    }
+
+    this.pollPodGroups(pvc);
+    this.accessModes = this.generateAccessModes(pvc);
+    this.ownerRefs = this.generateOwnerRefs(pvc);
+  }
+  get pvc() {
+    return this.prvPvc;
+  }
+
+  private pollPodGroups(pvc: V1PersistentVolumeClaim) {
+    this.pollSub.unsubscribe();
+
+    const request = this.backend.getPodsUsingPVC(pvc);
+
+    this.pollSub = this.poller.exponential(request).subscribe(
+      pods => {
+        this.podGroupsLoaded = true;
+        this.podGroups = this.generatePodGroups(pods, this.env.viewerUrl);
+      },
+      error => {
+        this.podGroupsLoaded = true;
+        this.podsMountedError = error;
+      },
+    );
+  }
+
+  private generatePodGroups(pods: V1Pod[], viewerUrl: string): LinkGroup[] {
+    const podObjects = pods
+      .map(pod => this.getPodDetails(pod))
+      .filter(podObj => podObj !== null);
+    const podGroups: LinkGroup[] = [];
+    for (const podObj of podObjects) {
+      const index = podGroups.findIndex(
+        group => group.name === podObj.groupName,
+      );
+      const podLink = this.newPodLink(
+        podObj.podName,
+        podObj.namespace,
+        podObj.groupName,
+        viewerUrl,
+      );
+      if (index < 0) {
+        podGroups.push(this.newPodGroup(podLink, podObj.groupName));
+      } else {
+        podGroups[index].links.push(podLink);
+      }
+    }
+    return podGroups;
+  }
+
+  private getPodDetails(
+    pod: V1Pod,
+  ): {
+    podName: string;
+    groupName: string;
+    namespace: string;
+  } {
+    const labels = pod.metadata.labels;
+    const namespace = pod.metadata.namespace;
+    if ('serving.kubeflow.org/inferenceservice' in labels) {
+      const component = labels.component;
+      const podName =
+        labels['serving.kubeflow.org/inferenceservice'] +
+        ' (' +
+        component +
+        ')';
+      const groupName = 'InferenceService';
+      return { podName, groupName, namespace };
+    } else if ('notebook-name' in labels) {
+      const podName = labels['notebook-name'];
+      const groupName = 'Notebooks';
+      return { podName, groupName, namespace };
+    } else {
+      return null;
+    }
+  }
+
+  private newPodGroup(podLink: LinkObject, groupName: string): LinkGroup {
+    const podsGroup: LinkGroup = {
+      name: groupName,
+      links: [podLink],
+    };
+    return podsGroup;
+  }
+
+  private newPodLink(
+    podName: string,
+    namespace: string,
+    groupName: string,
+    viewerUrl: string,
+  ): LinkObject {
+    let url = '';
+
+    if (groupName === 'Notebooks') {
+      url = `${viewerUrl}/jupyter/notebook/details/${namespace}/${podName}/`;
+    } else if (groupName === 'InferenceService') {
+      // Remove (component) from podName
+      const serviceName = podName.replace(/ *\([^)]*\) */g, '');
+      url = `${viewerUrl}/models/details/${namespace}/${serviceName}/`;
+    }
+
+    return { name: podName, url };
+  }
+
+  private generateAccessModes(pvc: V1PersistentVolumeClaim): ChipDescriptor[] {
+    const modes = pvc?.status?.accessModes || pvc?.spec?.accessModes || [];
+    const chips = [];
+    for (const mode of modes) {
+      if (mode) {
+        chips.push({
+          value: mode,
+          color: 'primary',
+        });
+      }
+    }
+    return chips;
+  }
+
+  private generateOwnerRefs(pvc: V1PersistentVolumeClaim): ChipDescriptor[] {
+    const chips = [];
+    if (pvc?.metadata?.ownerReferences) {
+      for (const ref of pvc.metadata.ownerReferences) {
+        chips.push({
+          value: `${ref.kind}: ${ref.name}`,
+          color: 'primary',
+        });
+      }
+    }
+    return chips;
+  }
+
+  get size(): string {
+    return this.getSize(this.pvc);
+  }
+
+  getSize(pvc: V1PersistentVolumeClaim): string {
+    return (
+      pvc?.status?.capacity?.storage ||
+      pvc?.spec?.resources?.requests?.storage ||
+      'null'
+    );
+  }
+
+  get storageClass(): string {
+    return this.getStorageClass(this.pvc);
+  }
+
+  getStorageClass(pvc: V1PersistentVolumeClaim): string {
+    return pvc?.spec?.storageClassName || 'null';
+  }
+
+  get volumeMode(): string {
+    return this.getVolumeMode(this.pvc);
+  }
+
+  getVolumeMode(pvc: V1PersistentVolumeClaim): string {
+    return pvc?.spec?.volumeMode || 'null';
+  }
+
+  get volumeName(): string {
+    return this.getVolumeName(this.pvc);
+  }
+
+  getVolumeName(pvc: V1PersistentVolumeClaim): string {
+    return pvc?.spec?.volumeName || 'null';
+  }
+
+  get ownerReferencesNotEmpty(): boolean {
+    return this.getOwnerReferencesNotEmpty(this.pvc);
+  }
+
+  getOwnerReferencesNotEmpty(pvc: V1PersistentVolumeClaim): boolean {
+    if (!pvc?.metadata?.ownerReferences) {
+      return false;
+    }
+    return pvc.metadata.ownerReferences.length > 0;
+  }
+
+  get podsMountedMessage(): string {
+    return this.getPodsMountedMessage(this.podsMountedError);
+  }
+
+  getPodsMountedMessage(error: string): string {
+    if (!error) {
+      return 'No pods are using this PVC.';
+    } else {
+      return `Failed to fetch mounted pods with error: ${error}`;
+    }
+  }
+
+  constructor(
+    public backend: VWABackendService,
+    public poller: PollerService,
+  ) {}
+
+  ngOnInit(): void {}
+
+  ngOnDestroy() {
+    if (this.pollSub) {
+      this.pollSub.unsubscribe();
+    }
+  }
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/overview.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { OverviewComponent } from './overview.component';
+import { ContentListItemModule, KubeflowModule } from 'kubeflow';
+import { LinkGroupsTableModule } from './link-groups-table/link-groups-table.module';
+
+@NgModule({
+  declarations: [OverviewComponent],
+  imports: [
+    CommonModule,
+    KubeflowModule,
+    ContentListItemModule,
+    LinkGroupsTableModule,
+  ],
+  exports: [OverviewComponent],
+})
+export class OverviewModule {}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.html
@@ -1,0 +1,32 @@
+<div class="lib-content-wrapper details-page">
+  <lib-title-actions-toolbar
+    title="Volume details"
+    [buttons]="buttonsConfig"
+    [backButton]="true"
+    (back)="navigateBack()"
+  >
+  </lib-title-actions-toolbar>
+
+  <div class="details-page-outer">
+    <lib-loading-spinner *ngIf="!pvcInfoLoaded"></lib-loading-spinner>
+
+    <ng-container *ngIf="pvcInfoLoaded">
+      <div class="details-page-inner">
+        <div class="details-page-inner-2">
+          <lib-status-icon></lib-status-icon>
+          <lib-status-icon
+            [stateChanging]="false"
+            [status]="status"
+          ></lib-status-icon>
+
+          <div class="title">{{ name }}</div>
+        </div>
+      </div>
+      <mat-tab-group dynamicHeight animationDuration="0ms">
+        <mat-tab label="OVERVIEW">
+          <app-overview [pvc]="pvc"></app-overview>
+        </mat-tab>
+      </mat-tab-group>
+    </ng-container>
+  </div>
+</div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.spec.ts
@@ -1,0 +1,48 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+  LoadingSpinnerModule,
+  NamespaceService,
+  TitleActionsToolbarModule,
+} from 'kubeflow';
+import { of } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
+
+import { VolumeDetailsPageComponent } from './volume-details-page.component';
+const VWABackendServiceStub: Partial<VWABackendService> = {
+  getPVC: () => of(),
+};
+const NamespaceServiceStub: Partial<NamespaceService> = {
+  updateSelectedNamespace: () => {},
+  getSelectedNamespace2: () => of(),
+};
+
+describe('VolumeDetailsPageComponent', () => {
+  let component: VolumeDetailsPageComponent;
+  let fixture: ComponentFixture<VolumeDetailsPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [VolumeDetailsPageComponent],
+      providers: [
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: NamespaceService, useValue: NamespaceServiceStub },
+      ],
+      imports: [
+        RouterTestingModule,
+        TitleActionsToolbarModule,
+        LoadingSpinnerModule,
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(VolumeDetailsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.ts
@@ -1,0 +1,79 @@
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+import { V1PersistentVolumeClaim } from '@kubernetes/client-node';
+import {
+  NamespaceService,
+  PollerService,
+  STATUS_TYPE,
+  ToolbarButton,
+} from 'kubeflow';
+import { Subscription } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
+
+@Component({
+  selector: 'app-volume-details-page',
+  templateUrl: './volume-details-page.component.html',
+  styleUrls: ['./volume-details-page.component.scss'],
+})
+export class VolumeDetailsPageComponent implements OnInit, OnDestroy {
+  public name: string;
+  public namespace: string;
+  public pvc: V1PersistentVolumeClaim;
+  public pvcInfoLoaded = false;
+  public buttonsConfig: ToolbarButton[] = [];
+
+  pollSub = new Subscription();
+
+  constructor(
+    public ns: NamespaceService,
+    public backend: VWABackendService,
+    public poller: PollerService,
+    public router: Router,
+    private route: ActivatedRoute,
+  ) {}
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      this.ns.updateSelectedNamespace(params.namespace);
+
+      this.name = params.pvcName;
+      this.namespace = params.namespace;
+
+      this.poll(this.namespace, this.name);
+    });
+  }
+
+  ngOnDestroy() {
+    this.pollSub.unsubscribe();
+  }
+
+  private poll(namespace: string, name: string) {
+    this.pollSub.unsubscribe();
+
+    const request = this.backend.getPVC(namespace, name);
+
+    this.pollSub = this.poller.exponential(request).subscribe(pvc => {
+      this.pvc = pvc;
+      this.pvcInfoLoaded = true;
+    });
+  }
+
+  navigateBack() {
+    this.router.navigate(['']);
+  }
+
+  get status(): STATUS_TYPE {
+    return this.getStatus(this.pvc);
+  }
+
+  getStatus(pvc: V1PersistentVolumeClaim): STATUS_TYPE {
+    if (pvc?.metadata?.deletionTimestamp) {
+      return STATUS_TYPE.TERMINATING;
+    }
+    if (pvc?.status?.phase === 'Bound') {
+      return STATUS_TYPE.READY;
+    } else {
+      return STATUS_TYPE.WARNING;
+    }
+  }
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { VolumeDetailsPageComponent } from './volume-details-page.component';
+import { KubeflowModule } from 'kubeflow';
+import { MatTabsModule } from '@angular/material/tabs';
+import { OverviewModule } from './overview/overview.module';
+
+@NgModule({
+  declarations: [VolumeDetailsPageComponent],
+  imports: [CommonModule, KubeflowModule, MatTabsModule, OverviewModule],
+})
+export class VolumeDetailsPageModule {}

--- a/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.ts
@@ -4,6 +4,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { PVCResponseObject, VWABackendResponse, PVCPostObject } from '../types';
+import { V1PersistentVolumeClaim, V1Pod } from '@kubernetes/client-node';
 
 @Injectable({
   providedIn: 'root',
@@ -39,6 +40,29 @@ export class VWABackendService extends BackendService {
     }
 
     return this.getPVCsAllNamespaces(ns);
+  }
+
+  public getPVC(
+    namespace: string,
+    pvcName: string,
+  ): Observable<V1PersistentVolumeClaim> {
+    const url = `api/namespaces/${namespace}/pvcs/${pvcName}`;
+
+    return this.http.get<VWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: VWABackendResponse) => resp.pvc),
+    );
+  }
+
+  public getPodsUsingPVC(pvc: V1PersistentVolumeClaim): Observable<V1Pod[]> {
+    const namespace = pvc.metadata.namespace;
+    const pvcName = pvc.metadata.name;
+    const url = `api/namespaces/${namespace}/pvcs/${pvcName}/pods`;
+
+    return this.http.get<VWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: VWABackendResponse) => resp.pods),
+    );
   }
 
   // POST

--- a/components/crud-web-apps/volumes/frontend/src/app/types/backend.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/types/backend.ts
@@ -1,7 +1,10 @@
+import { V1PersistentVolumeClaim, V1Pod } from '@kubernetes/client-node';
 import { Status, BackendResponse } from 'kubeflow';
 
 export interface VWABackendResponse extends BackendResponse {
   pvcs?: PVCResponseObject[];
+  pvc?: V1PersistentVolumeClaim;
+  pods?: V1Pod[];
 }
 
 export interface PVCResponseObject {


### PR DESCRIPTION
This PR is part of the [Details page for each Notebooks/Volumes/TensorBoards](https://github.com/kubeflow/kubeflow/issues/6707) effort and we used as a guideline what we 've done for [JWA ](https://github.com/kubeflow/kubeflow/pull/6769). It creates **a new volume details page where a user can navigate and see key information about each volume**. More specifically, it includes important information of the PVC focusing on `.spec` and `.status` fields. These can be _Access Modes, Size, Storage Class, OwnerReferences, Pods using the PVC._* 

Regarding Pods using the PVC, these will be grouped into "Pod types". As a first iteration, we will only include the following groups: `Notebook` and `InferenceService` since the rest of them require too many requests to deduce about the higher up owning objects. We also want to avoid exposing every pod, since a deployment (like a `Notebook`) ends up creating a `ReplicaSet` which in turn creates another pod and that would result in having duplicate links to the same `Notebook` object.