### PR TITLE
web-apps(front): Sort events & conditions tables by date

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/config.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/conditions-table/config.ts
@@ -59,5 +59,7 @@ export function generateConfig(): TableConfig {
         sort: true,
       },
     ],
+    sortByColumn: 'lastTransitionTime',
+    sortDirection: 'desc',
   };
 }

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/table/table.component.ts
@@ -128,7 +128,13 @@ export class TableComponent
       }
     });
 
-    this.sort.sort({ disableClear: true, id: 'name', start: 'asc' });
+    const sortByColumn = this.config.sortByColumn || 'name';
+    const sortDirection = this.config.sortDirection || 'asc';
+    this.sort.sort({
+      disableClear: true,
+      id: sortByColumn,
+      start: sortDirection,
+    });
   }
 
   ngOnChanges(changes: SimpleChanges): void {

--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/table.ts
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/lib/resource-table/types/table.ts
@@ -37,6 +37,8 @@ export interface TableConfig {
   width?: string;
   theme?: TABLE_THEME;
   dynamicNamespaceColumn?: boolean;
+  sortByColumn?: string;
+  sortDirection?: 'asc' | 'desc';
 }
 
 export enum TABLE_THEME {

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/events/config.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/events/config.ts
@@ -44,4 +44,6 @@ export const defaultConfig: TableConfig = {
       sort: true,
     },
   ],
+  sortByColumn: 'age',
+  sortDirection: 'desc',
 };

