### PR TITLE
gh-actions: Fix KF intergration tests for release branches

### DIFF
--- a/.github/workflows/centraldb_angular_intergration_test.yaml
+++ b/.github/workflows/centraldb_angular_intergration_test.yaml
@@ -41,11 +41,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/centraldashboard-angular/manifests
+        cd components/centraldashboard-angular/manifests/overlays/kserve
         kubectl create ns kubeflow
 
-        export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard-angular:latest
+        export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard-angular
         export PR_CENTRALDB_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_CENTRALDB_IMG}=${PR_CENTRALDB_IMG}
 
-        kustomize build overlays/kserve | sed "s#$CURRENT_CENTRALDB_IMG#$PR_CENTRALDB_IMG#g" | kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=centraldashboard-angular --for=condition=Ready --timeout=300s

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -41,11 +41,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/centraldashboard/manifests
+        cd components/centraldashboard/manifests/overlays/kserve
         kubectl create ns kubeflow
 
-        export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard:latest
+        export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard
         export PR_CENTRALDB_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_CENTRALDB_IMG}=${PR_CENTRALDB_IMG}
 
-        kustomize build overlays/kserve | sed "s#$CURRENT_CENTRALDB_IMG#$PR_CENTRALDB_IMG#g" | kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=centraldashboard --for=condition=Ready --timeout=300s

--- a/.github/workflows/jwa_intergration_test.yaml
+++ b/.github/workflows/jwa_intergration_test.yaml
@@ -42,11 +42,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/crud-web-apps/jupyter/manifests
+        cd components/crud-web-apps/jupyter/manifests/overlays/istio
         kubectl create ns kubeflow
 
-        export CURRENT_JWA_IMG=docker.io/kubeflownotebookswg/jupyter-web-app:latest
+        export CURRENT_JWA_IMG=docker.io/kubeflownotebookswg/jupyter-web-app
         export PR_JWA_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_JWA_IMG}=${PR_JWA_IMG}
 
-        kustomize build overlays/istio | sed "s#$CURRENT_JWA_IMG#$PR_JWA_IMG#g" | kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=jupyter-web-app --for=condition=Ready --timeout=300s

--- a/.github/workflows/nb_controller_intergration_test.yaml
+++ b/.github/workflows/nb_controller_intergration_test.yaml
@@ -41,11 +41,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/notebook-controller/config
+        cd components/notebook-controller/config/overlays/kubeflow
         kubectl create ns kubeflow
 
-        export CURRENT_NOTEBOOK_IMG=docker.io/kubeflownotebookswg/notebook-controller:latest
+        export CURRENT_NOTEBOOK_IMG=docker.io/kubeflownotebookswg/notebook-controller
         export PR_NOTEBOOK_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_NOTEBOOK_IMG}=${PR_NOTEBOOK_IMG}
 
-        kustomize build overlays/kubeflow | sed "s#$CURRENT_NOTEBOOK_IMG#$PR_NOTEBOOK_IMG#g" | kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=notebook-controller --for=condition=Ready --timeout=300s

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -44,12 +44,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/admission-webhook/manifests
+        cd components/admission-webhook/manifests/overlays/cert-manager
         kubectl create ns kubeflow
 
-        export CURRENT_PODDEFAULTS_IMG=docker.io/kubeflownotebookswg/poddefaults-webhook:latest
+        export CURRENT_PODDEFAULTS_IMG=docker.io/kubeflownotebookswg/poddefaults-webhook
         export PR_PODDEFAULTS_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_PODDEFAULTS_IMG}=${PR_PODDEFAULTS_IMG}
 
-
-        kustomize build overlays/cert-manager | sed "s#$CURRENT_PODDEFAULTS_IMG#$PR_PODDEFAULTS_IMG#g" | kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=poddefaults --for=condition=Ready --timeout=300s

--- a/.github/workflows/profiles_kfam_intergration_test.yaml
+++ b/.github/workflows/profiles_kfam_intergration_test.yaml
@@ -49,13 +49,14 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/profile-controller/config
+        cd components/profile-controller/config/overlays/kubeflow
         kubectl create ns kubeflow
 
