### PR TITLE
Adding support for linux-ppc64le in CI for profile-controller

### DIFF
--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -13,30 +13,39 @@ on:
     paths:
       - components/profile-controller/**
 
+env:
+  DOCKER_USER: kubeflownotebookswg
+  IMG: kubeflownotebookswg/profile-controller
+  ARCH: linux/ppc64le,linux/amd64
+
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Login to DockerHub
-      if: github.event_name == 'push'
-      uses: docker/login-action@v2
-      with:
-        username: kubeflownotebookswg
-        password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
+      - name: Login to DockerHub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v2
+        with:
+          username: kubeflownotebookswg
+          password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run Profile Controller build
-      run: |
-        cd components/profile-controller
-        export IMG=kubeflownotebookswg/profile-controller
-        make docker-build
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
 
-    - name: Run Profile Controller push
-      if: github.event_name == 'push'
-      run: |
-        cd components/profile-controller
-        export IMG=kubeflownotebookswg/profile-controller
-        make docker-push
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build multi-arch docker image
+        run: |
+          cd components/profile-controller
+          make docker-build-multi-arch
+
+      - name: Build  and push multi-arch docker image
+        if: github.event_name == 'push'
+        run: |
+          cd components/profile-controller
+          make docker-build-push-multi-arch

--- a/components/profile-controller/Makefile
+++ b/components/profile-controller/Makefile
@@ -1,6 +1,8 @@
 # Image URL to use all building/pushing image targets
 IMG ?= profile-controller
 TAG ?= $(shell git describe --tags --always --dirty)
+ARCH ?= linux/amd64
+
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.23
 
@@ -67,6 +69,14 @@ docker-build: ## Build docker image with the manager.
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
 	docker push ${IMG}:${TAG}
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} .
+
+.PHONY: docker-build-push-multi-arch
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push .
 
 .PHONY: image
 image: docker-build docker-push ## Build and push docker image with the manager.


### PR DESCRIPTION
* Adding support for linux-ppc64le in CI for profile-controller to release multi-arch-docker image
* Dropping the build profile-controller and push profile-controller from the workflow
*  Added build-multi-arch and build-push-multi-arch steps in workflow to build and push the multi-arch docker images for linux/amd64 and linux/ppc64le
*  Made the required changes in makefile for the same.