### PR TITLE
[Access management - kfam] k8s multi tenancy group

### DIFF
--- a/components/access-management/api/swagger.yaml
+++ b/components/access-management/api/swagger.yaml
@@ -72,7 +72,7 @@ paths:
       parameters:
       - name: "user"
         in: "query"
-        description: "User name, when not empty, only return bindings of this user"
+        description: "User name, when not empty, only return bindings of this user and its groups."
         required: false
         type: "string"
         x-exportParamName: "User"
@@ -84,6 +84,13 @@ paths:
         required: false
         type: "string"
         x-exportParamName: "Namespace"
+        x-optionalDataType: "String"
+      - name: "groups"
+        in: "query"
+        description: "User groups, when not empty, only return bindings of those groups."
+        required: false
+        type: "string"
+        x-exportParamName: "Groups"
         x-optionalDataType: "String"
       - name: "role"
         in: "query"

--- a/components/access-management/kfam/api_default.go
+++ b/components/access-management/kfam/api_default.go
@@ -318,8 +318,8 @@ func (c *KfamV1Alpha1Client) isClusterAdmin(queryUser string) bool {
 }
 
 func (c *KfamV1Alpha1Client) isKubeflowAdmin(queryUser string, groups []string, profileName string) bool {
-	roles, _ := c.bindingClient.List(queryUser, groups, []string{profileName}, roleBindingNameMap["kubeflow-admin"])
-	return len(roles.Bindings) > 0
+	roles, err := c.bindingClient.List(queryUser, groups, []string{profileName}, roleBindingNameMap["kubeflow-admin"])
+	return err != nil && len(roles.Bindings) > 0
 }
 
 //isOwnerOrAdmin return true if queryUser is cluster admin or profile owner

--- a/components/access-management/kfam/utils.go
+++ b/components/access-management/kfam/utils.go
@@ -13,3 +13,12 @@
 // limitations under the License.
 
 package kfam
+
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
The purpose of this PR is to establish a basis for allowing authorization access based on Kubernetes Group definition. According to https://github.com/kubeflow/dashboard/issues/42, they are many elements to take into account. Let's take them one by one.

## oidc-authservice

The [oidc-authservice](https://github.com/arrikto/oidc-authservice) support **GROUPS_HEADER** (_Name of the header containing the groups that will be added to the upstream request._). When using dex with a oauth2, LDAP or any connectors, groups can be transmit through the requests. In order to let the different services consume it, we need to explicitly add `kubeflow-groups` in the [authn-filter envoy-filter config](https://github.com/kubeflow/manifests/blob/master/common/oidc-authservice/base/envoy-filter.yaml) next to the kubeflow-userid pattern already allowed[^1] otherwise istio will not allow it.

## Kfam

### List bindings

The dashboard is using the `Kubeflow Access Management API`, this component currently will compare the annotation `user` in RoleBindingwith the username provided. The idea in this PR is to add an optional query parameter `groups`, which can be used by the centraldashboard, by sending the value of the GROUPS_HEADER he received.

The logic is to either use the username or the groups to ensure a user can use the role binding or not when listing bindings.

> I made a branch on my fork[^2] (currently no open PR) with the modified version of the centraldashboard using the version of the kfam proposed here. 

### Special case: kubeflow-admin

When a Profile is created, a `namespaceAdmin` RoleBinding is also created, it use the user as subject and the `kubeflow-admin` ClusterRole as reference. It allows to add and delete contributors in the centraldashboard. If we want to create a group of people responsible of a Profile/namespace, we need to add some logics in the kfam api to check for binding like:
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  annotations:
    group: admins
    role: admin
  name: namespaceAdminGroup
  namespace: kubeflow-group-example
subjects:
  - kind: Group
    apiGroup: rbac.authorization.k8s.io
    name: admins
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: kubeflow-admin
```

I added a function `isKubeflowAdmin` using the modified version of the code, which will list the binding based on username, user's groups, and the `admin` role selector.

### experimental-groups flag

I added an `experimental-groups` flag, defaulted to false, to disable by default the usage of the groups by kfam.

## crud-web-apps

To keep the PR small, I did not include the modification to allows crud-web-apps components to use the groups. However, I created a branch with the necessary modifications[^3]. The logic is to add the groups when using the k8s sdk for creating a V1SubjectAccessReviewSpec[^4].


[^1]: The istio [envoy-filter.yaml#L40](https://github.com/kubeflow/manifests/blob/f7dc14e359fb8ab07b5493cf2d6f1f8583d56f7f/common/oidc-authservice/base/envoy-filter.yaml#L40) config file necessary.
[^2]: The modified version of the centraldashboard can be found [here](https://github.com/axel7083/kubeflow/tree/centraldashboard_groups_support).
[^3]: You can found the branch with the modification for the crud-web-apps-groups [here](https://github.com/axel7083/kubeflow/tree/crud-web-apps-groups-support).
[^4]: The [V1SubjectAccessReviewSpec](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/V1SubjectAccessReviewSpec.md#properties) take a user (str) and a groups (list[str]) as optional arguments, the user is already provided by the USERID_HEADER, I added the GROUPS_HEADER for the groups argument.