### PR TITLE
Fix Makefiles/Workflows/Manifests for the example-notebook-server images

### DIFF
--- a/.github/workflows/nb_server_codeserver_python_docker_publish.yaml
+++ b/.github/workflows/nb_server_codeserver_python_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
       - releasing/version/VERSION
 
 env:
-  TAG: $(git describe --tags --always --dirty)
   DOCKER_USER: kubeflownotebookswg
   REGISTRY: kubeflownotebookswg
 
@@ -38,21 +37,25 @@ jobs:
         username: ${{ env.DOCKER_USER}}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Build Notebook Server images via their Makefile
+    - name: Build and push Notebook Server images
       run: |
         cd components/example-notebook-servers/
-        make docker-build -C codeserver-python
-    
-    - name: Push Notebook Server images
-      run: |
-        docker tag codeserver-python:${{env.TAG}} ${{env.REGISTRY}}/codeserver-python:${{env.TAG}}
-        docker push ${{env.REGISTRY}}/codeserver-python:${{env.TAG}}
+        make docker-build -C codeserver-python 
+        make docker-push -C codeserver-python
 
-    - name: Push Notebook Server images on Version change
+    - name: Build and push latest Notebook Server images
+      if: github.ref == 'refs/heads/master'
+      run: |
+        export TAG=latest
+        cd components/example-notebook-servers/
+        make docker-build -C codeserver-python
+        make docker-push -C codeserver-python
+
+    - name: Build and push Notebook Server images on Version change
       id: version
       if: steps.filter.outputs.version == 'true'
       run: |
-        docker tag codeserver-python:${{env.TAG}} ${{env.REGISTRY}}/codeserver-python:${VERSION_TAG}
-        docker push ${{env.REGISTRY}}/codeserver-python:${VERSION_TAG}
-      env:
-        VERSION_TAG: $(cat releasing/version/VERSION)
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/
+        make docker-build -C codeserver-python
+        make docker-push -C codeserver-python

--- a/.github/workflows/nb_server_jupyter_pytorch_full_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_pytorch_full_docker_publish.yaml
@@ -12,7 +12,6 @@ on:
       - releasing/version/VERSION
 
 env:
-  TAG: $(git describe --tags --always --dirty)
   DOCKER_USER: kubeflownotebookswg
   REGISTRY: kubeflownotebookswg
 
@@ -39,26 +38,31 @@ jobs:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Build Notebook Server images via their Makefile
+    - name: Build and push Notebook Server images
       run: |
         cd components/example-notebook-servers/
         make docker-build-cpu -C jupyter-pytorch-full
         make docker-build-cuda -C jupyter-pytorch-full
-    
-    - name: Push Notebook Server images
-      run: |
-        docker tag jupyter-pytorch-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-pytorch-full:${{env.TAG}}
-        docker push ${{env.REGISTRY}}/jupyter-pytorch-full:${{env.TAG}}
-        docker tag jupyter-pytorch-cuda-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-pytorch-cuda-full:${{env.TAG}}
-        docker push ${{env.REGISTRY}}/jupyter-pytorch-cuda-full:${{env.TAG}}
+        make docker-push-cpu -C jupyter-pytorch-full
+        make docker-push-cuda -C jupyter-pytorch-full
 
-    - name: Push Notebook Server images on Version change
+    - name: Build and push latest Notebook Server images
+      if: github.ref == 'refs/heads/master'
+      run: |
+        export TAG=latest
+        cd components/example-notebook-servers/
+        make docker-build-cpu -C jupyter-pytorch-full
+        make docker-build-cuda -C jupyter-pytorch-full
+        make docker-push-cpu -C jupyter-pytorch-full
+        make docker-push-cuda -C jupyter-pytorch-full 
+
+    - name: Build and push Notebook Server images on Version change
       id: version
       if: steps.filter.outputs.version == 'true'
       run: |
-        docker tag jupyter-pytorch-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-pytorch-full:${VERSION_TAG}
-        docker push ${{env.REGISTRY}}/jupyter-pytorch-full:${VERSION_TAG}
-        docker tag jupyter-pytorch-cuda-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-pytorch-cuda-full:${VERSION_TAG}
-        docker push ${{env.REGISTRY}}/jupyter-pytorch-cuda-full:${VERSION_TAG}
-      env:
-        VERSION_TAG: $(cat releasing/version/VERSION)
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/
+        make docker-build-cpu -C jupyter-pytorch-full
+        make docker-build-cuda -C jupyter-pytorch-full
+        make docker-push-cpu -C jupyter-pytorch-full
+        make docker-push-cuda -C jupyter-pytorch-full

