### PR TITLE
Namespace reconcile not setting controller reference and istio label on updates

### DIFF
--- a/components/profile-controller/api/v1/groupversion_info.go
+++ b/components/profile-controller/api/v1/groupversion_info.go
@@ -15,11 +15,13 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the  v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=kubeflow.org
+// +kubebuilder:object:generate=true
+// +groupName=kubeflow.org
 package v1
 
 import (
+	"reflect"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
@@ -33,4 +35,6 @@ var (
 
 	// AddToScheme adds the types in this group-version to the given scheme.
 	AddToScheme = SchemeBuilder.AddToScheme
+
+	ProfileKind = reflect.TypeOf(&Profile{}).Elem().Name()
 )

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -20,17 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"reflect"
-	"time"
 
-	"github.com/cenkalti/backoff"
 	"github.com/go-logr/logr"
 	profilev1 "github.com/kubeflow/kubeflow/components/profile-controller/api/v1"
 	"github.com/pkg/errors"
 	"gopkg.in/fsnotify.v1"
-	"gopkg.in/yaml.v2"
 	istioSecurity "istio.io/api/security/v1beta1"
 	istioSecurityClient "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -74,6 +69,14 @@ const (
 const DEFAULT_EDITOR = "default-editor"
 const DEFAULT_VIEWER = "default-viewer"
 
+const (
+	errGetNamespace                  = "error reading namespace"
+	errCreateNamespace               = "error creating namespace"
+	errUpdateNamespace               = "error updating namespace"
+	errSetControllerReference        = "error setting controller reference"
+	errFmtNamespaceNotOwnedByProfile = "namespace already exist, but not owned by profile creator %v"
+)
+
 type Plugin interface {
 	// Called when profile CR is created / updated
 	ApplyPlugin(*ProfileReconciler, *profilev1.Profile) error
@@ -91,6 +94,7 @@ type ProfileReconciler struct {
 	UserIdPrefix               string
 	WorkloadIdentity           string
 	DefaultNamespaceLabelsPath string
+	readLabelsFunc             func(path string) (map[string]string, error)
 }
 
 // +kubebuilder:rbac:groups=core,resources=namespaces,verbs="*"
@@ -104,12 +108,15 @@ type ProfileReconciler struct {
 // Automatically generate RBAC rules to allow the Controller to read and write Deployments
 func (r *ProfileReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	logger := r.Log.WithValues("profile", request.NamespacedName)
-	defaultKubeflowNamespaceLabels := r.readDefaultLabelsFromFile(r.DefaultNamespaceLabelsPath)
+	defaultKubeflowNamespaceLabels, err := r.readLabelsFunc(r.DefaultNamespaceLabelsPath)
+	if err != nil {
+		r.Log.Error(err, "Failed to read default namespace labels")
+	}
 
 	// Fetch the Profile instance
 	instance := &profilev1.Profile{}
 	logger.Info("Start to Reconcile.", "namespace", request.Namespace, "name", request.Name)
-	err := r.Get(ctx, request.NamespacedName, instance)
+	err = r.Client.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
@@ -123,79 +130,47 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		return reconcile.Result{}, err
 	}
 
-	// Update namespace
-	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Annotations: map[string]string{"owner": instance.Spec.Owner.Name},
-			// inject istio sidecar to all pods in target namespace by default.
-			Labels: map[string]string{
-				istioInjectionLabel: "enabled",
-			},
-			Name: instance.Name,
-		},
+	ns := &corev1.Namespace{}
+	ns.SetName(instance.GetName())
+	if err := r.Client.Get(ctx, client.ObjectKeyFromObject(ns), ns); err != nil {
+		if !apierrors.IsNotFound(err) {
+			IncRequestErrorCounter(errGetNamespace, SEVERITY_MAJOR)
+			logger.Error(err, errGetNamespace)
+			return ctrl.Result{}, errors.Wrap(err, errGetNamespace)
+		}
+		// Namespace isn't found, create it
+		addLabel(ns, istioInjectionLabel, "enabled")
+		setNamespaceLabels(ns, defaultKubeflowNamespaceLabels)
+		ns.SetAnnotations(map[string]string{"owner": instance.Spec.Owner.Name})
+		logger.Info("Creating Namespace: " + ns.Name)
+		if err := r.Client.Create(ctx, ns); err != nil {
+			IncRequestErrorCounter(errCreateNamespace, SEVERITY_MAJOR)
+			logger.Error(err, errCreateNamespace)
+			return ctrl.Result{}, errors.Wrap(err, errCreateNamespace)
+		}
 	}
-	setNamespaceLabels(ns, defaultKubeflowNamespaceLabels)
+	if ns.Annotations["owner"] != instance.Spec.Owner.Name {
+		logger.Info(fmt.Sprintf(errFmtNamespaceNotOwnedByProfile, instance.Spec.Owner.Name))
+		IncRequestCounter("reject profile taking over existing namespace")
+		return r.appendErrorConditionAndReturn(ctx, instance, fmt.Sprintf(errFmtNamespaceNotOwnedByProfile, instance.Spec.Owner.Name))
+	}
+
 	logger.Info("List of labels to be added to namespace", "labels", ns.Labels)
-	if err := controllerutil.SetControllerReference(instance, ns, r.Scheme); err != nil {
-		IncRequestErrorCounter("error setting ControllerReference", SEVERITY_MAJOR)
-		logger.Error(err, "error setting ControllerReference")
-		return reconcile.Result{}, err
-	}
-	foundNs := &corev1.Namespace{}
-	err = r.Get(ctx, types.NamespacedName{Name: ns.Name}, foundNs)
+	res, err := controllerutil.CreateOrUpdate(ctx, r.Client, ns, func() error {
+		setNamespaceLabels(ns, defaultKubeflowNamespaceLabels)
+		addLabel(ns, istioInjectionLabel, "enabled")
+		if err := controllerutil.SetControllerReference(instance, ns, r.Scheme); err != nil {
+			IncRequestErrorCounter(errSetControllerReference, SEVERITY_MAJOR)
+			logger.Error(err, errSetControllerReference)
+			return errors.Wrap(err, errSetControllerReference)
+		}
+		return nil
+	})
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			logger.Info("Creating Namespace: " + ns.Name)
-			err = r.Create(ctx, ns)
-			if err != nil {
-				IncRequestErrorCounter("error creating namespace", SEVERITY_MAJOR)
-				logger.Error(err, "error creating namespace")
-				return reconcile.Result{}, err
-			}
-			// wait 15 seconds for new namespace creation.
-			err = backoff.Retry(
-				func() error {
-					return r.Get(ctx, types.NamespacedName{Name: ns.Name}, foundNs)
-				},
-				backoff.WithMaxRetries(backoff.NewConstantBackOff(3*time.Second), 5))
-			if err != nil {
-				IncRequestErrorCounter("error namespace create completion", SEVERITY_MAJOR)
-				logger.Error(err, "error namespace create completion")
-				return r.appendErrorConditionAndReturn(ctx, instance,
-					"Owning namespace failed to create within 15 seconds")
-			}
-			logger.Info("Created Namespace: "+foundNs.Name, "status", foundNs.Status.Phase)
-		} else {
-			IncRequestErrorCounter("error reading namespace", SEVERITY_MAJOR)
-			logger.Error(err, "error reading namespace")
-			return reconcile.Result{}, err
-		}
-	} else {
-		// Check exising namespace ownership before move forward
-		owner, ok := foundNs.Annotations["owner"]
-		if ok && owner == instance.Spec.Owner.Name {
-			oldLabels := map[string]string{}
-			for k, v := range foundNs.Labels {
-				oldLabels[k] = v
-			}
-			setNamespaceLabels(foundNs, defaultKubeflowNamespaceLabels)
-			logger.Info("List of labels to be added to found namespace", "labels", ns.Labels)
-			if !reflect.DeepEqual(oldLabels, foundNs.Labels) {
-				err = r.Update(ctx, foundNs)
-				if err != nil {
-					IncRequestErrorCounter("error updating namespace label", SEVERITY_MAJOR)
-					logger.Error(err, "error updating namespace label")
-					return reconcile.Result{}, err
-				}
-			}
-		} else {
-			logger.Info(fmt.Sprintf("namespace already exist, but not owned by profile creator %v",
-				instance.Spec.Owner.Name))
-			IncRequestCounter("reject profile taking over existing namespace")
-			return r.appendErrorConditionAndReturn(ctx, instance, fmt.Sprintf(
-				"namespace already exist, but not owned by profile creator %v", instance.Spec.Owner.Name))
-		}
+		r.Log.Error(err, errUpdateNamespace)
+		return ctrl.Result{}, errors.Wrap(err, errUpdateNamespace)
 	}
