### PR TITLE
jwa(front): Add details page functionalities & unit tests

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/conditions-table.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/conditions-table.component.ts
@@ -30,6 +30,17 @@ export class ConditionsTableComponent {
         condition.statusPhase = STATUS_TYPE.READY;
       }
 
+      // Set default values that are necessary for sorting functionality
+      if (!condition.lastTransitionTime) {
+        condition.lastTransitionTime = '';
+      }
+      if (!condition.message) {
+        condition.message = '';
+      }
+      if (!condition.reason) {
+        condition.reason = '';
+      }
+
       condition.statusMessage = condition.status;
     }
   }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/config.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/config.ts
@@ -20,6 +20,7 @@ export function generateConfig(): TableConfig {
           fieldPhase: 'statusPhase',
           fieldMessage: 'statusMessage',
         }),
+        sort: true,
       },
       {
         matHeaderCellDef: 'Type',
@@ -28,6 +29,7 @@ export function generateConfig(): TableConfig {
         value: new PropertyValue({
           field: 'type',
         }),
+        sort: true,
       },
       {
         matHeaderCellDef: 'Last Transition Time',
@@ -36,6 +38,7 @@ export function generateConfig(): TableConfig {
         value: new DateTimeValue({
           field: 'lastTransitionTime',
         }),
+        sort: true,
       },
       {
         matHeaderCellDef: 'Reason',
@@ -44,6 +47,7 @@ export function generateConfig(): TableConfig {
         value: new PropertyValue({
           field: 'reason',
         }),
+        sort: true,
       },
       {
         matHeaderCellDef: 'Message',
@@ -52,6 +56,7 @@ export function generateConfig(): TableConfig {
         value: new PropertyValue({
           field: 'message',
         }),
+        sort: true,
       },
     ],
   };

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/backend/backend.service.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/backend/backend.service.ts
@@ -174,7 +174,7 @@ export class BackendService {
   public handleError(
     error: HttpErrorResponse | ErrorEvent | string,
     showSnackBar = true,
-  ) {
+  ): Observable<never> {
     // The backend returned an unsuccessful response code.
     // The response body may contain clues as to what went wrong,
     console.error(error);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.scss
@@ -42,11 +42,8 @@
 }
 
 .toolbar-buttons {
+  display: flex;
   margin: auto 0px;
-}
-
-.toolbar-button {
-  margin-left: 0.2rem;
 }
 
 .toolbar-buttons .toolbar-button:last-child {

--- a/components/crud-web-apps/jupyter/frontend/.eslintrc.json
+++ b/components/crud-web-apps/jupyter/frontend/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "root": true,
   "ignorePatterns": [
-    "projects/**/*"
+    "projects/**/*",
+    "src/app/pages/notebook-page/pod-mock.ts"
   ],
   "overrides": [
     {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/config.ts
@@ -5,42 +5,12 @@ import {
   ActionIconValue,
   ActionButtonValue,
   MenuValue,
-  DialogConfig,
   ComponentValue,
   TableConfig,
   DateTimeValue,
 } from 'kubeflow';
 import { ServerTypeComponent } from './server-type/server-type.component';
 import { quantityToScalar } from '@kubernetes/client-node/dist/util';
-
-// --- Configs for the Confirm Dialogs ---
-export function getDeleteDialogConfig(name: string): DialogConfig {
-  return {
-    title: $localize`Are you sure you want to delete this notebook server? ${name}`,
-    message: $localize`Warning: Your data might be lost if the notebook server
-                       is not backed by persistent storage`,
-    accept: $localize`DELETE`,
-    confirmColor: 'warn',
-    cancel: $localize`CANCEL`,
-    error: '',
-    applying: $localize`DELETING`,
-    width: '600px',
-  };
-}
-
-export function getStopDialogConfig(name: string): DialogConfig {
-  return {
-    title: $localize`Are you sure you want to stop this notebook server? ${name}`,
-    message: $localize`Warning: Your data might be lost if the notebook server
-                       is not backed by persistent storage.`,
-    accept: $localize`STOP`,
-    confirmColor: 'primary',
-    cancel: $localize`CANCEL`,
-    error: '',
-    applying: $localize`STOPPING`,
-    width: '600px',
-  };
-}
 
 // --- Config for the Resource Table ---
 export const defaultConfig: TableConfig = {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-rok/index-rok.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-rok/index-rok.component.ts
@@ -10,6 +10,7 @@ import {
 import { JWABackendService } from 'src/app/services/backend.service';
 import { Router } from '@angular/router';
 import { IndexDefaultComponent } from '../index-default/index-default.component';
+import { ActionsService } from 'src/app/services/actions.service';
 
 @Component({
   selector: 'app-index-rok',
@@ -25,8 +26,9 @@ export class IndexRokComponent extends IndexDefaultComponent implements OnInit {
     public popup: SnackBarService,
     public router: Router,
     public poller: PollerService,
+    public actions: ActionsService,
   ) {
-    super(ns, backend, confirmDialog, popup, router, poller);
+    super(ns, backend, confirmDialog, popup, router, poller, actions);
 
     this.rok.initCSRF();
   }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-mock.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-mock.ts
@@ -1,0 +1,101 @@
+import {
+  V1ContainerState,
+  V1ObjectMeta,
+  V1PodSpec,
+} from '@kubernetes/client-node';
+import { Condition } from 'src/app/types/condition';
+import { NotebookRawObject } from 'src/app/types/notebook';
+
+const metadataObject: V1ObjectMeta = {
+  annotations: {
+    'notebooks.kubeflow.org/http-headers-request-set':
+      '{"X-RStudio-Root-Path":"/notebook/kubeflow-user/asa232rstudio/"}',
+    'notebooks.kubeflow.org/http-rewrite-uri': '/',
+    'notebooks.kubeflow.org/last-activity': '2022-08-09T15:55:44Z',
+    'notebooks.kubeflow.org/server-type': 'group-two',
+  },
+  creationTimestamp: new Date('2022-07-08T09:53:26Z'),
+  generation: 2,
+  labels: {
+    app: 'asa232rstudio',
+  },
+  name: 'asa232rstudio',
+  namespace: 'kubeflow-user',
+  resourceVersion: '38098090',
+  selfLink:
+    '/apis/kubeflow.org/v1beta1/namespaces/kubeflow-user/notebooks/asa232rstudio',
+  uid: '84039fed-3a47-482b-9b04-817456d1d751',
+};
+
+const innerSpecObject: V1PodSpec = {
+  containers: [
+    {
+      image:
+        'public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:master-e9324d39',
+      imagePullPolicy: 'IfNotPresent',
+      name: 'asa232rstudio',
+      resources: {
+        requests: {
+          cpu: '500m',
+          memory: '1Gi',
+        },
+      },
+      volumeMounts: [
+        { mountPath: '/dev/shm', name: 'dshm' },
+        { mountPath: '/home/jovyan', name: 'asa232rstudio-workspace' },
+      ],
+    },
+  ],
+  serviceAccountName: 'default-editor',
+  volumes: [
+    {
+      emptyDir: {
+        medium: 'Memory',
+      },
+      name: 'dshm',
+    },
+    {
+      name: 'asa232rstudio-workspace',
+      persistentVolumeClaim: {
+        claimName: 'asa232rstudio-workspace',
+      },
+    },
+  ],
+};
+
+const specObject = {
+  template: {
+    spec: innerSpecObject,
+  },
+};
+
+const conditionsObject: Condition[] = [
+  { lastProbeTime: '2022-08-10T07:19:14Z', type: 'Running' },
+  {
+    lastProbeTime: '2022-08-10T07:17:42Z',
+    message: 'Completed',
+    reason: 'Completed',
+    type: 'Terminated',
+  },
+  { lastProbeTime: '2022-08-09T15:55:50Z', type: 'Running' },
+];
+
+const containerStateObject: V1ContainerState = {
+  running: {
+    startedAt: new Date('2022-08-10T07:19:10Z'),
+  },
+};
+
+const statusObject = {
+  conditions: conditionsObject,
+  containerState: containerStateObject,
+  readyReplicas: 1,
+};
+
+export const mockNotebook: NotebookRawObject = {
+  apiVersion: 'kubeflow.org/v1beta1',
+  kind: 'Notebook',
+  metadata: metadataObject,
+  spec: specObject,
+  status: statusObject,
+};

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.html
@@ -20,7 +20,12 @@
           <div class="title">{{ notebookName }}</div>
         </div>
       </div>
-      <mat-tab-group dynamicHeight animationDuration="0ms">
+      <mat-tab-group
+        dynamicHeight
+        animationDuration="0ms"
+        (selectedTabChange)="onTabChange($event)"
+        [selectedIndex]="selectedTab.index"
+      >
         <mat-tab label="OVERVIEW">
           <ng-template matTabContent>
             <app-overview

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.spec.ts
@@ -1,20 +1,49 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  discardPeriodicTasks,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { JWABackendService } from 'src/app/services/backend.service';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 
 import { NotebookPageComponent } from './notebook-page.component';
 import { RouterTestingModule } from '@angular/router/testing';
-import { KubeflowModule, NamespaceService } from 'kubeflow';
+import { ActionsService } from 'src/app/services/actions.service';
+import { KubeflowModule, NamespaceService, STATUS_TYPE } from 'kubeflow';
+import { ActivatedRoute } from '@angular/router';
+import { By } from '@angular/platform-browser';
+import { MatTabsModule } from '@angular/material/tabs';
+import { OverviewModule } from './overview/overview.module';
+import { LogsModule } from './logs/logs.module';
+import { YamlModule } from './yaml/yaml.module';
+import { EventsModule } from './events/events.module';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { mockNotebook } from './notebook-mock';
 
 const JWABackendServiceStub: Partial<JWABackendService> = {
-  getNotebook: () => of(),
+  getPodDefaults: () => of(),
+  getNotebook: () => of(mockNotebook),
   getNotebookPod: () => of(),
+  getNotebookEvents: () => of(),
+};
+const ActionsServiceStub: Partial<ActionsService> = {
+  connectToNotebook: () => {},
+  deleteNotebook: () => of(),
+  startNotebook: () => of(),
+  stopNotebook: () => of(),
 };
 const NamespaceServiceStub: Partial<NamespaceService> = {
   updateSelectedNamespace: () => {},
+  getSelectedNamespace2: () => of(),
+};
+const ActivatedRouteStub: Partial<ActivatedRoute> = {
+  params: of({ namespace: 'kubeflow-user', notebookName: 'asa232rstudio' }),
+  queryParams: of({}),
 };
 
-describe('NotebookInfoComponent', () => {
+describe('NotebookPageComponent', () => {
   let component: NotebookPageComponent;
   let fixture: ComponentFixture<NotebookPageComponent>;
 
@@ -23,19 +52,136 @@ describe('NotebookInfoComponent', () => {
       declarations: [NotebookPageComponent],
       providers: [
         { provide: JWABackendService, useValue: JWABackendServiceStub },
+        { provide: ActionsService, useValue: ActionsServiceStub },
         { provide: NamespaceService, useValue: NamespaceServiceStub },
+        {
+          provide: ActivatedRoute,
+          useValue: ActivatedRouteStub,
+        },
       ],
-      imports: [KubeflowModule, RouterTestingModule],
+      imports: [
+        RouterTestingModule,
+        KubeflowModule,
+        MatTabsModule,
+        OverviewModule,
+        LogsModule,
+        EventsModule,
+        YamlModule,
+        HttpClientTestingModule,
+      ],
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NotebookPageComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should show only the proper tab according to query parameters', fakeAsync(() => {
+    const checkActiveTab = (name: string) => {
+      const activeTab = fixture.debugElement.query(By.css(`app-${name}`));
+      expect(activeTab).toBeTruthy();
+    };
+
+    const checkInactiveTabs = (name: string) => {
+      const allTabs = ['overview', 'logs', 'events', 'yaml'];
+      const indexOfActiveTab = allTabs.findIndex(v => v === name);
+      allTabs.splice(indexOfActiveTab, 1);
+
+      allTabs.forEach(tab => {
+        const inactiveTab = fixture.debugElement.query(By.css(`app-${tab}`));
+        if (!inactiveTab) {
+          expect(inactiveTab).toBeFalsy();
+        } else {
+          const parentElement = inactiveTab.parent.nativeElement;
+          const styles = getComputedStyle(parentElement);
+          expect(styles.overflow).toEqual('hidden');
+        }
+      });
+    };
+
+    const activatedRoute: ActivatedRoute = TestBed.inject(ActivatedRoute);
+    const queryParams = new Subject();
+    activatedRoute.queryParams = queryParams;
+    fixture.detectChanges();
+    activatedRoute.queryParams.subscribe(params => {
+      fixture.detectChanges();
+      tick();
+      checkActiveTab(params.tab);
+      checkInactiveTabs(params.tab);
+    });
+    queryParams.next({ tab: 'logs' });
+    queryParams.next({ tab: 'events' });
+    queryParams.next({ tab: 'overview' });
+    queryParams.next({ tab: 'yaml' });
+
+    discardPeriodicTasks();
+  }));
+
+  it('should switchTabs according to queryParams', fakeAsync(() => {
+    const checkActiveTabIndex = (name: string) => {
+      const allTabs = ['overview', 'logs', 'events', 'yaml'];
+      const expectedIndexOfActiveTab = allTabs.findIndex(v => v === name);
+      expect(component.selectedTab.index).toEqual(expectedIndexOfActiveTab);
+    };
+
+    const activatedRoute: ActivatedRoute = TestBed.inject(ActivatedRoute);
+    const queryParams = new Subject();
+    activatedRoute.queryParams = queryParams;
+    fixture.detectChanges();
+    activatedRoute.queryParams.subscribe(params => {
+      fixture.detectChanges();
+      tick();
+      checkActiveTabIndex(params.tab);
+    });
+    queryParams.next({ tab: 'logs' });
+    queryParams.next({ tab: 'events' });
+    queryParams.next({ tab: 'overview' });
+    queryParams.next({ tab: 'yaml' });
+
+    discardPeriodicTasks();
+  }));
+
+  it('updateButtons should disable buttons according to notebook status', () => {
+    fixture.detectChanges();
+    component.notebook.status.readyReplicas = 1;
+    component.notebook.metadata.annotations['kubeflow-resource-stopped'] =
+      'date now';
+    expect(component.status).toEqual(STATUS_TYPE.TERMINATING);
+    for (const button of component.buttonsConfig) {
+      expect(button.disabled).toBeFalse();
+    }
+
+    const updateButtons = 'updateButtons';
+    component[updateButtons]();
+    for (const button of component.buttonsConfig) {
+      expect(button.disabled).toBeTrue();
+    }
+  });
+
+  it('updateButtons should update Start/Stop button according to notebook status ', () => {
+    fixture.detectChanges();
+    component.notebook.status.readyReplicas = 0;
+    component.notebook.metadata.annotations['kubeflow-resource-stopped'] =
+      Date.now.toString();
+    expect(component.status).toEqual(STATUS_TYPE.STOPPED);
+
+    let flag = component.buttonsConfig
+      .map(button => button.text)
+      .includes('STOP');
+    expect(flag).toBeTrue();
+    flag = component.buttonsConfig.map(button => button.text).includes('START');
+    expect(flag).toBeFalse();
+
+    const updateButtons = 'updateButtons';
+    component[updateButtons]();
+    flag = component.buttonsConfig.map(button => button.text).includes('STOP');
+    expect(flag).toBeFalse();
+    flag = component.buttonsConfig.map(button => button.text).includes('START');
+    expect(flag).toBeTrue();
   });
 });

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/notebook-page.component.ts
@@ -27,6 +27,7 @@ export class NotebookPageComponent implements OnInit, OnDestroy {
   public notebookStateChanging = false;
   public podRequestCompleted = false;
   public podRequestError = '';
+  public selectedTab = { index: 0, name: 'overview' };
   public buttonsConfig: ToolbarButton[] = [];
 
   pollSubNotebook = new Subscription();
@@ -50,6 +51,12 @@ export class NotebookPageComponent implements OnInit, OnDestroy {
       this.namespace = params.namespace;
 
       this.poll(this.namespace, this.notebookName);
+    });
+
+    this.route.queryParams.subscribe(params => {
+      this.selectedTab.name = params.tab;
+      this.selectedTab.index = this.switchTab(this.selectedTab.name).index;
+      this.selectedTab.name = this.switchTab(this.selectedTab.name).name;
     });
   }
 
@@ -77,6 +84,28 @@ export class NotebookPageComponent implements OnInit, OnDestroy {
     ) as NotebookRawObject;
 
     return notebookCopy;
+  }
+
+  private switchTab(name): { index: number; name: string } {
+    if (name === 'yaml') {
+      return { index: 3, name: 'yaml' };
+    } else if (name === 'events') {
+      return { index: 2, name: 'events' };
+    } else if (name === 'logs') {
+      return { index: 1, name: 'logs' };
+    } else {
+      return { index: 0, name: 'overview' };
+    }
+  }
+
+  public onTabChange(c) {
+    const queryParams = { tab: c.tab.textLabel.toLowerCase() };
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      replaceUrl: true,
+      queryParamsHandling: '',
+    });
   }
 
   private getNotebookPod(notebook: NotebookRawObject) {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.spec.ts
@@ -1,5 +1,4 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatSnackBarModule } from '@angular/material/snack-bar';
 import {
   ContentListItemModule,
   DetailsListModule,
@@ -7,12 +6,16 @@ import {
   LoadingSpinnerModule,
   PollerService,
   SnackBarModule,
+  STATUS_TYPE,
   VariablesGroupsTableModule,
 } from 'kubeflow';
 import { JWABackendService } from 'src/app/services/backend.service';
 import { ConfigurationsModule } from './configurations/configurations.module';
 import { OverviewComponent } from './overview.component';
 import { of } from 'rxjs';
+import { mockNotebook } from '../notebook-mock';
+import { mockPod } from '../pod-mock';
+
 const JWABackendServiceStub: Partial<JWABackendService> = {
   getPodDefaults: () => of(),
 };
@@ -47,9 +50,26 @@ describe('OverviewComponent', () => {
     fixture = TestBed.createComponent(OverviewComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    component.notebook = mockNotebook;
+    component.pod = mockPod;
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should return correct podDefaultsMessage', () => {
+    let message = component.getPodDefaultsMessage(true, []);
+    expect(message).toBeTruthy();
+
+    message = component.getPodDefaultsMessage(true, [{}, {}]);
+    expect(message).toBeFalsy();
+  });
+
+  it('should return correct docker image', () => {
+    const dockerImage = component.getDockerImage(component.notebook);
+    expect(dockerImage).toEqual(
+      'public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:master-e9324d39',
+    );
   });
 });

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/pod-mock.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/pod-mock.ts
@@ -1,0 +1,638 @@
+import { V1Pod } from '@kubernetes/client-node';
+
+export const mockPod: V1Pod = {
+  metadata: {
+    annotations: {
+      'kubectl.kubernetes.io/default-logs-container': 'asa232rstudio',
+      'prometheus.io/path': '/stats/prometheus',
+      'prometheus.io/port': '15020',
+      'prometheus.io/scrape': 'true',
+      'sidecar.istio.io/status':
+        '{"initContainers":["istio-init"],"containers":["istio-proxy"],"volumes":["istio-envoy","istio-data","istio-podinfo","istio-token","istiod-ca-cert"],"imagePullSecrets":null}',
+    },
+    creationTimestamp: new Date('2022-08-10T15:52:00+00:00'),
+    generateName: 'asa232rstudio-',
+    labels: {
+      app: 'asa232rstudio',
+      'controller-revision-hash': 'asa232rstudio-55b67656fc',
+      'istio.io/rev': 'default',
+      'notebook-name': 'asa232rstudio',
+      'security.istio.io/tlsMode': 'istio',
+      'service.istio.io/canonical-name': 'asa232rstudio',
+      'service.istio.io/canonical-revision': 'latest',
+      statefulset: 'asa232rstudio',
+      'statefulset.kubernetes.io/pod-name': 'asa232rstudio-0',
+    },
+    name: 'asa232rstudio-0',
+    namespace: 'kubeflow-user',
+    ownerReferences: [
+      {
+        apiVersion: 'apps/v1',
+        blockOwnerDeletion: true,
+        controller: true,
+        kind: 'StatefulSet',
+        name: 'asa232rstudio',
+        uid: '595a1069-c476-4969-bb11-8271664cbd56',
+      },
+    ],
+    resourceVersion: '38627585',
+    selfLink: '/api/v1/namespaces/kubeflow-user/pods/asa232rstudio-0',
+    uid: '0dac34c4-faa3-4416-b4f8-4ad9f9de8578',
+  },
+  spec: {
+    containers: [
+      {
+        env: [
+          {
+            name: 'NB_PREFIX',
+            value: '/notebook/kubeflow-user/asa232rstudio',
+          },
+        ],
+        image:
+          'public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:master-e9324d39',
+        imagePullPolicy: 'IfNotPresent',
+        name: 'asa232rstudio',
+        ports: [
+          {
+            containerPort: 8888,
+            name: 'notebook-port',
+            protocol: 'TCP',
+          },
+        ],
+        resources: {
+          requests: {
+            cpu: '1m',
+            memory: '1M',
+          },
+        },
+        terminationMessagePath: '/dev/termination-log',
+        terminationMessagePolicy: 'File',
+        volumeMounts: [
+          {
+            mountPath: '/dev/shm',
+            name: 'dshm',
+          },
+          {
+            mountPath: '/home/jovyan',
+            name: 'asa232rstudio-workspace',
+          },
+          {
+            mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+            name: 'default-editor-token-b77kp',
+            readOnly: true,
+          },
+        ],
+        workingDir: '/home/jovyan',
+      },
+      {
+        args: [
+          'proxy',
+          'sidecar',
+          '--domain',
+          '$(POD_NAMESPACE).svc.cluster.local',
+          '--serviceCluster',
+          'asa232rstudio.$(POD_NAMESPACE)',
+          '--proxyLogLevel=warning',
+          '--proxyComponentLogLevel=misc:error',
+          '--log_output_level=default:info',
+          '--concurrency',
+          '2',
+        ],
+        env: [
+          {
+            name: 'JWT_POLICY',
+            value: 'third-party-jwt',
+          },
+          {
+            name: 'PILOT_CERT_PROVIDER',
+            value: 'istiod',
+          },
+          {
+            name: 'CA_ADDR',
+            value: 'istiod.istio-system.svc:15012',
+          },
+          {
+            name: 'POD_NAME',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'metadata.name',
+              },
+            },
+          },
+          {
+            name: 'POD_NAMESPACE',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'metadata.namespace',
+              },
+            },
+          },
+          {
+            name: 'INSTANCE_IP',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'status.podIP',
+              },
+            },
+          },
+          {
+            name: 'SERVICE_ACCOUNT',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'spec.serviceAccountName',
+              },
+            },
+          },
+          {
+            name: 'HOST_IP',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'status.hostIP',
+              },
+            },
+          },
+          {
+            name: 'CANONICAL_SERVICE',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: "metadata.labels['service.istio.io/canonical-name']",
+              },
+            },
+          },
+          {
+            name: 'CANONICAL_REVISION',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath:
+                  "metadata.labels['service.istio.io/canonical-revision']",
+              },
+            },
+          },
+          {
+            name: 'PROXY_CONFIG',
+            value: '{"tracing":{}}\n',
+          },
+          {
+            name: 'ISTIO_META_POD_PORTS',
+            value:
+              '[\n    {"name":"notebook-port","containerPort":8888,"protocol":"TCP"}\n]',
+          },
+          {
+            name: 'ISTIO_META_APP_CONTAINERS',
+            value: 'asa232rstudio',
+          },
+          {
+            name: 'ISTIO_META_CLUSTER_ID',
+            value: 'Kubernetes',
+          },
+          {
+            name: 'ISTIO_META_INTERCEPTION_MODE',
+            value: 'REDIRECT',
+          },
+          {
+            name: 'ISTIO_META_WORKLOAD_NAME',
+            value: 'asa232rstudio',
+          },
+          {
+            name: 'ISTIO_META_OWNER',
+            value:
+              'kubernetes://apis/apps/v1/namespaces/kubeflow-user/statefulsets/asa232rstudio',
+          },
+          {
+            name: 'ISTIO_META_MESH_ID',
+            value: 'cluster.local',
+          },
+          {
+            name: 'TRUST_DOMAIN',
+            value: 'cluster.local',
+          },
+        ],
+        image: 'docker.io/istio/proxyv2:1.9.6',
+        imagePullPolicy: 'Never',
+        name: 'istio-proxy',
+        ports: [
+          {
+            containerPort: 15090,
+            name: 'http-envoy-prom',
+            protocol: 'TCP',
+          },
+        ],
+        readinessProbe: {
+          failureThreshold: 30,
+          httpGet: {
+            path: '/healthz/ready',
+            port: 15021,
+            scheme: 'HTTP',
+          },
+          initialDelaySeconds: 1,
+          periodSeconds: 2,
+          successThreshold: 1,
+          timeoutSeconds: 3,
+        },
+        resources: {
+          limits: {
+            cpu: '2',
+            memory: '1Gi',
+          },
+          requests: {
+            cpu: '1m',
+            memory: '1M',
+          },
+        },
+        securityContext: {
+          allowPrivilegeEscalation: false,
+          capabilities: {
+            drop: ['ALL'],
+          },
+          privileged: false,
+          readOnlyRootFilesystem: true,
+          runAsGroup: 1337,
+          runAsNonRoot: true,
+          runAsUser: 1337,
+        },
+        terminationMessagePath: '/dev/termination-log',
+        terminationMessagePolicy: 'File',
+        volumeMounts: [
+          {
+            mountPath: '/var/run/secrets/istio',
+            name: 'istiod-ca-cert',
+          },
+          {
+            mountPath: '/var/lib/istio/data',
+            name: 'istio-data',
+          },
+          {
+            mountPath: '/etc/istio/proxy',
+            name: 'istio-envoy',
+          },
+          {
+            mountPath: '/var/run/secrets/tokens',
+            name: 'istio-token',
+          },
+          {
+            mountPath: '/etc/istio/pod',
+            name: 'istio-podinfo',
+          },
+          {
+            mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+            name: 'default-editor-token-b77kp',
+            readOnly: true,
+          },
+        ],
+      },
+    ],
+    dnsPolicy: 'ClusterFirst',
+    enableServiceLinks: true,
+    hostname: 'asa232rstudio-0',
+    initContainers: [
+      {
+        args: ['--host', '$(HOST_IP)', '--port', '10101'],
+        env: [
+          {
+            name: 'HOST_IP',
+            valueFrom: {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'status.hostIP',
+              },
+            },
+          },
+        ],
+        image:
+          'gcr.io/arrikto-public/startup-lock-init@sha256:0fbe996a2f6b380d7c566ba16255ec034faec983c2661da778fe09b3e744ad21',
+        imagePullPolicy: 'Never',
+        name: 'startup-lock-init-container',
+        resources: {
+          requests: {
+            cpu: '1m',
+            memory: '1M',
+          },
+        },
+        securityContext: {
+          runAsUser: 1002,
+        },
+        terminationMessagePath: '/dev/termination-log',
+        terminationMessagePolicy: 'File',
+        volumeMounts: [
+          {
+            mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+            name: 'default-editor-token-b77kp',
+            readOnly: true,
+          },
+        ],
+      },
+      {
+        args: [
+          'istio-iptables',
+          '-p',
+          '15001',
+          '-z',
+          '15006',
+          '-u',
+          '1337',
+          '-m',
+          'REDIRECT',
+          '-i',
+          '*',
+          '-x',
+          '',
+          '-b',
+          '*',
+          '-d',
+          '15090,15021,15020',
+        ],
+        image: 'docker.io/istio/proxyv2:1.9.6',
+        imagePullPolicy: 'Never',
+        name: 'istio-init',
+        resources: {
+          limits: {
+            cpu: '2',
+            memory: '1Gi',
+          },
+          requests: {
+            cpu: '1m',
+            memory: '1M',
+          },
+        },
+        securityContext: {
+          allowPrivilegeEscalation: false,
+          capabilities: {
+            add: ['NET_ADMIN', 'NET_RAW'],
+            drop: ['ALL'],
+          },
+          privileged: false,
+          readOnlyRootFilesystem: false,
+          runAsGroup: 0,
+          runAsNonRoot: false,
+          runAsUser: 0,
+        },
+        terminationMessagePath: '/dev/termination-log',
+        terminationMessagePolicy: 'File',
+        volumeMounts: [
+          {
+            mountPath: '/var/run/secrets/kubernetes.io/serviceaccount',
+            name: 'default-editor-token-b77kp',
+            readOnly: true,
+          },
+        ],
+      },
+    ],
+    nodeName: 'orfeas-minikf-dev',
+    preemptionPolicy: 'PreemptLowerPriority',
+    priority: 0,
+    restartPolicy: 'Always',
+    schedulerName: 'default-scheduler',
+    securityContext: {
+      fsGroup: 1337,
+    },
+    serviceAccount: 'default-editor',
+    serviceAccountName: 'default-editor',
+    terminationGracePeriodSeconds: 30,
+    tolerations: [
+      {
+        effect: 'NoExecute',
+        key: 'node.kubernetes.io/not-ready',
+        operator: 'Exists',
+        tolerationSeconds: 300,
+      },
+      {
+        effect: 'NoExecute',
+        key: 'node.kubernetes.io/unreachable',
+        operator: 'Exists',
+        tolerationSeconds: 300,
+      },
+    ],
+    volumes: [
+      {
+        emptyDir: {
+          medium: 'Memory',
+        },
+        name: 'istio-envoy',
+      },
+      {
+        emptyDir: {},
+        name: 'istio-data',
+      },
+      {
+        downwardAPI: {
+          defaultMode: 420,
+          items: [
+            {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'metadata.labels',
+              },
+              path: 'labels',
+            },
+            {
+              fieldRef: {
+                apiVersion: 'v1',
+                fieldPath: 'metadata.annotations',
+              },
+              path: 'annotations',
+            },
+            {
+              path: 'cpu-limit',
+              resourceFieldRef: {
+                containerName: 'istio-proxy',
+                divisor: '1m',
+                resource: 'limits.cpu',
+              },
+            },
+            {
+              path: 'cpu-request',
+              resourceFieldRef: {
+                containerName: 'istio-proxy',
+                divisor: '1m',
+                resource: 'requests.cpu',
+              },
+            },
+          ],
+        },
+        name: 'istio-podinfo',
+      },
+      {
+        name: 'istio-token',
+        projected: {
+          defaultMode: 420,
+          sources: [
+            {
+              serviceAccountToken: {
+                audience: 'istio-ca',
+                expirationSeconds: 43200,
+                path: 'istio-token',
+              },
+            },
+          ],
+        },
+      },
+      {
+        configMap: {
+          defaultMode: 420,
+          name: 'istio-ca-root-cert',
+        },
+        name: 'istiod-ca-cert',
+      },
+      {
+        emptyDir: {
+          medium: 'Memory',
+        },
+        name: 'dshm',
+      },
+      {
+        name: 'asa232rstudio-workspace',
+        persistentVolumeClaim: {
+          claimName: 'asa232rstudio-workspace',
+        },
+      },
+      {
+        name: 'default-editor-token-b77kp',
+        secret: {
+          defaultMode: 420,
+          secretName: 'default-editor-token-b77kp',
+        },
+      },
+    ],
+  },
+  status: {
+    conditions: [
+      {
+        lastTransitionTime: new Date('2022-08-11T07:06:51+00:00'),
+        status: 'True',
+        type: 'Initialized',
+      },
+      {
+        lastTransitionTime: new Date('2022-08-11T07:07:00+00:00'),
+        status: 'True',
+        type: 'Ready',
+      },
+      {
+        lastTransitionTime: new Date('2022-08-11T07:07:00+00:00'),
+        status: 'True',
+        type: 'ContainersReady',
+      },
+      {
+        lastTransitionTime: new Date('2022-08-10T15:52:00+00:00'),
+        status: 'True',
+        type: 'PodScheduled',
+      },
+    ],
+    containerStatuses: [
+      {
+        containerID:
+          'docker://e7267343bd9721289db5c8ef0c522387b2918ed5dbfcf8258c8e8838d27a11e7',
+        image:
+          'public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse:master-e9324d39',
+        imageID:
+          'docker-pullable://public.ecr.aws/j1r0q0g6/notebooks/notebook-servers/rstudio-tidyverse@sha256:b4d760b865fab0a44181c757b1db21851f2e99a6a77b27847866559015f286eb',
+        lastState: {
+          terminated: {
+            containerID:
+              'docker://b0cedeceae355658389aca0a98616be2d8df5d0005c807893a9c90b824ef40fa',
+            exitCode: 0,
+            finishedAt: new Date('2022-08-10T19:01:02+00:00'),
+            reason: 'Completed',
+            startedAt: new Date('2022-08-10T15:52:12+00:00'),
+          },
+        },
+        name: 'asa232rstudio',
+        ready: true,
+        restartCount: 1,
+        started: true,
+        state: {
+          running: {
+            startedAt: new Date('2022-08-11T07:06:57+00:00'),
+          },
+        },
+      },
+      {
+        containerID:
+          'docker://9fdc6868d46a14d607f18919d12f58aa5b9dacb8da96938eb0d5514437687ee0',
+        image: 'istio/proxyv2:1.9.6',
+        imageID:
+          'docker-pullable://istio/proxyv2@sha256:87a9db561d2ef628deea7a4cbd0adf008a2f64355a2796e3b840d445b7e9cd3e',
+        lastState: {
+          terminated: {
+            containerID:
+              'docker://a366a3746f852be605a9ce475531a2a29d6f7429ef3159b138784dfbde5d4fbb',
+            exitCode: 0,
+            finishedAt: new Date('2022-08-10T19:01:06+00:00'),
+            reason: 'Completed',
+            startedAt: new Date('2022-08-10T15:52:12+00:00'),
+          },
+        },
+        name: 'istio-proxy',
+        ready: true,
+        restartCount: 1,
+        started: true,
+        state: {
+          running: {
+            startedAt: new Date('2022-08-11T07:06:58+00:00'),
+          },
+        },
+      },
+    ],
+    hostIP: '10.10.10.10',
+    initContainerStatuses: [
+      {
+        containerID:
+          'docker://6f3ea551bdeee6c2ad697205346fae64257203fd64333f207f38b231fb43e5aa',
+        image:
+          'sha256:5d794711f8601a29ee4095c2cff8f14e69aced79a400008fa9c252fc43d22d24',
+        imageID:
+          'docker-pullable://gcr.io/arrikto-public/startup-lock-init@sha256:0fbe996a2f6b380d7c566ba16255ec034faec983c2661da778fe09b3e744ad21',
+        lastState: {},
+        name: 'startup-lock-init-container',
+        ready: true,
+        restartCount: 1,
+        state: {
+          terminated: {
+            containerID:
+              'docker://6f3ea551bdeee6c2ad697205346fae64257203fd64333f207f38b231fb43e5aa',
+            exitCode: 0,
+            finishedAt: new Date('2022-08-11T07:06:50+00:00'),
+            reason: 'Completed',
+            startedAt: new Date('2022-08-11T07:06:45+00:00'),
+          },
+        },
+      },
+      {
+        containerID:
+          'docker://0e4883449f3a0a61e7a19ca917c72e2112eacfa4a3551ce40f26701b2fc6ca85',
+        image: 'istio/proxyv2:1.9.6',
+        imageID:
+          'docker-pullable://istio/proxyv2@sha256:87a9db561d2ef628deea7a4cbd0adf008a2f64355a2796e3b840d445b7e9cd3e',
+        lastState: {},
+        name: 'istio-init',
+        ready: true,
+        restartCount: 0,
+        state: {
+          terminated: {
+            containerID:
+              'docker://0e4883449f3a0a61e7a19ca917c72e2112eacfa4a3551ce40f26701b2fc6ca85',
+            exitCode: 0,
+            finishedAt: new Date('2022-08-11T07:06:52+00:00'),
+            reason: 'Completed',
+            startedAt: new Date('2022-08-11T07:06:52+00:00'),
+          },
+        },
+      },
+    ],
+    phase: 'Running',
+    podIP: '172.17.0.80',
+    podIPs: [
+      {
+        ip: '172.17.0.80',
+      },
+    ],
+    qosClass: 'Burstable',
+    startTime: new Date('2022-08-10T15:52:00+00:00'),
+  },
+};

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/actions.service.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/actions.service.spec.ts
@@ -4,15 +4,12 @@ import { of } from 'rxjs';
 import { ActionsService } from './actions.service';
 import { ConfirmDialogService, SnackBarService } from 'kubeflow';
 