--- a/components/crud-web-apps/volumes/frontend/src/app/app.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/app.component.spec.ts
@@ -3,12 +3,14 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 
 describe('AppComponent', () => {
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [AppComponent],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        imports: [RouterTestingModule],
+        declarations: [AppComponent],
+      }).compileComponents();
+    }),
+  );
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-rok/form-rok.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-rok/form-rok.component.spec.ts
@@ -44,19 +44,21 @@ describe('FormRokComponent', () => {
   let component: FormRokComponent;
   let fixture: ComponentFixture<FormRokComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [FormRokComponent],
-      providers: [
-        { provide: FormBuilder, useValue: FormBuilderStub },
-        { provide: VWABackendService, useValue: VWABackendServiceStub },
-        { provide: MatDialogRef, useValue: {} },
-        { provide: RokService, useValue: RokServiceStub },
-        { provide: BackendService, useValue: MockBackendService },
-      ],
-      imports: [KubeflowModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [FormRokComponent],
+        providers: [
+          { provide: FormBuilder, useValue: FormBuilderStub },
+          { provide: VWABackendService, useValue: VWABackendServiceStub },
+          { provide: MatDialogRef, useValue: {} },
+          { provide: RokService, useValue: RokServiceStub },
+          { provide: BackendService, useValue: MockBackendService },
+        ],
+        imports: [KubeflowModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FormRokComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-rok/form-rok.component.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/form/form-rok/form-rok.component.ts
@@ -31,8 +31,7 @@ import { Observable } from 'rxjs';
 // TODO: Use an abstract class to eliminate common code
 export class FormRokComponent
   extends FormDefaultComponent
-  implements OnInit, OnDestroy
-{
+  implements OnInit, OnDestroy {
   public env = environment;
 
   private rokManagedStorageClasses: string[] = [];

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-default/index-default.component.spec.ts
@@ -35,20 +35,22 @@ describe('IndexDefaultComponent', () => {
   let component: IndexDefaultComponent;
   let fixture: ComponentFixture<IndexDefaultComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [IndexDefaultComponent],
-      providers: [
-        { provide: ConfirmDialogService, useValue: {} },
-        { provide: VWABackendService, useValue: VWABackendServiceStub },
-        { provide: SnackBarService, useValue: SnackBarServiceStub },
-        { provide: NamespaceService, useValue: NamespaceServiceStub },
-        { provide: PollerService, useValue: {} },
-        { provide: BackendService, useValue: MockBackendService },
-      ],
-      imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [IndexDefaultComponent],
+        providers: [
+          { provide: ConfirmDialogService, useValue: {} },
+          { provide: VWABackendService, useValue: VWABackendServiceStub },
+          { provide: SnackBarService, useValue: SnackBarServiceStub },
+          { provide: NamespaceService, useValue: NamespaceServiceStub },
+          { provide: PollerService, useValue: {} },
+          { provide: BackendService, useValue: MockBackendService },
+        ],
+        imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IndexDefaultComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index-rok/index-rok.component.spec.ts
@@ -39,21 +39,23 @@ describe('IndexRokComponent', () => {
   let component: IndexRokComponent;
   let fixture: ComponentFixture<IndexRokComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [IndexRokComponent],
-      providers: [
-        { provide: ConfirmDialogService, useValue: {} },
-        { provide: VWABackendService, useValue: VWABackendServiceStub },
-        { provide: SnackBarService, useValue: SnackBarServiceStub },
-        { provide: NamespaceService, useValue: NamespaceServiceStub },
-        { provide: PollerService, useValue: {} },
-        { provide: BackendService, useValue: MockBackendService },
-        { provide: RokService, useValue: RokServiceStub },
-      ],
-      imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [IndexRokComponent],
+        providers: [
+          { provide: ConfirmDialogService, useValue: {} },
+          { provide: VWABackendService, useValue: VWABackendServiceStub },
+          { provide: SnackBarService, useValue: SnackBarServiceStub },
+          { provide: NamespaceService, useValue: NamespaceServiceStub },
+          { provide: PollerService, useValue: {} },
+          { provide: BackendService, useValue: MockBackendService },
+          { provide: RokService, useValue: RokServiceStub },
+        ],
+        imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IndexRokComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/index/index.component.spec.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/index/index.component.spec.ts
@@ -36,20 +36,22 @@ describe('IndexComponent', () => {
   let component: IndexComponent;
   let fixture: ComponentFixture<IndexComponent>;
 
-  beforeEach(waitForAsync(() => {
-    TestBed.configureTestingModule({
-      declarations: [IndexComponent, IndexDefaultComponent],
-      providers: [
-        { provide: ConfirmDialogService, useValue: {} },
-        { provide: VWABackendService, useValue: VWABackendServiceStub },
-        { provide: SnackBarService, useValue: SnackBarServiceStub },
-        { provide: NamespaceService, useValue: NamespaceServiceStub },
-        { provide: PollerService, useValue: {} },
-        { provide: BackendService, useValue: MockBackendService },
-      ],
-      imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
-    }).compileComponents();
-  }));
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [IndexComponent, IndexDefaultComponent],
+        providers: [
+          { provide: ConfirmDialogService, useValue: {} },
+          { provide: VWABackendService, useValue: VWABackendServiceStub },
+          { provide: SnackBarService, useValue: SnackBarServiceStub },
+          { provide: NamespaceService, useValue: NamespaceServiceStub },
+          { provide: PollerService, useValue: {} },
+          { provide: BackendService, useValue: MockBackendService },
+        ],
+        imports: [MatDialogModule, RouterTestingModule, KubeflowModule],
+      }).compileComponents();
+    }),
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IndexComponent);

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/config.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/events/config.ts
@@ -44,4 +44,6 @@ export const defaultConfig: TableConfig = {
       sort: true,
     },
   ],
+  sortByColumn: 'age',
+  sortDirection: 'desc',
 };

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/pod-groups-mock.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/pod-groups-mock.ts
@@ -6,11 +6,13 @@ export const mockPodGroups: LinkGroup[] = [
     links: [
       {
         name: 'serving-openvaccine-0-486kc (predictor)',
-        url: 'viewerUrl/models/details/kubeflow-user/serving-openvaccine-0-486kc/',
+        url:
+          'viewerUrl/models/details/kubeflow-user/serving-openvaccine-0-486kc/',
       },
       {
         name: 'serving-openvaccine-0-486kc (transformer)',
-        url: 'viewerUrl/models/details/kubeflow-user/serving-openvaccine-0-486kc/',
+        url:
+          'viewerUrl/models/details/kubeflow-user/serving-openvaccine-0-486kc/',
       },
     ],
   },

--- a/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/pods-mock.ts
+++ b/components/crud-web-apps/volumes/frontend/src/app/pages/volume-details-page/overview/pods-mock.ts
@@ -157,7 +157,7 @@ export const mockPods: V1Pod[] = [
                 fieldRef: {
                   apiVersion: 'v1',
                   fieldPath:
-                    'metadata.labels[\'service.istio.io/canonical-name\']',
+                    "metadata.labels['service.istio.io/canonical-name']",
                 },
               },
             },
@@ -167,7 +167,7 @@ export const mockPods: V1Pod[] = [
                 fieldRef: {
                   apiVersion: 'v1',
                   fieldPath:
-                    'metadata.labels[\'service.istio.io/canonical-revision\']',
+                    "metadata.labels['service.istio.io/canonical-revision']",
                 },
               },
             },
@@ -655,7 +655,8 @@ export const mockPods: V1Pod[] = [
           blockOwnerDeletion: true,
           controller: true,
           kind: 'ReplicaSet',
-          name: 'serving-openvaccine-0-486kc-predictor-default-00001-deployment-7695bf497f',
+          name:
+            'serving-openvaccine-0-486kc-predictor-default-00001-deployment-7695bf497f',
           uid: 'a2b15c20-2731-4640-862e-7c3ddfd2ca49',
         },
       ],
@@ -1243,7 +1244,8 @@ export const mockPods: V1Pod[] = [
           blockOwnerDeletion: true,
           controller: true,
           kind: 'ReplicaSet',
-          name: 'serving-openvaccine-2786a7fd31c47d404c0bd18da10bd203-deployment-84654847dc',
+          name:
+            'serving-openvaccine-2786a7fd31c47d404c0bd18da10bd203-deployment-84654847dc',
           uid: 'c98ae290-16b2-4822-9d8f-f5079fdb642e',
         },
       ],


### PR DESCRIPTION
**Context**
In our WAs' details pages, we keep tables exposing events and conditions of each object in order to help the user have a better overview of its state and be able to troubleshoot problems that may arise. However, all tables are sorted by default according to their **Name** column. This feels counterintuitive since both events and conditions are attributes that expose the history of what has happened with the object. Thus, we would like to expose them by default sorted by timestamp.

**Changes**
 - Configure tables to accept input for which column & direction they should sort during initialization
 - Implement this functionality in tables with events and conditions in our WAs, in order to initialize these tables based on timestamp.