### PR TITLE
feat: use native RBAC subject to find RoleBindings in KFAM, rather than annotations

### DIFF
--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -186,7 +186,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 		for _, roleBinding := range roleBindings {
 			var subject rbacv1.Subject
 			for _, roleBindingSubject := range roleBinding.Subjects {
-				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
+				if roleBindingSubject.Kind == rbacv1.UserKind && roleBindingSubject.Name == user {
 					subject = roleBindingSubject
 					break
 				}
@@ -202,12 +202,18 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 				subject = roleBinding.Subjects[0]
 			}
 			
-			roleVal, ok := roleBinding.Annotations[ROLE]
-			if !ok {
-				continue
-			}
-			if role != "" && role != roleVal && role != roleBinding.RoleRef.Name {
-				continue
+			if role != "" {
+				if role != roleBinding.RoleRef.Name {
+					continue
+				}
+
+				roleVal, ok := roleBinding.Annotations[ROLE]
+				if !ok {
+					continue
+				}
+				if role != roleVal {
+					continue
+				}
 			}
 			binding := Binding{
 				User: &rbacv1.Subject{

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -184,7 +184,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 			return nil, err
 		}
 		for _, roleBinding := range roleBindings {
-			subject = nil
+			var subject rbacv1.Subject = nil
 			for _, roleBindingSubject := range roleBinding.Subjects {
 				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
 					subject = roleBindingSubject

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -191,7 +191,7 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 					break
 				}
 			}
-			if subject == rbacv1.Subject{} {
+			if subject == (rbacv1.Subject{}) {
 				userVal, ok := roleBinding.Annotations[USER]
 				if !ok {
 					continue

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -184,14 +184,14 @@ func (c *BindingClient) List(user string, namespaces []string, role string) (*Bi
 			return nil, err
 		}
 		for _, roleBinding := range roleBindings {
-			var subject rbacv1.Subject = nil
+			var subject rbacv1.Subject
 			for _, roleBindingSubject := range roleBinding.Subjects {
 				if roleBindingSubject.Kind == USER && roleBindingSubject.Name == user {
 					subject = roleBindingSubject
 					break
 				}
 			}
-			if roleBindingSubject == nil {
+			if subject == rbacv1.Subject{} {
 				userVal, ok := roleBinding.Annotations[USER]
 				if !ok {
 					continue


### PR DESCRIPTION
The current implementation of the listing of namespaces in the Kubeflow UI top-nav if you dig through the path of calls eventually hits this method when a user is authenticated. The `user` argument is populated with their `email` (in our implementation at least, but assuming it's some `user` identifier more broadly), we want to move away from checks on hard-coded annotations towards checks on Kubernetes native concepts themselves.

This refactor keeps existing checks on `annotations`, but also optionally checks the `Subjects` list and `RoleRef` to see if the matches occur there.

The rationale for this change is that currently within a `Namespace` we **must** deploy `O(U)` (where `U` is the # of users) `RoleBinding` resources as each one must have a `user: <user identifier>` `annotation`, then for other RBAC operations the `Subjects` list (including the now removed check) must have `len(subjects) == 1`. With this change we can instead deploy `O(1)` `RoleBinding` resources with `O(U)` `Subjects`. 

This will simplify our deployments here at Zillow and generally make this system more maintainable for us to use. Please let us know if there are any blockers in this, happy to refactor as needed!

Tested both approaches on our clusters, seems to work for our use cases but we've modified Kubeflow a bit from the vanilla and don't deploy everything 😅 