### PR TITLE
centraldashboard: Support dynamic logout URL

### DIFF
--- a/components/centraldashboard/app/k8s_service.ts
+++ b/components/centraldashboard/app/k8s_service.ts
@@ -2,7 +2,8 @@ import * as k8s from '@kubernetes/client-node';
 
 /** Retrieve Dashboard configmap Name */
 const {
-  DASHBOARD_CONFIGMAP = "centraldashboard-config"
+  DASHBOARD_CONFIGMAP = "centraldashboard-config",
+  LOGOUT_URL = '/logout'
 } = process.env;
 
 /** Information about the Kubernetes hosting platform. */
@@ -10,6 +11,7 @@ export interface PlatformInfo {
   provider: string;
   providerName: string;
   kubeflowVersion: string;
+  logoutUrl: string;
 }
 
 /**
@@ -111,7 +113,8 @@ export class KubernetesService {
       return {
         kubeflowVersion: version,
         provider,
-        providerName: provider.split(':')[0]
+        providerName: provider.split(':')[0],
+        logoutUrl : LOGOUT_URL,
       };
     } catch (err) {
       console.error('Unexpected error', err);

--- a/components/centraldashboard/app/k8s_service_test.ts
+++ b/components/centraldashboard/app/k8s_service_test.ts
@@ -228,7 +228,8 @@ describe('KubernetesService', () => {
         provider:
             'gce://kubeflow-dev/us-east1-d/gke-kubeflow-default-pool-59885f2c-08tm',
         providerName: 'gce',
-        kubeflowVersion: '1.0.0'
+        kubeflowVersion: '1.0.0',
+        logoutUrl: '/logout'
       });
     });
 
@@ -269,7 +270,8 @@ describe('KubernetesService', () => {
       expect(platformInfo).toEqual({
         provider: 'other://',
         providerName: 'other',
-        kubeflowVersion: '1.0.0'
+        kubeflowVersion: '1.0.0',
+        logoutUrl: '/logout'
       });
     });
 
@@ -316,7 +318,8 @@ describe('KubernetesService', () => {
         provider:
             'gce://kubeflow-dev/us-east1-d/gke-kubeflow-default-pool-59885f2c-08tm',
         providerName: 'gce',
-        kubeflowVersion: 'unknown'
+        kubeflowVersion: 'unknown',
+        logoutUrl: '/logout'
       });
     });
 
@@ -330,7 +333,8 @@ describe('KubernetesService', () => {
       expect(platformInfo).toEqual({
         provider: 'other://',
         providerName: 'other',
-        kubeflowVersion: 'unknown'
+        kubeflowVersion: 'unknown',
+        logoutUrl: '/logout'
       });
     });
   });

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -40,4 +40,6 @@ spec:
           value: $(CD_REGISTRATION_FLOW)
         - name: DASHBOARD_LINKS_CONFIGMAP
           value: $(CD_CONFIGMAP_NAME)
+        - name: LOGOUT_URL
+          value: '/authservice/logout'
       serviceAccountName: centraldashboard

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -13,12 +13,12 @@ export class LogoutButton extends PolymerElement {
     static get template() {
         return html`
             <paper-button id="logout-button" on-tap="logout">
-                <iron-icon icon='kubeflow:logout' title="Logout"
+                <iron-icon icon='kubeflow:logout' title="Logout">
                 </iron-icon>
             </paper-button>
             <iron-ajax
                     id='logout'
-                    url='/logout'
+                    url$='{{logoutUrl}}'
                     method='post'
                     handle-as='json'
                     headers='{{headers}}'
@@ -32,6 +32,9 @@ export class LogoutButton extends PolymerElement {
             headers: {
                 type: Object,
                 computed: '_setHeaders()',
+            },
+            logoutUrl: {
+                type: String,
             },
         };
     }

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -88,6 +88,7 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             errorText: {type: String, value: ''},
             buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
+            logoutUrl: {type: String, value: '/logout'},
             platformInfo: Object,
             inIframe: {type: Boolean, value: false, readOnly: true},
             hideTabs: {type: Boolean, value: false, readOnly: true},
@@ -475,6 +476,9 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
         const kVer = this.platformInfo.kubeflowVersion;
         if (kVer && kVer != 'unknown') {
             this.buildVersion = this.platformInfo.kubeflowVersion;
+        }
+        if (platform.logoutUrl) {
+            this.logoutUrl = platform.logoutUrl;
         }
         // trigger template render
         this.menuLinks = JSON.parse(JSON.stringify(this.menuLinks));

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -82,7 +82,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     all-namespaces='[[allNamespaces]]', 
                     user='[[user]]')
                 footer#User-Badge
-                    logout-button
+                    logout-button(logout-url='[[logoutUrl]]')
         main#Content
             section#ViewTabs(hidden$='[[hideTabs]]')
                 paper-tabs(selected='[[page]]', attr-for-selected='page')

--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -9,7 +9,7 @@ import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 
 export const ALL_NAMESPACES = 'All namespaces';
 export const ALL_NAMESPACES_ALLOWED_LIST = ['jupyter', 'volumes',
-                                            'tensorboards'];
+    'tensorboards'];
 
 const allNamespacesAllowedPaths = ALL_NAMESPACES_ALLOWED_LIST
     .map(( p)=>`/_/${p}/`);


### PR DESCRIPTION
Use dynamic URL for the logout button that can be set by the `LOGOUT_URL` ENV variable in the deployment of the app. If it is unset, a default '/logout' string is passed from the backend to the frontend.

I documented in the issue [here ](https://github.com/kubeflow/kubeflow/issues/6940#issuecomment-1427637200)details on how I dealt with binding data between Polymer elements.

During this PR, we also had to fix a test that was broken. It seems that the test was failing because `new Date ()` added whitespace that was not equal to the space character during comparison. Instead of comparing objects of type `Date` and `string` in the expect statement, we went with comparing `Date` objects in order to ensure comparison in a uniform and type-strict way.