### PR TITLE
fix: use "required" in tensorboard node affinity, rather than "preferred"

### DIFF
--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -404,8 +404,8 @@ func extractPVCSubPath(path string) string {
 	}
 }
 
-//Searches a corev1.PodList for running pods and returns
-//a running corev1.Pod (if exists)
+// Searches a corev1.PodList for running pods and returns
+// a running corev1.Pod (if exists)
 func findRunningPod(pods *corev1.PodList) corev1.Pod {
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == "Running" {
@@ -444,12 +444,12 @@ func generateNodeAffinity(affinity *corev1.Affinity, pvcname string, r *Tensorbo
 	if nodename == "" {
 		return nil
 	}
+
 	*affinity = corev1.Affinity{
 		NodeAffinity: &corev1.NodeAffinity{
-			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.PreferredSchedulingTerm{
-				{
-					Weight: 100,
-					Preference: corev1.NodeSelectorTerm{
+			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+				NodeSelectorTerms: []corev1.NodeSelectorTerm{
+					{
 						MatchExpressions: []corev1.NodeSelectorRequirement{
 							{
 								Key:      "kubernetes.io/hostname",
@@ -462,12 +462,13 @@ func generateNodeAffinity(affinity *corev1.Affinity, pvcname string, r *Tensorbo
 			},
 		},
 	}
+
 	return nil
 }
 
-//Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
-//'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
-//returned boolean is set to 'false', so that the scheduling functionality is off by default.
+// Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
+// 'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
+// returned boolean is set to 'false', so that the scheduling functionality is off by default.
 func rwoPVCScheduling() (error, bool) {
 	if value, exists := os.LookupEnv("RWO_PVC_SCHEDULING"); !exists || value == "false" || value == "False" || value == "FALSE" {
 		return nil, false


### PR DESCRIPTION
When `RWO_PVC_SCHEDULING` is set to `true`, a `nodeAffinity` is generated to deploy the tensorboard image to the same node as the running pod using the `PVC`. This is done with `preferredDuringSchedulingIgnoredDuringExecution` with a weight of `100`. However, [this does not guarantee that the kube-scheduler will schedule the tensorboard pod to be on the same node, just with an added weight when considering which node to schedule to.](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#node-affinity-weight) This could result in times where the pod will still be scheduled on a different node, causing volume mount errors with `ReadWriteOnce` PVCs. 

Thus, this PR is to change the `nodeAffinity` to `RequiredDuringSchedulingIgnoredDuringExecution` instead, to force the kube-scheduler to schedule the tensorboard image into the correct node.

Since the user would have only `ReadWriteOnce` persistent volumes if they set  `RWO_PVC_SCHEDULING` to `true`, it would not affect the user if the scheduling is changed to `RequiredDuringSchedulingIgnoredDuringExecution`, since the tensorboard image will fail to start at all if the pod is schedule on any other pod.