### PR TITLE
read pod defaults should only return valid pod defaults

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get_test.py
@@ -1,0 +1,184 @@
+from dataclasses import dataclass
+from unittest import TestCase
+
+from .get import read_pod_defaults
+
+
+@dataclass
+class Lister:
+    _data: dict
+
+    def list_poddefaults(self, namespace):
+        return self._data[namespace]
+
+
+class TestListPodDefaults(TestCase):
+
+    def test_read_pod_defaults(self):
+
+        namespaces = {
+            "foo": {
+                "items": [{
+                    "metadata": {
+                        "name": "add-foo"
+                    },
+                    "spec": {
+                        "desc": "apply foo",
+                        "selector": {
+                            "matchLabels": {
+                                "foo": "true",
+                            }
+                        }
+                    }
+                }, {
+                    "metadata": {
+                        "name": "add-bar",
+                    },
+                    "spec": {
+                        "desc": "apply bar",
+                        "selector": {
+                            "matchLabels": {
+                                "bar": "true",
+                            }
+                        }
+                    }
+                }]
+            }
+        }
+
+        content = read_pod_defaults("foo", client=Lister(namespaces))
+        self.assertEqual(content, [
+            {
+                "label": "foo",
+                "desc": "apply foo",
+                "metadata": {
+                    "name": "add-foo"
+                },
+                "spec": {
+                    "desc": "apply foo",
+                    "selector": {
+                        "matchLabels": {
+                            "foo": "true",
+                        }
+                    }
+                }
+            }, {
+                "label": "bar",
+                "desc": "apply bar",
+                "metadata": {
+                    "name": "add-bar",
+                },
+                "spec": {
+                    "desc": "apply bar",
+                    "selector": {
+                        "matchLabels": {
+                            "bar": "true",
+                        }
+                    }
+                }
+            }
+        ])
+
+    def test_read_pod_defaults_defaults_to_name_for_description(self):
+        pod_defaults = {
+            "foo": {
+                "items": [{
+                    "metadata": {
+                        "name": "add-bar",
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "bar": "true",
+                            }
+                        }
+                    }
+                }]
+            }
+        }
+
+        content = read_pod_defaults("foo", client=Lister(pod_defaults))
+        self.assertEqual(content, [{
+                "label": "bar",
+                "desc": "add-bar",
+                "metadata": {
+                    "name": "add-bar",
+                },
+                "spec": {
+                    "selector": {
+                        "matchLabels": {
+                            "bar": "true",
+                        }
+                    }
+                }
+            }])
+
+    def test_read_pod_defaults_ignores_pod_defaults_without_match_labels(self):
+        pod_defaults = {
+            "foo": {
+                "items": [{
+                    "metadata": {
+                        "name": "add-env",
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchExpressions": [
+                                {"key": "notebook-name", "operator": "Exists"}
+                            ]
+                        },
+                        "env": [{
+                            "name": "PIP_CONFIG_FILE",
+                            "value": "/var/run/example.org/pip.conf",
+                        }]
+                    }
+                }, {
+                    "metadata": {
+                        "name": "add-bar",
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {
+                                "bar": "true",
+                            }
+                        },
+                        "env": [{
+                            "name": "BAR",
+                            "value": "bar",
+                        }]
+                    }
+                }, {
+                    "metadata": {
+                        "name": "append-volume",
+                    },
+                    "spec": {
+                        "selector": {
+                            "matchLabels": {}
+                        },
+                        "volumes": [{
+                            "name": "shm",
+                            "emptyDir": {},
+                        }]
+                    }
+                }]
+            }
+        }
+
+        content = read_pod_defaults("foo", client=Lister(pod_defaults))
+        self.assertEqual(content, [{
+            "label": "bar",
+            "desc": "add-bar",
+            "metadata": {
+                "name": "add-bar",
+            },
+            "spec": {
+                "selector": {
+                    "matchLabels": {
+                        "bar": "true",
+                    }
+                },
+                "env": [{
+                    "name": "BAR",
+                    "value": "bar",
+                }]
+            }
+        }])


### PR DESCRIPTION
This PR is to address the issue of creating `PodDefaults` without `matchLabels`, or too many `matchLabals`. Creating a `PodDefault` like the following can be super useful for applying defaults to all notebooks in a namespace.

```yaml
---
apiVersion: kubeflow.org/v1alpha1
kind: PodDefault
metadata:
  name: foo-bar
  namespace: kubeflow-user-example-com
spec:
  selector:
    matchExpressions:
    - key: notebook-name
      operator: Exists
  env:
  - name: BAR
    value: FOO
```
That PodDefault will unfortunately break the UI here https://github.com/kubeflow/kubeflow/blob/c946c624cd8974ef53cac04582e4714b466d546e/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py#L37.
![image](https://user-images.githubusercontent.com/7153166/220530105-599fb03c-115b-4414-babb-5692766e4d5b.png)
```sh
2023-02-22 05:22:07,568 | kubeflow.kubeflow.crud_backend.errors.handlers | ERROR | 'matchLabels'
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1820, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1796, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/src/apps/common/routes/get.py", line 32, in get_poddefaults
    label = list(pd["spec"]["selector"]["matchLabels"].keys())[0]
KeyError: 'matchLabels'

```
While is doesn't prevent users from creating new notebooks, it does prevent them from selecting existing configurations.

 Another issue is that some configurations can be selected, but won't be applied, such as the following.
```yaml
---
apiVersion: kubeflow.org/v1alpha1
kind: PodDefault
metadata:
  name: foo-bar-0
  namespace: kubeflow-user-example-com
spec:
  selector:
    matchLabels:
      kubeflow.org/foo: "true"
      kubeflow.org/bar: "true"
  env:
  - name: FOO
    value: BAR
---
apiVersion: kubeflow.org/v1alpha1
kind: PodDefault
metadata:
  name: foo-bar-1
  namespace: kubeflow-user-example-com
spec:
  selector:
    matchLabels:
      kubeflow.org/bar: "foo"
  env:
  - name: BAR
    value: FOO
```

![image](https://user-images.githubusercontent.com/7153166/220527844-e56a607a-38e3-47e6-b0e9-d3e607b72514.png)

```sh
➜  manifests git:(v1.6-branch) ✗ kubectl get pod/jupyter-scipy-0 -n kubeflow-user-example-com -o yaml | yq  '.spec.containers[0].env'
[
  {
    "name": "NB_PREFIX",
    "value": "/notebook/kubeflow-user-example-com/jupyter-scipy"
  }
]
```

This can be misleading to users who may have selected configurations that weren't applied to their notebook. These changes resolve both of these issues by only returning `PodDefaults` that can be applied when selected. I'm also not 100% sure this is the right solution. I think it's the most flexible, but if the intention is for `PodDefaults` to only match on a single label, then the right solution might be a validating webhook for `PodDefaults`.
