### PR TITLE
vwa: Add EVENTS tab to Volume details page

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
@@ -30,6 +30,16 @@ def get_pvc(pvc, namespace):
     )
     return v1_core.read_namespaced_persistent_volume_claim(pvc, namespace)
 
+def list_pvc_events(namespace, pvc_name):
+    authz.ensure_authorized(
+        "list", "", "v1", "events", namespace
+    )
+
+    field_selector = "involvedObject.kind=PersistentVolumeClaim,involvedObject.name=" + pvc_name
+    return v1_core.list_namespaced_event(
+        namespace=namespace, field_selector=field_selector
+    )
+
 def patch_pvc(name, namespace, pvc, auth=True):
     if auth:
         authz.ensure_authorized("patch", "", "v1", "persistentvolumeclaims",

--- a/components/crud-web-apps/volumes/backend/apps/default/routes/get.py
+++ b/components/crud-web-apps/volumes/backend/apps/default/routes/get.py
@@ -24,3 +24,9 @@ def get_pvc_pods(namespace, pvc_name):
     pods = utils.get_pods_using_pvc(pvc_name, namespace)
 
     return api.success_response("pods", api.serialize(pods))
+
+@bp.route("/api/namespaces/<namespace>/pvcs/<pvc_name>/events")
+def get_pvc_events(namespace, pvc_name):
+    events = api.list_pvc_events(namespace, pvc_name).items
+
+    return api.success_response("events", api.serialize(events))

--- a/components/crud-web-apps/volumes/backend/apps/rok/routes/get.py
+++ b/components/crud-web-apps/volumes/backend/apps/rok/routes/get.py
@@ -35,3 +35,9 @@ def get_pvc_pods(namespace, pvc_name):
     pods = get_pods_using_pvc(pvc_name, namespace)
 
     return api.success_response("pods", api.serialize(pods))
+
+@bp.route("/api/namespaces/<namespace>/pvcs/<pvc_name>/events")
+def get_pvc_events(namespace, pvc_name):
+    events = api.list_pvc_events(namespace, pvc_name).items
+
+    return api.success_response("events", api.serialize(events))

--- a/components/crud-web-apps/volumes/frontend/angular.json
+++ b/components/crud-web-apps/volumes/frontend/angular.json
@@ -163,7 +163,8 @@
             "styles": [
               "src/styles.scss"
             ],
-            "scripts": []
+            "scripts": [],
+            "preserveSymlinks": true
           }
         },
         "lint": {

--- a/components/crud-web-apps/volumes/frontend/src/app/app.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/app.component.spec.ts
@@ -3,33 +3,16 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        imports: [RouterTestingModule],
-        declarations: [AppComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      declarations: [AppComponent],
+    }).compileComponents();
+  }));
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
-  });
-
-  it(`should have as title 'frontend'`, () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('frontend');
-  });
-
-  it('should render title', () => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('.content span').textContent).toContain(
-      'frontend app is running!',
-    );
   });
 });

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-default/form-default.component.spec.ts
@@ -1,18 +1,55 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { KubeflowModule } from 'kubeflow';
+import { of } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
 
 import { FormDefaultComponent } from './form-default.component';