--- a/.github/workflows/nb_server_jupyter_scipy_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_scipy_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
       - releasing/version/VERSION
 
 env:
-  TAG: $(git describe --tags --always --dirty)
   DOCKER_USER: kubeflownotebookswg
   REGISTRY: kubeflownotebookswg
 
@@ -38,21 +37,25 @@ jobs:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Build Notebook Server images via their Makefile
+    - name: Build and push Notebook Server images
       run: |
         cd components/example-notebook-servers/
         make docker-build -C jupyter-scipy
-    
-    - name: Push Notebook Server images
-      run: |
-        docker tag jupyter-scipy:${{env.TAG}} ${{env.REGISTRY}}/jupyter-scipy:${{env.TAG}}
-        docker push ${{env.REGISTRY}}/jupyter-scipy:${{env.TAG}}
+        make docker-push -C jupyter-scipy
 
-    - name: Push Notebook Server images on Version change
+    - name: Build and push latest Notebook Server images
+      if: github.ref == 'refs/heads/master'
+      run: |
+        export TAG=latest
+        cd components/example-notebook-servers/
+        make docker-build -C jupyter-scipy
+        make docker-push -C jupyter-scipy
+
+    - name: Build and push Notebook Server images on Version change
       id: version
       if: steps.filter.outputs.version == 'true'
       run: |
-        docker tag jupyter-scipy:${{env.TAG}} ${{env.REGISTRY}}/jupyter-scipy:${VERSION_TAG}
-        docker push ${{env.REGISTRY}}/jupyter-scipy:${VERSION_TAG}
-      env:
-        VERSION_TAG: $(cat releasing/version/VERSION)
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/
+        make docker-build -C jupyter-scipy
+        make docker-push -C jupyter-scipy

--- a/.github/workflows/nb_server_jupyter_tf_full_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_tf_full_docker_publish.yaml
@@ -12,7 +12,6 @@ on:
       - releasing/version/VERSION
 
 env:
-  TAG: $(git describe --tags --always --dirty)
   DOCKER_USER: kubeflownotebookswg
   REGISTRY: kubeflownotebookswg
 
@@ -39,26 +38,31 @@ jobs:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Build Notebook Server images via their Makefile
+    - name: Build and push Notebook Server images
       run: |
         cd components/example-notebook-servers/
         make docker-build-cpu -C jupyter-tensorflow-full
         make docker-build-cuda -C jupyter-tensorflow-full
-    
-    - name: Push Notebook Server images
-      run: |
-        docker tag jupyter-tensorflow-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-tensorflow-full:${{env.TAG}}
-        docker push ${{env.REGISTRY}}/jupyter-tensorflow-full:${{env.TAG}}
-        docker tag jupyter-tensorflow-cuda-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-tensorflow-cuda-full:${{env.TAG}}
-        docker push ${{env.REGISTRY}}/jupyter-tensorflow-cuda-full:${{env.TAG}}
+        make docker-push-cpu -C jupyter-tensorflow-full
+        make docker-push-cuda -C jupyter-tensorflow-full
 
-    - name: Push Notebook Server images on Version change
+    - name: Build and push latest Notebook Server images
+      if: github.ref == 'refs/heads/master'
+      run: |
+        export TAG=latest
+        cd components/example-notebook-servers/
+        make docker-build-cpu -C jupyter-tensorflow-full
+        make docker-build-cuda -C jupyter-tensorflow-full
+        make docker-push-cpu -C jupyter-tensorflow-full
+        make docker-push-cuda -C jupyter-tensorflow-full
+
+    - name: Build and push Notebook Server images on Version change
       id: version
       if: steps.filter.outputs.version == 'true'
       run: |
