### PR TITLE
feat(notebooks): propagate annotations from notebook cr to pods

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -377,18 +377,30 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 				},
 			},
 			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-					"statefulset":   instance.Name,
-					"notebook-name": instance.Name,
-				}},
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"statefulset":   instance.Name,
+						"notebook-name": instance.Name,
+					},
+					Annotations: map[string]string{},
+				},
 				Spec: *instance.Spec.Template.Spec.DeepCopy(),
 			},
 		},
 	}
+
 	// copy all of the Notebook labels to the pod including poddefault related labels
 	l := &ss.Spec.Template.ObjectMeta.Labels
 	for k, v := range instance.ObjectMeta.Labels {
 		(*l)[k] = v
+	}
+
+	// copy all of the Notebook annotations to the pod.
+	a := &ss.Spec.Template.ObjectMeta.Annotations
+	for k, v := range instance.ObjectMeta.Annotations {
+		if !strings.Contains(k, "kubectl") && !strings.Contains(k, "notebook") {
+			(*a)[k] = v
+		}
 	}
 
 	podSpec := &ss.Spec.Template.Spec


### PR DESCRIPTION
Added Annotation propagation logic to notebook controllers. This will help to  propagate custom annotations like kiam to notebook pods from notebook custom resource. 

This pr fixes issue https://github.com/kubeflow/kubeflow/issues/6677

Results:

Annotation on Notebook CR:

<img width="558" alt="image" src="https://user-images.githubusercontent.com/30414791/228589083-c09b9956-5173-404c-bac9-ca0c80ff92a3.png">

Annotation on Notebook Pod:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/30414791/228616251-4ed2b089-5c13-4f58-922e-2554286b2c53.png">

 