### PR TITLE
jwa(front): Add YAML tab to Notebook details page

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
@@ -48,6 +48,15 @@
           </ng-template>
         </mat-tab>
 
+        <mat-tab label="YAML">
+          <ng-template matTabContent>
+            <app-yaml
+              [podRequestCompleted]="podRequestCompleted"
+              [notebook]="notebook"
+              [pod]="notebookPod"
+            ></app-yaml>
+          </ng-template>
+        </mat-tab>
       </mat-tab-group>
     </ng-container>
   </div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.module.ts
@@ -7,6 +7,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatDividerModule } from '@angular/material/divider';
 import { NotebookPageComponent } from './notebook-page.component';
 import { OverviewModule } from './overview/overview.module';
+import { YamlModule } from './yaml/yaml.module';
 import { LogsModule } from './logs/logs.module';
 import { RouterModule } from '@angular/router';
 import { EventsModule } from './events/events.module';
@@ -20,6 +21,7 @@ import { EventsModule } from './events/events.module';
     MatDividerModule,
     MatTabsModule,
     OverviewModule,
+    YamlModule,
     MatProgressSpinnerModule,
     LogsModule,
     RouterModule,

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.html
@@ -1,0 +1,24 @@
+<div class="yaml-tab-container">
+  <div class="message">
+    <p>{{ infoMessage }}</p>
+  </div>
+  <div>
+    <mat-form-field appearance="outline" floatLabel="always">
+      <mat-select
+        [(value)]="selection"
+        (selectionChange)="selectionChanged($event)"
+      >
+        <mat-option value="notebook"> Notebook </mat-option>
+        <mat-option value="pod"> Pod </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+</div>
+
+<lib-monaco-editor
+  [text]="yaml"
+  language="yaml"
+  [readOnly]="true"
+  [height]="490"
+>
+</lib-monaco-editor>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.scss
@@ -1,0 +1,10 @@
+.yaml-tab-container {
+  display: flex;
+  margin-top: 0.4em;
+  margin-bottom: -0.6em;
+}
+
+.message {
+  margin-top: 0.1em;
+  margin-right: 0.4em;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EditorModule, KubeflowModule } from 'kubeflow';
+
+import { YamlComponent } from './yaml.component';
+
+describe('YamlComponent', () => {
+  let component: YamlComponent;
+  let fixture: ComponentFixture<YamlComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [YamlComponent],
+      imports: [KubeflowModule, EditorModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(YamlComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.component.ts
@@ -1,0 +1,69 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Event } from '@angular/router';
+import { V1Pod } from '@kubernetes/client-node';
+import { dump } from 'js-yaml';
+import { NotebookRawObject } from 'src/app/types';
+
+@Component({
+  selector: 'app-yaml',
+  templateUrl: './yaml.component.html',
+  styleUrls: ['./yaml.component.scss'],
+})
+export class YamlComponent implements OnInit {
+  public yaml: string;
+  public selection = 'notebook';
+  public infoMessage = 'Show the full YAML of the ';
+  private podYaml = 'Pod information is still being loaded.';
+  private prvPod: V1Pod;
+
+  @Input() podRequestCompleted = false;
+  @Input() notebook: NotebookRawObject;
+  @Input()
+  set pod(pod: V1Pod) {
+    this.prvPod = pod;
+
+    if (!pod && !this.podRequestCompleted) {
+      this.podYaml = 'Pod information is still being loaded.';
+      return;
+    }
+
+    if (!pod) {
+      this.podYaml = 'No pod available for this notebook.';
+      if (this.selection === 'pod') {
+        this.yaml = this.podYaml;
+      }
+      return;
+    }
+
+    this.podYaml = dump(this.pod);
+    if (this.podYaml !== this.yaml && this.selection === 'pod') {
+      this.yaml = this.podYaml;
+    }
+  }
+  get pod() {
+    return this.prvPod;
+  }
+
+  selectionChanged(option: Event) {
+    const value = 'value';
+    if (option[value] === 'notebook') {
+      this.selection = 'notebook';
+      this.yaml = this.notebookYaml;
+    } else if (option[value] === 'pod') {
+      this.selection = 'pod';
+      this.yaml = this.podYaml;
+    }
+  }
+
+  get notebookYaml() {
+    if (!this.notebook) {
+      return 'No data has been found...';
+    }
+
+    return dump(this.notebook);
+  }
+
+  ngOnInit() {
+    this.yaml = this.notebookYaml;
+  }
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/yaml/yaml.module.ts
@@ -1,0 +1,21 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { YamlComponent } from './yaml.component';
+import { MatTabsModule } from '@angular/material/tabs';
+import { EditorModule, KubeflowModule } from 'kubeflow';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+@NgModule({
+  declarations: [YamlComponent],
+  imports: [
+    CommonModule,
+    EditorModule,
+    MatTabsModule,
+    KubeflowModule,
+    MatSelectModule,
+    MatTooltipModule,
+  ],
+  exports: [YamlComponent],
+})
+export class YamlModule {}

--- a/components/crud-web-apps/jupyter/frontend/src/styles.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/styles.scss
@@ -6,3 +6,10 @@
 mat-form-field {
   margin-bottom: 0.25rem;
 }
+
+.yaml-tab-container {
+  .mat-form-field-flex > .mat-form-field-infix {
+    margin-bottom: -0.4em;
+    margin-top: -0.6em;
+  }
+}


### PR DESCRIPTION
This PR adds a YAML tab to the new JWA details page. It is part of the [Details page for each Notebooks/Volumes/TensorBoards](https://github.com/kubeflow/kubeflow/issues/6707) effort and a follow-up PR to [this](https://github.com/kubeflow/kubeflow/pull/6782). This tab presents to the user the full YAML both from the Notebook and from its underlying pod, when there is one.