### PR TITLE
Adding support for linux-ppc64le in CI  to release multi-arch docker image volumes-web-app 

### DIFF
--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -15,30 +15,39 @@ on:
       - components/crud-web-apps/volumes/**
       - components/crud-web-apps/common/**
 
+env:
+  DOCKER_USER: kubeflownotebookswg
+  IMG: kubeflownotebookswg/volumes-web-app
+  ARCH: linux/ppc64le,linux/amd64
+
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Login to DockerHub
-      if: github.event_name == 'push'
-      uses: docker/login-action@v2
-      with:
-        username: kubeflownotebookswg
-        password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
+      - name: Login to DockerHub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ env.DOCKER_USER }}
+          password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Run VWA build
-      run: |
-        cd components/crud-web-apps/volumes
-        export IMG=kubeflownotebookswg/volumes-web-app
-        make docker-build
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v2
 
-    - name: Run VWA push
-      if: github.event_name == 'push'
-      run: |
-        cd components/crud-web-apps/volumes
-        export IMG=kubeflownotebookswg/volumes-web-app
-        make docker-push
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build multi-arch docker image
+        run: |
+          cd  components/crud-web-apps/volumes
+          make docker-build-multi-arch
+
+      - name: Build  and push multi-arch docker image
+        if: github.event_name == 'push'
+        run: |
+          cd  components/crud-web-apps/volumes
+          make docker-build-push-multi-arch

--- a/components/crud-web-apps/volumes/Makefile
+++ b/components/crud-web-apps/volumes/Makefile
@@ -1,11 +1,21 @@
 IMG ?= volumes-web-app
 TAG ?= $(shell git describe --tags --always --dirty)
+ARCH ?= linux/amd64
 
 docker-build:
 	docker build -t ${IMG}:${TAG} -f Dockerfile ..
 
 docker-push:
 	docker push $(IMG):$(TAG)
+
+
+.PHONY: docker-build-multi-arch
+docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} -f Dockerfile ..
+
+.PHONY: docker-build-push-multi-arch
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push -f Dockerfile ..
 
 image: docker-build docker-push
 	@echo "Updated image ${IMG}:${TAG}"


### PR DESCRIPTION
* Adding support for linux-ppc64le in CI to release  multi-arch docker image of volumes-web-app for linux/amd64 and linux/ppc64le
*  Dropping build build and push steps from the workflow 
*  replacing with build-multi-arch and build-push-multi-arch steps 
*  Made the required changes in Makefile of volumes-web-app 