### PR TITLE
centraldashboard: Allow all-namespaces option for kwa

### DIFF
--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -9,7 +9,7 @@ import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 
 export const ALL_NAMESPACES = 'All namespaces';
 export const ALL_NAMESPACES_ALLOWED_LIST = ['jupyter', 'volumes',
-    'tensorboards'];
+    'tensorboards', 'katib'];
 
 const allNamespacesAllowedPaths = ALL_NAMESPACES_ALLOWED_LIST
     .map(( p)=>`/_/${p}/`);


### PR DESCRIPTION
In this PR, we enable all-namespace support in KWA by displaying the `All namespaces` option in the dashboard.

Related PR: https://github.com/kubeflow/katib/pull/2119