### PR TITLE
cdb(front): Fetch left sidebar links

### DIFF
--- a/components/centraldashboard-angular/frontend/cypress/e2e/url-syncing.cy.ts
+++ b/components/centraldashboard-angular/frontend/cypress/e2e/url-syncing.cy.ts
@@ -2,6 +2,8 @@ describe('Browser and Iframe URL syncing', () => {
   beforeEach(() => {
     cy.notebooksRequest();
     cy.mockPodDefaultsRequest();
+    cy.mockDashboardLinksRequest();
+    cy.mockEnvInfoRequest();
   });
 
   it('checks the URLs when the user navigates to pages inside the same WA', () => {
@@ -9,7 +11,7 @@ describe('Browser and Iframe URL syncing', () => {
     cy.notebookPodRequest();
     cy.visit('/');
 
-    cy.get('[data-cy-sidenav-menu-item="Jupyter"]')
+    cy.get('[data-cy-sidenav-menu-item="Notebooks"]')
       .should('be.visible')
       .click();
     cy.getIframeBody().find('button').contains('New Notebook').click();
@@ -35,7 +37,7 @@ describe('Browser and Iframe URL syncing', () => {
     cy.notebookPodRequest();
     cy.visit('/');
 
-    cy.get('[data-cy-sidenav-menu-item="Jupyter"]')
+    cy.get('[data-cy-sidenav-menu-item="Notebooks"]')
       .should('be.visible')
       .click();
 
@@ -62,7 +64,7 @@ describe('Browser and Iframe URL syncing', () => {
     cy.notebookPodRequest();
     cy.visit('/');
 
-    cy.get('[data-cy-sidenav-menu-item="Jupyter"]')
+    cy.get('[data-cy-sidenav-menu-item="Notebooks"]')
       .should('be.visible')
       .click();
 

--- a/components/centraldashboard-angular/frontend/cypress/fixtures/dashboardlinks.json
+++ b/components/centraldashboard-angular/frontend/cypress/fixtures/dashboardlinks.json
@@ -1,0 +1,142 @@
+{
+  "menuLinks": [
+    {
+      "type": "item",
+      "link": "/jupyter/",
+      "text": "Notebooks",
+      "icon": "book"
+    },
+    {
+      "type": "item",
+      "link": "/tensorboards/",
+      "text": "Tensorboards",
+      "icon": "assessment"
+    },
+    {
+      "type": "item",
+      "link": "/models/",
+      "text": "Models",
+      "icon": "kubeflow:models"
+    },
+    {
+      "type": "item",
+      "link": "/rok/",
+      "text": "Snapshots",
+      "icon": "kubeflow:rok"
+    },
+    {
+      "type": "item",
+      "link": "/volumes/",
+      "text": "Volumes",
+      "icon": "device:storage"
+    },
+    {
+      "type": "item",
+      "link": "/katib/",
+      "text": "Experiments (AutoML)",
+      "icon": "kubeflow:katib"
+    },
+    {
+      "type": "item",
+      "text": "Experiments (KFP)",
+      "link": "/pipeline/#/experiments",
+      "icon": "done-all"
+    },
+    {
+      "type": "item",
+      "link": "/pipeline/#/pipelines",
+      "text": "Pipelines",
+      "icon": "kubeflow:pipeline-centered"
+    },
+    {
+      "type": "item",
+      "link": "/pipeline/#/runs",
+      "text": "Runs",
+      "icon": "maps:directions-run"
+    },
+    {
+      "type": "item",
+      "link": "/pipeline/#/recurringruns",
+      "text": "Recurring Runs",
+      "icon": "device:access-alarm"
+    },
+    {
+      "type": "item",
+      "link": "/pipeline/#/artifacts",
+      "text": "Artifacts",
+      "icon": "editor:bubble-chart"
+    },
+    {
+      "type": "item",
+      "link": "/pipeline/#/executions",
+      "text": "Executions",
+      "icon": "av:play-arrow"
+    },
+    {
+      "type": "item",
+      "link": "/monitoring/",
+      "text": "Metrics",
+      "icon": "kubeflow:metrics"
+    }
+  ],
+  "externalLinks": [],
+  "quickLinks": [
+    {
+      "text": "Upload a pipeline",
+      "desc": "Pipelines",
+      "link": "/pipeline/"
+    },
+    {
+      "text": "View all pipeline runs",
+      "desc": "Pipelines",
+      "link": "/pipeline/#/runs"
+    },
+    {
+      "text": "Create a new Notebook server",
+      "desc": "Notebook Servers",
+      "link": "/jupyter/new?namespace=kubeflow"
+    },
+    {
+      "text": "View Katib Experiments",
+      "desc": "Katib",
+      "link": "/katib/"
+    }
+  ],
+  "documentationItems": [
+    {
+      "text": "Getting Started with Kubeflow",
+      "desc": "Get your machine-learning workflow up and running on Kubeflow",
+      "link": "https://www.kubeflow.org/docs/started/getting-started/"
+    },
+    {
+      "text": "MiniKF",
+      "desc": "A fast and easy way to deploy Kubeflow locally",
+      "link": "https://www.kubeflow.org/docs/started/getting-started-minikf/"
+    },
+    {
+      "text": "Microk8s for Kubeflow",
+      "desc": "Quickly get Kubeflow running locally on native hypervisors",
+      "link": "https://www.kubeflow.org/docs/started/getting-started-multipass/"
+    },
+    {
+      "text": "Minikube for Kubeflow",
+      "desc": "Quickly get Kubeflow running locally",
+      "link": "https://www.kubeflow.org/docs/started/getting-started-minikube/"
+    },
+    {
+      "text": "Kubeflow on GCP",
+      "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
+      "link": "https://www.kubeflow.org/docs/gke/"
+    },
+    {
+      "text": "Kubeflow on AWS",
+      "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
+      "link": "https://www.kubeflow.org/docs/aws/"
+    },
+    {
+      "text": "Requirements for Kubeflow",
+      "desc": "Get more detailed information about using Kubeflow and its components",
+      "link": "https://www.kubeflow.org/docs/started/requirements/"
+    }
+  ]
+}

--- a/components/centraldashboard-angular/frontend/cypress/fixtures/envinfo.json
+++ b/components/centraldashboard-angular/frontend/cypress/fixtures/envinfo.json
@@ -1,0 +1,18 @@
+{
+  "user": "user",
+  "platform": {
+    "provider": "provider:///path/to/provider",
+    "providerName": "aws",
+    "buildLabel": "Build Label",
+    "buildVersion": "Version",
+    "buildId": "Id"
+  },
+  "namespaces": [
+    {
+      "user": "user",
+      "namespace": "kubeflow-user",
+      "role": "owner"
+    }
+  ],
+  "isClusterAdmin": false
+}

--- a/components/centraldashboard-angular/frontend/cypress/support/commands.ts
+++ b/components/centraldashboard-angular/frontend/cypress/support/commands.ts
@@ -85,3 +85,15 @@ Cypress.Commands.add('notebookPodRequest', () => {
     '/jupyter/api/namespaces/kubeflow-user/notebooks/test-notebook/pod',
   ).as('notebookPodRequest');
 });
+
+Cypress.Commands.add('mockDashboardLinksRequest', () => {
+  cy.intercept('GET', '/api/dashboard-links', { fixture: 'dashboardlinks' }).as(
+    'mockDashboardLinksRequest',
+  );
+});
+
+Cypress.Commands.add('mockEnvInfoRequest', () => {
+  cy.intercept('GET', '/api/workgroup/env-info', { fixture: 'envinfo' }).as(
+    'mockEnvInfoRequest',
+  );
+});

--- a/components/centraldashboard-angular/frontend/cypress/support/e2e.ts
+++ b/components/centraldashboard-angular/frontend/cypress/support/e2e.ts
@@ -52,6 +52,16 @@ declare global {
        * underlying pod request
        */
       notebookPodRequest(): Chainable<void>;
+
+      /**
+       * Custom command that mocks Dashboard links request
+       */
+      mockDashboardLinksRequest(): Chainable<void>;
+
+      /**
+       * Custom command that mocks Env Info request
+       */
+      mockEnvInfoRequest(): Chainable<void>;
     }
   }
 }

--- a/components/centraldashboard-angular/frontend/src/app/pages/iframe-wrapper/iframe-wrapper.component.ts
+++ b/components/centraldashboard-angular/frontend/src/app/pages/iframe-wrapper/iframe-wrapper.component.ts
@@ -102,7 +102,14 @@ export class IframeWrapperComponent implements AfterViewInit, OnDestroy {
         this.iframeLocation = currentUrl;
         const path = iframeWindow?.location.pathname;
         const queryParams = this.getQueryParams(iframeWindow?.location.search);
-        this.router.navigate(['/_' + path], { queryParams });
+        /**
+         * Contrary to comparing URLs, here we prefer an undefined string instead
+         * of an empty one, because Angular's router will ignore an undefined
+         * fragment while it will go ahead and append a '#' when the fragment
+         * is an empty string
+         */
+        const fragment = iframeWindow?.location.hash?.split('#')[1];
+        this.router.navigate(['/_' + path], { queryParams, fragment });
       }
     }, 100);
   }

--- a/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.html
+++ b/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.html
@@ -11,17 +11,14 @@
     <mat-nav-list>
       <a data-cy-sidenav-menu-item="Home" mat-list-item routerLink="/">Home</a>
       <a
-        data-cy-sidenav-menu-item="Jupyter"
         mat-list-item
-        routerLink="/_/jupyter/"
-        >Jupyter</a
+        *ngFor="let link of menuLinks"
+        [routerLink]="getUrlPath(link.link)"
+        [fragment]="getUrlFragment(link.link)"
+        [attr.data-cy-sidenav-menu-item]="link.text"
       >
-      <a
-        data-cy-sidenav-menu-item="Volumes"
-        mat-list-item
-        routerLink="/_/volumes/"
-        >Volume</a
-      >
+        {{ link.text }}
+      </a>
     </mat-nav-list>
 
     <mat-toolbar class="footer">

--- a/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.html
+++ b/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.html
@@ -9,12 +9,20 @@
   >
     <mat-toolbar>Menu</mat-toolbar>
     <mat-nav-list>
-      <a data-cy-sidenav-menu-item="Home" mat-list-item routerLink="/">Home</a>
+      <a
+        mat-list-item
+        routerLink="/"
+        [routerLinkActive]="['active']"
+        [routerLinkActiveOptions]="{ exact: true }"
+        [attr.data-cy-sidenav-menu-item]="'Home'"
+        >Home</a
+      >
       <a
         mat-list-item
         *ngFor="let link of menuLinks"
         [routerLink]="getUrlPath(link.link)"
         [fragment]="getUrlFragment(link.link)"
+        [class.active]="isLinkActive(link.link)"
         [attr.data-cy-sidenav-menu-item]="link.text"
       >
         {{ link.text }}

--- a/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.scss
+++ b/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.scss
@@ -47,3 +47,7 @@
     display: inline;
   }
 }
+
+.active {
+  background-color: #ececec;
+}

--- a/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.ts
+++ b/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.ts
@@ -5,13 +5,14 @@ import { map, shareReplay } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { CDBBackendService } from 'src/app/services/backend.service';
 import { envInfo } from '../../types/env-info';
+import { DashboardLinks, Link, MenuLink } from 'src/app/types/dashboard-links';
 
 @Component({
   selector: 'app-main-page',
   templateUrl: './main-page.component.html',
   styleUrls: ['./main-page.component.scss'],
 })
-export class MainPageComponent implements OnInit, OnDestroy {
+export class MainPageComponent implements OnInit {
   isHandset$: Observable<boolean> = this.breakpointObserver
     .observe(Breakpoints.Handset)
     .pipe(
@@ -28,7 +29,10 @@ export class MainPageComponent implements OnInit, OnDestroy {
   public get buildIdWithLabel() {
     return this.computeBuildValue(this.buildLabel, this.buildId);
   }
-  public envInfoSub: Subscription;
+  public menuLinks: MenuLink[];
+  public externalLinks: any[];
+  public quickLinks: Link[];
+  public documentationItems: Link[];
 
   constructor(
     private breakpointObserver: BreakpointObserver,
@@ -36,15 +40,13 @@ export class MainPageComponent implements OnInit, OnDestroy {
   ) {}
 
   ngOnInit() {
-    this.envInfoSub = this.backend.getEnvInfo().subscribe((res: envInfo) => {
+    this.backend.getEnvInfo().subscribe((res: envInfo) => {
       this.handleEnvInfo(res);
     });
-  }
 
-  ngOnDestroy(): void {
-    if (this.envInfoSub) {
-      this.envInfoSub.unsubscribe();
-    }
+    this.backend.getDashboardLinks().subscribe((res: DashboardLinks) => {
+      this.handleDashboardLinks(res);
+    });
   }
 
   handleEnvInfo(env: envInfo) {
@@ -62,5 +64,27 @@ export class MainPageComponent implements OnInit, OnDestroy {
 
   computeBuildValue(label: string, buildValue: string): string {
     return `${label} ${buildValue}`;
+  }
+
+  handleDashboardLinks(links: DashboardLinks) {
+    const { menuLinks, externalLinks, quickLinks, documentationItems } = links;
+    this.menuLinks = menuLinks || [];
+    this.externalLinks = externalLinks || [];
+    this.quickLinks = quickLinks || [];
+    this.documentationItems = documentationItems || [];
+  }
+
+  getUrlPath(url: string) {
+    const urlWithoutFragment = url.split('#')[0];
+    return this.appendPrefix(urlWithoutFragment);
+  }
+
+  getUrlFragment(url: string): string {
+    const fragment = url.split('#')[1];
+    return fragment;
+  }
+
+  appendPrefix(url: string): string {
+    return '/_' + url;
   }
 }

--- a/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.ts
+++ b/components/centraldashboard-angular/frontend/src/app/pages/main-page/main-page.component.ts
@@ -6,6 +6,8 @@ import { environment } from 'src/environments/environment';
 import { CDBBackendService } from 'src/app/services/backend.service';
 import { envInfo } from '../../types/env-info';
 import { DashboardLinks, Link, MenuLink } from 'src/app/types/dashboard-links';
+import { Router } from '@angular/router';
+import { appendBackslash, removePrefixFrom } from 'src/app/shared/utils';
 
 @Component({
   selector: 'app-main-page',
@@ -37,6 +39,7 @@ export class MainPageComponent implements OnInit {
   constructor(
     private breakpointObserver: BreakpointObserver,
     private backend: CDBBackendService,
+    private router: Router,
   ) {}
 
   ngOnInit() {
@@ -86,5 +89,13 @@ export class MainPageComponent implements OnInit {
 
   appendPrefix(url: string): string {
     return '/_' + url;
+  }
+
+  isLinkActive(url: string): boolean {
+    let browserUrl = this.router.url;
+    browserUrl = appendBackslash(browserUrl);
+    browserUrl = removePrefixFrom(browserUrl);
+    url = appendBackslash(url);
+    return browserUrl.startsWith(url);
   }
 }

--- a/components/centraldashboard-angular/frontend/src/app/services/backend.service.ts
+++ b/components/centraldashboard-angular/frontend/src/app/services/backend.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
+import { DashboardLinks } from '../types/dashboard-links';
 import { envInfo } from '../types/env-info';
 
 @Injectable({
@@ -13,5 +14,11 @@ export class CDBBackendService {
     const url = `api/workgroup/env-info`;
 
     return this.http.get<envInfo>(url);
+  }
+
+  public getDashboardLinks(): Observable<DashboardLinks> {
+    const url = 'api/dashboard-links';
+
+    return this.http.get<DashboardLinks>(url);
   }
 }

--- a/components/centraldashboard-angular/frontend/src/app/shared/utils.ts
+++ b/components/centraldashboard-angular/frontend/src/app/shared/utils.ts
@@ -22,9 +22,15 @@ export function appendBackslash(url: string): string {
 
   let urlPath = urlObject.pathname;
   urlPath += urlPath?.endsWith('/') ? '' : '/';
-  const urlParams = urlObject.search;
+  /**
+   * We need an empty string as a default value because in case
+   * of undefined strings, Javascript will go ahead and append the
+   * string 'undefined' in string additions/concats
+   */
+  const urlParams = urlObject.search || '';
+  const urlFragment = urlObject.hash || '';
 
-  return urlPath + urlParams;
+  return urlPath + urlParams + urlFragment;
 }
 
 export function removePrefixFrom(url: string) {

--- a/components/centraldashboard-angular/frontend/src/app/types/dashboard-links.ts
+++ b/components/centraldashboard-angular/frontend/src/app/types/dashboard-links.ts
@@ -1,0 +1,19 @@
+export interface DashboardLinks {
+  menuLinks: MenuLink[];
+  externalLinks?: any[];
+  quickLinks?: Link[];
+  documentationItems?: Link[];
+}
+
+export interface MenuLink {
+  type: string;
+  link: string;
+  text: string;
+  icon: string;
+}
+
+export interface Link {
+  text: string;
+  desc: string;
+  link: string;
+}


### PR DESCRIPTION
This PR is part of the [Rewrite the Central Dashboard in Angular effort](https://github.com/kubeflow/kubeflow/issues/6000) and implements the following two functionalities:

 - Fetch the left sidebar links

Here, we also had to handle the until now unhandled **fragment/hash** in links. For that, we decided to always split links to its sub-parts (`path`, `queryParams`, `fragment`) and use the `fragment` option in `router.navigate`.

 - Automatically change selected link from the sidebar

We couldn't go only with `routerLinkActive` for this and used a custom implementation instead since we need the `path + fragment` combination to be a subset of the browser's URL. In this implementation, we also added an explicit condition for checking when the user is in Recurring Runs WA since the KFP removes the 's' from its path when navigating inside a Recurring Run's details page ( `/_/pipeline/#/recurringruns` in contrast to `/_/pipeline/#/recurringrun/details/`).
