### PR TITLE
vwa(front): Add YAML tab to Volume details page

### DIFF
--- a/components/crud-web-apps/volumes/frontend/angular.json
+++ b/components/crud-web-apps/volumes/frontend/angular.json
@@ -34,11 +34,14 @@
             "tsConfig": "tsconfig.app.json",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor",
+                "output": "assets/monaco-editor"
+              }
             ],
-            "styles": [
-              "src/styles.scss"
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": [],
             "crossOrigin": "use-credentials",
             "vendorChunk": true,

--- a/components/crud-web-apps/volumes/frontend/karma.conf.js
+++ b/components/crud-web-apps/volumes/frontend/karma.conf.js
@@ -10,15 +10,33 @@ module.exports = function (config) {
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
-      require('@angular-devkit/build-angular/plugins/karma')
+      require('@angular-devkit/build-angular/plugins/karma'),
     ],
+    files: [
+      {
+        pattern: 'node_modules/monaco-editor/**',
+        watched: false,
+        included: false,
+        served: true,
+      },
+      {
+        pattern: 'src/assets/**',
+        watched: false,
+        included: false,
+        served: true,
+      },
+    ],
+    proxies: {
+      '/static/assets/monaco-editor/': '/base/node_modules/monaco-editor/',
+      '/static/assets/': '/base/src/assets/',
+    },
     client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
       dir: require('path').join(__dirname, './coverage/frontend'),
       reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
+      fixWebpackSourcePaths: true,
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,
@@ -27,6 +45,6 @@ module.exports = function (config) {
     autoWatch: true,
     browsers: ['Chrome'],
     singleRun: false,
-    restartOnFileChange: true
+    restartOnFileChange: true,
   });
 };

--- a/components/crud-web-apps/volumes/frontend/package-lock.json
+++ b/components/crud-web-apps/volumes/frontend/package-lock.json
@@ -9586,6 +9586,11 @@
         "minimist": "^1.2.5"
       }
     },
+    "monaco-editor": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.33.0.tgz",
+      "integrity": "sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw=="
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",

--- a/components/crud-web-apps/volumes/frontend/package.json
+++ b/components/crud-web-apps/volumes/frontend/package.json
@@ -41,6 +41,7 @@
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.11",
     "material-icons": "^0.7.3",
+    "monaco-editor": "^0.33.0",
     "raw-loader": "^4.0.0",
     "rxjs": "~6.6.7",
     "tslib": "^2.0.0",

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.component.html
@@ -32,6 +32,12 @@
             <app-events [pvc]="pvc"></app-events>
           </ng-template>
         </mat-tab>
+
+        <mat-tab label="YAML">
+          <ng-template matTabContent>
+            <app-yaml [pvcInfoLoaded]="pvcInfoLoaded" [pvc]="pvc"></app-yaml>
+          </ng-template>
+        </mat-tab>
       </mat-tab-group>
     </ng-container>
   </div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/volume-details-page.module.ts
@@ -5,6 +5,7 @@ import { KubeflowModule } from 'kubeflow';
 import { MatTabsModule } from '@angular/material/tabs';
 import { OverviewModule } from './overview/overview.module';
 import { EventsModule } from './events/events.module';
+import { YamlModule } from './yaml/yaml.module';
 
 @NgModule({
   declarations: [VolumeDetailsPageComponent],
@@ -14,6 +15,7 @@ import { EventsModule } from './events/events.module';
     MatTabsModule,
     OverviewModule,
     EventsModule,
+    YamlModule,
   ],
 })
 export class VolumeDetailsPageModule {}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.component.html
@@ -1,0 +1,8 @@
+<div>
+  <lib-monaco-editor
+    [text]="yaml"
+    language="yaml"
+    [readOnly]="true"
+    [height]="540"
+  ></lib-monaco-editor>
+</div>

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { EditorModule } from 'kubeflow';
+
+import { YamlComponent } from './yaml.component';
+
+describe('YamlComponent', () => {
+  let component: YamlComponent;
+  let fixture: ComponentFixture<YamlComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [YamlComponent],
+      imports: [EditorModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(YamlComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.component.ts
@@ -1,0 +1,31 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { V1PersistentVolumeClaim } from '@kubernetes/client-node';
+import { dump } from 'js-yaml';
+
+@Component({
+  selector: 'app-yaml',
+  templateUrl: './yaml.component.html',
+  styleUrls: ['./yaml.component.scss'],
+})
+export class YamlComponent implements OnInit {
+  @Input() pvc: V1PersistentVolumeClaim;
+  @Input() pvcInfoLoaded = false;
+
+  get yaml(): string {
+    return this.getYaml(this.pvc, this.pvcInfoLoaded);
+  }
+
+  getYaml(pvc: V1PersistentVolumeClaim, pvcInfoLoaded: boolean): string {
+    if (!pvc && !pvcInfoLoaded) {
+      return 'PVC information is being loaded.';
+    } else if (!pvc && pvcInfoLoaded) {
+      return 'No data has been found.';
+    } else {
+      return dump(pvc);
+    }
+  }
+
+  constructor() {}
+
+  ngOnInit(): void {}
+}

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.module.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/yaml/yaml.module.ts
@@ -1,0 +1,11 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { YamlComponent } from './yaml.component';
+import { EditorModule } from 'kubeflow';
+
+@NgModule({
+  declarations: [YamlComponent],
+  imports: [CommonModule, EditorModule],
+  exports: [YamlComponent],
+})
+export class YamlModule {}


### PR DESCRIPTION
This PR is part of the [Details page for each Notebooks/Volumes/TensorBoards](https://github.com/kubeflow/kubeflow/issues/6707) effort and a follow-up PR to [this](https://github.com/kubeflow/kubeflow/pull/6806). It adds a tab to show the full `yaml` file of the PVC.