### PR TITLE
vwa: Update cluster role to list notebooks

### DIFF
--- a/components/crud-web-apps/volumes/manifests/base/cluster-role.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/cluster-role.yaml
@@ -43,6 +43,12 @@ rules:
   - events
   verbs:
   - list
+- apiGroups:
+  - kubeflow.org
+  resources:
+  - notebooks
+  verbs:
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
This is a complimentary PR to this https://github.com/kubeflow/kubeflow/pull/6788 and part of the [Details page for each Notebooks/Volumes/TensorBoards](https://github.com/kubeflow/kubeflow/issues/6707) effort. We need this in order to be able to show notebooks related to a PVC inside VWA.