### PR TITLE
gh-actions: Create testing setup for CDB tests

### DIFF
--- a/.github/workflows/centraldb_angular_frontend_test.yaml
+++ b/.github/workflows/centraldb_angular_frontend_test.yaml
@@ -42,3 +42,63 @@ jobs:
           cd components/centraldashboard-angular/frontend/
           npm i
           npm run test:prod
+
+  run-tests-in-chrome:
+    name: UI tests in chrome
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node version to 12
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12
+
+      - name: Install KinD
+        run: ./components/testing/gh-actions/install_kind.sh
+
+      - name: Create KinD Cluster
+        run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
+
+      - name: Install kustomize
+        run: ./components/testing/gh-actions/install_kustomize.sh
+
+      - name: Install Istio
+        run: ./components/testing/gh-actions/install_istio.sh
+
+      - name: Apply KF Controllers
+        run: |
+          cd components
+          kubectl create namespace kubeflow
+          kustomize build profile-controller/config/overlays/kubeflow | kubectl apply -f -
+          kustomize build notebook-controller/config/overlays/kubeflow | kubectl apply -f -
+          kubectl wait pods -n kubeflow -l kustomize.component=profiles --for=condition=Ready --timeout=300s
+          kubectl wait pods -n kubeflow -l app=notebook-controller --for=condition=Ready --timeout=300s
+
+      - name: Apply JWA manifests
+        run: |
+          cd components/crud-web-apps/jupyter/manifests
+          kustomize build overlays/istio | kubectl apply -f -
+          kubectl wait pods -n kubeflow -l app=jupyter-web-app --for=condition=Ready --timeout=300s
+          kubectl port-forward -n kubeflow svc/jupyter-web-app-service 8086:80 &
+
+      - name: Apply VWA manifests
+        run: |
+          cd components/crud-web-apps/volumes/manifests
+          kustomize build overlays/istio | kubectl apply -f -
+          kubectl wait pods -n kubeflow -l app=volumes-web-app --for=condition=Ready --timeout=300s
+          kubectl port-forward -n kubeflow svc/volumes-web-app-service 8087:80 &
+
+      - name: Apply necessary CRs
+        run: |
+          kustomize build https://github.com/kubeflow/manifests//common/kubeflow-roles/base?ref=master | kubectl apply -f -
+          cd components/testing/gh-actions/resources
+          kubectl apply -f user-profile.yaml
+          while ! kubectl get ns kubeflow-user; do sleep 1; done
+          kubectl apply -f test-notebook.yaml
+          kubectl wait notebooks -n kubeflow-user -l app=test-notebook --for=condition=Ready --timeout=300s
+
+      - name: Test proxied apps
+        run: |
+          curl -H "kubeflow-userid: user" localhost:8086
+          curl -H "kubeflow-userid: user" localhost:8087

--- a/components/testing/gh-actions/resources/test-notebook.yaml
+++ b/components/testing/gh-actions/resources/test-notebook.yaml
@@ -1,0 +1,38 @@
+apiVersion: kubeflow.org/v1beta1
+kind: Notebook
+metadata:
+  labels:
+    app: test-notebook
+  name: test-notebook
+  namespace: kubeflow-user
+spec:
+  template:
+    spec:
+      containers:
+        - image: nginx
+          imagePullPolicy: IfNotPresent
+          name: test-notebook
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+          volumeMounts:
+            - mountPath: /home/jovyan
+              name: test-notebook-workspace
+      serviceAccountName: default-editor
+      volumes:
+        - name: test-notebook-workspace
+          persistentVolumeClaim:
+            claimName: test-notebook-workspace
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test-notebook-workspace
+  namespace: kubeflow-user
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/components/testing/gh-actions/resources/user-profile.yaml
+++ b/components/testing/gh-actions/resources/user-profile.yaml
@@ -1,0 +1,10 @@
+apiVersion: kubeflow.org/v1
+kind: Profile
+metadata:
+  name: kubeflow-user
+spec:
+  owner:
+    apiGroup: rbac.authorization.k8s.io
+    kind: User
+    name: user
+  resourceQuotaSpec: {}


### PR DESCRIPTION
In this commit we extend workflow for running CDB (Angular) frontend tests. For the CentralDashboard (Angular) tests we also need to ensure some underlying apps are proxied.

In this commit we extended the dedicated workflow for the frontend tests by:
1. Applying the necessary KF Controllers (Profiles, Notebooks)
2. Applying the JWA manifests and port-forward its k8s Service
3. Applying the VWA manifests and port-forward its k8s Service
4. Creating a user namespace (kubeflow-user) via a Profile
5. Creating a test Notebook, with a PVC, in that namespace

Next steps will be to run the Cypress tests of the CDB (Angular) that will be using the proxied apps.

/cc @orfeas-k 
/cc @tasos-ale 
/cc @apo-ger 