+	r.Log.Info("Finished reconciling profile namespace", "name", instance.Name, "result", res)
 
 	// Update Istio AuthorizationPolicy
 	// Create Istio AuthorizationPolicy in target namespace, which will give ns owner permission to access services in ns.
@@ -265,9 +240,9 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		}
 	} else {
 		found := &corev1.ResourceQuota{}
-		err := r.Get(ctx, types.NamespacedName{Name: KFQUOTA, Namespace: instance.Name}, found)
+		err := r.Client.Get(ctx, types.NamespacedName{Name: KFQUOTA, Namespace: instance.Name}, found)
 		if err == nil {
-			if err := r.Delete(ctx, found); err != nil {
+			if err := r.Client.Delete(ctx, found); err != nil {
 				logger.Error(err, "error deleting resource quota", "namespace", instance.Name)
 				return ctrl.Result{}, err
 			}
@@ -300,7 +275,7 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 		// registering our finalizer.
 		if !containsString(instance.ObjectMeta.Finalizers, PROFILEFINALIZER) {
 			instance.ObjectMeta.Finalizers = append(instance.ObjectMeta.Finalizers, PROFILEFINALIZER)
-			if err := r.Update(ctx, instance); err != nil {
+			if err := r.Client.Update(ctx, instance); err != nil {
 				logger.Error(err, "error updating finalizer", "namespace", instance.Name)
 				IncRequestErrorCounter("error updating finalizer", SEVERITY_MAJOR)
 				return ctrl.Result{}, err
@@ -322,7 +297,7 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 
 			// remove our finalizer from the list and update it.
 			instance.ObjectMeta.Finalizers = removeString(instance.ObjectMeta.Finalizers, PROFILEFINALIZER)
-			if err := r.Update(ctx, instance); err != nil {
+			if err := r.Client.Update(ctx, instance); err != nil {
 				logger.Error(err, "error removing finalizer", "namespace", instance.Name)
 				IncRequestErrorCounter("error removing finalizer", SEVERITY_MAJOR)
 				return ctrl.Result{}, err
@@ -340,7 +315,7 @@ func (r *ProfileReconciler) appendErrorConditionAndReturn(ctx context.Context, i
 		Type:    profilev1.ProfileFailed,
 		Message: message,
 	})
-	if err := r.Update(ctx, instance); err != nil {
+	if err := r.Client.Update(ctx, instance); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{}, nil
@@ -502,7 +477,7 @@ func (r *ProfileReconciler) updateIstioAuthorizationPolicy(profileIns *profilev1
 		return err
 	}
 	foundAuthorizationPolicy := &istioSecurityClient.AuthorizationPolicy{}
-	err := r.Get(
+	err := r.Client.Get(
 		context.TODO(),
 		types.NamespacedName{
 			Name:      istioAuth.ObjectMeta.Name,
@@ -514,7 +489,7 @@ func (r *ProfileReconciler) updateIstioAuthorizationPolicy(profileIns *profilev1
 		if apierrors.IsNotFound(err) {
 			logger.Info("Creating Istio AuthorizationPolicy", "namespace", istioAuth.ObjectMeta.Namespace,
 				"name", istioAuth.ObjectMeta.Name)
-			err = r.Create(context.TODO(), istioAuth)
+			err = r.Client.Create(context.TODO(), istioAuth)
 			if err != nil {
 				return err
 			}
@@ -526,7 +501,7 @@ func (r *ProfileReconciler) updateIstioAuthorizationPolicy(profileIns *profilev1
 			foundAuthorizationPolicy.Spec = *istioAuth.Spec.DeepCopy()
 			logger.Info("Updating Istio AuthorizationPolicy", "namespace", istioAuth.ObjectMeta.Namespace,
 				"name", istioAuth.ObjectMeta.Name)
-			err = r.Update(context.TODO(), foundAuthorizationPolicy)
+			err = r.Client.Update(context.TODO(), foundAuthorizationPolicy)
 			if err != nil {
 				return err
 			}
@@ -544,11 +519,11 @@ func (r *ProfileReconciler) updateResourceQuota(profileIns *profilev1.Profile,
 		return err
 	}
 	found := &corev1.ResourceQuota{}
-	err := r.Get(ctx, types.NamespacedName{Name: resourceQuota.Name, Namespace: resourceQuota.Namespace}, found)
+	err := r.Client.Get(ctx, types.NamespacedName{Name: resourceQuota.Name, Namespace: resourceQuota.Namespace}, found)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Creating ResourceQuota", "namespace", resourceQuota.Namespace, "name", resourceQuota.Name)
-			err = r.Create(ctx, resourceQuota)
+			err = r.Client.Create(ctx, resourceQuota)
 			if err != nil {
 				return err
 			}
@@ -559,7 +534,7 @@ func (r *ProfileReconciler) updateResourceQuota(profileIns *profilev1.Profile,
 		if !(reflect.DeepEqual(resourceQuota.Spec, found.Spec)) {
 			found.Spec = resourceQuota.Spec
 			logger.Info("Updating ResourceQuota", "namespace", resourceQuota.Namespace, "name", resourceQuota.Name)
-			err = r.Update(ctx, found)
+			err = r.Client.Update(ctx, found)
 			if err != nil {
 				return err
 			}
@@ -582,12 +557,12 @@ func (r *ProfileReconciler) updateServiceAccount(profileIns *profilev1.Profile, 
 		return err
 	}
 	found := &corev1.ServiceAccount{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: serviceAccount.Name, Namespace: serviceAccount.Namespace}, found)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: serviceAccount.Name, Namespace: serviceAccount.Namespace}, found)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Creating ServiceAccount", "namespace", serviceAccount.Namespace,
 				"name", serviceAccount.Name)
-			err = r.Create(context.TODO(), serviceAccount)
+			err = r.Client.Create(context.TODO(), serviceAccount)
 			if err != nil {
 				return err
 			}
@@ -625,11 +600,11 @@ func (r *ProfileReconciler) updateRoleBinding(profileIns *profilev1.Profile,
 		return err
 	}
 	found := &rbacv1.RoleBinding{}
-	err := r.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, found)
+	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: roleBinding.Name, Namespace: roleBinding.Namespace}, found)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			logger.Info("Creating RoleBinding", "namespace", roleBinding.Namespace, "name", roleBinding.Name)
-			err = r.Create(context.TODO(), roleBinding)
+			err = r.Client.Create(context.TODO(), roleBinding)
 			if err != nil {
 				return err
 			}
@@ -641,7 +616,7 @@ func (r *ProfileReconciler) updateRoleBinding(profileIns *profilev1.Profile,
 			found.RoleRef = roleBinding.RoleRef
 			found.Subjects = roleBinding.Subjects
 			logger.Info("Updating RoleBinding", "namespace", roleBinding.Namespace, "name", roleBinding.Name)
-			err = r.Update(context.TODO(), found)
+			err = r.Client.Update(context.TODO(), found)
 			if err != nil {
 				return err
 			}
@@ -706,7 +681,7 @@ func (r *ProfileReconciler) PatchDefaultPluginSpec(ctx context.Context, profileI
 			})
 		}
 	}
-	if err := r.Update(ctx, profileIns); err != nil {
+	if err := r.Client.Update(ctx, profileIns); err != nil {
 		return err
 	}
 	return nil
@@ -752,19 +727,11 @@ func setNamespaceLabels(ns *corev1.Namespace, newLabels map[string]string) {
 	}
 }
 
-func (r *ProfileReconciler) readDefaultLabelsFromFile(path string) map[string]string {
-	logger := r.Log.WithName("read-config-file").WithValues("path", path)
-	dat, err := ioutil.ReadFile(path)
-	if err != nil {
-		logger.Error(err, "namespace labels properties file doesn't exist")
-		os.Exit(1)
+func addLabel(obj client.Object, key, value string) {
+	labels := obj.GetLabels()
+	if labels == nil {
+		labels = make(map[string]string)
 	}
-
-	labels := map[string]string{}
-	err = yaml.Unmarshal(dat, &labels)
-	if err != nil {
-		logger.Error(err, "Unable to parse default namespace labels.")
-		os.Exit(1)
-	}
-	return labels
+	labels[key] = value
+	obj.SetLabels(labels)
 }

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -116,7 +116,7 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, request ctrl.Request)
 	// Fetch the Profile instance
 	instance := &profilev1.Profile{}
 	logger.Info("Start to Reconcile.", "namespace", request.Namespace, "name", request.Name)
-	err = r.Client.Get(ctx, request.NamespacedName, instance)
+	err = r.Get(ctx, request.NamespacedName, instance)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
@@ -489,7 +489,7 @@ func (r *ProfileReconciler) updateIstioAuthorizationPolicy(profileIns *profilev1
 		if apierrors.IsNotFound(err) {
 			logger.Info("Creating Istio AuthorizationPolicy", "namespace", istioAuth.ObjectMeta.Namespace,
 				"name", istioAuth.ObjectMeta.Name)
-			err = r.Client.Create(context.TODO(), istioAuth)
+			err = r.Create(context.TODO(), istioAuth)
 			if err != nil {
 				return err
 			}

--- a/components/profile-controller/controllers/profile_controller_test.go
+++ b/components/profile-controller/controllers/profile_controller_test.go
@@ -209,15 +209,6 @@ func createMockReconciler() *ProfileReconciler {
 	return reconciler
 }
 
-func newScheme(t *testing.T) *runtime.Scheme {
-	scheme := runtime.NewScheme()
-	assert.Nil(t, profilev1.AddToScheme(scheme))
-	assert.Nil(t, corev1.AddToScheme(scheme))
-	assert.Nil(t, rbacv1.AddToScheme(scheme))
-	assert.Nil(t, istioRegister.AddToScheme(scheme))
-	return scheme
-}
-
 func TestProfileReconciler_ReconcileNamespace(t *testing.T) {
 	cases := map[string]struct {
 		profile     *profilev1.Profile
@@ -457,4 +448,13 @@ func passThroughLabelReader(m map[string]string) func(string) (map[string]string
 	return func(_ string) (map[string]string, error) {
 		return m, nil
 	}
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	assert.Nil(t, profilev1.AddToScheme(scheme))
+	assert.Nil(t, corev1.AddToScheme(scheme))
+	assert.Nil(t, rbacv1.AddToScheme(scheme))
+	assert.Nil(t, istioRegister.AddToScheme(scheme))
+	return scheme
 }

--- a/components/profile-controller/controllers/profile_controller_test.go
+++ b/components/profile-controller/controllers/profile_controller_test.go
@@ -1,17 +1,27 @@
 package controllers
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
 
+	qt "github.com/frankban/quicktest"
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	profilev1 "github.com/kubeflow/kubeflow/components/profile-controller/api/v1"
 	"github.com/stretchr/testify/assert"
+	istioRegister "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 type namespaceLabelSuite struct {
@@ -197,4 +207,254 @@ func createMockReconciler() *ProfileReconciler {
 		DefaultNamespaceLabelsPath: "dummy",
 	}
 	return reconciler
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	assert.Nil(t, profilev1.AddToScheme(scheme))
+	assert.Nil(t, corev1.AddToScheme(scheme))
+	assert.Nil(t, rbacv1.AddToScheme(scheme))
+	assert.Nil(t, istioRegister.AddToScheme(scheme))
+	return scheme
+}
+
+func TestProfileReconciler_ReconcileNamespace(t *testing.T) {
+	cases := map[string]struct {
+		profile     *profilev1.Profile
+		initObjects []client.Object
+		want        *corev1.Namespace
+		opts        []ProfileReconcilerOption
+	}{
+		"CreatesANamespace": {
+			opts: []ProfileReconcilerOption{WithLabelReaderFunc(nopLabelReader)},
+			profile: &profilev1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					UID:  "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+				},
+				Spec: profilev1.ProfileSpec{
+					Owner: rbacv1.Subject{
+						Name: "chunk@example.com",
+						Kind: rbacv1.UserKind,
+					},
+				},
+			},
+			initObjects: []client.Object{},
+			want: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					Annotations: map[string]string{
+						"owner": "chunk@example.com",
+					},
+					Labels: map[string]string{
+						"istio-injection": "enabled",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         "kubeflow.org/v1",
+						Kind:               profilev1.ProfileKind,
+						Name:               "chunk",
+						UID:                "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+						Controller:         pointer.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
+					}},
+				},
+			},
+		},
+		"CreatesANamespaceWithProvidedLabels": {
+			opts: []ProfileReconcilerOption{WithLabelReaderFunc(
+				passThroughLabelReader(map[string]string{
+					"app.kubernetes.io/part-of": "kubeflow-profile",
+					"foo":                       "bar",
+				}),
+			)},
+			profile: &profilev1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					UID:  "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+				},
+				Spec: profilev1.ProfileSpec{
+					Owner: rbacv1.Subject{
+						Name: "chunk@example.com",
+						Kind: rbacv1.UserKind,
+					},
+				},
+			},
+			initObjects: []client.Object{},
+			want: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					Annotations: map[string]string{
+						"owner": "chunk@example.com",
+					},
+					Labels: map[string]string{
+						"istio-injection":           "enabled",
+						"app.kubernetes.io/part-of": "kubeflow-profile",
+						"foo":                       "bar",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         "kubeflow.org/v1",
+						Kind:               profilev1.ProfileKind,
+						Name:               "chunk",
+						UID:                "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+						Controller:         pointer.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
+					}},
+				},
+			},
+		},
+		"IgnoresANamespacesNotOwned": {
+			opts: []ProfileReconcilerOption{WithLabelReaderFunc(nopLabelReader)},
+			profile: &profilev1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					UID:  "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+				},
+				Spec: profilev1.ProfileSpec{
+					Owner: rbacv1.Subject{
+						Name: "chunk@example.com",
+						Kind: rbacv1.UserKind,
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "chunk",
+					},
+				},
+			},
+			want: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+				},
+			},
+		},
+		"AdoptsAnAnnotatedNamespace": {
+			opts: []ProfileReconcilerOption{WithLabelReaderFunc(passThroughLabelReader(
+				map[string]string{"foo": "bar"},
+			))},
+			profile: &profilev1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					UID:  "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+				},
+				Spec: profilev1.ProfileSpec{
+					Owner: rbacv1.Subject{
+						Name: "chunk@example.com",
+						Kind: rbacv1.UserKind,
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "chunk",
+						Annotations: map[string]string{
+							"owner": "chunk@example.com",
+						},
+					},
+				},
+			},
+			want: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					Annotations: map[string]string{
+						"owner": "chunk@example.com",
+					},
+					Labels: map[string]string{
+						"foo":             "bar",
+						"istio-injection": "enabled",
+					},
+					OwnerReferences: []metav1.OwnerReference{{
+						APIVersion:         "kubeflow.org/v1",
+						Kind:               profilev1.ProfileKind,
+						Name:               "chunk",
+						UID:                "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+						Controller:         pointer.Bool(true),
+						BlockOwnerDeletion: pointer.Bool(true),
+					}},
+				},
+			},
+		},
+		"IgnoresNamespaceAnnotatedWithDifferentOwner": {
+			opts: []ProfileReconcilerOption{WithLabelReaderFunc(nopLabelReader)},
+			profile: &profilev1.Profile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					UID:  "53ac5675-9391-4f62-8b4f-cae88bdaaf0f",
+				},
+				Spec: profilev1.ProfileSpec{
+					Owner: rbacv1.Subject{
+						Name: "chunk@example.com",
+						Kind: rbacv1.UserKind,
+					},
+				},
+			},
+			initObjects: []client.Object{
+				&corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "chunk",
+						Annotations: map[string]string{
+							"owner": "sloth@example.com",
+						},
+					},
+				},
+			},
+			want: &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "chunk",
+					Annotations: map[string]string{
+						"owner": "sloth@example.com",
+					},
+				},
+			},
+		},
+	}
+	zl := zap.New(zap.UseDevMode(true))
+	ctx := context.TODO()
+
+	for name, subtest := range cases {
+		t.Run(name, func(t *testing.T) {
+			k8s := fake.NewClientBuilder().
+				WithObjects(subtest.profile).
+				WithObjects(subtest.initObjects...).
+				WithScheme(newScheme(t)).
+				Build()
+
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(subtest.profile)}
+			r := NewProfileReconciler(newFakeManager(k8s, zl), subtest.opts...)
+			res, err := r.Reconcile(ctx, req)
+
+			qt.Assert(t, err, qt.IsNil)
+			qt.Assert(t, res, qt.Equals, ctrl.Result{})
+			got := &corev1.Namespace{}
+			qt.Assert(t, k8s.Get(ctx, client.ObjectKeyFromObject(subtest.want), got), qt.IsNil)
+			qt.Assert(t, got, qt.CmpEquals(
+				cmpopts.IgnoreFields(corev1.Namespace{}, "ResourceVersion", "TypeMeta"),
+			), subtest.want)
+		})
+	}
+}
+
+func newFakeManager(cli client.Client, logger logr.Logger) *fakeManager {
+	return &fakeManager{client: cli, logger: logger}
+}
+
+type fakeManager struct {
+	client client.Client
+	logger logr.Logger
+}
+
+func (fm *fakeManager) GetClient() client.Client   { return fm.client }
+func (fm *fakeManager) GetScheme() *runtime.Scheme { return fm.client.Scheme() }
+func (fm *fakeManager) GetLogger() logr.Logger     { return fm.logger }
+
+func nopLabelReader(path string) (map[string]string, error) {
+	return map[string]string{}, nil
+}
+
+func passThroughLabelReader(m map[string]string) func(string) (map[string]string, error) {
+	return func(_ string) (map[string]string, error) {
+		return m, nil
+	}
 }

