### PR TITLE
web-apps(front): Install prettier and create a frontend workflow

### DIFF
--- a/.github/workflows/common_frontend_tests.yaml
+++ b/.github/workflows/common_frontend_tests.yaml
@@ -1,0 +1,47 @@
+name: Common Frontend Tests
+on:
+  pull_request:
+    paths:
+      - components/crud-web-apps/common/frontend/kubeflow-common-lib/**
+
+jobs:
+  frontend-format-lint-check:
+    name: Check code format and lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12
+
+      - name: Check frontend code formatting
+        run: |
+          cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+          npm i
+          npm run format:check
+      - name: Check frontend code linting
+        run: |
+          cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+          npm i
+          npm run lint-check
+
+  frontend-unit-tests:
+    runs-on: ubuntu-latest
+    name: Unit tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node version to 12
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12
+
+      - name: Install Kubeflow common library dependecies
+        run: |
+          cd components/crud-web-apps/common/frontend/kubeflow-common-lib
+          npm i
+          npm run test:prod

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package-lock.json
@@ -12831,6 +12831,12 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "prettier": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.2.tgz",
+      "integrity": "sha512-lnJzDfJ66zkMy58OL5/NY5zp70S7Nz6KqcKkXYzn2tMVrNxvbqaBpg7H3qHaLxCJ5lNMsGuM8+ohS7cZrthdLQ==",
+      "dev": true
+    },
     "pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -8,6 +8,7 @@
     "test": "ng test",
     "test-ci": "ng test --no-watch --no-progress --browsers=ChromeHeadlessCI",
     "test-docker": "docker run -v $(pwd):/usr/src/app browserless/chrome:1.44-chrome-stable npm run test-ci",
+    "test:prod": "ng test --browsers=ChromeHeadless --watch=false",
     "lint-check": "ng lint",
     "lint": "ng lint --fix",
     "e2e": "ng e2e",

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/package.json
@@ -13,7 +13,9 @@
     "e2e": "ng e2e",
     "copyCSS": "cp ./projects/kubeflow/src/kubeflow.css ./dist/kubeflow && cp ./projects/kubeflow/src/styles.scss ./dist/kubeflow && cp ./projects/kubeflow/src/lib/variables.scss ./dist/kubeflow/lib && cp ./projects/kubeflow/src/lib/fonts.scss ./dist/kubeflow/lib",
     "copyAssets": "cp -r ./projects/kubeflow/src/assets ./dist/kubeflow/assets",
-    "postinstall": "ngcc"
+    "postinstall": "ngcc",
+    "format:check": "prettier --check 'projects/kubeflow/src/**/*.{js,ts,html,scss,css}' || node scripts/check-format-error.js",
+    "format:write": "prettier --write 'projects/kubeflow/src/**/*.{js,ts,html,scss,css}'"
   },
   "private": true,
   "dependencies": {
@@ -70,6 +72,7 @@
     "karma-jasmine": "~4.0.0",
     "karma-jasmine-html-reporter": "^1.6.0",
     "ng-packagr": "^12.0.8",
+    "prettier": "2.3.2",
     "protractor": "~7.0.0",
     "ts-node": "^10.4.0",
     "typescript": "~4.2.4"

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/conditions-table.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/conditions-table.component.spec.ts
@@ -7,11 +7,13 @@ describe('ConditionsTableComponent', () => {
   let component: ConditionsTableComponent;
   let fixture: ComponentFixture<ConditionsTableComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [ConditionsTableModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ConditionsTableModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConditionsTableComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/confirm-dialog/dialog/dialog.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/confirm-dialog/dialog/dialog.component.spec.ts
@@ -8,27 +8,29 @@ describe('ConfirmDialogComponent', () => {
   let component: ConfirmDialogComponent;
   let fixture: ComponentFixture<ConfirmDialogComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [ConfirmDialogModule],
-      providers: [
-        { provide: MatDialogRef, useValue: {} },
-        {
-          provide: MAT_DIALOG_DATA,
-          useValue: {
-            title: '',
-            message: '',
-            accept: '',
-            applying: '',
-            error: '',
-            confirmColor: '',
-            cancel: '',
-            width: '',
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ConfirmDialogModule],
+        providers: [
+          { provide: MatDialogRef, useValue: {} },
+          {
+            provide: MAT_DIALOG_DATA,
+            useValue: {
+              title: '',
+              message: '',
+              accept: '',
+              applying: '',
+              error: '',
+              confirmColor: '',
+              cancel: '',
+              width: '',
+            },
           },
-        },
-      ],
-    }).compileComponents();
-  }));
+        ],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfirmDialogComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/content-list-item/content-list-item.component.spec.ts
@@ -8,9 +8,8 @@ describe('ContentListItemComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ ContentListItemComponent ]
-    })
-    .compileComponents();
+      declarations: [ContentListItemComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/date-time/date-time.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/date-time/date-time.component.spec.ts
@@ -8,11 +8,13 @@ describe('DateTimeComponent', () => {
   let component: DateTimeComponent;
   let fixture: ComponentFixture<DateTimeComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [DateTimeModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [DateTimeModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DateTimeComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list-item/details-list-item.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list-item/details-list-item.component.spec.ts
@@ -9,15 +9,17 @@ describe('DetailsListItemComponent', () => {
   let component: DetailsListItemComponent;
   let fixture: ComponentFixture<DetailsListItemComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [DetailsListModule],
-      providers: [
-        DetailsListItemComponent,
-        { provide: SnackBarService, useClass: MockSnackBarService },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [DetailsListModule],
+        providers: [
+          DetailsListItemComponent,
+          { provide: SnackBarService, useClass: MockSnackBarService },
+        ],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DetailsListItemComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/details-list/details-list.component.spec.ts
@@ -7,11 +7,13 @@ describe('DetailsListComponent', () => {
   let component: DetailsListComponent;
   let fixture: ComponentFixture<DetailsListComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [DetailsListModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [DetailsListModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DetailsListComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/fonts.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/fonts.scss
@@ -3,15 +3,18 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('../assets/fonts/roboto-cyrillicext-normal300.woff2') format('woff2');
-  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  src: local('Roboto Light'), local('Roboto-Light'),
+    url('../assets/fonts/roboto-cyrillicext-normal300.woff2') format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
+    U+FE2E-FE2F;
 }
 /* cyrillic */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('../assets/fonts/roboto-cyrillic-normal300.woff2') format('woff2');
+  src: local('Roboto Light'), local('Roboto-Light'),
+    url('../assets/fonts/roboto-cyrillic-normal300.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -19,7 +22,8 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('../assets/fonts/roboto-greekext-normal300.woff2') format('woff2');
+  src: local('Roboto Light'), local('Roboto-Light'),
+    url('../assets/fonts/roboto-greekext-normal300.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -27,7 +31,8 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('../assets/fonts/roboto-greek-normal300.woff2') format('woff2');
+  src: local('Roboto Light'), local('Roboto-Light'),
+    url('../assets/fonts/roboto-greek-normal300.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -35,39 +40,49 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('../assets/fonts/roboto-vietnamese-normal300.woff2') format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+  src: local('Roboto Light'), local('Roboto-Light'),
+    url('../assets/fonts/roboto-vietnamese-normal300.woff2') format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1,
+    U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('../assets/fonts/roboto-latinext-normal300.woff2') format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: local('Roboto Light'), local('Roboto-Light'),
+    url('../assets/fonts/roboto-latinext-normal300.woff2') format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
+    U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('../assets/fonts/roboto-latin-normal300.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: local('Roboto Light'), local('Roboto-Light'),
+    url('../assets/fonts/roboto-latin-normal300.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('../assets/fonts/roboto-cyrillicext-normal400.woff2') format('woff2');
-  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  src: local('Roboto'), local('Roboto-Regular'),
+    url('../assets/fonts/roboto-cyrillicext-normal400.woff2') format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
+    U+FE2E-FE2F;
 }
 /* cyrillic */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('../assets/fonts/roboto-cyrillic-normal400.woff2') format('woff2');
+  src: local('Roboto'), local('Roboto-Regular'),
+    url('../assets/fonts/roboto-cyrillic-normal400.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -75,7 +90,8 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('../assets/fonts/roboto-greekext-normal400.woff2') format('woff2');
+  src: local('Roboto'), local('Roboto-Regular'),
+    url('../assets/fonts/roboto-greekext-normal400.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -83,7 +99,8 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('../assets/fonts/roboto-greek-normal400.woff2') format('woff2');
+  src: local('Roboto'), local('Roboto-Regular'),
+    url('../assets/fonts/roboto-greek-normal400.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -91,39 +108,49 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('../assets/fonts/roboto-vietnamese-normal400.woff2') format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+  src: local('Roboto'), local('Roboto-Regular'),
+    url('../assets/fonts/roboto-vietnamese-normal400.woff2') format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1,
+    U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('../assets/fonts/roboto-latinext-normal400.woff2') format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: local('Roboto'), local('Roboto-Regular'),
+    url('../assets/fonts/roboto-latinext-normal400.woff2') format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
+    U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('../assets/fonts/roboto-latin-normal400.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: local('Roboto'), local('Roboto-Regular'),
+    url('../assets/fonts/roboto-latin-normal400.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
 }
 /* cyrillic-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('../assets/fonts/roboto-cyrillicext-normal500.woff2') format('woff2');
-  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F, U+FE2E-FE2F;
+  src: local('Roboto Medium'), local('Roboto-Medium'),
+    url('../assets/fonts/roboto-cyrillicext-normal500.woff2') format('woff2');
+  unicode-range: U+0460-052F, U+1C80-1C88, U+20B4, U+2DE0-2DFF, U+A640-A69F,
+    U+FE2E-FE2F;
 }
 /* cyrillic */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('../assets/fonts/roboto-cyrillic-normal500.woff2') format('woff2');
+  src: local('Roboto Medium'), local('Roboto-Medium'),
+    url('../assets/fonts/roboto-cyrillic-normal500.woff2') format('woff2');
   unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
 /* greek-ext */
@@ -131,7 +158,8 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('../assets/fonts/roboto-greekext-normal500.woff2') format('woff2');
+  src: local('Roboto Medium'), local('Roboto-Medium'),
+    url('../assets/fonts/roboto-greekext-normal500.woff2') format('woff2');
   unicode-range: U+1F00-1FFF;
 }
 /* greek */
@@ -139,7 +167,8 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('../assets/fonts/roboto-greek-normal500.woff2') format('woff2');
+  src: local('Roboto Medium'), local('Roboto-Medium'),
+    url('../assets/fonts/roboto-greek-normal500.woff2') format('woff2');
   unicode-range: U+0370-03FF;
 }
 /* vietnamese */
@@ -147,22 +176,29 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('../assets/fonts/roboto-vietnamese-normal500.woff2') format('woff2');
-  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1, U+01AF-01B0, U+1EA0-1EF9, U+20AB;
+  src: local('Roboto Medium'), local('Roboto-Medium'),
+    url('../assets/fonts/roboto-vietnamese-normal500.woff2') format('woff2');
+  unicode-range: U+0102-0103, U+0110-0111, U+0128-0129, U+0168-0169, U+01A0-01A1,
+    U+01AF-01B0, U+1EA0-1EF9, U+20AB;
 }
 /* latin-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('../assets/fonts/roboto-latinext-normal500.woff2') format('woff2');
-  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
+  src: local('Roboto Medium'), local('Roboto-Medium'),
+    url('../assets/fonts/roboto-latinext-normal500.woff2') format('woff2');
+  unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB,
+    U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('../assets/fonts/roboto-latin-normal500.woff2') format('woff2');
-  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+  src: local('Roboto Medium'), local('Roboto-Medium'),
+    url('../assets/fonts/roboto-latin-normal500.woff2') format('woff2');
+  unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA,
+    U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215,
+    U+FEFF, U+FFFD;
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/advanced-options/advanced-options.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/advanced-options/advanced-options.component.spec.ts
@@ -7,11 +7,13 @@ describe('AdvancedOptionsComponent', () => {
   let component: AdvancedOptionsComponent;
   let fixture: ComponentFixture<AdvancedOptionsComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [FormModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [FormModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AdvancedOptionsComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/name-namespace-inputs/name-input/name-input.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/name-namespace-inputs/name-input/name-input.component.spec.ts
@@ -9,11 +9,13 @@ describe('NameInputComponent', () => {
   let component: NameInputComponent;
   let fixture: ComponentFixture<NameInputComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [FormModule, BrowserAnimationsModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [FormModule, BrowserAnimationsModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NameInputComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/name-namespace-inputs/name-namespace-inputs.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/name-namespace-inputs/name-namespace-inputs.component.spec.ts
@@ -10,11 +10,13 @@ describe('NameNamespaceInputsComponent', () => {
   let component: NameNamespaceInputsComponent;
   let fixture: ComponentFixture<NameNamespaceInputsComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [FormModule, BrowserAnimationsModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [FormModule, BrowserAnimationsModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NameNamespaceInputsComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/positive-number-input/positive-number-input.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/positive-number-input/positive-number-input.component.html
@@ -8,6 +8,6 @@
     [formControl]="sizeControl"
   />
   <mat-error *ngIf="sizeControl.hasError('min')" i18n>
-    Cannot be less than {{min}}.
+    Cannot be less than {{ min }}.
   </mat-error>
 </mat-form-field>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/positive-number-input/positive-number-input.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/positive-number-input/positive-number-input.component.spec.ts
@@ -9,11 +9,13 @@ describe('PositiveNumberInputComponent', () => {
   let component: PositiveNumberInputComponent;
   let fixture: ComponentFixture<PositiveNumberInputComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [FormModule, BrowserAnimationsModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [FormModule, BrowserAnimationsModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PositiveNumberInputComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/rok-url-input/rok-url-input.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/rok-url-input/rok-url-input.component.spec.ts
@@ -11,16 +11,18 @@ describe('RokUrlInputComponent', () => {
   let component: RokUrlInputComponent;
   let fixture: ComponentFixture<RokUrlInputComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        FormModule,
-        BrowserAnimationsModule,
-        MatSnackBarModule,
-        HttpClientModule,
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [
+          FormModule,
+          BrowserAnimationsModule,
+          MatSnackBarModule,
+          HttpClientModule,
+        ],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RokUrlInputComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/section/section.component.spec.ts
@@ -7,11 +7,13 @@ describe('FormSectionComponent', () => {
   let component: FormSectionComponent;
   let fixture: ComponentFixture<FormSectionComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [FormModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [FormModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FormSectionComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/step-info/step-info.component.spec.ts
@@ -6,12 +6,13 @@ describe('StepInfoComponent', () => {
   let component: StepInfoComponent;
   let fixture: ComponentFixture<StepInfoComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [ StepInfoComponent ]
-    })
-    .compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [StepInfoComponent],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StepInfoComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/submit-bar/submit-bar.component.spec.ts
@@ -7,11 +7,13 @@ describe('SubmitBarComponent', () => {
   let component: SubmitBarComponent;
   let fixture: ComponentFixture<SubmitBarComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [FormModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [FormModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SubmitBarComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/validators.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/form/validators.ts
@@ -22,6 +22,7 @@ export interface IValidator {
 export const dns1123Validator: IValidator = {
   regex: '^' + dns1123LabelFmt + '(\\.' + dns1123LabelFmt + ')*' + '$',
   help:
+    // prettier-ignore
     'Name must consist of lowercase alphanumeric characters or \'-\', and"' +
     ' must start and end with an alphanumeric character',
 };
@@ -56,6 +57,7 @@ export const cpuValidator: IValidator = {
   regex: '^[0-9]*(m|[.][0-9]+)?$',
   help:
     'Invalid cpu limit: Should be a fixed-point integer or an integer ' +
+    // prettier-ignore
     'followed by \'m\'',
 };
 
@@ -65,7 +67,8 @@ export const DEBOUNCE_TIME = 500;
 export function mergeAndDebounceValidators(
   syncValidators: ValidatorFn[],
 ): AsyncValidatorFn {
-  return (control: AbstractControl): Observable<ValidationErrors | null> => timer(DEBOUNCE_TIME).pipe(
+  return (control: AbstractControl): Observable<ValidationErrors | null> =>
+    timer(DEBOUNCE_TIME).pipe(
       switchMap(() => {
         // Run all synchronous validators and return their concatenated output
         let validationResult: ValidationErrors = {};
@@ -107,7 +110,8 @@ export function getNameError(nameCtrl: AbstractControl, resource: string) {
 }
 
 export function getExistingNameValidator(names: Set<string>): ValidatorFn {
-  return (control: AbstractControl): { [key: string]: any } => names.has(control.value) ? { existingName: true } : null;
+  return (control: AbstractControl): { [key: string]: any } =>
+    names.has(control.value) ? { existingName: true } : null;
 }
 
 export function getNameSyncValidators() {
@@ -150,10 +154,12 @@ export function rokUrlValidator(rok: RokService): AsyncValidatorFn {
     // Ensure a protocol is given
     // Don't fire while the user is writting
     return timer(DEBOUNCE_TIME).pipe(
-      switchMap(() => rok.getObjectMetadata(url, false).pipe(
+      switchMap(() =>
+        rok.getObjectMetadata(url, false).pipe(
           map(resp => null),
           catchError((msg: string) => observableOf({ invalidRokUrl: true })),
-        )),
+        ),
+      ),
     );
   };
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/heading-subheading-row/heading-subheading-row.component.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/heading-subheading-row/heading-subheading-row.component.scss
@@ -1,5 +1,5 @@
 :host {
-    display: block;
+  display: block;
 }
 
 .heading {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/heading-subheading-row/heading-subheading-row.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/heading-subheading-row/heading-subheading-row.component.spec.ts
@@ -7,11 +7,13 @@ describe('HeadingSubheadingRowComponent', () => {
   let component: HeadingSubheadingRowComponent;
   let fixture: ComponentFixture<HeadingSubheadingRowComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [HeadingSubheadingRowModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [HeadingSubheadingRowModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HeadingSubheadingRowComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/icon/icon.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/icon/icon.component.spec.ts
@@ -7,13 +7,15 @@ describe('IconComponent', () => {
   let component: IconComponent;
   let fixture: ComponentFixture<IconComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [IconModule],
-    }).compileComponents();
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [IconModule],
+      }).compileComponents();
 
-    TestBed.compileComponents();
-  }));
+      TestBed.compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IconComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/loading-spinner/loading-spinner.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/loading-spinner/loading-spinner.component.spec.ts
@@ -7,11 +7,13 @@ describe('LoadingSpinnerComponent', () => {
   let component: LoadingSpinnerComponent;
   let fixture: ComponentFixture<LoadingSpinnerComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [LoadingSpinnerModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [LoadingSpinnerModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoadingSpinnerComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/namespace-select/namespace-select.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/namespace-select/namespace-select.component.spec.ts
@@ -12,12 +12,14 @@ describe('NamespaceSelectComponent', () => {
   let component: NamespaceSelectComponent;
   let fixture: ComponentFixture<NamespaceSelectComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [NamespaceSelectModule],
-      providers: [{ provide: BackendService, useClass: MockBackendService }],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [NamespaceSelectModule],
+        providers: [{ provide: BackendService, useClass: MockBackendService }],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NamespaceSelectComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/panel/panel.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/panel/panel.component.spec.ts
@@ -7,11 +7,13 @@ describe('PanelComponent', () => {
   let component: PanelComponent;
   let fixture: ComponentFixture<PanelComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [PanelModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [PanelModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PanelComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/popover/popover.directive.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/popover/popover.directive.ts
@@ -167,12 +167,15 @@ export class PopoverDirective implements OnDestroy {
   }
 
   getPositionStrategy(): FlexibleConnectedPositionStrategy {
-    const originPos: OriginPosition = this.getOriginPos(this.libPopoverPosition);
-    const overlayPos: OverlayPosition = this.getOverlayPos(this.libPopoverPosition);
-
-    const scrollableAncestors = this.scrollDispatcher.getAncestorScrollContainers(
-      this.elemRef,
+    const originPos: OriginPosition = this.getOriginPos(
+      this.libPopoverPosition,
     );
+    const overlayPos: OverlayPosition = this.getOverlayPos(
+      this.libPopoverPosition,
+    );
+
+    const scrollableAncestors =
+      this.scrollDispatcher.getAncestorScrollContainers(this.elemRef);
     return this.overlay
       .position()
       .flexibleConnectedTo(this.elemRef)

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/action-button/action-button.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/action-button/action-button.component.spec.ts
@@ -8,11 +8,13 @@ describe('ActionButtonComponent', () => {
   let component: ActionButtonComponent;
   let fixture: ComponentFixture<ActionButtonComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [ResourceTableModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ResourceTableModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ActionButtonComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/action/action.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/action/action.component.spec.ts
@@ -8,11 +8,13 @@ describe('ActionComponent', () => {
   let component: ActionComponent;
   let fixture: ComponentFixture<ActionComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [ResourceTableModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ResourceTableModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ActionComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/chips-list/chips-list.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/chips-list/chips-list.component.spec.ts
@@ -16,12 +16,14 @@ describe('TableChipsListComponent', () => {
   let component: TableChipsListComponent;
   let fixture: ComponentFixture<TableChipsListComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [TableChipsListComponent],
-      imports: [MatTooltipModule, MatChipsModule, CommonModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [TableChipsListComponent],
+        imports: [MatTooltipModule, MatChipsModule, CommonModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TableChipsListComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/component-value/component-value.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/component-value/component-value.component.spec.ts
@@ -41,11 +41,13 @@ describe('ComponentValueComponent', () => {
   let component: ComponentValueComponent;
   let fixture: ComponentFixture<ComponentValueComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [ResourceTableModule, MockModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ResourceTableModule, MockModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ComponentValueComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/status/status.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/status/status.component.spec.ts
@@ -7,11 +7,13 @@ describe('StatusComponent', () => {
   let component: StatusComponent;
   let fixture: ComponentFixture<StatusComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [ResourceTableModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ResourceTableModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(StatusComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.html
@@ -252,8 +252,10 @@
     *matRowDef="let row; let i = index; columns: displayedColumns"
     [ngClass]="highlightRow(row, highlightedRow)"
   >
-  {{row}}
-</tr>
+    {{
+      row
+    }}
+  </tr>
 
   <!-- Row shown when there is no matching data. -->
   <tr class="mat-row" *matNoDataRow>

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.spec.ts
@@ -94,11 +94,13 @@ describe('TableComponent', () => {
   let component: TableComponent;
   let fixture: ComponentFixture<TableComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [ResourceTableModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [ResourceTableModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TableComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/namespace.service.ts
@@ -47,9 +47,8 @@ export class NamespaceService {
             // Binds a callback that gets invoked anytime the Dashboard's
             // namespace is changed
             cdeh.onNamespaceSelected = this.updateSelectedNamespace.bind(this);
-            cdeh.onAllNamespacesSelected = this.updateAllSelectedNamespaces.bind(
-              this,
-            );
+            cdeh.onAllNamespacesSelected =
+              this.updateAllSelectedNamespaces.bind(this);
           },
         );
 

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/poller.service.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/services/poller.service.ts
@@ -14,11 +14,11 @@ export class PollerService {
     let currData: any;
 
     /*
-    * The poller$ observable is pushing values in an exponential manner.
-    * The `expand` operator is emitting values by using the value from the
-    * previous emit. In our case we also use delay with a dynamic period
-    * to achieve resetable exponential delay.
-    */
+     * The poller$ observable is pushing values in an exponential manner.
+     * The `expand` operator is emitting values by using the value from the
+     * previous emit. In our case we also use delay with a dynamic period
+     * to achieve resetable exponential delay.
+     */
     const poller$ = of(1).pipe(expand(x => of(period).pipe(delay(x * 1000))));
 
     const request$ = poller$.pipe(

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/snack-bar/component/snack-bar.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/snack-bar/component/snack-bar.component.spec.ts
@@ -1,22 +1,27 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { SnackBarComponent } from './snack-bar.component';
-import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material/snack-bar';
+import {
+  MAT_SNACK_BAR_DATA,
+  MatSnackBarRef,
+} from '@angular/material/snack-bar';
 import { SnackBarModule } from '../snack-bar.module';
 
 describe('SnackBarComponent', () => {
   let component: SnackBarComponent;
   let fixture: ComponentFixture<SnackBarComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [SnackBarModule],
-      providers: [
-        { provide: MatSnackBarRef, useValue: {} },
-        { provide: MAT_SNACK_BAR_DATA, useValue: {} },
-      ],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [SnackBarModule],
+        providers: [
+          { provide: MatSnackBarRef, useValue: {} },
+          { provide: MAT_SNACK_BAR_DATA, useValue: {} },
+        ],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SnackBarComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/snack-bar/component/snack-bar.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/snack-bar/component/snack-bar.component.ts
@@ -1,5 +1,8 @@
 import { Component, Inject, EventEmitter } from '@angular/core';
-import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material/snack-bar';
+import {
+  MAT_SNACK_BAR_DATA,
+  MatSnackBarRef,
+} from '@angular/material/snack-bar';
 import { SnackType } from '../types';
 
 @Component({

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/status-icon/status-icon.component.spec.ts
@@ -8,9 +8,8 @@ describe('StatusIconComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ StatusIconComponent ]
-    })
-    .compileComponents();
+      declarations: [StatusIconComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/title-actions-toolbar/title-actions-toolbar.component.spec.ts
@@ -7,11 +7,13 @@ describe('TitleActionsToolbarComponent', () => {
   let component: TitleActionsToolbarComponent;
   let fixture: ComponentFixture<TitleActionsToolbarComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [TitleActionsToolbarModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [TitleActionsToolbarModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TitleActionsToolbarComponent);

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/utils/kubernetes.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/utils/kubernetes.ts
@@ -1,5 +1,5 @@
-import {K8sObject} from './kubernetes.model';
-import {Condition} from '../conditions-table/types';
+import { K8sObject } from './kubernetes.model';
+import { Condition } from '../conditions-table/types';
 
 export function getCondition(obj: K8sObject, condition: string): Condition {
   let cs: Condition[] = [];

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.spec.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/variables-groups-table/variables-groups-table.component.spec.ts
@@ -8,9 +8,8 @@ describe('VariablesGroupsTableComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ VariablesGroupsTableComponent ]
-    })
-    .compileComponents();
+      declarations: [VariablesGroupsTableComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/scripts/check-format-error.js
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/scripts/check-format-error.js
@@ -1,0 +1,6 @@
+console.error();
+console.error('-----------------------------------------------');
+console.error('Please run `npm run format:write` to format your code.');
+console.error('-----------------------------------------------');
+console.error();
+process.exit(1);


### PR DESCRIPTION
In this PR:

- Install Prettier
- Format code
- Create `common_frontend_tests` workflow for linting, formatting and unit tests

