### PR TITLE
Update requirements.txt

### DIFF
--- a/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
@@ -17,6 +17,3 @@ scikit-learn==0.24.2
 scipy==1.7.0
 seaborn==0.11.1
 xgboost==1.4.2
-
-# tensorflow packages
-keras==2.4.3


### PR DESCRIPTION
Hi KF team,
there was a PR https://github.com/kubeflow/kubeflow/pull/6755 which broke import of `tf.keras`

the issue is following:
if you have TF==2.9.3 then it requires `keras`>2.9
if you pin `keras` to 2.4.3, then it gets deleted and notebooks based on `jupyter-tensorflow-full` image will not be able to run notebooks where `keras` is imported

overall, new tensorflow versions come with supported version of `keras` via dependency, thus, pinning it in another file is dangerous. 
also, `keras` as standalone module is deprecated and the migration path is to use `tf.keras`

It for sure should be deleted in `components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt` 


the simplest way to check:
```
python3 -m venv venv_tf
source venv_tf/bin/activate
pip install tensorflow==2.9.3
pip install keras==2.4.3
python -c "import tensorflow.keras"
```

while the same code without pinning (allowing pip to resolve dependency) works:
```
python3 -m venv venv_tf
source venv_tf/bin/activate
pip install tensorflow==2.9.3
python -c "import tensorflow.keras"
```