--- a/components/profile-controller/controllers/setup.go
+++ b/components/profile-controller/controllers/setup.go
@@ -1,0 +1,101 @@
+package controllers
+
+import (
+	"context"
+	"os"
+
+	"github.com/go-logr/logr"
+	profilev1 "github.com/kubeflow/kubeflow/components/profile-controller/api/v1"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+const (
+	errListProfiles = "Failed to list profiles in order to trigger reconciliation"
+)
+
+type Manager interface {
+	GetClient() client.Client
+	GetScheme() *runtime.Scheme
+	GetLogger() logr.Logger
+}
+
+type ProfileReconcilerOption func(r *ProfileReconciler)
+
+func WithLogger(logger logr.Logger) ProfileReconcilerOption {
+	return func(r *ProfileReconciler) {
+		r.Log = logger
+	}
+}
+
+func WithUserIdHeader(header string) ProfileReconcilerOption {
+	return func(r *ProfileReconciler) {
+		r.UserIdHeader = header
+	}
+}
+
+func WithUserIdPrefix(pre string) ProfileReconcilerOption {
+	return func(r *ProfileReconciler) {
+		r.UserIdPrefix = pre
+	}
+}
+
+func WithWorkloadIdentity(wi string) ProfileReconcilerOption {
+	return func(r *ProfileReconciler) {
+		r.WorkloadIdentity = wi
+	}
+}
+
+func WithDefaultNamespaceLabelsPath(path string) ProfileReconcilerOption {
+	return func(r *ProfileReconciler) {
+		r.DefaultNamespaceLabelsPath = path
+	}
+}
+
+func WithLabelReaderFunc(f func(path string) (map[string]string, error)) ProfileReconcilerOption {
+	return func(r *ProfileReconciler) {
+		r.readLabelsFunc = f
+	}
+}
+
+func NewProfileReconciler(mgr Manager, opts ...ProfileReconcilerOption) *ProfileReconciler {
+	r := &ProfileReconciler{
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		Log:              mgr.GetLogger(),
+		UserIdPrefix:     "",
+		UserIdHeader:     "kubeflow-userid",
+		WorkloadIdentity: "",
+		readLabelsFunc: func(path string) (map[string]string, error) {
+			var m map[string]string
+			f, err := os.Open(path)
+			if err != nil {
+				return nil, err
+			}
+			return m, yaml.NewDecoder(f).Decode(&m)
+		},
+	}
+
+	for _, f := range opts {
+		f(r)
+	}
+	return r
+}
+
+func enqueueRequestsForProfiles(reader client.Reader, log logr.Logger) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(o client.Object) []ctrl.Request {
+		proList := &profilev1.ProfileList{}
+		if err := reader.List(context.TODO(), proList); err != nil {
+			log.Error(err, errListProfiles)
+			return nil
+		}
+		var reqs []ctrl.Request
+		for _, item := range proList.Items {
+			reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
+		}
+		return reqs
+	})
+}

