### PR TITLE
[Profile controller IAM plugin] Support annotation only

### DIFF
--- a/components/profile-controller/controllers/plugin_iam_test.go
+++ b/components/profile-controller/controllers/plugin_iam_test.go
@@ -2,12 +2,11 @@ package controllers
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
 )
 
 type AWSTestCase struct {
@@ -300,4 +299,16 @@ func TestRemoveServiceAccountInAssumeRolePolicy(t *testing.T) {
 		result, _ := removeServiceAccountInAssumeRolePolicy(test.policy, test.serviceAccountNamespace, test.serviceAccountName)
 		require.JSONEq(t, test.expectedPolicy, result)
 	}
+}
+
+func TestIsAnnotateOnly(t *testing.T) {
+	aws := &AwsIAMForServiceAccount{AnnotateOnly: true}
+
+	// Check that the result is true
+	assert.True(t, aws.isAnnotateOnly())
+
+
+	aws = &AwsIAMForServiceAccount{AnnotateOnly: false}
+	// Check that the result is true
+	assert.False(t, aws.isAnnotateOnly())
 }


### PR DESCRIPTION
AWS IAM service account profile plugin mutates the trust relationship in the iam role specified in the spec. 

Customers have different ways to manage roles and their company policies might not allow Kubeflow profile controller to allow changing the trust relationship. 

Adding a boolean variable to the AwsIAMForServiceAccount struct to enable users to specify if they want AnnotateOnly which will cause IAM roles and policy will not be mutated.

This change will not effect existing users who do not have the boolean field in their yaml files.