### PR TITLE
Add approvers to the frontends

### DIFF
--- a/components/crud-web-apps/common/frontend/OWNERS
+++ b/components/crud-web-apps/common/frontend/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- elenzio9
+- orfeas-k
+- tasos-ale

--- a/components/crud-web-apps/jupyter/frontend/OWNERS
+++ b/components/crud-web-apps/jupyter/frontend/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- elenzio9
+- orfeas-k
+- tasos-ale

--- a/components/crud-web-apps/tensorboards/frontend/OWNERS
+++ b/components/crud-web-apps/tensorboards/frontend/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- elenzio9
+- orfeas-k
+- tasos-ale

--- a/components/crud-web-apps/volumes/frontend/OWNERS
+++ b/components/crud-web-apps/volumes/frontend/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- elenzio9
+- orfeas-k
+- tasos-ale


### PR DESCRIPTION
Making a PR to update the OWNERS for the frontend code of our `crud-web-app`. It had taken me way to long to send this PR, and thus I'm adding new approvers and not going gradually via first assigning reviewers.

Both @orfeas-k and @elenzio9 have both a ton of PRs for the frontends and also reviewed a lot of the PRs. Listing some for completeness:

For @orfeas-k: https://github.com/kubeflow/kubeflow/commits?author=orfeas-k
* https://github.com/kubeflow/kubeflow/pull/6899
* https://github.com/kubeflow/kubeflow/pull/6822
* https://github.com/kubeflow/kubeflow/pull/6788
* https://github.com/kubeflow/kubeflow/pull/6862

For @elenzio9: https://github.com/kubeflow/kubeflow/commits?author=elenzio9
* https://github.com/kubeflow/kubeflow/pull/6826
* https://github.com/kubeflow/kubeflow/pull/6742
* https://github.com/kubeflow/kubeflow/pull/6743
* https://github.com/kubeflow/kubeflow/pull/6754
* https://github.com/kubeflow/kubeflow/pull/6763

Then @tasos-ale has mentored me a lot, especially in the early days. Almost all of the PRs for the frontend I would send upstream were first reviewed by him internally. So it's also way overdue to give him some acknowledgement! 
* https://github.com/kubeflow/kubeflow/pull/5710
* https://github.com/kubeflow/kubeflow/pull/5567
* https://github.com/kubeflow/kubeflow/pull/6875
* https://github.com/kubeflow/kubeflow/pull/6674
* https://github.com/kubeflow/kubeflow/pull/5513

@tasos-ale is also now working with @orfeas-k on the new CentralDashboard in Angular
* https://github.com/kubeflow/kubeflow/pull/6895
* https://github.com/kubeflow/kubeflow/pull/6918

/cc @kubeflow/wg-notebooks-leads  