### PR TITLE
profile-controller: Support custom cluster domain other than cluster.local

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -417,6 +417,13 @@ func (r *ProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile) istioSecurity.AuthorizationPolicy {
+
+	clusterDomain := "cluster.local"
+	if clusterDomainFromEnv, ok := os.LookupEnv("CLUSTER_DOMAIN"); ok {
+		clusterDomain = clusterDomainFromEnv
+	}
+	principals := fmt.Sprintf("%s/ns/kubeflow/sa/notebook-controller-service-account", clusterDomain)
+
 	return istioSecurity.AuthorizationPolicy{
 		Action: istioSecurity.AuthorizationPolicy_ALLOW,
 		// Empty selector == match all workloads in namespace
@@ -466,7 +473,7 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 				From: []*istioSecurity.Rule_From{
 					{
 						Source: &istioSecurity.Source{
-							Principals: []string{"cluster.local/ns/kubeflow/sa/notebook-controller-service-account"},
+							Principals: []string{principals},
 						},
 					},
 				},


### PR DESCRIPTION
profile controller does not work on the clusters which have a custom cluster domain because of the hardcoded "Principals".  

- https://github.com/kubeflow/kubeflow/blob/master/components/profile-controller/controllers/profile_controller.go#L466-L472 

Original code: 
```go
				From: []*istioSecurity.Rule_From{
					{
						Source: &istioSecurity.Source{
							Principals: []string{"cluster.local/ns/kubeflow/sa/notebook-controller-service-account"},
						},
					},
				},
```


This PR adds support for arbitrary cluster domains by using the `CLUSTER_DOMAIN` environment variable.  
The environment variable `CLUSTER_DOMAIN` is optional, so the profile controller uses "cluster.local" as is when not set.  

Kindly review this PR.  