--- a/components/profile-controller/controllers/setup.go
+++ b/components/profile-controller/controllers/setup.go
@@ -1,16 +1,12 @@
 package controllers
 
 import (
-	"context"
 	"os"
 
 	"github.com/go-logr/logr"
-	profilev1 "github.com/kubeflow/kubeflow/components/profile-controller/api/v1"
 	"gopkg.in/yaml.v2"
 	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 )
 
 const (
@@ -83,19 +79,4 @@ func NewProfileReconciler(mgr Manager, opts ...ProfileReconcilerOption) *Profile
 		f(r)
 	}
 	return r
-}
-
-func enqueueRequestsForProfiles(reader client.Reader, log logr.Logger) handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(func(o client.Object) []ctrl.Request {
-		proList := &profilev1.ProfileList{}
-		if err := reader.List(context.TODO(), proList); err != nil {
-			log.Error(err, errListProfiles)
-			return nil
-		}
-		var reqs []ctrl.Request
-		for _, item := range proList.Items {
-			reqs = append(reqs, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(&item)})
-		}
-		return reqs
-	})
 }

--- a/components/profile-controller/go.mod
+++ b/components/profile-controller/go.mod
@@ -5,7 +5,9 @@ go 1.17
 require (
 	github.com/aws/aws-sdk-go v1.44.22
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/frankban/quicktest v1.14.4
 	github.com/go-logr/logr v1.2.0
+	github.com/google/go-cmp v0.5.9
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/gomega v1.18.1
 	github.com/pkg/errors v0.9.1
@@ -22,6 +24,7 @@ require (
 	k8s.io/api v0.24.0
 	k8s.io/apimachinery v0.24.0
 	k8s.io/client-go v0.24.0
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.1
 )
 
@@ -50,7 +53,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.5 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
 	github.com/googleapis/gax-go/v2 v2.0.5 // indirect
@@ -58,6 +60,8 @@ require (
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/pretty v0.3.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -68,6 +72,7 @@ require (
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rogpeppe/go-internal v1.9.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
@@ -93,7 +98,6 @@ require (
 	k8s.io/component-base v0.24.0 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/components/profile-controller/go.sum
+++ b/components/profile-controller/go.sum
@@ -150,6 +150,8 @@ github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
+github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
@@ -240,8 +242,9 @@ github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
@@ -334,6 +337,8 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -398,6 +403,7 @@ github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFSt
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -437,6 +443,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
@@ -813,7 +821,6 @@ golang.org/x/tools v0.1.10-0.20220218145154-897bd77cd717/go.mod h1:Uh6Zz+xoGYZom
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
 gomodules.xyz/jsonpatch/v2 v2.2.0/go.mod h1:WXp+iVDkoLQqPudfQ9GBlwB2eZ5DKOnjQZCYdOS8GPY=

--- a/components/profile-controller/main.go
+++ b/components/profile-controller/main.go
@@ -96,15 +96,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.ProfileReconciler{
-		Client:                     mgr.GetClient(),
-		Scheme:                     mgr.GetScheme(),
-		Log:                        ctrl.Log.WithName("controllers").WithName("Profile"),
-		UserIdHeader:               userIdHeader,
-		UserIdPrefix:               userIdPrefix,
-		WorkloadIdentity:           workloadIdentity,
-		DefaultNamespaceLabelsPath: defaultNamespaceLabelsPath,
-	}).SetupWithManager(mgr); err != nil {
+	if err := controllers.NewProfileReconciler(mgr,
+		controllers.WithLogger(ctrl.Log.WithName("controllers").WithName("Profile")),
+		controllers.WithUserIdHeader(userIdHeader),
+		controllers.WithUserIdPrefix(userIdPrefix),
+		controllers.WithWorkloadIdentity(workloadIdentity),
+		controllers.WithDefaultNamespaceLabelsPath(defaultNamespaceLabelsPath),
+	).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Profile")
 		os.Exit(1)
 	}


### PR DESCRIPTION
I was hoping to help out by adding some more tests for the `ProfileReconciler`, and I noticed that the only namespace attributes being updated during reconciliation were the default namespace labels, but controller ref and `istio-injection=enabled` were not being added.

```sh
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns --selector istio-injection=enabled                             
NAME                        STATUS   AGE
kubeflow                    Active   23h
kubeflow-user-example-com   Active   94m
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl label namespace kubeflow-user-example-com istio-injection= --overwrite
namespace/kubeflow-user-example-com labeled
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns --selector istio-injection=enabled                             
NAME       STATUS   AGE
kubeflow   Active   23h
```
The `istio-injection` label seems too important to not enforce (will cause networking issues for Notebooks). 

These changes produce
```sh
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns --selector istio-injection=enabled
NAME                        STATUS   AGE
kubeflow                    Active   23h
kubeflow-user-example-com   Active   97m
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl label namespace kubeflow-user-example-com istio-injection= --overwrite
namespace/kubeflow-user-example-com labeled
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns --selector istio-injection=enabled                             
NAME                        STATUS   AGE
kubeflow                    Active   23h
kubeflow-user-example-com   Active   97m
```

Similarly, the controller reference on a namespace is also not added after creation
```sh
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns kubeflow-user-example-com -o yaml | yq .metadata.ownerReferences                                 
[
  {
    "apiVersion": "kubeflow.org/v1",
    "blockOwnerDeletion": true,
    "controller": true,
    "kind": "Profile",
    "name": "kubeflow-user-example-com",
    "uid": "eede261d-caca-4dd2-af95-9f000d219497"
  }
]
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl patch ns kubeflow-user-example-com --type=json -p='[{"op":"remove","path":"/metadata/ownerReferences"}]'
namespace/kubeflow-user-example-com patched
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns kubeflow-user-example-com -o yaml | yq .metadata.ownerReferences                                 
null

```
This change produces
```bash
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns kubeflow-user-example-com -o yaml | yq .metadata.ownerReferences
[
  {
    "apiVersion": "kubeflow.org/v1",
    "blockOwnerDeletion": true,
    "controller": true,
    "kind": "Profile",
    "name": "kubeflow-user-example-com",
    "uid": "eede261d-caca-4dd2-af95-9f000d219497"
  }
]
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl patch ns kubeflow-user-example-com --type=json -p='[{"op":"remove","path":"/metadata/ownerReferences"}]'
namespace/kubeflow-user-example-com patched
➜  profile-controller git:(namespace-reconcile-missing-values) ✗ kubectl get ns kubeflow-user-example-com -o yaml | yq .metadata.ownerReferences                                 
[
  {
    "apiVersion": "kubeflow.org/v1",
    "blockOwnerDeletion": true,
    "controller": true,
    "kind": "Profile",
    "name": "kubeflow-user-example-com",
    "uid": "eede261d-caca-4dd2-af95-9f000d219497"
  }
]
```