-        export CURRENT_PROFILE_IMG=docker.io/kubeflownotebookswg/profile-controller:latest
-        export CURRENT_KFAM_IMG=docker.io/kubeflownotebookswg/kfam:latest
+        export CURRENT_PROFILE_IMG=docker.io/kubeflownotebookswg/profile-controller
+        export CURRENT_KFAM_IMG=docker.io/kubeflownotebookswg/kfam
         export PR_PROFILE_IMG=${{env.PROFILE_IMG}}:${{env.TAG}}
         export PR_KFAM_IMG=${{env.KFAM_IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_PROFILE_IMG}=${PR_PROFILE_IMG} ${CURRENT_KFAM_IMG}=${PR_KFAM_IMG} 
 
-        kustomize build overlays/kubeflow | sed "s#$CURRENT_PROFILE_IMG#$PR_PROFILE_IMG#g" | sed "s#$CURRENT_KFAM_IMG#$PR_KFAM_IMG#g" | kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l kustomize.component=profiles --for=condition=Ready --timeout=300s

--- a/.github/workflows/tb_controller_intergration_test.yaml
+++ b/.github/workflows/tb_controller_intergration_test.yaml
@@ -41,11 +41,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/tensorboard-controller/config
+        cd components/tensorboard-controller/config/overlays/kubeflow
         kubectl create ns kubeflow
 
-        export CURRENT_TENSORBOARD_IMG=docker.io/kubeflownotebookswg/tensorboard-controller:latest
-        export export PR_TENSORBOARD_IMG=${{env.IMG}}:${{env.TAG}}
+        export CURRENT_TENSORBOARD_IMG=docker.io/kubeflownotebookswg/tensorboard-controller
+        export PR_TENSORBOARD_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_TENSORBOARD_IMG}=${PR_TENSORBOARD_IMG}
 
-        kustomize build overlays/kubeflow | sed "s#$CURRENT_TENSORBOARD_IMG#$PR_TENSORBOARD_IMG#g" | kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=tensorboard-controller --for=condition=Ready --timeout=300s

--- a/.github/workflows/twa_intergration_test.yaml
+++ b/.github/workflows/twa_intergration_test.yaml
@@ -42,11 +42,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/crud-web-apps/tensorboards/manifests
+        cd components/crud-web-apps/tensorboards/manifests/overlays/istio
         kubectl create ns kubeflow
 
-        export CURRENT_TWA_IMG=docker.io/kubeflownotebookswg/tensorboards-web-app:latest
+        export CURRENT_TWA_IMG=docker.io/kubeflownotebookswg/tensorboards-web-app
         export PR_TWA_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_TWA_IMG}=${PR_TWA_IMG}
 
-        kustomize build overlays/istio | sed "s#$CURRENT_TWA_IMG#$PR_TWA_IMG#g" |  kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=tensorboards-web-app --for=condition=Ready --timeout=300s

--- a/.github/workflows/vwa_intergration_test.yaml
+++ b/.github/workflows/vwa_intergration_test.yaml
@@ -42,11 +42,12 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/crud-web-apps/volumes/manifests
+        cd components/crud-web-apps/volumes/manifests/overlays/istio
         kubectl create ns kubeflow
 
-        export CURRENT_VWA_IMG=docker.io/kubeflownotebookswg/volumes-web-app:latest
+        export CURRENT_VWA_IMG=docker.io/kubeflownotebookswg/volumes-web-app
         export PR_VWA_IMG=${{env.IMG}}:${{env.TAG}}
+        kustomize edit set image ${CURRENT_VWA_IMG}=${PR_VWA_IMG}
 
-        kustomize build overlays/istio | sed "s#$CURRENT_VWA_IMG#$PR_VWA_IMG#g" |  kubectl apply -f -
+        kustomize build . | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=volumes-web-app --for=condition=Ready --timeout=300s


### PR DESCRIPTION
This PR addresses https://github.com/kubeflow/kubeflow/pull/6916#issuecomment-1408865920 and is part of https://github.com/kubeflow/kubeflow/issues/6766

Right now, the KF integration tests do not work when we update the manifests for RCs. The `sed` command does not work since it tries to replace the `latest` tag, which doesn't exist in the release branches.

Changes:

* Update the workflows to use the `kustomize edit image <curr_img>=<new_img>:<tag>` command (https://github.com/kubernetes-sigs/kustomize/blob/master/examples/image.md) to set the appropriate tag in the manifests before they are applied . 

Signed-off-by: Apostolos Gerakaris <apoger@arrikto.com>