### PR TITLE
Update GH Action script for installing Cert Manager

### DIFF
--- a/components/testing/gh-actions/install_cert_manager.sh
+++ b/components/testing/gh-actions/install_cert_manager.sh
@@ -1,14 +1,12 @@
 #!/bin/bash
 set -e
-echo "Installing cert-manager ..."
+echo "Fetching cert-manager manifests..."
 CERT_MANAGER_VERSION="v1.10.1"
-mkdir cert_tmp
-pushd cert_tmp > /dev/null
-    OS=$(go env GOOS); ARCH=$(go env GOARCH); \
-        curl -L -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/$CERT_MANAGER_VERSION/cmctl-$OS-$ARCH.tar.gz
-    tar xzf cmctl.tar.gz
-    sudo mv cmctl /usr/local/bin
-    cmctl x install
-popd
+CERT_MANAGER_URL="https://github.com/cert-manager/cert-manager/releases/download/$CERT_MANAGER_VERSION/cert-manager.yaml"
+curl -sL -o cert-manager.yaml $CERT_MANAGER_URL
+
+echo "Applying the Cert Manager manifests..."
+kubectl apply -f cert-manager.yaml
+
 echo "Waiting for cert-manager to be ready ..."
 kubectl wait --for=condition=ready pod -l 'app in (cert-manager,webhook)' --timeout=180s -n cert-manager


### PR DESCRIPTION
This PR is based on the initial work of @kimwnasptd: https://github.com/kubeflow/kubeflow/pull/6921

This should fix the problem we bumped into with using cmctl to generate the manfiests
```
chart requires kubeVersion: >= 1.21.0-0 which is incompatible with Kubernetes v1.20.0
```
We've seen this error in a couple of PRs https://github.com/kubeflow/kubeflow/pull/6893 https://github.com/kubeflow/kubeflow/pull/6917

Instead we'll use the generated cert-manager.yaml file that comes with each Cert Manager release. I.e.
https://github.com/cert-manager/cert-manager/releases/tag/v1.11.0