-        docker tag jupyter-tensorflow-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-tensorflow-full:${VERSION_TAG}
-        docker push ${{env.REGISTRY}}/jupyter-tensorflow-full:${VERSION_TAG}
-        docker tag jupyter-tensorflow-cuda-full:${{env.TAG}} ${{env.REGISTRY}}/jupyter-tensorflow-cuda-full:${VERSION_TAG}
-        docker push ${{env.REGISTRY}}/jupyter-tensorflow-cuda-full:${VERSION_TAG}
-      env:
-        VERSION_TAG: $(cat releasing/version/VERSION)
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/
+        make docker-build-cpu -C jupyter-tensorflow-full
+        make docker-build-cuda -C jupyter-tensorflow-full
+        make docker-push-cpu -C jupyter-tensorflow-full
+        make docker-push-cuda -C jupyter-tensorflow-full

--- a/.github/workflows/nb_server_rstudio_tidyverse_docker_publish.yaml
+++ b/.github/workflows/nb_server_rstudio_tidyverse_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
       - releasing/version/VERSION
 
 env:
-  TAG: $(git describe --tags --always --dirty)
   DOCKER_USER: kubeflownotebookswg
   REGISTRY: kubeflownotebookswg
 
@@ -38,21 +37,25 @@ jobs:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
-    - name: Build Notebook Server images via their Makefile
+    - name: Build and push Notebook Server images
       run: |
         cd components/example-notebook-servers/
         make docker-build -C rstudio-tidyverse
-    
-    - name: Push Notebook Server images
-      run: |
-        docker tag rstudio-tidyverse:${{env.TAG}} ${{env.REGISTRY}}/rstudio-tidyverse:${{env.TAG}}
-        docker push ${{env.REGISTRY}}/rstudio-tidyverse:${{env.TAG}}
+        make docker-push -C rstudio-tidyverse
 
-    - name: Push Notebook Server images on Version change
+    - name: Build and push latest Notebook Server images
+      if: github.ref == 'refs/heads/master'
+      run: |
+        export TAG=latest
+        cd components/example-notebook-servers/
+        make docker-build -C rstudio-tidyverse
+        make docker-push -C rstudio-tidyverse
+
+    - name: Build and push Notebook Server images on Version change
       id: version
       if: steps.filter.outputs.version == 'true'
       run: |
-        docker tag rstudio-tidyverse:${{env.TAG}} ${{env.REGISTRY}}/rstudio-tidyverse:${VERSION_TAG}
-        docker push ${{env.REGISTRY}}/rstudio-tidyverse:${VERSION_TAG}
-      env:
-        VERSION_TAG: $(cat releasing/version/VERSION)
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/example-notebook-servers/
+        make docker-build -C rstudio-tidyverse
+        make docker-push -C rstudio-tidyverse

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -17,23 +17,23 @@
 spawnerFormDefaults:
   image:
     # The container Image for the user's Jupyter Notebook
-    value: kubeflownotebookswg/jupyter-scipy:v1.5.0
+    value: kubeflownotebookswg/jupyter-scipy:latest
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/jupyter-scipy:v1.5.0
-    - kubeflownotebookswg/jupyter-pytorch-full:v1.5.0
-    - kubeflownotebookswg/jupyter-pytorch-cuda-full:v1.5.0
-    - kubeflownotebookswg/jupyter-tensorflow-full:v1.5.0
-    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:v1.5.0
+    - kubeflownotebookswg/jupyter-scipy:latest
+    - kubeflownotebookswg/jupyter-pytorch-full:latest
+    - kubeflownotebookswg/jupyter-pytorch-cuda-full:latest
+    - kubeflownotebookswg/jupyter-tensorflow-full:latest
+    - kubeflownotebookswg/jupyter-tensorflow-cuda-full:latest
   imageGroupOne:
     # The container Image for the user's Group One Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
     # is applied to notebook in this group, configuring
     # the Istio rewrite for containers that host their web UI at `/`
-    value: kubeflownotebookswg/codeserver-python:v1.5.0
+    value: kubeflownotebookswg/codeserver-python:latest
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/codeserver-python:v1.5.0
+    - kubeflownotebookswg/codeserver-python:latest
   imageGroupTwo:
     # The container Image for the user's Group Two Server
     # The annotation `notebooks.kubeflow.org/http-rewrite-uri: /`
@@ -42,10 +42,10 @@ spawnerFormDefaults:
     # The annotation `notebooks.kubeflow.org/http-headers-request-set`
     # is applied to notebook in this group, configuring Istio
     # to add the `X-RStudio-Root-Path` header to requests
