### PR TITLE
Adding support for linux/ppc64le in CI for tensorboard-controller multi-arch docker images.

### DIFF
--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -13,6 +13,11 @@ on:
     paths:
       - components/tensorboard-controller/**
 
+env:
+  DOCKER_USER: kubeflownotebookswg
+  IMG: kubeflownotebookswg/tensorboard-controller
+  ARCH: linux/ppc64le,linux/amd64
+
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
@@ -25,18 +30,22 @@ jobs:
       if: github.event_name == 'push'
       uses: docker/login-action@v2
       with:
-        username: kubeflownotebookswg
+        username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
+        
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
 
-    - name: Run Tensorboard Controller build
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch docker image
       run: |
         cd components/tensorboard-controller
-        export IMG=kubeflownotebookswg/tensorboard-controller
-        make docker-build
-
-    - name: Run Tensorboard Controller push
+        make docker-build-multi-arch
+        
+    - name: Build  and push multi-arch docker image
       if: github.event_name == 'push'
       run: |
         cd components/tensorboard-controller
-        export IMG=kubeflownotebookswg/tensorboard-controller
-        make docker-push
+        make docker-build-push-multi-arch

--- a/components/tensorboard-controller/Makefile
+++ b/components/tensorboard-controller/Makefile
@@ -1,6 +1,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= tensorboard-controller
 TAG ?= $(shell git describe --tags --always --dirty)
+ARCH ?= linux/amd64
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
@@ -78,6 +79,15 @@ docker-build:
 .PHONY: docker-push
 docker-push:
 	docker push ${IMG}:${TAG}
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
+	cd ../ && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} -f tensorboard-controller/Dockerfile .
+
+
+.PHONY: docker-build-push-multi-arch
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
+	cd ../ && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push -f tensorboard-controller/Dockerfile .
 
 ##@ Deployment
 


### PR DESCRIPTION
- The workflow "TB_Controller_Docker_Publish" releases docker image for Linux-amd64.
- Added docker-build-multi-arch and build-push-multi-arch targets in the Makefile of the Tensorboard-controller component.
- Dropping docker-build and docker-push from the workflow.
- Keeping these steps will increase the workflow runtime.
- Docker-build-push-multi-arch builds and pushes the images for Linux-amd64 and Linux-ppc64le
- Below are the link to the workflow running from my fork and the published images.
     Build Result Link:- https://github.com/amitmukati-2604/kubeflow/actions/runs/3619078575
     Publish image Link:- https://hub.docker.com/r/amitmukati2604/tensorboard-controller/tags