-let JWABackendServiceStub: Partial<JWABackendService>;
-let SnackBarServiceStub: Partial<SnackBarService>;
-
-JWABackendServiceStub = {
+const JWABackendServiceStub: Partial<JWABackendService> = {
   deleteNotebook: () => of(),
   startNotebook: () => of(),
   stopNotebook: () => of(),
 };
-SnackBarServiceStub = {
+const SnackBarServiceStub: Partial<SnackBarService> = {
   open: () => {},
   close: () => {},
 };

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/actions.service.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/actions.service.spec.ts
@@ -1,0 +1,37 @@
+import { TestBed } from '@angular/core/testing';
+import { JWABackendService } from './backend.service';
+import { of } from 'rxjs';
+import { ActionsService } from './actions.service';
+import { ConfirmDialogService, SnackBarService } from 'kubeflow';
+
+let JWABackendServiceStub: Partial<JWABackendService>;
+let SnackBarServiceStub: Partial<SnackBarService>;
+
+JWABackendServiceStub = {
+  deleteNotebook: () => of(),
+  startNotebook: () => of(),
+  stopNotebook: () => of(),
+};
+SnackBarServiceStub = {
+  open: () => {},
+  close: () => {},
+};
+
+describe('ActionsService', () => {
+  let service: ActionsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: JWABackendService, useValue: JWABackendServiceStub },
+        { provide: ConfirmDialogService, useValue: {} },
+        { provide: SnackBarService, useValue: SnackBarServiceStub },
+      ],
+    }).compileComponents();
+    service = TestBed.inject(ActionsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/actions.service.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/actions.service.ts
@@ -1,0 +1,118 @@
+import { Injectable } from '@angular/core';
+import {
+  ConfirmDialogService,
+  DIALOG_RESP,
+  SnackBarService,
+  SnackType,
+} from 'kubeflow';
+import { getDeleteDialogConfig, getStopDialogConfig } from './config';
+import { JWABackendService } from './backend.service';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ActionsService {
+  constructor(
+    public backend: JWABackendService,
+    public confirmDialog: ConfirmDialogService,
+    private snackBar: SnackBarService,
+  ) {}
+
+  deleteNotebook(namespace: string, name: string): Observable<string> {
+    return new Observable(subscriber => {
+      const deleteDialogConfig = getDeleteDialogConfig(name);
+
+      const ref = this.confirmDialog.open(name, deleteDialogConfig);
+      const delSub = ref.componentInstance.applying$.subscribe(applying => {
+        if (!applying) {
+          return;
+        }
+
+        // Close the open dialog only if the DELETE request succeeded
+        this.backend.deleteNotebook(namespace, name).subscribe({
+          next: _ => {
+            ref.close(DIALOG_RESP.ACCEPT);
+            const object = `${namespace}/${name}`;
+            this.snackBar.open(
+              `${object}: Delete request was sent.`,
+              SnackType.Info,
+              5000,
+            );
+          },
+          error: err => {
+            const errorMsg = `Error ${err}`;
+            deleteDialogConfig.error = errorMsg;
+            ref.componentInstance.applying$.next(false);
+            subscriber.next(`fail`);
+          },
+        });
+
+        // DELETE request has succeeded
+        ref.afterClosed().subscribe(result => {
+          delSub.unsubscribe();
+          subscriber.next(result);
+          subscriber.complete();
+        });
+      });
+    });
+  }
+
+  connectToNotebook(namespace: string, name: string): void {
+    // Open new tab to work on the Notebook
+    window.open(`/notebook/${namespace}/${name}/`);
+  }
+
+  startNotebook(namespace: string, name: string): Observable<string> {
+    return new Observable(subscriber => {
+      this.backend.startNotebook(namespace, name).subscribe(response => {
+        this.snackBar.open(
+          $localize`Starting Notebook server '${name}'...`,
+          SnackType.Info,
+          3000,
+        );
+
+        subscriber.next(response);
+        subscriber.complete();
+      });
+    });
+  }
+
+  stopNotebook(namespace: string, name: string): Observable<string> {
+    return new Observable(subscriber => {
+      const stopDialogConfig = getStopDialogConfig(name);
+      const ref = this.confirmDialog.open(name, stopDialogConfig);
+      const stopSub = ref.componentInstance.applying$.subscribe(applying => {
+        if (!applying) {
+          return;
+        }
+
+        // Close the open dialog only if the request succeeded
+        this.backend.stopNotebook(namespace, name).subscribe({
+          next: _ => {
+            ref.close(DIALOG_RESP.ACCEPT);
+
+            this.snackBar.open(
+              $localize`Stopping Notebook server '${name}'...`,
+              SnackType.Info,
+              3000,
+            );
+          },
+          error: err => {
+            const errorMsg = `Error ${err}`;
+            stopDialogConfig.error = errorMsg;
+            ref.componentInstance.applying$.next(false);
+            subscriber.next(`fail`);
+          },
+        });
+
+        // request has succeeded
+        ref.afterClosed().subscribe(result => {
+          stopSub.unsubscribe();
+          subscriber.next(result);
+          subscriber.complete();
+        });
+      });
+    });
+  }
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
@@ -151,9 +151,7 @@ export class JWABackendService extends BackendService {
   }
 
   // PATCH
-  public startNotebook(notebook: NotebookProcessedObject): Observable<string> {
-    const name = notebook.name;
-    const namespace = notebook.namespace;
+  public startNotebook(namespace: string, name: string): Observable<string> {
     const url = `api/namespaces/${namespace}/notebooks/${name}`;
 
     return this.http.patch<JWABackendResponse>(url, { stopped: false }).pipe(
@@ -162,9 +160,7 @@ export class JWABackendService extends BackendService {
     );
   }
 
-  public stopNotebook(notebook: NotebookProcessedObject): Observable<string> {
-    const name = notebook.name;
-    const namespace = notebook.namespace;
+  public stopNotebook(namespace: string, name: string): Observable<string> {
     const url = `api/namespaces/${namespace}/notebooks/${name}`;
 
     return this.http.patch<JWABackendResponse>(url, { stopped: true }).pipe(
@@ -187,7 +183,7 @@ export class JWABackendService extends BackendService {
   public handleErrorExtended(
     error: HttpErrorResponse | ErrorEvent | string,
     codes: number[] = [],
-  ) {
+  ): Observable<never> {
     if (
       error instanceof HttpErrorResponse &&
       codes.includes(error.error.status)

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/config.ts
@@ -1,0 +1,30 @@
+import { DialogConfig } from 'kubeflow';
+
+// --- Configs for the Confirm Dialogs ---
+export function getDeleteDialogConfig(name: string): DialogConfig {
+  return {
+    title: $localize`Are you sure you want to delete this notebook server? ${name}`,
+    message: $localize`Warning: Your data might be lost if the notebook server
+                       is not backed by persistent storage`,
+    accept: $localize`DELETE`,
+    confirmColor: 'warn',
+    cancel: $localize`CANCEL`,
+    error: '',
+    applying: $localize`DELETING`,
+    width: '600px',
+  };
+}
+
+export function getStopDialogConfig(name: string): DialogConfig {
+  return {
+    title: $localize`Are you sure you want to stop this notebook server? ${name}`,
+    message: $localize`Warning: Your data might be lost if the notebook server
+                       is not backed by persistent storage.`,
+    accept: $localize`STOP`,
+    confirmColor: 'primary',
+    cancel: $localize`CANCEL`,
+    error: '',
+    applying: $localize`STOPPING`,
+    width: '600px',
+  };
+}


### PR DESCRIPTION
This PR is part of the [Details page for each Notebooks/Volumes/TensorBoards](https://github.com/kubeflow/kubeflow/issues/6707) effort and a follow-up PR to [this](https://github.com/kubeflow/kubeflow/pull/6790). It introduces:

 - Buttons in the Notebook details page for **Connect, Start/Stop and Delete** actions.
 - Query parameter handling for each tab in order for the user to be able to **navigate directly to the tab of choice** inside the Notebook details page.
 - A fixup in Conditions table sorting functionality by adding default values to each column.
 - **Unit tests for notebook-page component**. More specifically, tests check that the page
     - Shows only the proper tab according to query parameters passed.
     - Switches tabs according to query parameters passed.
     - Updates disabled field of buttons according to notebook status.
     - Updates start/stop button according to notebook status.
 - **Unit tests for OVERVIEW tab** component

Here's how the details page looks with the new buttons:

![image](https://user-images.githubusercontent.com/44405072/206694363-457f14b5-1e43-4eb1-8102-3ecdfd35087c.png)