-    value: kubeflownotebookswg/rstudio-tidyverse:v1.5.0
+    value: kubeflownotebookswg/rstudio-tidyverse:latest
     # The list of available standard container Images
     options:
-    - kubeflownotebookswg/rstudio-tidyverse:v1.5.0
+    - kubeflownotebookswg/rstudio-tidyverse:latest
   # If true, hide registry and/or tag name in the image selection dropdown
   hideRegistry: true
   hideTag: false

--- a/components/example-notebook-servers/Makefile
+++ b/components/example-notebook-servers/Makefile
@@ -3,59 +3,96 @@ REGISTRY ?= kubeflownotebookswg
 
 docker-build-all:
 	@echo "\nBuilding base image...\n"
-	make docker-build -C base TAG=${TAG}
+	make docker-build -C base
 
 	@echo "\nBuilding codeserver image...\n"
-	make docker-build -C codeserver TAG=${TAG} 
+	make docker-build -C codeserver
 
 	@echo "\nBuilding codeserver-python image...\n"
-	make docker-build -C codeserver-python TAG=${TAG} 
+	make docker-build -C codeserver-python
 
 	@echo "\nBuilding rstudio image...\n"
-	make docker-build -C rstudio TAG=${TAG} 
+	make docker-build -C rstudio
 
 	@echo "\nBuilding rstudio-tidyverse image...\n"
-	make docker-build -C rstudio-tidyverse TAG=${TAG} 
+	make docker-build -C rstudio-tidyverse
 
 	@echo "\nBuilding jupyter image...\n"
-	make docker-build -C jupyter TAG=${TAG} 
+	make docker-build -C jupyter 
 
 	@echo "\nBuilding jupyter-scipy image...\n"
-	make docker-build -C jupyter-scipy TAG=${TAG} 
+	make docker-build -C jupyter-scipy
 
 	@echo "\nBuilding jupyter-pytorch image...\n"
-	make docker-build-cpu -C jupyter-pytorch TAG=${TAG} 
+	make docker-build-cpu -C jupyter-pytorch
 
 	@echo "\nBuilding jupyter-pytorch-cuda image...\n"
-	make docker-build-cuda -C jupyter-pytorch TAG=${TAG} 
+	make docker-build-cuda -C jupyter-pytorch
 
 	@echo "\nBuilding jupyter-pytorch-full image...\n"
-	make docker-build-cpu -C jupyter-pytorch-full TAG=${TAG}
+	make docker-build-cpu -C jupyter-pytorch-full
 
 	@echo "\nBuilding jupyter-pytorch-cuda-full image...\n"
-	make docker-build-cuda -C jupyter-pytorch-full TAG=${TAG} 
+	make docker-build-cuda -C jupyter-pytorch-full
 
 	@echo "\nBuilding jupyter-tensorflow image...\n"
-	make docker-build-cpu -C jupyter-tensorflow TAG=${TAG} 
+	make docker-build-cpu -C jupyter-tensorflow
 
 	@echo "\nBuilding jupyter-tensorflow-cuda image...\n"
-	make docker-build-cuda -C jupyter-tensorflow TAG=${TAG} 
+	make docker-build-cuda -C jupyter-tensorflow
 
 	@echo "\nBuilding jupyter-tensorflow-full image...\n"
-	make docker-build-cpu -C jupyter-tensorflow-full TAG=${TAG} 
+	make docker-build-cpu -C jupyter-tensorflow-full
 
 	@echo "\nBuilding jupyter-tensorflow-cuda-full image...\n"
-	make docker-build-cuda -C jupyter-tensorflow-full TAG=${TAG} 
+	make docker-build-cuda -C jupyter-tensorflow-full
 
 	@echo "\nAll notebook-server images have been successfully built...\n"
 
 docker-push-all:
-	for img in base codeserver codeserver-python jupyter jupyter-scipy jupyter-pytorch-full jupyter-pytorch-cuda-full jupyter-tensorflow-full \
-	jupyter-tensorflow-cuda-full rstudio rstudio-tidyverse ; do \
-		docker tag $$img:${TAG} ${REGISTRY}/$$img:${TAG} ; \
-		docker push ${REGISTRY}/$$img:${TAG} ; \
-	done
+	@echo "\nPushing base image...\n"
+	make docker-push -C base
 
