### PR TITLE
Document the release process for Notebooks

### DIFF
--- a/releasing/README.md
+++ b/releasing/README.md
@@ -6,7 +6,8 @@ for the components of this repository.
 ## Release Process
 
 The Notebooks Working Group release process follows the Kubeflow [release timeline](https://github.com/kubeflow/community/blob/master/releases/handbook.md#timeline) 
- and the [release versioning policy](https://github.com/kubeflow/community/blob/master/releases/handbook.md#versioning-policy).
+ and the [release versioning policy](https://github.com/kubeflow/community/blob/master/releases/handbook.md#versioning-policy),
+ as defined in the [Kubeflow release handbook](https://github.com/kubeflow/community/blob/master/releases/handbook.md).
 
 ## Steps for releasing
 

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -3,6 +3,11 @@
 This folder contains scripts and instructions for releasing images and manifests
 for the components of this repository.
 
+## Release Process
+
+The Notebooks Working Group release process follows the Kubeflow [release timeline](https://github.com/kubeflow/community/blob/master/releases/handbook.md#timeline) 
+ and the [release versioning policy](https://github.com/kubeflow/community/blob/master/releases/handbook.md#versioning-policy).
+
 ## Steps for releasing
 
 1. Create a new release branch:


### PR DESCRIPTION
Add the release process to the `/releasing` README with reference to the release handbook

- Resolves https://github.com/kubeflow/kubeflow/issues/6900
- Replaces https://github.com/kubeflow/community/pull/603 and https://github.com/kubeflow/community/pull/601 (Discussed with @jbottum and the CNCF transition members in the last meeting)

/hold for https://github.com/kubeflow/community/pull/610

cc @kimwnasptd @jbottum
