### PR TITLE
cdb-angular(front): Fix Iframe's sizing to fit to screen

### DIFF
--- a/components/centraldashboard-angular/frontend/src/app/pages/iframe-wrapper/iframe-wrapper.component.html
+++ b/components/centraldashboard-angular/frontend/src/app/pages/iframe-wrapper/iframe-wrapper.component.html
@@ -1,8 +1,3 @@
-<iframe
-  #iframe
-  style="width: 100%; height: 100%"
-  [src]="srcPath | safe"
-  (load)="onLoad($event)"
->
+<iframe #iframe [src]="srcPath | safe" (load)="onLoad($event)">
   <p>Your browser does not support iframes.</p>
 </iframe>

--- a/components/centraldashboard-angular/frontend/src/app/pages/iframe-wrapper/iframe-wrapper.component.scss
+++ b/components/centraldashboard-angular/frontend/src/app/pages/iframe-wrapper/iframe-wrapper.component.scss
@@ -1,0 +1,9 @@
+:host {
+  flex: 1;
+}
+
+iframe {
+  border: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.html
+++ b/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.html
@@ -14,7 +14,7 @@
       <a mat-list-item routerLink="/_/volumes/">Volume</a>
     </mat-nav-list>
   </mat-sidenav>
-  <mat-sidenav-content>
+  <mat-sidenav-content class="main-page-content">
     <mat-toolbar color="primary">
       <button
         type="button"

--- a/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.scss
+++ b/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.scss
@@ -10,6 +10,12 @@
   background: inherit;
 }
 
+.main-page-content {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .mat-toolbar.mat-primary {
   position: sticky;
   top: 0;


### PR DESCRIPTION
Style the dashboard and the iframe in order for the iframe to be responsive, fit in the screen and not exceed it. 

This resolves the issue from the comment here https://github.com/kubeflow/kubeflow/pull/6856#issuecomment-1381649212 and is part of the [Central Dashboard Rewrite effort](https://github.com/kubeflow/kubeflow/issues/6000).

cc @kimwnasptd 