### PR TITLE
centraldashboard(make): Use correct dir

### DIFF
--- a/components/centraldashboard/Makefile
+++ b/components/centraldashboard/Makefile
@@ -1,7 +1,7 @@
 IMG ?= centraldashboard
 TAG ?= $(shell git describe --tags --always --dirty)
 COMMIT = $(shell git rev-parse HEAD)
-DOCKERFILE ?= centraldashboard/Dockerfile
+DOCKERFILE ?= Dockerfile
 ARCH ?= linux/amd64
 
 
@@ -32,12 +32,12 @@ docker-push:
 
 .PHONY: docker-build-multi-arch
 docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
-	cd ../ && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} -f ${DOCKERFILE} .
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} -f ${DOCKERFILE} .
 
 
 .PHONY: docker-build-push-multi-arch
-docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
-	cd ../ && docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push -f ${DOCKERFILE} .
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry
+	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push -f ${DOCKERFILE} .
 
 # Build but don't attach the latest tag. This allows manual testing/inspection of the image
 # first.


### PR DESCRIPTION
Previously the app would not use the correct directory when running the docker buildx command, which resulted in the image to fail to get built.

I also realized that we are not testing the `docker buildx` flow in each PR, this is why this was never caught in https://github.com/kubeflow/kubeflow/pull/6923. We'll need to extend the current actions to use the same build process to ensure we catch this in a timely manner. 

I'll ping on the corresponding issue
/cc @elikatsis 