### PR TITLE
centraldashboard: Allow all-namespaces option for mwa

### DIFF
--- a/components/centraldashboard/public/components/namespace-selector.js
+++ b/components/centraldashboard/public/components/namespace-selector.js
@@ -9,7 +9,7 @@ import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
 
 export const ALL_NAMESPACES = 'All namespaces';
 export const ALL_NAMESPACES_ALLOWED_LIST = ['jupyter', 'volumes',
-    'tensorboards', 'katib'];
+    'tensorboards', 'katib', 'models'];
 
 const allNamespacesAllowedPaths = ALL_NAMESPACES_ALLOWED_LIST
     .map(( p)=>`/_/${p}/`);


### PR DESCRIPTION
In this PR, we enable all-namespace support in MWA by displaying the `All namespaces` option in the dashboard.

Related PR: https://github.com/kserve/models-web-app/pull/68