### PR TITLE
remove dangerous links from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@ The Kubeflow community is organized into working groups (WGs) with associated re
 * [Training](https://github.com/kubeflow/community/tree/master/wg-training)
 
 ## Quick Links
-* [Prow jobs dashboard](http://prow.kubeflow-testing.com)
 * [PR Dashboard](https://k8s-gubernator.appspot.com/pr)
-* [Argo UI for E2E tests](https://argo.kubeflow-testing.com)
 
 ## Get Involved
 Please refer to the [Community](https://www.kubeflow.org/docs/about/community/) page.


### PR DESCRIPTION
We no longer control the `kubeflow-testing.com` domain, and it seems to be being squatted by some kind of data harvesting group.