### PR TITLE
fix: add error handling to tensorboard controller

### DIFF
--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -111,6 +111,9 @@ func (r *TensorboardReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	// Reconcile istio virtual service.
 	virtualService, err := generateVirtualService(instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	if err := ctrl.SetControllerReference(instance, virtualService, r.Scheme()); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -404,8 +407,8 @@ func extractPVCSubPath(path string) string {
 	}
 }
 
-//Searches a corev1.PodList for running pods and returns
-//a running corev1.Pod (if exists)
+// Searches a corev1.PodList for running pods and returns
+// a running corev1.Pod (if exists)
 func findRunningPod(pods *corev1.PodList) corev1.Pod {
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == "Running" {
@@ -465,9 +468,9 @@ func generateNodeAffinity(affinity *corev1.Affinity, pvcname string, r *Tensorbo
 	return nil
 }
 
-//Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
-//'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
-//returned boolean is set to 'false', so that the scheduling functionality is off by default.
+// Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
+// 'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
+// returned boolean is set to 'false', so that the scheduling functionality is off by default.
 func rwoPVCScheduling() (error, bool) {
 	if value, exists := os.LookupEnv("RWO_PVC_SCHEDULING"); !exists || value == "false" || value == "False" || value == "FALSE" {
 		return nil, false


### PR DESCRIPTION
Close https://github.com/kubeflow/kubeflow/issues/7040
If you apply this controller without ISTIO_GATEWAY config, virtualService will be nil and crush with nil pointer at [L114](https://github.com/kubeflow/kubeflow/blob/bbc55dd4a981d5c8e7de038715b11b07fa6883c2/components/tensorboard-controller/controllers/tensorboard_controller.go#L114).
So we should handle errors at [L113](https://github.com/kubeflow/kubeflow/blob/bbc55dd4a981d5c8e7de038715b11b07fa6883c2/components/tensorboard-controller/controllers/tensorboard_controller.go#L113).