### PR TITLE
gh-actions: Revert changes for fetching full git history in the workflows

### DIFF
--- a/.github/workflows/centraldb_angular_docker_publish.yaml
+++ b/.github/workflows/centraldb_angular_docker_publish.yaml
@@ -19,8 +19,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -19,8 +19,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/nb_server_codeserver_python_docker_publish.yaml
+++ b/.github/workflows/nb_server_codeserver_python_docker_publish.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/nb_server_jupyter_pytorch_full_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_pytorch_full_docker_publish.yaml
@@ -22,8 +22,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/nb_server_jupyter_scipy_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_scipy_docker_publish.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/nb_server_jupyter_tf_full_docker_publish.yaml
+++ b/.github/workflows/nb_server_jupyter_tf_full_docker_publish.yaml
@@ -22,8 +22,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/nb_server_rstudio_tidyverse_docker_publish.yaml
+++ b/.github/workflows/nb_server_rstudio_tidyverse_docker_publish.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter


### PR DESCRIPTION
This is a follow up PR to address https://github.com/kubeflow/kubeflow/pull/6860#issuecomment-1360960463 and is part of https://github.com/kubeflow/kubeflow/issues/6766

- Revert changes introduced in https://github.com/kubeflow/kubeflow/pull/6849 regarding fetching all history for all tags and branches when workflows run. This is because the images end up having a tag for `RC0` of `v1.5` from the main branch.
- The workflows build/push images with hash commit tags.

Signed-off-by: Apostolos Gerakaris <apoger@arrikto.com>