-	
+	@echo "\nPushing codeserver image...\n"
+	make docker-push -C codeserver
 
-	
+	@echo "\nPushing codeserver-python image...\n"
+	make docker-push -C codeserver-python 
+
+	@echo "\nPushing rstudio image...\n"
+	make docker-push -C rstudio
+
+	@echo "\nPushing rstudio-tidyverse image...\n"
+	make docker-push -C rstudio-tidyverse
+
+	@echo "\nPushing jupyter image...\n"
+	make docker-push -C jupyter
+
+	@echo "\nPushing jupyter-scipy image...\n"
+	make docker-push -C jupyter-scipy
+
+	@echo "\nPushing jupyter-pytorch image...\n"
+	make docker-push-cpu -C jupyter-pytorch
+
+	@echo "\nPushing jupyter-pytorch-cuda image...\n"
+	make docker-push-cuda -C jupyter-pytorch
+
+	@echo "\nPushing jupyter-pytorch-full image...\n"
+	make docker-push-cpu -C jupyter-pytorch-full
+
+	@echo "\nPushing jupyter-pytorch-cuda-full image...\n"
+	make docker-push-cuda -C jupyter-pytorch-full
+
+	@echo "\nPushing jupyter-tensorflow image...\n"
+	make docker-push-cpu -C jupyter-tensorflow
+
+	@echo "\nPushing jupyter-tensorflow-cuda image...\n"
+	make docker-push-cuda -C jupyter-tensorflow
+
+	@echo "\nPushing jupyter-tensorflow-full image...\n"
+	make docker-push-cpu -C jupyter-tensorflow-full
+
+	@echo "\nPushing jupyter-tensorflow-cuda-full image...\n"
+	make docker-push-cuda -C jupyter-tensorflow-full
+
+	@echo "\nAll notebook-server images have been successfully pushed...\n"

--- a/components/example-notebook-servers/base/Makefile
+++ b/components/example-notebook-servers/base/Makefile
@@ -1,7 +1,8 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build:
-	docker build -t base:${TAG} -f Dockerfile .
+	docker build -t ${REGISTRY}/base:${TAG} -f Dockerfile .
 
 docker-push:
-	docker push base:${TAG}
+	docker push ${REGISTRY}/base:${TAG}

--- a/components/example-notebook-servers/codeserver-python/Makefile
+++ b/components/example-notebook-servers/codeserver-python/Makefile
@@ -1,10 +1,11 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-codeserver:
 	make docker-build -C ../codeserver TAG=${TAG}
 
 docker-build: docker-build-codeserver
-	docker build -t codeserver-python:${TAG} --build-arg BASE_IMG=codeserver:${TAG} -f Dockerfile . 
+	docker build -t ${REGISTRY}/codeserver-python:${TAG} --build-arg BASE_IMG=${REGISTRY}/codeserver:${TAG} -f Dockerfile . 
 
 docker-push:
-	docker push codeserver-python:${TAG}
+	docker push ${REGISTRY}/codeserver-python:${TAG}

--- a/components/example-notebook-servers/codeserver/Makefile
+++ b/components/example-notebook-servers/codeserver/Makefile
@@ -1,10 +1,11 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-base:
 	make docker-build -C ../base TAG=${TAG}
 
 docker-build: docker-build-base
-	docker build -t codeserver:${TAG} --build-arg BASE_IMG=base:${TAG} -f Dockerfile . 
+	docker build -t ${REGISTRY}/codeserver:${TAG} --build-arg BASE_IMG=${REGISTRY}/base:${TAG} -f Dockerfile . 
 
 docker-push:
-	docker push codeserver:${TAG}
+	docker push ${REGISTRY}/codeserver:${TAG}

--- a/components/example-notebook-servers/jupyter-pytorch-full/Makefile
+++ b/components/example-notebook-servers/jupyter-pytorch-full/Makefile
@@ -1,4 +1,5 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-jupyter-pytorch:
 	make docker-build-cpu -C ../jupyter-pytorch TAG=${TAG} 
@@ -7,13 +8,13 @@ docker-build-jupyter-pytorch-cuda:
 	make docker-build-cuda -C ../jupyter-pytorch TAG=${TAG} 
 
 docker-build-cpu: docker-build-jupyter-pytorch
