### PR TITLE
Adding support for linux/ppc64le in CI for jupyter-web-app multi-arch…

### DIFF
--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -15,6 +15,11 @@ on:
       - components/crud-web-apps/jupyter/**
       - components/crud-web-apps/common/**
 
+env:
+  DOCKER_USER: kubeflownotebookswg
+  IMG: kubeflownotebookswg/jupyter-web-app
+  ARCH: linux/ppc64le,linux/amd64
+
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
@@ -27,18 +32,22 @@ jobs:
       if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
-        username: kubeflownotebookswg
+        username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run JWA build
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch docker image
       run: |
         cd components/crud-web-apps/jupyter
-        export IMG=kubeflownotebookswg/jupyter-web-app
-        make docker-build
+        make docker-build-multi-arch
 
-    - name: Run JWA push
+    - name: Build and push multi-arch docker image
       if: github.event_name == 'push'
       run: |
-        cd components/crud-web-apps/jupyter
-        export IMG=kubeflownotebookswg/jupyter-web-app
-        make docker-push
+          cd components/crud-web-apps/jupyter
+          make docker-build-push-multi-arch

--- a/components/crud-web-apps/jupyter/Makefile
+++ b/components/crud-web-apps/jupyter/Makefile
@@ -1,6 +1,7 @@
 IMG ?= jupyter-web-app
 TAG ?= $(shell git describe --tags --always --dirty)
 DOCKERFILE ?= jupyter/Dockerfile
+ARCH ?= linux/amd64
 
 
 docker-build:
@@ -8,5 +9,14 @@ docker-build:
 
 docker-push:
 	docker push $(IMG):$(TAG)
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
+	cd ../ && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} -f ${DOCKERFILE} .
+
+
+.PHONY: docker-build-push-multi-arch
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
+	cd ../ && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push -f ${DOCKERFILE} .
 
 image: docker-build docker-push


### PR DESCRIPTION
- The workflow "JWA_Docker_Publish" releases docker image for Linux-amd64.
- Added docker-build-multi-arch and build-push-multi-arch targets in the Makefile of the Jupyter-web-app component
- Dropping docker-build and docker-push from the workflow.
- Keeping these steps will increase the workflow runtime.
- Docker-build-push-multi-arch builds and pushes the images for Linux-amd64 and Linux-ppc64le
- Below are the link to the workflow running from my fork and the published images.
     Build Results Link:- https://github.com/amitmukati-2604/kubeflow/actions/runs/3591449860
     Published Image Link:- https://hub.docker.com/r/amitmukati2604/jupyter-web-app/tags