### PR TITLE
gh-actions(cdb): Fix Build and Publish action

### DIFF
--- a/.github/workflows/centraldb_angular_docker_publish.yaml
+++ b/.github/workflows/centraldb_angular_docker_publish.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
 
     - uses: dorny/paths-filter@v2
       id: filter


### PR DESCRIPTION
It looks like after when the PR of mine [Show KF Version](https://github.com/kubeflow/kubeflow/pull/6918) was merged, the [Build & Publish CentralDashboard-Angular Docker image](https://github.com/kubeflow/kubeflow/blob/master/.github/workflows/centraldb_angular_docker_publish.yaml) GH action started [failing](https://github.com/kubeflow/kubeflow/actions/runs/4165479958/jobs/7208537657). 

This PR fixes the issue which was caused due to shallow clone of the repo. This means that during the clone, git skips cloning the whole history and thus the following `docker build` command results with an empty `kubeflowversion` which is defined by this command `kubeflowversion=$(shell git describe --abbrev=0 --tags)`
```
docker build  -t centraldashboard-angular:intergration-test -f Dockerfile .. \
	--build-arg kubeflowversion= \
	--build-arg commit=dd3b7e3992d9e5afa6ceaa609e5ea19e904f5665 \
	--label=git-verions=intergration-test
```

This in return, caused the `$BUILD_VERSION` to be undefined inside the Dockerfile and thus it failed with the following error
```
 Step 21/34 : RUN node scripts/replace-string-in-file.js src/environments/environment.prod.ts 'BUILD_VERSION' $BUILD_VERSION
 ---> Running in 39acf1b67aaa
Error, not enough arguments given! This script expects 3 arguments in the following order: File name, String between ${ } that should be replaced, New string
```

 
