### PR TITLE
[WIP] centraldashboard: Don't run tests in docker build

### DIFF
--- a/.github/workflows/centraldb_frontend_tests.yaml
+++ b/.github/workflows/centraldb_frontend_tests.yaml
@@ -1,0 +1,32 @@
+name: CentralDashboard Frontend Tests
+on:
+  pull_request:
+    paths:
+      - components/centraldashboard/**
+    branches:
+      - master
+      - v*-branch
+
+jobs:
+  frontend-tests:
+    runs-on: ubuntu-latest
+    name: Unit tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup node version to 12
+        uses: actions/setup-node@v3
+        with:
+          node-version: 12
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
+
+      - name: Run frontend tests
+        run: |
+          cd components/centraldashboard
+          npm install
+          CHROMIUM_BIN=$(which chrome) npm run test

--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -8,7 +8,7 @@ ENV BUILD_COMMIT=$commit
 ENV CHROME_BIN=/usr/bin/chromium
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN apt update -qq && apt install -qq -y chromium gnulib
+RUN apt update -qq && apt install -qq -y gnulib
 
 COPY . /centraldashboard
 WORKDIR /centraldashboard
@@ -20,7 +20,6 @@ RUN BUILDARCH="$(dpkg --print-architecture)" &&  npm rebuild && \
     export CXXFLAGS=-Wno-error;  \
     fi && \
     npm install && \
-    npm test && \
     npm run build && \
     npm prune --production
 


### PR DESCRIPTION
Run the frontend tests outside of the Dockerfile and inside a dedicated GH Action. We should separate the testing process from the building one.

The dashboard's Dockerfile was running the tests because in the early days, when Kubeflow didn't have a CI, this was the only reproducible way to ensure the tests had passed when creating an image.

This is a follow up from https://github.com/kubeflow/kubeflow/pull/6960#issuecomment-1431434933