+
+let VWABackendServiceStub: Partial<VWABackendService>;
+let FormBuilderStub: Partial<FormBuilder>;
+
+VWABackendServiceStub = {
+  getStorageClasses: () => of(),
+  getDefaultStorageClass: () => of(),
+  getPVCs: () => of(),
+  createPVC: () => of(),
+};
+
+function getFormDefaults(): FormGroup {
+  const fb = new FormBuilder();
+
+  return fb.group({
+    type: ['empty', [Validators.required]],
+    name: ['', [Validators.required]],
+    namespace: ['', [Validators.required]],
+    size: [10, []],
+    class: ['$empty', [Validators.required]],
+    mode: ['ReadWriteOnce', [Validators.required]],
+  });
+}
+const mockFormGroup: FormGroup = getFormDefaults();
+
+FormBuilderStub = {
+  group: () => mockFormGroup,
+};
 
 describe('FormDefaultComponent', () => {
   let component: FormDefaultComponent;
   let fixture: ComponentFixture<FormDefaultComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [FormDefaultComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [FormDefaultComponent],
+      providers: [
+        { provide: FormBuilder, useValue: FormBuilderStub },
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: MatDialogRef, useValue: {} },
+      ],
+      imports: [KubeflowModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FormDefaultComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-rok/form-rok.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-rok/form-rok.component.spec.ts
@@ -1,18 +1,70 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+import { BackendService, KubeflowModule, RokService } from 'kubeflow';
+import { Observable, of } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
 
 import { FormRokComponent } from './form-rok.component';
+let VWABackendServiceStub: Partial<VWABackendService>;
+let FormBuilderStub: Partial<FormBuilder>;
+let RokServiceStub: Partial<RokService>;
+let MockBackendService: Partial<BackendService>;
+
+VWABackendServiceStub = {
+  getStorageClasses: () => of(),
+  getDefaultStorageClass: () => of(),
+  getPVCs: () => of(),
+  createPVC: () => of(),
+};
+
+function getFormDefaults(): FormGroup {
+  const fb = new FormBuilder();
+
+  return fb.group({
+    type: ['empty', [Validators.required]],
+    name: ['', [Validators.required]],
+    namespace: ['', [Validators.required]],
+    size: [10, []],
+    class: ['$empty', [Validators.required]],
+    mode: ['ReadWriteOnce', [Validators.required]],
+  });
+}
+const mockFormGroup: FormGroup = getFormDefaults();
+
+FormBuilderStub = {
+  group: () => mockFormGroup,
+};
+
+RokServiceStub = {
+  initCSRF: () => {},
+  getObjectMetadata: () => of(),
+  getRokManagedStorageClasses: () => of(),
+};
+
+MockBackendService = {
+  getNamespaces(): Observable<string[]> {
+    return of([]);
+  },
+};
 
 describe('FormRokComponent', () => {
   let component: FormRokComponent;
   let fixture: ComponentFixture<FormRokComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [FormRokComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [FormRokComponent],
+      providers: [
+        { provide: FormBuilder, useValue: FormBuilderStub },
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: MatDialogRef, useValue: {} },
+        { provide: RokService, useValue: RokServiceStub },
+        { provide: BackendService, useValue: MockBackendService },
+      ],
+      imports: [KubeflowModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FormRokComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.spec.ts
@@ -1,18 +1,62 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+  BackendService,
+  ConfirmDialogService,
+  KubeflowModule,
+  NamespaceService,
+  PollerService,
+  SnackBarService,
+} from 'kubeflow';
+import { Observable, of } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
 
 import { IndexDefaultComponent } from './index-default.component';
+
+let VWABackendServiceStub: Partial<VWABackendService>;
+let SnackBarServiceStub: Partial<SnackBarService>;
+let NamespaceServiceStub: Partial<NamespaceService>;
+let MockBackendService: Partial<BackendService>;
+
+VWABackendServiceStub = {
+  getPVCs: () => of(),
+};
+
+SnackBarServiceStub = {
+  open: () => {},
+  close: () => {},
+};
+
+NamespaceServiceStub = {
+  getSelectedNamespace: () => of(),
+  getSelectedNamespace2: () => of(),
+};
+
+MockBackendService = {
+  getNamespaces(): Observable<string[]> {
+    return of([]);
+  },
+};
 
 describe('IndexDefaultComponent', () => {
   let component: IndexDefaultComponent;
   let fixture: ComponentFixture<IndexDefaultComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [IndexDefaultComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [IndexDefaultComponent],
+      providers: [
+        { provide: ConfirmDialogService, useValue: {} },
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: SnackBarService, useValue: SnackBarServiceStub },
+        { provide: NamespaceService, useValue: NamespaceServiceStub },
+        { provide: PollerService, useValue: {} },
+        { provide: BackendService, useValue: MockBackendService },
+      ],
+      imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IndexDefaultComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.spec.ts
@@ -1,18 +1,69 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import {
+  BackendService,
+  ConfirmDialogService,
+  KubeflowModule,
+  NamespaceService,
+  PollerService,
+  RokService,
+  SnackBarService,
+} from 'kubeflow';
+import { VWABackendService } from 'src/app/services/backend.service';
+import { Observable, of } from 'rxjs';
 
 import { IndexRokComponent } from './index-rok.component';
+import { MatDialogModule } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
+
+let VWABackendServiceStub: Partial<VWABackendService>;
+let SnackBarServiceStub: Partial<SnackBarService>;
+let NamespaceServiceStub: Partial<NamespaceService>;
+let MockBackendService: Partial<BackendService>;
+let RokServiceStub: Partial<RokService>;
+
+VWABackendServiceStub = {
+  getPVCs: () => of(),
+};
+
+SnackBarServiceStub = {
+  open: () => {},
+  close: () => {},
+};
+
+NamespaceServiceStub = {
+  getSelectedNamespace: () => of(),
+  getSelectedNamespace2: () => of(),
+};
+
+MockBackendService = {
+  getNamespaces(): Observable<string[]> {
+    return of([]);
+  },
+};
+
+RokServiceStub = {
+  initCSRF: () => {},
+};
 
 describe('IndexRokComponent', () => {
   let component: IndexRokComponent;
   let fixture: ComponentFixture<IndexRokComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [IndexRokComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [IndexRokComponent],
+      providers: [
+        { provide: ConfirmDialogService, useValue: {} },
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: SnackBarService, useValue: SnackBarServiceStub },
+        { provide: NamespaceService, useValue: NamespaceServiceStub },
+        { provide: PollerService, useValue: {} },
+        { provide: BackendService, useValue: MockBackendService },
+        { provide: RokService, useValue: RokServiceStub },
+      ],
+      imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IndexRokComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.ts
@@ -18,6 +18,7 @@ import { FormRokComponent } from '../../form/form-rok/form-rok.component';
 import { rokConfig } from './config';
 import { PVCProcessedObjectRok, PVCResponseObjectRok } from 'src/app/types';
 import { Router } from '@angular/router';
+import { ActionsService } from 'src/app/services/actions.service';
 
 @Component({
   selector: 'app-index-rok',
@@ -38,8 +39,18 @@ export class IndexRokComponent
     public rok: RokService,
     public poller: PollerService,
     public router: Router,
+    public actions: ActionsService,
   ) {
-    super(ns, confirmDialog, backend, dialog, snackBar, poller, router);
+    super(
+      ns,
+      confirmDialog,
+      backend,
+      dialog,
+      snackBar,
+      poller,
+      router,
+      actions,
+    );
   }
 
   ngOnInit() {

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index.component.spec.ts
@@ -1,18 +1,63 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MatDialogModule } from '@angular/material/dialog';
+import { RouterTestingModule } from '@angular/router/testing';
+import {
+  BackendService,
+  ConfirmDialogService,
+  KubeflowModule,
+  NamespaceService,
+  PollerService,
+  SnackBarService,
+} from 'kubeflow';
+import { Observable, of } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
+import { IndexDefaultComponent } from './index-default/index-default.component';
 
 import { IndexComponent } from './index.component';
+
+let VWABackendServiceStub: Partial<VWABackendService>;
+let SnackBarServiceStub: Partial<SnackBarService>;
+let NamespaceServiceStub: Partial<NamespaceService>;
+let MockBackendService: Partial<BackendService>;
+
+VWABackendServiceStub = {
+  getPVCs: () => of(),
+};
+
+SnackBarServiceStub = {
+  open: () => {},
+  close: () => {},
+};
+
+NamespaceServiceStub = {
+  getSelectedNamespace: () => of(),
+  getSelectedNamespace2: () => of(),
+};
+
+MockBackendService = {
+  getNamespaces(): Observable<string[]> {
+    return of([]);
+  },
+};
 
 describe('IndexComponent', () => {
   let component: IndexComponent;
   let fixture: ComponentFixture<IndexComponent>;
 
-  beforeEach(
-    waitForAsync(() => {
-      TestBed.configureTestingModule({
-        declarations: [IndexComponent],
-      }).compileComponents();
-    }),
-  );
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      declarations: [IndexComponent, IndexDefaultComponent],
+      providers: [
+        { provide: ConfirmDialogService, useValue: {} },
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: SnackBarService, useValue: SnackBarServiceStub },
+        { provide: NamespaceService, useValue: NamespaceServiceStub },
+        { provide: PollerService, useValue: {} },
+        { provide: BackendService, useValue: MockBackendService },
+      ],
+      imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
+    }).compileComponents();
+  }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IndexComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/config.ts
@@ -1,0 +1,47 @@
+import { PropertyValue, TableConfig, DateTimeValue } from 'kubeflow';
+
+// --- Config for the Resource Table ---
+export const defaultConfig: TableConfig = {
+  dynamicNamespaceColumn: true,
+  columns: [
+    {
+      matHeaderCellDef: $localize`Type`,
+      matColumnDef: 'type',
+      style: { width: '12%' },
+      value: new PropertyValue({
+        field: 'type',
+        tooltipField: 'type',
+        truncate: true,
+      }),
+      sort: true,
+    },
+    {
+      matHeaderCellDef: $localize`Reason`,
+      matColumnDef: 'reason',
+      style: { width: '12%' },
+      value: new PropertyValue({
+        field: 'reason',
+        tooltipField: 'reason',
+        truncate: true,
+      }),
+      sort: true,
+    },
+    {
+      matHeaderCellDef: $localize`Created at`,
+      matColumnDef: 'age',
+      style: { width: '12%' },
+      value: new DateTimeValue({ field: 'metadata.creationTimestamp' }),
+      sort: true,
+    },
+    {
+      matHeaderCellDef: $localize`Message`,
+      matColumnDef: 'message',
+      value: new PropertyValue({
+        field: 'message',
+        tooltipField: 'message',
+        truncate: true,
+      }),
+      sort: true,
+    },
+  ],
+};

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.component.html
@@ -1,0 +1,3 @@
+<div class="page-padding lib-flex-grow lib-overflow-auto">
+  <lib-table [config]="config" [data]="events"></lib-table>
+</div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.component.spec.ts
@@ -1,0 +1,41 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { KubeflowModule, PollerService } from 'kubeflow';
+import { VWABackendService } from 'src/app/services/backend.service';
+import { of } from 'rxjs';
+import { EventsComponent } from './events.component';
+
+let VWABackendServiceStub: Partial<VWABackendService>;
+let PollerServiceStub: Partial<PollerService>;
+
+VWABackendServiceStub = {
+  getPVCEvents: () => of(),
+};
+PollerServiceStub = {
+  exponential: () => of(),
+};
+
+describe('EventsComponent', () => {
+  let component: EventsComponent;
+  let fixture: ComponentFixture<EventsComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [EventsComponent],
+      imports: [KubeflowModule],
+      providers: [
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: PollerService, useValue: PollerServiceStub },
+      ],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EventsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { V1PersistentVolumeClaim } from '@kubernetes/client-node';
+import { PollerService } from 'kubeflow';
+import { Subscription } from 'rxjs';
+import { VWABackendService } from 'src/app/services/backend.service';
+import { EventObject } from 'src/app/types/event';
+import { defaultConfig } from './config';
+
+@Component({
+  selector: 'app-events',
+  templateUrl: './events.component.html',
+  styleUrls: ['./events.component.scss'],
+})
+export class EventsComponent implements OnInit, OnDestroy {
+  public events: EventObject[] = [];
+  private prvPvc: V1PersistentVolumeClaim;
+
+  config = defaultConfig;
+  pollSub = new Subscription();
+
+  constructor(
+    public backend: VWABackendService,
+    public poller: PollerService,
+  ) {}
+
+  ngOnInit(): void {}
+
+  ngOnDestroy() {
+    if (this.pollSub) {
+      this.pollSub.unsubscribe();
+    }
+  }
+
+  @Input()
+  set pvc(pvc: V1PersistentVolumeClaim) {
+    this.prvPvc = pvc;
+    this.poll(pvc);
+  }
+  get pvc(): V1PersistentVolumeClaim {
+    return this.prvPvc;
+  }
+
+  private poll(pvc: V1PersistentVolumeClaim) {
+    this.pollSub.unsubscribe();
+
+    const request = this.backend.getPVCEvents(pvc);
+
+    this.pollSub = this.poller.exponential(request).subscribe(events => {
+      this.events = events;
+    });
+  }
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/events.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { EventsComponent } from './events.component';
+import { KubeflowModule } from 'kubeflow';
+
+@NgModule({
+  declarations: [EventsComponent],
+  imports: [CommonModule, KubeflowModule],
+  exports: [EventsComponent],
+})
+export class EventsModule {}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.html
@@ -26,6 +26,12 @@
         <mat-tab label="OVERVIEW">
           <app-overview [pvc]="pvc"></app-overview>
         </mat-tab>
+
+        <mat-tab label="EVENTS">
+          <ng-template matTabContent>
+            <app-events [pvc]="pvc"></app-events>
+          </ng-template>
+        </mat-tab>
       </mat-tab-group>
     </ng-container>
   </div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.ts
@@ -2,12 +2,14 @@ import { Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { V1PersistentVolumeClaim } from '@kubernetes/client-node';
 import {
+  DIALOG_RESP,
   NamespaceService,
   PollerService,
   STATUS_TYPE,
   ToolbarButton,
 } from 'kubeflow';
 import { Subscription } from 'rxjs';
+import { ActionsService } from 'src/app/services/actions.service';
 import { VWABackendService } from 'src/app/services/backend.service';
 
 @Component({
@@ -20,7 +22,16 @@ export class VolumeDetailsPageComponent implements OnInit, OnDestroy {
   public namespace: string;
   public pvc: V1PersistentVolumeClaim;
   public pvcInfoLoaded = false;
-  public buttonsConfig: ToolbarButton[] = [];
+  public buttonsConfig: ToolbarButton[] = [
+    new ToolbarButton({
+      text: 'DELETE',
+      icon: 'delete',
+      tooltip: 'Delete this volume',
+      fn: () => {
+        this.deleteVolume();
+      },
+    }),
+  ];
 
   pollSub = new Subscription();
 
@@ -29,6 +40,7 @@ export class VolumeDetailsPageComponent implements OnInit, OnDestroy {
     public backend: VWABackendService,
     public poller: PollerService,
     public router: Router,
+    public actions: ActionsService,
     private route: ActivatedRoute,
   ) {}
 
@@ -60,6 +72,15 @@ export class VolumeDetailsPageComponent implements OnInit, OnDestroy {
 
   navigateBack() {
     this.router.navigate(['']);
+  }
+
+  private deleteVolume() {
+    this.actions.deleteVolume(this.name, this.namespace).subscribe(result => {
+      if (result !== DIALOG_RESP.ACCEPT) {
+        return;
+      }
+      this.navigateBack();
+    });
   }
 
   get status(): STATUS_TYPE {

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.module.ts
@@ -4,9 +4,16 @@ import { VolumeDetailsPageComponent } from './volume-details-page.component';
 import { KubeflowModule } from 'kubeflow';
 import { MatTabsModule } from '@angular/material/tabs';
 import { OverviewModule } from './overview/overview.module';
+import { EventsModule } from './events/events.module';
 
 @NgModule({
   declarations: [VolumeDetailsPageComponent],
-  imports: [CommonModule, KubeflowModule, MatTabsModule, OverviewModule],
+  imports: [
+    CommonModule,
+    KubeflowModule,
+    MatTabsModule,
+    OverviewModule,
+    EventsModule,
+  ],
 })
 export class VolumeDetailsPageModule {}

--- a/components/crud-web-apps/volumes/frontend/src/app/services/actions.service.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/services/actions.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+import { ConfirmDialogService, SnackBarService } from 'kubeflow';
+import { of } from 'rxjs';
+import { ActionsService } from './actions.service';
+import { VWABackendService } from './backend.service';
+
+let VWABackendServiceStub: Partial<VWABackendService>;
+let SnackBarServiceStub: Partial<SnackBarService>;
+
+VWABackendServiceStub = {
+  deletePVC: () => of(),
+};
+SnackBarServiceStub = {
+  open: () => {},
+};
+
+describe('ActionsService', () => {
+  let service: ActionsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ConfirmDialogService, useValue: {} },
+        { provide: VWABackendService, useValue: VWABackendServiceStub },
+        { provide: SnackBarService, useValue: SnackBarServiceStub },
+      ],
+    });
+    service = TestBed.inject(ActionsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/volumes/frontend/src/app/services/actions.service.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/services/actions.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+import {
+  ConfirmDialogService,
+  DialogConfig,
+  DIALOG_RESP,
+  SnackBarService,
+  SnackType,
+} from 'kubeflow';
+import { Observable } from 'rxjs';
+import { VWABackendService } from './backend.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ActionsService {
+  constructor(
+    public confirmDialog: ConfirmDialogService,
+    public backend: VWABackendService,
+    public snackBar: SnackBarService,
+  ) {}
+
+  deleteVolume(name: string, namespace: string): Observable<string> {
+    return new Observable(subscriber => {
+      const deleteDialogConfig = this.getDeleteDialogConfig(name);
+
+      const ref = this.confirmDialog.open(name, deleteDialogConfig);
+      const delSub = ref.componentInstance.applying$.subscribe(applying => {
+        if (!applying) {
+          return;
+        }
+
+        // Close the open dialog only if the DELETE request succeeded
+        this.backend.deletePVC(namespace, name).subscribe({
+          next: _ => {
+            ref.close(DIALOG_RESP.ACCEPT);
+
+            const object = `${namespace}/${name}`;
+            this.snackBar.open(
+              `${object}: Delete request was sent.`,
+              SnackType.Info,
+              3000,
+            );
+          },
+          error: err => {
+            const errorMsg = `Error ${err}`;
+            deleteDialogConfig.error = errorMsg;
+            ref.componentInstance.applying$.next(false);
+            subscriber.next('fail');
+          },
+        });
+
+        // DELETE request has succeeded
+        ref.afterClosed().subscribe(result => {
+          delSub.unsubscribe();
+          subscriber.next(result);
+          subscriber.complete();
+        });
+      });
+    });
+  }
+
+  private getDeleteDialogConfig(name: string): DialogConfig {
+    return {
+      title: $localize`Are you sure you want to delete this volume? ${name}`,
+      message: $localize`Warning: All data in this volume will be lost.`,
+      accept: $localize`DELETE`,
+      confirmColor: 'warn',
+      cancel: $localize`CANCEL`,
+      error: '',
+      applying: $localize`DELETING`,
+      width: '600px',
+    };
+  }
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.spec.ts
@@ -1,12 +1,19 @@
 import { TestBed } from '@angular/core/testing';
-
 import { VWABackendService } from './backend.service';
 import { HttpClientModule } from '@angular/common/http';
+import { SnackBarService } from 'kubeflow';
+
+let SnackBarServiceStub: Partial<SnackBarService>;
+
+SnackBarServiceStub = {
+  open: () => {},
+};
 
 describe('VWABackendService', () => {
   beforeEach(() =>
     TestBed.configureTestingModule({
       imports: [HttpClientModule],
+      providers: [{ provide: SnackBarService, useValue: SnackBarServiceStub }],
     }),
   );
 

--- a/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/services/backend.service.ts
@@ -5,6 +5,7 @@ import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import { PVCResponseObject, VWABackendResponse, PVCPostObject } from '../types';
 import { V1PersistentVolumeClaim, V1Pod } from '@kubernetes/client-node';
+import { EventObject } from '../types/event';
 
 @Injectable({
   providedIn: 'root',
@@ -51,6 +52,19 @@ export class VWABackendService extends BackendService {
     return this.http.get<VWABackendResponse>(url).pipe(
       catchError(error => this.handleError(error)),
       map((resp: VWABackendResponse) => resp.pvc),
+    );
+  }
+
+  public getPVCEvents(pvc: V1PersistentVolumeClaim): Observable<EventObject[]> {
+    const namespace = pvc.metadata.namespace;
+    const pvcName = pvc.metadata.name;
+    const url = `api/namespaces/${namespace}/pvcs/${pvcName}/events`;
+
+    return this.http.get<VWABackendResponse>(url).pipe(
+      catchError(error => this.handleError(error)),
+      map((resp: VWABackendResponse) => {
+        return resp.events;
+      }),
     );
   }
 

--- a/components/crud-web-apps/volumes/frontend/src/app/types/backend.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/types/backend.ts
@@ -1,9 +1,11 @@
 import { V1PersistentVolumeClaim, V1Pod } from '@kubernetes/client-node';
 import { Status, BackendResponse } from 'kubeflow';
+import { EventObject } from './event';
 
 export interface VWABackendResponse extends BackendResponse {
   pvcs?: PVCResponseObject[];
   pvc?: V1PersistentVolumeClaim;
+  events?: EventObject[];
   pods?: V1Pod[];
 }
 

--- a/components/crud-web-apps/volumes/frontend/src/app/types/event.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/types/event.ts
@@ -1,0 +1,5 @@
+import { EventsV1Event } from '@kubernetes/client-node';
+
+export interface EventObject extends EventsV1Event {
+  message?: string;
+}


### PR DESCRIPTION
This PR is part of the [Details page for each Notebooks/Volumes/TensorBoards](https://github.com/kubeflow/kubeflow/issues/6707) effort and a follow-up PR to [this](https://github.com/kubeflow/kubeflow/pull/6788). 

 - This adds an EVENTS tab to the new VWA details page. The goal of this tab is to present `Events` as we view them with `kubectl describe persistentvolumeclaim <pvc-name> -n <namespace>`.
 - Fixes unit VWA tests
 - Adds Delete Button to details page