### PR TITLE
jwa(front): Rework the create page

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/form.module.ts
@@ -50,6 +50,7 @@ import { StepInfoComponent } from './step-info/step-info.component';
     IconModule,
     MatProgressSpinnerModule,
     PopoverModule,
+    MatIconModule,
   ],
   exports: [
     FormSectionComponent,

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.html
@@ -1,6 +1,14 @@
 <div class="form--section-bottom">
   <div class="header">
     <lib-icon *ngIf="icon" [icon]="icon"></lib-icon>{{ title }}
+    <mat-icon
+      class="icon"
+      *ngIf="helpText"
+      [matTooltip]="helpText"
+      matTooltipPosition="above"
+    >
+      help
+    </mat-icon>
   </div>
   <p>{{ text }}</p>
   <p *ngIf="readOnly">*The cluster admin has disabled setting this section!</p>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.scss
@@ -7,6 +7,7 @@ p {
 .header {
   font-weight: 500;
   font-size: 20px;
+  display: flex;
 }
 
 .lib-icon {
@@ -17,4 +18,8 @@ p {
 // inside of a form section
 .form--section-bottom {
   margin-bottom: 0.5em;
+}
+
+.icon {
+  margin-left: 5px;
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.ts
@@ -21,6 +21,9 @@ export class FormSectionComponent implements OnInit {
   @Input()
   icon: string;
 
+  @Input()
+  helpText: string;
+
   constructor() {}
 
   ngOnInit() {}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-cpu-ram/form-cpu-ram.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-cpu-ram/form-cpu-ram.component.html
@@ -1,6 +1,7 @@
 <lib-form-section
   title="CPU / RAM"
   i18n-title="Title for the CPU/RAM form section"
+  helpText="Configure the resources allocated to the notebook. Minimum and maximum values correspond to K8s requests and limits for the resources of the underlying Pod."
 >
   <div class="row">
     <!--CPU-->
@@ -9,7 +10,7 @@
       min="0"
       step="0.1"
       [sizeControl]="parentForm.get('cpu')"
-      label="Requested CPUs"
+      label="Minimum CPU"
       i18n-label
     ></lib-positive-number-input>
 
@@ -19,7 +20,7 @@
       min="0"
       step="0.1"
       [sizeControl]="parentForm.get('memory')"
-      label="Requested memory in Gi"
+      label="Minimum Memory Gi"
       i18n-label
     ></lib-positive-number-input>
   </div>
@@ -29,7 +30,7 @@
       <!--CPU-->
       <div class="column">
         <mat-form-field appearance="outline" class="wide">
-          <mat-label i18n>CPU limit</mat-label>
+          <mat-label i18n>Maximum CPU</mat-label>
           <input
             matInput
             type="number"
@@ -43,7 +44,7 @@
       <!--RAM-->
       <div class="column">
         <mat-form-field appearance="outline" class="wide">
-          <mat-label i18n> Memory limit in Gi </mat-label>
+          <mat-label i18n>Maximum Memory Gi</mat-label>
           <input
             matInput
             type="number"

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-cpu-ram/form-cpu-ram.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-cpu-ram/form-cpu-ram.component.ts
@@ -13,6 +13,7 @@ export class FormCpuRamComponent implements OnInit {
   @Input() readonlyMemory: boolean;
   @Input() cpuLimitFactor: string;
   @Input() memoryLimitFactor: string;
+  @Input() popoverPosition = 'below';
 
   constructor() {}
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.html
@@ -1,16 +1,5 @@
-<lib-form-section
-  title="OCI Image"
-  i18n-title="Title for the Image section of the form"
->
+<lib-form-section>
   <div class="flex-column">
-    <mat-checkbox
-      *ngIf="allowCustomImage"
-      [formControl]="parentForm.get('customImageCheck')"
-      i18n
-    >
-      Custom Image
-    </mat-checkbox>
-
     <mat-button-toggle-group
       [formControl]="parentForm.get('serverType')"
       class="server-type-wrapper"
@@ -22,133 +11,164 @@
         attr.aria-label="Use JupyterLab based server"
         i18n-aria-label="Aria label for JupyterLab type server"
       >
-        <mat-icon class="server-type" svgIcon="jupyterlab"></mat-icon>
+        <mat-icon class="server-type-icon" svgIcon="jupyter-icon"></mat-icon>
+        <p class="server-type-title">JupyterLab</p>
+        <p class="server-type-content">
+          An interactive development environment for notebooks, code, and data.
+          Ideal for prototyping and experimentation.
+        </p>
       </mat-button-toggle>
 
       <mat-button-toggle
         value="group-one"
-        *ngIf="!parentForm.get('imageGroupOne')?.disabled"
         attr.aria-label="Use Group One based server"
         i18n-aria-label="Aria label for Group One server"
       >
-        <mat-icon class="server-type" svgIcon="group-one"></mat-icon>
+        <mat-icon class="server-type-icon" svgIcon="group-one"></mat-icon>
+        <p class="server-type-title">VisualStudio Code</p>
+        <p class="server-type-content">
+          A lightweight but powerful source code editor, redefined and optimized
+          for building and debugging modern web and cloud applications.
+        </p>
       </mat-button-toggle>
+
       <mat-button-toggle
         value="group-two"
-        *ngIf="!parentForm.get('imageGroupTwo')?.disabled"
         attr.aria-label="Use Group Two based server"
         i18n-aria-label="Aria label for Group Two server"
       >
-        <mat-icon class="server-type" svgIcon="group-two"></mat-icon>
+        <mat-icon class="server-type-icon" svgIcon="group-two"></mat-icon>
+        <p class="server-type-title">RStudio</p>
+        <p class="server-type-content">
+          An integrated development environment for R, a programming language
+          for statistical computing and graphics.
+        </p>
       </mat-button-toggle>
     </mat-button-toggle-group>
+
+    <mat-accordion class="custom-notebook-accordion">
+      <mat-expansion-panel>
+        <mat-expansion-panel-header>
+          <mat-panel-title> Custom Notebook </mat-panel-title>
+        </mat-expansion-panel-header>
+
+        <mat-form-field
+          class="wide"
+          appearance="outline"
+          *ngIf="parentForm?.value.serverType === 'jupyter'"
+        >
+          <!-- If readonly, then make it an input element instead of select -->
+          <mat-label i18n>Image</mat-label>
+          <mat-select
+            placeholder="OCI Image"
+            i18n-placeholder
+            [formControl]="parentForm.get('image')"
+          >
+            <mat-option
+              *ngFor="let img of images"
+              [value]="img"
+              [matTooltip]="img"
+            >
+              {{ imageDisplayName(img) }}
+            </mat-option>
+          </mat-select>
+          <mat-error i18n>Please provide an Image to use</mat-error>
+        </mat-form-field>
+
+        <mat-form-field
+          class="wide"
+          appearance="outline"
+          *ngIf="parentForm?.value.serverType === 'group-one'"
+        >
+          <!-- If readonly, then make it an input element instead of select -->
+          <mat-label i18n>Image</mat-label>
+          <mat-select
+            placeholder="OCI Image"
+            i18n-placeholder
+            [formControl]="parentForm.get('imageGroupOne')"
+          >
+            <mat-option
+              *ngFor="let img of imagesGroupOne"
+              [value]="img"
+              [matTooltip]="img"
+            >
+              {{ imageDisplayName(img) }}
+            </mat-option>
+          </mat-select>
+          <mat-error i18n>Please provide an Image to use</mat-error>
+        </mat-form-field>
+
+        <mat-form-field
+          class="wide"
+          appearance="outline"
+          *ngIf="parentForm?.value.serverType === 'group-two'"
+        >
+          <!-- If readonly, then make it an input element instead of select -->
+          <mat-label i18n>Image</mat-label>
+          <mat-select
+            placeholder="OCI Image"
+            i18n-placeholder
+            [formControl]="parentForm.get('imageGroupTwo')"
+          >
+            <mat-option
+              *ngFor="let img of imagesGroupTwo"
+              [value]="img"
+              [matTooltip]="img"
+            >
+              {{ imageDisplayName(img) }}
+            </mat-option>
+          </mat-select>
+          <mat-error i18n>Please provide an Image to use</mat-error>
+        </mat-form-field>
+
+        <lib-advanced-options>
+          <div class="flex-column">
+            <mat-checkbox
+              *ngIf="allowCustomImage"
+              [formControl]="parentForm.get('customImageCheck')"
+              (change)="onSelect($event)"
+              i18n
+            >
+              Custom Image
+            </mat-checkbox>
+
+            <mat-form-field
+              class="wide"
+              appearance="outline"
+              *ngIf="parentForm?.value.customImageCheck"
+            >
+              <mat-label i18n>Custom Image</mat-label>
+              <input
+                matInput
+                placeholder="Provide a custom Image"
+                [formControl]="parentForm.get('customImage')"
+                #cstmimg
+              />
+              <mat-error i18n>Please provide an Image to use</mat-error>
+            </mat-form-field>
+
+            <div class="row">
+              <mat-form-field class="column" appearance="outline">
+                <mat-label i18n>Image pull policy</mat-label>
+                <mat-select [formControl]="parentForm.get('imagePullPolicy')">
+                  <mat-option value="Always" i18n="ImagePullPolicy: Always">
+                    Always
+                  </mat-option>
+                  <mat-option
+                    value="IfNotPresent"
+                    i18n="ImagePullPolicy: IfNotPresent"
+                  >
+                    IfNotPresent
+                  </mat-option>
+                  <mat-option value="Never" i18n="ImagePullPolicy: Never">
+                    Never
+                  </mat-option>
+                </mat-select>
+              </mat-form-field>
+            </div>
+          </div>
+        </lib-advanced-options>
+      </mat-expansion-panel>
+    </mat-accordion>
   </div>
-
-  <mat-form-field
-    class="wide"
-    appearance="outline"
-    *ngIf="
-      !parentForm?.value.customImageCheck &&
-      parentForm?.value.serverType === 'jupyter'
-    "
-  >
-    <!-- If readonly, then make it an input element instead of select -->
-    <mat-label i18n>Image</mat-label>
-    <mat-select
-      placeholder="OCI Image"
-      i18n-placeholder
-      [formControl]="parentForm.get('image')"
-    >
-      <mat-option *ngFor="let img of images" [value]="img" [matTooltip]="img">
-        {{ imageDisplayName(img) }}
-      </mat-option>
-    </mat-select>
-    <mat-error i18n>Please provide an Image to use</mat-error>
-  </mat-form-field>
-
-  <mat-form-field
-    class="wide"
-    appearance="outline"
-    *ngIf="
-      !parentForm?.value.customImageCheck &&
-      parentForm?.value.serverType === 'group-one'
-    "
-  >
-    <!-- If readonly, then make it an input element instead of select -->
-    <mat-label i18n>Image</mat-label>
-    <mat-select
-      placeholder="OCI Image"
-      i18n-placeholder
-      [formControl]="parentForm.get('imageGroupOne')"
-    >
-      <mat-option
-        *ngFor="let img of imagesGroupOne"
-        [value]="img"
-        [matTooltip]="img"
-      >
-        {{ imageDisplayName(img) }}
-      </mat-option>
-    </mat-select>
-    <mat-error i18n>Please provide an Image to use</mat-error>
-  </mat-form-field>
-
-  <mat-form-field
-    class="wide"
-    appearance="outline"
-    *ngIf="
-      !parentForm?.value.customImageCheck &&
-      parentForm?.value.serverType === 'group-two'
-    "
-  >
-    <!-- If readonly, then make it an input element instead of select -->
-    <mat-label i18n>Image</mat-label>
-    <mat-select
-      placeholder="OCI Image"
-      i18n-placeholder
-      [formControl]="parentForm.get('imageGroupTwo')"
-    >
-      <mat-option
-        *ngFor="let img of imagesGroupTwo"
-        [value]="img"
-        [matTooltip]="img"
-      >
-        {{ imageDisplayName(img) }}
-      </mat-option>
-    </mat-select>
-    <mat-error i18n>Please provide an Image to use</mat-error>
-  </mat-form-field>
-
-  <mat-form-field
-    class="wide"
-    appearance="outline"
-    *ngIf="parentForm?.value.customImageCheck"
-  >
-    <mat-label i18n>Custom Image</mat-label>
-    <input
-      matInput
-      placeholder="Provide a custom Image"
-      [formControl]="parentForm.get('customImage')"
-      #cstmimg
-    />
-    <mat-error i18n>Please provide an Image to use</mat-error>
-  </mat-form-field>
-
-  <lib-advanced-options>
-    <div class="row">
-      <mat-form-field class="column" appearance="outline">
-        <mat-label i18n>Image pull policy</mat-label>
-        <mat-select [formControl]="parentForm.get('imagePullPolicy')">
-          <mat-option value="Always" i18n="ImagePullPolicy: Always">
-            Always
-          </mat-option>
-          <mat-option value="IfNotPresent" i18n="ImagePullPolicy: IfNotPresent">
-            IfNotPresent
-          </mat-option>
-          <mat-option value="Never" i18n="ImagePullPolicy: Never">
-            Never
-          </mat-option>
-        </mat-select>
-      </mat-form-field>
-    </div>
-  </lib-advanced-options>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.scss
@@ -1,9 +1,40 @@
-.server-type {
-  height: 32px;
-  width: 150px;
+.server-type-wrapper {
+  margin-bottom: 2rem;
+  border: none;
+  justify-content: space-between;
+
+  .mat-button-toggle {
+    width: 188px;
+    border: solid 1px rgba(0, 0, 0, 0.12);
+    border-radius: 5px;
+  }
+
+  .mat-button-toggle-checked {
+    border: 2px solid #1e88e5;
+    background-color: white;
+  }
+
+  .server-type-icon {
+    height: 62px;
+    width: 150px;
+    margin-top: 1rem;
+  }
+
+  .server-type-title {
+    color: rgba(0, 0, 0, 0.66);
+    font-weight: 500;
+    font-size: 20px;
+  }
+
+  .server-type-content {
+    white-space: pre-line;
+    line-height: 18px;
+    font-weight: 500;
+    font-size: 12px;
+    color: rgba(0, 0, 0, 0.54);
+  }
 }
 
-.server-type-wrapper {
+.custom-notebook-accordion {
   margin-bottom: 1rem;
-  width: fit-content;
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.spec.ts
@@ -10,6 +10,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
 import { FormModule as KfFormModule } from 'kubeflow';
 import { MatIconTestingModule } from '@angular/material/icon/testing';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatCheckboxChange } from '@angular/material/checkbox';
 
 describe('FormImageComponent', () => {
   let component: FormImageComponent;
@@ -30,6 +32,7 @@ describe('FormImageComponent', () => {
           MatSelectModule,
           ReactiveFormsModule,
           MatIconTestingModule,
+          MatExpansionModule,
         ],
       }).compileComponents();
     }),
@@ -53,5 +56,25 @@ describe('FormImageComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should toggle image controls when custom image is checked', () => {
+    const image = component.parentForm.get('image');
+    const imageGroupOne = component.parentForm.get('imageGroupOne');
+    const imageGroupTwo = component.parentForm.get('imageGroupTwo');
+
+    let event = { checked: true } as MatCheckboxChange;
+    component.onSelect(event);
+
+    expect(image.disabled).toBe(true);
+    expect(imageGroupOne.disabled).toBe(true);
+    expect(imageGroupTwo.disabled).toBe(true);
+
+    event = { checked: false } as MatCheckboxChange;
+    component.onSelect(event);
+
+    expect(image.enabled).toBe(true);
+    expect(imageGroupOne.enabled).toBe(true);
+    expect(imageGroupTwo.enabled).toBe(true);
   });
 });

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-image/form-image.component.ts
@@ -4,6 +4,7 @@ import { Subscription } from 'rxjs';
 import { environment } from '@app/environment';
 import { DomSanitizer } from '@angular/platform-browser';
 import { MatIconRegistry } from '@angular/material/icon';
+import { MatCheckboxChange } from '@angular/material/checkbox';
 
 @Component({
   selector: 'app-form-image',
@@ -23,16 +24,16 @@ export class FormImageComponent implements OnInit, OnDestroy {
 
   constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer) {
     iconRegistry.addSvgIcon(
-      'jupyterlab',
-      sanitizer.bypassSecurityTrustResourceUrl(environment.jupyterlabLogo),
+      'jupyter-icon',
+      sanitizer.bypassSecurityTrustResourceUrl(environment.jupyterIcon),
     );
     iconRegistry.addSvgIcon(
       'group-one',
-      sanitizer.bypassSecurityTrustResourceUrl(environment.groupOneLogo),
+      sanitizer.bypassSecurityTrustResourceUrl(environment.groupOneIcon),
     );
     iconRegistry.addSvgIcon(
       'group-two',
-      sanitizer.bypassSecurityTrustResourceUrl(environment.groupTwoLogo),
+      sanitizer.bypassSecurityTrustResourceUrl(environment.groupTwoIcon),
     );
   }
 
@@ -77,9 +78,22 @@ export class FormImageComponent implements OnInit, OnDestroy {
     );
   }
 
+  onSelect(event: MatCheckboxChange): void {
+    if (event.checked) {
+      this.parentForm.get('image').disable();
+      this.parentForm.get('imageGroupOne').disable();
+      this.parentForm.get('imageGroupTwo').disable();
+    } else {
+      this.parentForm.get('image').enable();
+      this.parentForm.get('imageGroupOne').enable();
+      this.parentForm.get('imageGroupTwo').enable();
+    }
+  }
+
   ngOnDestroy() {
     this.subs.unsubscribe();
   }
+
   imageDisplayName(image: string): string {
     const [name, tag = null] = image.split(':');
     const tokens = name.split('/');

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-name/form-name.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-name/form-name.component.html
@@ -1,10 +1,8 @@
-<lib-form-section title="Name" i18n-title>
-  <lib-form-name-namespace-inputs
+<lib-form-section title="" i18n-title>
+  <lib-name-input
     [nameControl]="parentForm.get('name')"
     maxLength="40"
-    [namespaceControl]="parentForm.get('namespace')"
     resourceName="Notebook Server"
     [existingNames]="existingNotebooks"
-  >
-  </lib-form-name-namespace-inputs>
+  ></lib-name-input>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-name/form-name.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-name/form-name.component.ts
@@ -10,7 +10,7 @@ import { Subscription } from 'rxjs';
 import { JWABackendService } from 'src/app/services/backend.service';
 
 @Component({
-  selector: 'app-form-name-namespace',
+  selector: 'app-form-name',
   templateUrl: './form-name.component.html',
   styleUrls: ['./form-name.component.scss'],
 })

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.html
@@ -54,33 +54,46 @@
       >
       </app-form-data-volumes>
 
-      <app-form-configurations
-        [parentForm]="formCtrl"
-      ></app-form-configurations>
+      <lib-advanced-options>
+        <app-form-configurations
+          [parentForm]="formCtrl"
+        ></app-form-configurations>
 
-      <app-form-affinity-tolerations
-        [parentForm]="formCtrl"
-        [affinityConfigs]="config?.affinityConfig?.options"
-        [tolerationGroups]="config?.tolerationGroup?.options"
-      ></app-form-affinity-tolerations>
+        <app-form-affinity-tolerations
+          [parentForm]="formCtrl"
+          [affinityConfigs]="config?.affinityConfig?.options"
+          [tolerationGroups]="config?.tolerationGroup?.options"
+        ></app-form-affinity-tolerations>
 
-      <app-form-advanced-options
-        [parentForm]="formCtrl"
-      ></app-form-advanced-options>
+        <app-form-advanced-options
+          [parentForm]="formCtrl"
+        ></app-form-advanced-options>
+      </lib-advanced-options>
     </form>
 
     <div class="form-buttons">
+      <div
+        [matTooltip]="setTooltipText(formCtrl)"
+        [matTooltipDisabled]="formCtrl.valid"
+      >
+        <button
+          mat-raised-button
+          color="primary"
+          (click)="onSubmit()"
+          [disabled]="!formCtrl.valid"
+          i18n
+        >
+          LAUNCH
+        </button>
+      </div>
+
       <button
         mat-raised-button
-        color="primary"
-        (click)="onSubmit()"
-        [disabled]="!formCtrl.valid || blockSubmit"
+        type="button"
+        class="cancel-button"
+        (click)="onCancel()"
         i18n
       >
-        LAUNCH
-      </button>
-
-      <button mat-raised-button type="button" (click)="onCancel()" i18n>
         CANCEL
       </button>
     </div>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.html
@@ -14,9 +14,7 @@
       (ngSubmit)="onSubmit()"
       [formGroup]="formCtrl"
     >
-      <app-form-name-namespace
-        [parentForm]="formCtrl"
-      ></app-form-name-namespace>
+      <app-form-name [parentForm]="formCtrl"></app-form-name>
 
       <app-form-image
         [parentForm]="formCtrl"

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.scss
@@ -5,5 +5,12 @@
 }
 
 .form-buttons {
+  display: flex;
+  margin-top: 2rem;
+  margin-left: 1rem;
   margin-bottom: 1rem;
+}
+
+.cancel-button {
+  margin-left: 0.5rem;
 }

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.spec.ts
@@ -23,7 +23,11 @@ import { FormNewComponent } from './form-new.component';
 import { FormWorkspaceVolumeModule } from './form-workspace-volume/form-workspace-volume.module';
 import { VolumeModule } from './volume/volume.module';
 
-const JWABackendServiceStub: Partial<JWABackendService> = {
+let JWABackendServiceStub: Partial<JWABackendService>;
+let NamespaceServiceStub: Partial<NamespaceService>;
+let SnackBarServiceStub: Partial<SnackBarService>;
+
+JWABackendServiceStub = {
   getConfig: () => of(),
   createNotebook: () => of(),
   getGPUVendors: () => of(),
@@ -31,12 +35,12 @@ const JWABackendServiceStub: Partial<JWABackendService> = {
   getDefaultStorageClass: () => of(),
 };
 
-const NamespaceServiceStub: Partial<NamespaceService> = {
+NamespaceServiceStub = {
   getSelectedNamespace: () => of(),
   getSelectedNamespace2: () => of(),
 };
 
-const SnackBarServiceStub: Partial<SnackBarService> = {
+SnackBarServiceStub = {
   open: () => {},
   close: () => {},
 };

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.spec.ts
@@ -23,11 +23,7 @@ import { FormNewComponent } from './form-new.component';
 import { FormWorkspaceVolumeModule } from './form-workspace-volume/form-workspace-volume.module';
 import { VolumeModule } from './volume/volume.module';
 
-let JWABackendServiceStub: Partial<JWABackendService>;
-let NamespaceServiceStub: Partial<NamespaceService>;
-let SnackBarServiceStub: Partial<SnackBarService>;
-
-JWABackendServiceStub = {
+const JWABackendServiceStub = {
   getConfig: () => of(),
   createNotebook: () => of(),
   getGPUVendors: () => of(),
@@ -35,12 +31,12 @@ JWABackendServiceStub = {
   getDefaultStorageClass: () => of(),
 };
 
-NamespaceServiceStub = {
+const NamespaceServiceStub = {
   getSelectedNamespace: () => of(),
   getSelectedNamespace2: () => of(),
 };
 
-SnackBarServiceStub = {
+const SnackBarServiceStub = {
   open: () => {},
   close: () => {},
 };

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.component.ts
@@ -17,12 +17,7 @@ export class FormNewComponent implements OnInit, OnDestroy {
   formCtrl: FormGroup;
   config: Config;
 
-  ephemeral = false;
   defaultStorageclass = false;
-
-  blockSubmit = false;
-  formReady = false;
-  existingNotebooks = new Set<string>();
 
   subscriptions = new Subscription();
 
@@ -147,6 +142,17 @@ export class FormNewComponent implements OnInit, OnDestroy {
     }
 
     return notebook;
+  }
+
+  // Set the tooltip text based on form's validity
+  setTooltipText(form: FormGroup): string {
+    let text: string;
+    if (!form.get('name').valid) {
+      text = 'No value of the Notebook name was provided';
+    } else if (!form.controls.valid) {
+      text = 'The form contains invalid fields';
+    }
+    return text;
   }
 
   onSubmit() {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-new.module.ts
@@ -6,7 +6,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatExpansionModule } from '@angular/material/expansion';
-import { FormNewComponent } from './form-new.component';
+
 import {
   FormModule as KfFormModule,
   TitleActionsToolbarModule,
@@ -21,6 +21,7 @@ import { FormGpusModule } from './form-gpus/form-gpus.module';
 import { FormImageModule } from './form-image/form-image.module';
 import { FormNameModule } from './form-name/form-name.module';
 import { FormWorkspaceVolumeModule } from './form-workspace-volume/form-workspace-volume.module';
+import { FormNewComponent } from './form-new.component';
 
 @NgModule({
   declarations: [FormNewComponent],

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-workspace-volume/form-workspace-volume.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-workspace-volume/form-workspace-volume.component.html
@@ -86,9 +86,9 @@
 
   <div class="volume-buttons">
     <button
+      *ngIf="volGroup.disabled || readonly"
       type="button"
       color="primary"
-      [disabled]="!volGroup.disabled || readonly"
       (click)="addNewVolume()"
       mat-stroked-button
       i18n
@@ -97,9 +97,9 @@
     </button>
 
     <button
+      *ngIf="volGroup.disabled || readonly"
       type="button"
       color="primary"
-      [disabled]="!volGroup.disabled || readonly"
       (click)="attachExistingVolume()"
       mat-stroked-button
       i18n

--- a/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/panel.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/panel.ts
@@ -107,8 +107,6 @@ function getExistingVolumeDesc(vol: Volume): string {
   }
 
   return name;
-
-  const values: string[] = [];
 }
 
 function getNewVolumeDesc(vol: Volume): string {


### PR DESCRIPTION
This PR reworks JWA's create page by performing the following changes:

- Remove the `namespace` input field
- Have the icon buttons with the logos of the IDEs on top, and hide the image customization into a collapsible section
- Expanding the `Custom Notebook` panel allows two different actions:
   - To select among a list of pre-configured images of each type
   - To configure a completely custom image. By checking the `Custom Image` checkbox, a new `Custom Image` field appears and the `Image` field is disabled
- CPU/RAM
   -  Rename `Requests CPUs` to `Minimum CPU`, `Requested memory in Gi` to `Minimum Memory Gi`, `CPU Limit` to `Maximum CPU`, and `Memory limit in Gi` to `Maximum Memory Gi`
- Volumes
    - Limit to just one workspace volume:
        - Hide the add buttons when one workspace volume is present
        - Allow removing the current workspace volume to create a new one and in that case show the two buttons
- Hide all the sections after the Volumes into an `Advanced options` expandable section

<details>
  <summary>Click here for some screenshots of how the new page will look like.</summary>

  ![image](https://user-images.githubusercontent.com/87971102/206444008-942e3a6a-75e3-4ab9-8c0d-5e9458013007.png)
![image](https://user-images.githubusercontent.com/87971102/206444118-b1153765-4af0-4c84-ae3b-a76fc7d12335.png)
![image](https://user-images.githubusercontent.com/87971102/206446072-1aa13edd-1bd5-4f68-9438-da7f220807a7.png)
![image](https://user-images.githubusercontent.com/87971102/206444564-6e9400db-d2bf-40ec-8cf3-3b3c1df3a635.png)
</details>


