### PR TITLE
Profile controller and KFAM allow unauthenticated in-cluster traffic

### DIFF
--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -35,7 +35,7 @@ const AuthorizationPolicy = "authorizationpolicies"
 const USER = "user"
 const ROLE = "role"
 
-//roleBindingNameMap maps frontend role names to k8s role names and vice-versa
+// roleBindingNameMap maps frontend role names to k8s role names and vice-versa
 var roleBindingNameMap = map[string]string{
 	"kubeflow-admin": "admin",
 	"kubeflow-edit":  "edit",
@@ -57,7 +57,7 @@ type BindingClient struct {
 	roleBindingLister v1.RoleBindingLister
 }
 
-//getBindingName returns bindingName, which is combination of user kind, username, RoleRef kind, RoleRef name.
+// getBindingName returns bindingName, which is combination of user kind, username, RoleRef kind, RoleRef name.
 func getBindingName(binding *Binding) (string, error) {
 	// Only keep lower case letters and numbers, replace other with -
 	reg, err := regexp.Compile("[^a-zA-Z0-9]+")
@@ -88,6 +88,13 @@ func getAuthorizationPolicy(binding *Binding, userIdHeader string, userIdPrefix 
 						},
 					},
 				},
+				From: []*istioSecurity.Rule_From{{
+					Source: &istioSecurity.Source{
+						Principals: []string{
+							"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account",
+						},
+					},
+				}},
 			},
 		},
 	}

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -433,6 +433,13 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 						},
 					},
 				},
+				From: []*istioSecurity.Rule_From{{
+					Source: &istioSecurity.Source{
+						Principals: []string{
+							"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account",
+						},
+					},
+				}},
 			},
 			{
 				When: []*istioSecurity.Condition{


### PR DESCRIPTION
This is similar to this kerve issue https://github.com/kserve/kserve/issues/2197#issue-1248404440. Users can be impersonated without authentication by attaching the header `kubeflow-userid: ` with a valid profile contributor name to a request going to any namespace within the mesh.

```sh
(base) jovyan@tensorflow-0:~$ curl -sS -D - http://jupyter-scipy.kubeflow-user-example-com.svc.cluster.local/notebook/kubeflow-user-example-com/jupyter-scipy/api/sessions -o /dev/null
HTTP/1.1 403 Forbidden
content-length: 19
content-type: text/plain
date: Tue, 07 Mar 2023 04:02:17 GMT
server: envoy
x-envoy-upstream-service-time: 4

(base) jovyan@tensorflow-0:~$ curl -H "kubeflow-userid: user@example.com" -sS -D - http://jupyter-scipy.kubeflow-user-example-com.svc.cluster.local/notebook/kubeflow-user-example-com/jupyter-scipy/api/sessions -o /dev/null
HTTP/1.1 200 OK
server: envoy
content-type: application/json
date: Tue, 07 Mar 2023 04:03:22 GMT
x-content-type-options: nosniff
content-security-policy: frame-ancestors 'self'; report-uri /notebook/kubeflow-user-example-com/jupyter-scipy/api/security/csp-report; default-src 'none'
access-control-allow-origin: *
etag: "97d170e1550eee4afc0af065b78cda302a97674c"
content-length: 2
x-envoy-upstream-service-time: 106
```

Adding this change resolves that
```sh
kubectl patch deployment profiles-deployment -n kubeflow --type=json -p='[{"op": "replace", "path": "/spec/template/spec/containers/1/image", "value": "profile-controller:v1.7.0-rc.1-dirty"}]'
deployment.apps/profiles-deployment patched
```

```sh
➜  ~ kubectl get authorizationpolicies/ns-owner-access-istio -n kubeflow-user-example-com -o json | jq '.spec.rules[0]'

{
  "from": [
    {
      "source": {
        "principals": [
          "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
        ]
      }
    }
  ],
  "when": [
    {
      "key": "request.headers[kubeflow-userid]",
      "values": [
        "user@example.com"
      ]
    }
  ]
}
```

```sh
(base) jovyan@tensorflow-0:~$ curl -sS -D - http://jupyter-scipy.kubeflow-user-example-com.svc.cluster.local/notebook/kubeflow-user-example-com/jupyter-scipy/api/sessions -o /dev/null
HTTP/1.1 403 Forbidden
content-length: 19
content-type: text/plain
date: Tue, 07 Mar 2023 04:26:19 GMT
server: envoy
x-envoy-upstream-service-time: 32

(base) jovyan@tensorflow-0:~$ curl -H "kubeflow-userid: user@example.com" -sS -D - http://jupyter-scipy.kubeflow-user-example-com.svc.cluster.local/notebook/kubeflow-user-example-com/jupyter-scipy/api/sessions -o /dev/null
HTTP/1.1 403 Forbidden
content-length: 19
content-type: text/plain
date: Tue, 07 Mar 2023 04:26:22 GMT
server: envoy
x-envoy-upstream-service-time: 9
```

The authorization policy created by KFAM also has the same issue.
<img width="720" alt="Screenshot 2023-03-06 at 11 39 47 PM" src="https://user-images.githubusercontent.com/7153166/223323285-641851ad-1244-4990-b946-db6b13cca7cb.png">

```sh
(base) jovyan@tensorflow-0:~$ curl -H "kubeflow-userid: jack@example.com" -sS -D - http://jupyter-scipy.kubeflow-user-example-com.svc.cluster.local/notebook/kubeflow-user-example-com/jupyter-scipy/api/sessions -o /dev/null | head -n 1
HTTP/1.1 200 OK
```
