### PR TITLE
adding privacy information to dashboard config to make it easily customizable

### DIFF
--- a/components/centraldashboard/config/centraldashboard-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-config.yaml
@@ -86,7 +86,19 @@ data:
           "desc": "Get more detailed information about using Kubeflow and its components",
           "link": "https://www.kubeflow.org/docs/started/requirements/"
         }
-      ]
+      ],
+      "legalLinks": [
+        {
+          "text": "Privacy",
+          "desc": "Kubeflow Privacy Policy",
+          "link": "https://policies.google.com/privacy"
+        },
+        {
+          "text": "Usage Reporting",
+          "desc": "Kubeflow Usage Reporting",
+          "link": "https://www.kubeflow.org/docs/other-guides/usage-reporting/"
+        }
+    ]
     }
 kind: ConfigMap
 metadata:

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -85,6 +85,10 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
                 type: Array,
                 value: [],
             },
+            legalLinks: {
+                type: Array,
+                value: [],
+            },
             errorText: {type: String, value: ''},
             buildVersion: {type: String, value: BUILD_VERSION},
             dashVersion: {type: String, value: VERSION},
@@ -180,11 +184,13 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
             externalLinks,
             quickLinks,
             documentationItems,
+            legalLinks
         } = ev.detail.response;
         this.menuLinks = menuLinks || [];
         this.externalLinks = externalLinks || [];
         this.quickLinks = quickLinks || [];
         this.documentationItems = documentationItems || [];
+        this.legalLinks = legalLinks || [];
     }
 
     /**

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -62,9 +62,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     iron-icon.external(icon="launch")
         footer.footer
             section.information
-                a.privacy(title='Kubeflow Privacy Policy', target='_blank', href='https://policies.google.com/privacy') Privacy
-                .bullet
-                a.usage(title='Kubeflow Usage Reporting', target='_blank', href='https://www.kubeflow.org/docs/other-guides/usage-reporting/') Usage Reporting
+                 template(is='dom-repeat', items='[[legalLinks]]')
+                      a.privacy(title='[[item.desc]]', target='_blank', href='[[item.link]]') [[item.text]] &nbsp; 
             section.build build version&nbsp;
                 span(title="Build: [[buildVersion]] | Dashboard: v[[dashVersion]] | Isolation-Mode: [[isolationMode]]") [[buildVersion]]
     app-header-layout(fullbleed)

--- a/components/centraldashboard/public/components/registration-page.js
+++ b/components/centraldashboard/public/components/registration-page.js
@@ -46,6 +46,10 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
                 // eslint-disable-next-line
                 value: '[-a-z0-9\.]',
             },
+            legalLinks: {
+                type: Array,
+                value: [],
+            },
         };
     }
 
@@ -119,6 +123,21 @@ export class RegistrationPage extends utilitiesMixin(PolymerElement) {
         this.flowComplete = true;
         this.set('error', {});
         this.fireEvent('flowcomplete');
+    }
+
+    /**
+     * Set state for Central dashboard links
+     * @param {Event} ev AJAX-response
+     */
+    _onHasDashboardLinksResponse(ev) {
+        const {
+            menuLinks,
+            externalLinks,
+            quickLinks,
+            documentationItems,
+            legalLinks
+        } = ev.detail.response;
+        this.legalLinks = legalLinks || [];
     }
 }
 

--- a/components/centraldashboard/public/components/registration-page.pug
+++ b/components/centraldashboard/public/components/registration-page.pug
@@ -1,5 +1,7 @@
 iron-ajax#MakeNamespace(method='POST', url='/api/workgroup/create', handle-as='json', last-error='{{error}}', last-response='{{resp}}',
     content-type='application/json', loading='{{submittingWorkgroup}}', on-input='clearInvalidation')
+iron-ajax(auto, url='/api/dashboard-links', handle-as='json',
+    on-response='_onHasDashboardLinksResponse', on-error='_onHasDashboardLinksError', loading='{{pageLoading}}')
 iron-ajax#GetMyNamespace(url='/api/workgroup/exists', handle-as='json')
 paper-card#MainCard
     figure#Logo !{logo}
@@ -25,4 +27,5 @@ paper-card#MainCard
 nav#Links
     a(href='https://github.com/kubeflow/kubeflow', tabindex='-1', target="_blank") GitHub
     a(href='https://www.kubeflow.org/docs/about/kubeflow/', tabindex='-1', target="_blank") Documentation
-    a(href='https://policies.google.com/privacy', tabindex='-1', target="_blank") Privacy
+    template(is='dom-repeat', items='[[legalLinks]]')
+         a.privacy(title='[[item.desc]]', target='_blank', href='[[item.link]]') [[item.text]]


### PR DESCRIPTION
Problem:
The git version of kubeflow dashboard has hard coded privacy policy links that point to the google privacy statement. While this might be acceptable for private installations, it can cause problems in public or semi public installations (in my case a university internal service). In should be customizable to point to the organization specific privacy statement and maybe additional documents, if needed.

Proposal:
This PR adds the legal links to the dashboard config. It is handled as the other menu items or parts of the main page. Therefore, everyone can simply change the links if needed in his configmap. This PR changes all occurances of hardcoded privacy links that I have found (main-page and registration page). The standard values in the config still points to the old google links.
