### PR TITLE
Add ability to use kubernetes generic ephemeral volumes in jupyter

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/utils.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/utils.ts
@@ -40,6 +40,7 @@ export function getFormDefaults(): FormGroup {
           }),
         }),
       }),
+      ephemeral: [false, []],
     }),
     affinityConfig: ['', []],
     tolerationGroup: ['', []],

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.component.html
@@ -60,3 +60,13 @@
     ></app-volume-access-modes>
   </ng-container>
 </ng-container>
+
+<div class="form-title" i18n>Data persistency</div>
+<mat-checkbox
+  i18n
+  [checked]="volGroup.get('ephemeral').value"
+  (change)="volGroup.get('ephemeral').setValue($event.checked)"
+  [formControl]="volGroup.get('ephemeral')"
+>
+Ephemeral
+</mat-checkbox>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.component.scss
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.component.scss
@@ -11,3 +11,9 @@
   margin-bottom: 1rem;
   white-space: pre-wrap;
 }
+
+.form-title {
+  font-weight: 500;
+  margin-bottom: 0.4rem;
+  color: rgba(0, 0, 0, 0.64);
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.component.spec.ts
@@ -32,6 +32,7 @@ describe('NewVolumeComponent', () => {
     component = fixture.componentInstance;
     component.volGroup = new FormGroup({
       newPvc: new FormControl(),
+      ephemeral: new FormControl(),
     });
 
     fixture.detectChanges();

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.module.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/volume/new/new.module.ts
@@ -7,6 +7,7 @@ import { VolumeAccessModesModule } from './access-modes/access-modes.module';
 import { VolumeSizeModule } from './size/size.module';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { EditorModule } from 'kubeflow';
@@ -23,6 +24,7 @@ import { EditorModule } from 'kubeflow';
     MatSelectModule,
     ReactiveFormsModule,
     MatFormFieldModule,
+    MatCheckboxModule,
     EditorModule,
   ],
   exports: [NewVolumeComponent],

--- a/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/shared/utils/volumes/forms.ts
@@ -98,6 +98,7 @@ export function createNewPvcVolumeFormGroup(
   return new FormGroup({
     name: new FormControl('', []),
     mount: new FormControl('', Validators.required),
+    ephemeral: new FormControl(false, []),
     newPvc: createNewPvcFormGroup(name),
   });
 }
@@ -214,6 +215,7 @@ export function createNewPvcFormGroupFromVolume(
 export function createFormGroupFromVolume(volume: Volume): FormGroup {
   const group = new FormGroup({
     mount: new FormControl(volume.mount, [Validators.required]),
+    ephemeral: new FormControl(volume.ephemeral, []),
   });
 
   if (volume.newPvc) {

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/volume/interfaces.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/volume/interfaces.ts
@@ -11,4 +11,5 @@ export interface Volume {
   mount: string;
   newPvc?: V1PersistentVolumeClaim;
   existingSource?: V1Volume;
+  ephemeral?: boolean;
 }

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -150,7 +150,7 @@ spawnerFormDefaults:
     # (to have no default, set `value: null`)
     value:
       mount: /home/jovyan
-
+      ephemeral: false
       # pvc configs for creating new workspace volumes
       # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#persistentvolumeclaim-v1-core
       newPvc:
@@ -175,6 +175,7 @@ spawnerFormDefaults:
     value: []
     #value:
     #  - mount: /home/jovyan/datavol-1
+    #    ephemeral: true
     #    newPvc:
     #      metadata:
     #        name: "{notebook-name}-datavol-1"


### PR DESCRIPTION
Add checkbox to new volume form to create ephemeral workspace and/or data volume. Used generic ephemeral volumes as implementation https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes. 
Can resolve kubeflow/notebooks#71 in some cases