### PR TITLE
web-apps(front): Fix namespace selector bug

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.html
@@ -1,6 +1,9 @@
 <div class="lib-content-wrapper">
   <lib-title-actions-toolbar title="Notebooks" [buttons]="buttons" i18n-title>
-    <lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+    <lib-namespace-select
+      *ngIf="(ns.dashboardConnected$ | async) === dashboardDisconnectedState"
+      namespacesUrl="/api/namespaces"
+    ></lib-namespace-select>
   </lib-title-actions-toolbar>
 
   <!--scrollable page content-->

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/index/index-default/index-default.component.ts
@@ -14,6 +14,7 @@ import {
   addColumn,
   removeColumn,
   PollerService,
+  DashboardState,
 } from 'kubeflow';
 import { JWABackendService } from 'src/app/services/backend.service';
 import { Observable, Subscription, of, forkJoin } from 'rxjs';
@@ -41,6 +42,7 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
   currNamespace: string | string[];
   config = defaultConfig;
   processedData: NotebookProcessedObject[] = [];
+  dashboardDisconnectedState = DashboardState.Disconnected;
 
   private newNotebookButton = new ToolbarButton({
     text: $localize`New Notebook`,

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.html
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.html
@@ -4,7 +4,10 @@
     [buttons]="buttons"
     i18n-title
   >
-    <lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+    <lib-namespace-select
+      *ngIf="(ns.dashboardConnected$ | async) === dashboardDisconnectedState"
+      namespacesUrl="/api/namespaces"
+    ></lib-namespace-select>
   </lib-title-actions-toolbar>
 
   <!--scrollable page content-->

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/index.component.ts
@@ -13,6 +13,7 @@ import {
   ToolbarButton,
   PollerService,
   ToolbarButtonConfig,
+  DashboardState,
 } from 'kubeflow';
 import { defaultConfig } from './config';
 import { environment } from '@app/environment';
@@ -37,6 +38,7 @@ export class IndexComponent implements OnInit, OnDestroy {
   public env = environment;
   public config = defaultConfig;
   public processedData: TensorboardProcessedObject[] = [];
+  public dashboardDisconnectedState = DashboardState.Disconnected;
 
   private newTensorBoardButton = new ToolbarButton({
     text: $localize`New TensorBoard`,

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.html
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.html
@@ -1,6 +1,9 @@
 <div class="lib-content-wrapper">
   <lib-title-actions-toolbar title="Volumes" [buttons]="buttons" i18n-title>
-    <lib-namespace-select *ngIf="!env.production"></lib-namespace-select>
+    <lib-namespace-select
+      *ngIf="(ns.dashboardConnected$ | async) === dashboardDisconnectedState"
+      namespacesUrl="/api/namespaces"
+    ></lib-namespace-select>
   </lib-title-actions-toolbar>
 
   <!--scrollable page content-->

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.ts
@@ -11,6 +11,7 @@ import {
   SnackType,
   ToolbarButton,
   PollerService,
+  DashboardState,
 } from 'kubeflow';
 import { defaultConfig } from './config';
 import { environment } from '@app/environment';
@@ -35,6 +36,7 @@ export class IndexDefaultComponent implements OnInit, OnDestroy {
   public currNamespace: string | string[];
   public processedData: PVCProcessedObject[] = [];
   public pvcsWaitingViewer = new Set<string>();
+  public dashboardDisconnectedState = DashboardState.Disconnected;
 
   private newVolumeButton = new ToolbarButton({
     text: $localize`New Volume`,


### PR DESCRIPTION
**Context**

Fix a bug in the namespace selectors of JWA, VWA and TWA. In order to show the namespace selector, they only checked if there is no `env.production` variable available. This resulted in the selector not showing even if there was no dashboard which is not expected. 

**Solution**

We will just copy what we do in KWA https://github.com/kubeflow/katib/blob/master/pkg/new-ui/v1beta1/frontend/src/app/pages/experiments/experiments.component.html#L3-L6 