### PR TITLE
web-apps: Create .gitignore file to ignore web-apps-dev files

### DIFF
--- a/components/crud-web-apps/.gitignore
+++ b/components/crud-web-apps/.gitignore
@@ -1,0 +1,1 @@
+**/web-apps-dev


### PR DESCRIPTION
This PR creates a `.gitignore` file to ignore `web-apps-dev` files generated during the virtual env creation.

Signed-off-by: Elena Zioga <elena@arrikto.com>