### PR TITLE
rstudio: Update version to properly handle X-Forwarded headers

### DIFF
--- a/components/example-notebook-servers/rstudio/Dockerfile
+++ b/components/example-notebook-servers/rstudio/Dockerfile
@@ -6,13 +6,13 @@ USER root
 
 # args - software versions
 ARG MINIFORGE_ARCH="x86_64"
- # renovate: datasource=github-tags depName=conda-forge/miniforge versioning=loose
+# renovate: datasource=github-tags depName=conda-forge/miniforge versioning=loose
 ARG MINIFORGE_VERSION=4.10.1-4
 ARG PIP_VERSION=21.1.2
 ARG PYTHON_VERSION=3.8.10
 ARG RSTUDIO_ARCH="amd64"
- # renovate: datasource=github-tags depName=rstudio/rstudio versioning=semver
-ARG RSTUDIO_VERSION=v1.4.1717
+# renovate: datasource=github-tags depName=rstudio/rstudio versioning=semver
+ARG RSTUDIO_VERSION=2022.12.0+353
 ARG R_BASE_VERSION=4.1.0
 ARG R_RETICULATE_VERSION=1.20
 ARG R_PNG_VERSION=0.1_7
@@ -52,7 +52,7 @@ USER ${NB_UID}
 RUN curl -sL "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-${MINIFORGE_ARCH}.sh" -o /tmp/Miniforge3.sh \
  && curl -sL "https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE_VERSION}/Miniforge3-${MINIFORGE_VERSION}-Linux-${MINIFORGE_ARCH}.sh.sha256" -o /tmp/Miniforge3.sh.sha256 \
  && echo "$(cat /tmp/Miniforge3.sh.sha256 | awk '{ print $1; }') /tmp/Miniforge3.sh" | sha256sum --check \
- && rm /tmp/Miniforge3.sh.sha256 \ 
+ && rm /tmp/Miniforge3.sh.sha256 \
  && /bin/bash /tmp/Miniforge3.sh -b -f -p ${CONDA_DIR} \
  && rm /tmp/Miniforge3.sh \
  && conda config --system --set auto_update_conda false \
@@ -83,8 +83,8 @@ RUN echo "TZ=${TZ}" >> ${R_HOME}/etc/Renviron.site
 USER root
 
 # install - rstudio-server
-# Affero General Public License may apply to RStudio: https://www.gnu.org/licenses/agpl-3.0.en.html 
-RUN curl -sL "https://download2.rstudio.org/server/bionic/${RSTUDIO_ARCH}/rstudio-server-${RSTUDIO_VERSION/v/}-${RSTUDIO_ARCH}.deb" -o /tmp/rstudio-server.deb \
+# Affero General Public License may apply to RStudio: https://www.gnu.org/licenses/agpl-3.0.en.html
+RUN curl -sL "https://download2.rstudio.org/server/bionic/${RSTUDIO_ARCH}/rstudio-server-${RSTUDIO_VERSION//+/-}-${RSTUDIO_ARCH}.deb" -o /tmp/rstudio-server.deb \
     # add rstudio public code-signing key
  && gpg --keyserver keys.gnupg.net --keyserver pgp.surfnet.nl --recv-keys 3F32EE77E331692F \
     # validate the build signature


### PR DESCRIPTION
Update the RStudio image to be able to handle multiple values in the `X-Forwarded-{Proto,Host}` headers. The server should care about the first values which are the ones the user's browser is using.

The fixes for these have been integrated in https://github.com/rstudio/rstudio/issues/11010 and https://github.com/rstudio/rstudio/issues/10965

Note, to bump into this you need to have at least 2 proxies that handle the `X-Forwarded-*` headers. In our case we had both an ALB loadbalancer and an NGINX in front of the ingressgateway, and that's why we bumped into this.