-	docker build -t jupyter-pytorch-full:${TAG} --build-arg BASE_IMG=jupyter-pytorch:${TAG} -f cpu.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-pytorch-full:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter-pytorch:${TAG} -f cpu.Dockerfile . 
 
 docker-build-cuda: docker-build-jupyter-pytorch-cuda
-	docker build -t jupyter-pytorch-cuda-full:${TAG} --build-arg BASE_IMG=jupyter-pytorch-cuda:${TAG} -f cuda.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-pytorch-cuda-full:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter-pytorch-cuda:${TAG} -f cuda.Dockerfile . 
 
 docker-push-cpu:
-	docker push jupyter-pytorch-full:${TAG}
+	docker push ${REGISTRY}/jupyter-pytorch-full:${TAG}
 
 docker-push-cuda:
-	docker push jupyter-pytorch-cuda-full:${TAG}
+	docker push ${REGISTRY}/jupyter-pytorch-cuda-full:${TAG}

--- a/components/example-notebook-servers/jupyter-pytorch/Makefile
+++ b/components/example-notebook-servers/jupyter-pytorch/Makefile
@@ -1,16 +1,17 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-jupyter:
 	make docker-build -C ../jupyter TAG=${TAG}
 
 docker-build-cpu: docker-build-jupyter
-	docker build -t jupyter-pytorch:${TAG} --build-arg BASE_IMG=jupyter:${TAG} -f cpu.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-pytorch:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter:${TAG} -f cpu.Dockerfile . 
 
 docker-build-cuda: docker-build-jupyter
-	docker build -t jupyter-pytorch-cuda:${TAG} --build-arg BASE_IMG=jupyter:${TAG} -f cuda.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-pytorch-cuda:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter:${TAG} -f cuda.Dockerfile . 
 
 docker-push-cpu:
-	docker push jupyter-pytorch:${TAG}
+	docker push ${REGISTRY}/jupyter-pytorch:${TAG}
 
 docker-push-cuda:
-	docker push jupyter-pytorch-cuda:${TAG}
+	docker push ${REGISTRY}/jupyter-pytorch-cuda:${TAG}

--- a/components/example-notebook-servers/jupyter-scipy/Makefile
+++ b/components/example-notebook-servers/jupyter-scipy/Makefile
@@ -1,10 +1,11 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-jupyter:
 	make docker-build -C ../jupyter TAG=${TAG} 
 
 docker-build: docker-build-jupyter
-	docker build -t jupyter-scipy:${TAG} --build-arg BASE_IMG=jupyter:${TAG} -f Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-scipy:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter:${TAG} -f Dockerfile . 
 
 docker-push:
-	docker push jupyter-scipy:${TAG}
+	docker push ${REGISTRY}/jupyter-scipy:${TAG}

--- a/components/example-notebook-servers/jupyter-tensorflow-full/Makefile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/Makefile
@@ -1,4 +1,5 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-jupyter-tensorflow:
 	make docker-build-cpu -C ../jupyter-tensorflow TAG=${TAG}
@@ -7,13 +8,13 @@ docker-build-jupyter-tensorflow-cuda:
 	make docker-build-cuda -C ../jupyter-tensorflow TAG=${TAG}
 
 docker-build-cpu: docker-build-jupyter-tensorflow
-	docker build -t jupyter-tensorflow-full:${TAG} --build-arg BASE_IMG=jupyter-tensorflow:${TAG} -f cpu.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-tensorflow-full:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter-tensorflow:${TAG} -f cpu.Dockerfile . 
 
 docker-build-cuda: docker-build-jupyter-tensorflow-cuda
-	docker build -t jupyter-tensorflow-cuda-full:${TAG} --build-arg BASE_IMG=jupyter-tensorflow-cuda:${TAG} -f cuda.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-tensorflow-cuda-full:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter-tensorflow-cuda:${TAG} -f cuda.Dockerfile . 
 
 docker-push-cpu:
-	docker push jupyter-tensorflow-full:${TAG}
+	docker push ${REGISTRY}/jupyter-tensorflow-full:${TAG}
 
 docker-push-cuda:
-	docker push jupyter-tensorflow-cuda-full:${TAG}
+	docker push ${REGISTRY}/jupyter-tensorflow-cuda-full:${TAG}

