### PR TITLE
Support Pod Defaults in Tensorboard controller

### DIFF
--- a/components/tensorboard-controller/config/base/kustomization.yaml
+++ b/components/tensorboard-controller/config/base/kustomization.yaml
@@ -6,7 +6,7 @@ configMapGenerator:
 - name: tensorboard-controller-config
   literals:
   - RWO_PVC_SCHEDULING="True"
-  - TENSORBOARD_IMAGE=tensorflow/tensorflow:2.1.0
+  - TENSORBOARD_IMAGE=tensorflow/tensorflow:2.5.1
   - ISTIO_GATEWAY=kubeflow/kubeflow-gateway
 patchesStrategicMerge:
 - patches/add_controller_config.yaml

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -246,6 +246,12 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 		})
 	}
 
+	// copy all of the CR labels to the pod which includes poddefault related labels
+	podLabels := map[string]string{"app": tb.Name}
+	for k, v := range tb.ObjectMeta.Labels {
+		(podLabels)[k] = v
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tb.Name,
@@ -260,7 +266,7 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"app": tb.Name},
+					Labels: podLabels,
 				},
 				Spec: corev1.PodSpec{
 					Affinity:      affinity,

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -247,10 +247,11 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 	}
 
 	// copy all of the CR labels to the pod which includes poddefault related labels
-	podLabels := map[string]string{"app": tb.Name}
+	podLabels := map[string]string{}
 	for k, v := range tb.ObjectMeta.Labels {
 		(podLabels)[k] = v
 	}
+	(podLabels)["app"] = tb.Name
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
This PR adds functionality for adding pod default related labels for tensorboard pods in tensorboard controller.  This can be used for various things like configuring cloud storage parameters using environment variables(#6493), service account, tolerations etc.

User experience:
1. User creates a tensorboard CR with required labels (`metadata.labels`)
2. Controller will create the deployment with labels on the pod copied from the tensorboard CR
3. Admission webhook will take care of injecting necessary configurations according to poddefault

Updated the image version because v2.1.0 did not work with IAM roles. Using the latest version would require building and maintaining an image because some functionality is moved out to a different package(tensorflow-io). This package is not installed by default in tensorflow image and I would like to focus on completing the core functionality first.

@kimwnasptd @kandrio  @elikatsis 

Is there anyone who can help with implementing the webapp frontend related changes or
I would appreciate if anyone can give me a quick intro on the frontend Angular part of the code so I can make the changes myself?