--- a/components/example-notebook-servers/jupyter-tensorflow/Makefile
+++ b/components/example-notebook-servers/jupyter-tensorflow/Makefile
@@ -1,16 +1,17 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-jupyter:
 	make docker-build -C ../jupyter TAG=${TAG} 
 
 docker-build-cpu: docker-build-jupyter
-	docker build -t jupyter-tensorflow:${TAG} --build-arg BASE_IMG=jupyter:${TAG} -f cpu.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-tensorflow:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter:${TAG} -f cpu.Dockerfile . 
 
 docker-build-cuda: docker-build-jupyter
-	docker build -t jupyter-tensorflow-cuda:${TAG} --build-arg BASE_IMG=jupyter:${TAG} -f cuda.Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter-tensorflow-cuda:${TAG} --build-arg BASE_IMG=${REGISTRY}/jupyter:${TAG} -f cuda.Dockerfile . 
 
 docker-push-cpu: 
-	docker push jupyter-tensorflow:${TAG}
+	docker push ${REGISTRY}/jupyter-tensorflow:${TAG}
 
 docker-push-cuda:
-	docker push jupyter-tensorflow-cuda:${TAG}
+	docker push ${REGISTRY}/jupyter-tensorflow-cuda:${TAG}

--- a/components/example-notebook-servers/jupyter/Makefile
+++ b/components/example-notebook-servers/jupyter/Makefile
@@ -1,10 +1,11 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-base:
 	make docker-build -C ../base TAG=${TAG}
 
 docker-build: docker-build-base
-	docker build -t jupyter:${TAG} --build-arg BASE_IMG=base:${TAG} -f Dockerfile . 
+	docker build -t ${REGISTRY}/jupyter:${TAG} --build-arg BASE_IMG=${REGISTRY}/base:${TAG} -f Dockerfile . 
 
 docker-push:
-	docker push jupyter:${TAG}
+	docker push ${REGISTRY}/jupyter:${TAG}

--- a/components/example-notebook-servers/rstudio-tidyverse/Makefile
+++ b/components/example-notebook-servers/rstudio-tidyverse/Makefile
@@ -1,10 +1,11 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-rstudio:
 	make docker-build -C ../rstudio TAG=${TAG} 
 
 docker-build: docker-build-rstudio
-	docker build -t rstudio-tidyverse:${TAG} --build-arg BASE_IMG=rstudio:${TAG} -f Dockerfile . 
+	docker build -t ${REGISTRY}/rstudio-tidyverse:${TAG} --build-arg BASE_IMG=${REGISTRY}/rstudio:${TAG} -f Dockerfile . 
 
 docker-push:
-	docker push rstudio-tidyverse:${TAG}
+	docker push ${REGISTRY}/rstudio-tidyverse:${TAG}

--- a/components/example-notebook-servers/rstudio/Makefile
+++ b/components/example-notebook-servers/rstudio/Makefile
@@ -1,10 +1,11 @@
 TAG ?= $(shell git describe --tags --always --dirty)
+REGISTRY ?= kubeflownotebookswg
 
 docker-build-base:
 	make docker-build -C ../base TAG=${TAG}
 
 docker-build: docker-build-base
-	docker build -t rstudio:${TAG} --build-arg BASE_IMG=base:${TAG} -f Dockerfile . 
+	docker build -t ${REGISTRY}/rstudio:${TAG} --build-arg BASE_IMG=${REGISTRY}/base:${TAG} -f Dockerfile . 
 
 docker-push:
-	docker push rstudio:${TAG}
+	docker push ${REGISTRY}/rstudio:${TAG}


### PR DESCRIPTION
This is a follow-up PR to address https://github.com/kubeflow/kubeflow/pull/6854#discussion_r1053260293 and is part of https://github.com/kubeflow/kubeflow/issues/6766

Changes:
- Fix Makefiles to use a `REGISTRY` env var to set registry prefix when building/pushing notebook-server images
- Fix publish workflows to Build/Push notebook-server images via `docker-build` & `docker-push` Makefile rules with appropriate tags:
  - Always Build/Push notebook-server images with `TAG=$(shell git describe --tags --always --dirty)`
  - Build/Push notebook-server images with `TAG=latest` only when the target branch is master
  - Build/Push notebook-server images with `TAG=$(cat releasing/version/VERSION)` when
  Version changes
- Update KF manifests to use `latest` tag for notebook-server images