### PR TITLE
web-apps: Implement watch to avoid constant polling from backend to K8s

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/apis.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/apis.py
@@ -1,5 +1,10 @@
+import logging
+
 from kubernetes import client, config
 from kubernetes.config import ConfigException
+
+logging.getLogger("kubernetes").setLevel(logging.INFO)
+
 
 try:
     config.load_incluster_config()

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/notebook.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/notebook.py
@@ -1,14 +1,37 @@
+import logging
+
+from werkzeug import exceptions
+
 from .. import authz
-from . import custom_api, events, utils
+from . import custom_api, events, utils, watch
+
+log = logging.getLogger(__name__)
+
+# This object will be handle by the watch.py helpers completely. The dict has
+# namespaces as keys. This is done for performance reasons, since most requests
+# will be asking for namespaced data
+#
+# CACHE = {"namespace1": [...],
+#          "namespace2": [...]}
+CACHE = {}
 
 
-def get_notebook(notebook, namespace):
+def get_notebook(name, namespace):
     authz.ensure_authorized(
         "get", "kubeflow.org", "v1beta1", "notebooks", namespace
     )
-    return custom_api.get_namespaced_custom_object(
-        "kubeflow.org", "v1beta1", namespace, "notebooks", notebook
-    )
+
+    if not watch.should_use_cache(CACHE):
+        return custom_api.get_namespaced_custom_object(
+            "kubeflow.org", "v1beta1", namespace, "notebooks", name
+        )
+
+    # use data from the cache
+    notebook = watch.get_namespaced_object(name, namespace, CACHE)
+    if notebook is None:
+        raise exceptions.NotFound("Notebook %s/%s is not found"
+                                  % (namespace, name))
+    return notebook
 
 
 def create_notebook(notebook, namespace, dry_run=False):
@@ -25,9 +48,15 @@ def list_notebooks(namespace):
     authz.ensure_authorized(
         "list", "kubeflow.org", "v1beta1", "notebooks", namespace
     )
-    return custom_api.list_namespaced_custom_object(
-        "kubeflow.org", "v1beta1", namespace, "notebooks"
-    )
+
+    if not watch.should_use_cache(CACHE):
+        log.debug("Can't use the cache. Will send request to K8s.")
+        return custom_api.list_namespaced_custom_object(
+            "kubeflow.org", "v1beta1", namespace, "notebooks"
+        )["items"]
+
+    log.info("A watch is in place for Notebooks. Will use cached data.")
+    return CACHE.get(namespace, [])
 
 
 def delete_notebook(notebook, namespace):
@@ -59,3 +88,20 @@ def list_notebook_events(notebook, namespace):
     field_selector = utils.events_field_selector("Notebook", notebook)
 
     return events.list_events(namespace, field_selector)
+
+
+def list_notebooks_all_namespaces(*args, **kwargs):
+    # This function should also be used when watching for CRs in all namespaces
+    # https://github.com/kubernetes-client/python/issues/1750#issuecomment-1083606064
+    return custom_api.list_cluster_custom_object(
+        "kubeflow.org", "v1beta1", "notebooks", *args, **kwargs
+    )
+
+
+def watch_notebooks_all_namespaces():
+    """Start a long running watch for Notebooks in all namespaces.
+
+    This will setup an infinite retry loop. Should be used withing a long
+    running greenlet.
+    """
+    watch.indefinitely(CACHE, list_notebooks_all_namespaces)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
@@ -1,14 +1,37 @@
+import logging
+
 from .. import authz
-from . import v1_core
+from . import utils, v1_core, watch
+
+log = logging.getLogger(__name__)
+
+# This object will be handle by the watch.py helpers completely. The dict has
+# namespaces as keys. This is done for performance reasons, since most requests
+# will be asking for namespaced data
+#
+# CACHE = {"namespace1": [...],
+#          "namespace2": [...]}
+CACHE = {}
 
 
 def list_pods(namespace, auth=True, label_selector=None):
     if auth:
         authz.ensure_authorized("list", "", "v1", "pods", namespace)
 
-    return v1_core.list_namespaced_pod(
-        namespace=namespace,
-        label_selector=label_selector)
+    if not watch.should_use_cache(CACHE):
+        return v1_core.list_namespaced_pod(namespace=namespace,
+                                           label_selector=label_selector).items
+
+    log.info("A watch is in place for Pods. Will use cached data.")
+    pods = CACHE.get(namespace, [])
+
+    if label_selector is None:
+        return pods
+
+    # filter based on label_selector
+    return [pod for pod in pods
+            if utils.label_selector_matches(label_selector,
+                                            pod.metadata.labels)]
 
 
 def get_pod_logs(namespace, pod, container, auth=True):
@@ -18,3 +41,12 @@ def get_pod_logs(namespace, pod, container, auth=True):
     return v1_core.read_namespaced_pod_log(
         namespace=namespace, name=pod, container=container
     )
+
+
+def watch_pods_all_namespaces():
+    """Start a long running watch for Pods in all namespaces.
+
+    This will setup an infinite retry loop. Should be used withing a long
+    running greenlet.
+    """
+    watch.indefinitely(CACHE, v1_core.list_pod_for_all_namespaces)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pvc.py
@@ -1,5 +1,20 @@
+import logging
+
+from werkzeug import exceptions
+
 from .. import authz
-from . import v1_core, utils, events
+from . import events, utils, v1_core, watch
+
+log = logging.getLogger(__name__)
+
+# This object will be handle by the watch.py helpers completely. The dict has
+# namespaces as keys. This is done for performance reasons, since most requests
+# will be asking for namespaced data
+#
+# CACHE = {"namespace1": [...],
+#          "namespace2": [...]}
+CACHE = {}
+SELECTOR = "involvedObject.kind=PersistentVolumeClaim,involvedObject.name="
 
 
 def create_pvc(pvc, namespace, dry_run=False):
@@ -22,21 +37,32 @@ def list_pvcs(namespace):
     authz.ensure_authorized(
         "list", "", "v1", "persistentvolumeclaims", namespace
     )
-    return v1_core.list_namespaced_persistent_volume_claim(namespace)
+
+    if watch.should_use_cache(CACHE):
+        log.info("A watch is in place for PVCs. Will use cached data.")
+        return CACHE.get(namespace, [])
+
+    return v1_core.list_namespaced_persistent_volume_claim(namespace).items
 
 
-def get_pvc(pvc, namespace):
+def get_pvc(name, namespace):
     authz.ensure_authorized(
         "get", "", "v1", "persistentvolumeclaims", namespace
     )
-    return v1_core.read_namespaced_persistent_volume_claim(pvc, namespace)
+
+    if not watch.should_use_cache:
+        return v1_core.read_namespaced_persistent_volume_claim(name, namespace)
+
+    pvc = watch.get_namespaced_object(name, namespace, CACHE)
+    if pvc is None:
+        raise exceptions.NotFound("PVC %s/%s is not found" % namespace, name)
+
+    return pvc
 
 
 def list_pvc_events(namespace, pvc_name):
-
-    field_selector = utils.events_field_selector(
-        "PersistentVolumeClaim", pvc_name)
-
+    field_selector = utils.events_field_selector("PersistentVolumeClaim",
+                                                 pvc_name)
     return events.list_events(namespace, field_selector)
 
 
@@ -47,3 +73,13 @@ def patch_pvc(name, namespace, pvc, auth=True):
 
     return v1_core.patch_namespaced_persistent_volume_claim(name, namespace,
                                                             pvc)
+
+
+def watch_pvcs_all_namespaces():
+    """Start a long running watch for PVCs in all namespaces.
+
+    This will setup an infinite retry loop. Should be used withing a long
+    running greenlet.
+    """
+    watch.indefinitely(CACHE,
+                       v1_core.list_persistent_volume_claim_for_all_namespaces)

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/utils.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/utils.py
@@ -26,6 +26,29 @@ def failed_response(msg, error_code):
     return resp, error_code
 
 
+def label_selector_matches(label_selector, labels):
+    """Check if a label_selector matches a label from the provided labels."""
+    if "=" not in label_selector:
+        raise ValueError("Provided label_selector does not have = operator: %s"
+                         % (label_selector))
+
+    selector_key = label_selector.split("=")[0]
+    selector_value = label_selector.split("=")[1]
+
+    for label in labels:
+        if label != selector_key:
+            continue
+
+        # label key matched, checking for value
+        if labels[label] != selector_value:
+            continue
+
+        return True
+
+    # the label_selector did not match
+    return False
+
+
 def events_field_selector(kind, name):
     return "involvedObject.kind=%s,involvedObject.name=%s" % (kind, name)
 

--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/watch.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/watch.py
@@ -1,0 +1,218 @@
+import logging
+import traceback
+
+from kubernetes import client, watch
+
+api = client.ApiClient()
+log = logging.getLogger(__name__)
+
+
+WATCH_CACHE = {}
+CACHE_INIT_KEY = ".initialized"
+
+
+def clear_cache(cache):
+    """Reset the cache dict. Set necessery metadata fields as well."""
+    cache.clear()
+    cache[CACHE_INIT_KEY] = False
+
+
+def should_use_cache(cache):
+    """Checks whether the cache is valid and initialized."""
+    return cache and cache.get(CACHE_INIT_KEY, False)
+
+
+def get_namespaced_object(name, namespace, cache):
+    """
+    Search the cache for the namespaced object. Return None if not found.
+    """
+    for item in cache.get(namespace, []):
+        if get_metadata_name(item) == name:
+            return item
+
+    return None
+
+# In case of CustomResources the data is just a Dict object. In case of
+# builtin objects, like Pods, PVCs etc, the objects are of a specific class.
+
+
+def get_metadata_name(item):
+    """Return the metadata.name of either a JSON or class object."""
+    if hasattr(item, "metadata"):
+        return item.metadata.name
+    elif isinstance(item, dict):
+        return item["metadata"]["name"]
+
+
+def get_metadata_namespace(item):
+    """Return the metadata.namespace of either a JSON or class object."""
+    if hasattr(item, "metadata"):
+        return item.metadata.namespace
+    elif isinstance(item, dict):
+        return item["metadata"]["namespace"]
+
+
+def get_metadata_uid(item):
+    """Return the metadata.uid of either a JSON or class object."""
+    if hasattr(item, "metadata"):
+        return item.metadata.uid
+    elif isinstance(item, dict):
+        return item["metadata"]["uid"]
+
+
+def get_metadata_resource_version(item):
+    """Return the metadata.resourceVersion of either a JSON or class object."""
+    if hasattr(item, "metadata"):
+        return item.metadata.resource_version
+    elif isinstance(item, dict):
+        return item["metadata"]["resourceVersion"]
+
+
+def get_kind(item):
+    """Return the Kind of either a JSON or a class object."""
+    if hasattr(item, "kind"):
+        if item.kind is not None:
+            return item.kind
+
+        return item.__class__.__name__
+    elif isinstance(item, dict):
+        return item["kind"]
+
+
+def get_items(objects_list):
+    """Return the .items of a K8s list response"""
+    if hasattr(objects_list, "metadata"):
+        return objects_list.items
+    elif isinstance(objects_list, dict):
+        return objects_list["items"]
+
+
+def named_object(item):
+    """Return a (name, namespace) tuple for a K8s object."""
+    name = get_metadata_name(item)
+    namespace = get_metadata_namespace(item)
+    return (name, namespace)
+
+
+# Hander functions for the ADDED, MODIFIED and DELETED events of a watch stream
+def handle_added_event(cache, event):
+    """
+    Append a new CR, from event, to the existing list.
+
+    Ensures the list for each namespace is sorted by name, when adding the
+    new object.
+    """
+    new_object = event["object"]
+    log.info("Handling ADDED event for %s: %s", get_kind(new_object),
+             named_object(new_object))
+
+    # Function for sorting based on metadata.name
+    def name_key(item):
+        return get_metadata_name(item)
+
+    namespace = get_metadata_namespace(new_object)
+    current_list = cache.get(namespace, [])
+
+    # sort based on the metadata.name
+    current_list.append(new_object)
+    current_list.sort(key=name_key)
+
+    # must always re-add the list, since in case of initially empty list the
+    # dict had no key for that namespace.
+    cache[namespace] = current_list
+
+
+def handle_modified_event(cache, event):
+    """Update an existing CR, from event, to the existing list"""
+    new_object = event["object"]
+    log.info("Handling MODIFIED event for %s: %s", get_kind(new_object),
+             named_object(new_object))
+
+    namespace = get_metadata_namespace(new_object)
+    current_list = cache.get(namespace, [])
+    for i, item in enumerate(current_list):
+        if get_metadata_uid(item) != get_metadata_uid(new_object):
+            continue
+
+        # found, then update the list
+        current_list[i] = new_object
+        break
+
+
+def handle_deleted_event(cache, event):
+    """Delete a new CR, from event, from the existing list"""
+    new_object = event["object"]
+    log.info("Handling DELETED event for %s: %s", get_kind(new_object),
+             named_object(new_object))
+
+    namespace = get_metadata_namespace(new_object)
+    current_list = cache.get(namespace, [])
+    for i, item in enumerate(current_list):
+        if get_metadata_uid(item) != get_metadata_uid(new_object):
+            continue
+
+        # if found, then update the list
+        del current_list[i]
+        break
+
+
+# Watch buisiness logic
+def update_cache_from_watch(cache, watcher, list_fn, *args, **kwargs):
+    """Perform the K8s watch on CustomResource objects"""
+    # Flush the current cache since a new watch operation starts
+    clear_cache(cache)
+
+    log.info("Fetching the initial list of objects.")
+    objects_list = list_fn(*args, **kwargs)
+    log.info("Fetched the initial list of %s.", get_kind(objects_list))
+
+    # Create keys in the cache dict for each namespace and assign the list of
+    # CRs to each namespace
+    rv = get_metadata_resource_version(objects_list)
+    items = get_items(objects_list)
+
+    for item in items:
+        # We treat as each distinct item was from an ADDED event
+        handle_added_event(cache, {"object": item})
+
+    kind = get_kind(objects_list)
+
+    log.info("Initialized the cache for %s.", kind)
+    cache[CACHE_INIT_KEY] = True
+
+    log.info("Starting a watch for %s after resourceVersion: %s", kind, rv)
+
+    # Handle the ADDED, MODIFIED, DELETED events that come from the stream
+    # The greenlet sleeps here until new data is received
+    for event in watcher.stream(list_fn, *args, **kwargs, resource_version=rv):
+        if event["type"] == "ADDED":
+            handle_added_event(cache, event)
+        if event["type"] == "MODIFIED":
+            handle_modified_event(cache, event)
+        if event["type"] == "DELETED":
+            handle_deleted_event(cache, event)
+
+
+def indefinitely(cache, list_fn, *args, **kwargs):
+    """
+    Meant to be used inside a greenlet to continuously create a watch.
+
+    The function will use a retry logic in case of any unexpected error. The
+    cache will be considered initialized, and ready to use, once the initial
+    list request is done. In case the cache is not ready then a request to K8s
+    will be done instead.
+
+    Each indefinite watch will keep a persistent connection to the API Server.
+    This means that there will be a persistent connection / per watch / per
+    gunicorn worker.
+    """
+
+    while True:
+        w = watch.Watch()
+
+        try:
+            update_cache_from_watch(cache, w, list_fn, *args, **kwargs)
+        except Exception:
+            log.error(traceback.format_exc())
+            clear_cache(cache)
+            w.stop()

--- a/components/crud-web-apps/jupyter/backend/Makefile
+++ b/components/crud-web-apps/jupyter/backend/Makefile
@@ -11,12 +11,10 @@ unittest:
 
 run:
 	APP_PREFIX=/jupyter \
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
 	gunicorn \
-		-w 3 \
+		-w 1 \
 		--worker-class=gevent \
 		--bind 0.0.0.0:5000 \
-		--access-logfile - entrypoint:app
 
 run-dev:
 	UI_FLAVOR=default \
@@ -24,8 +22,7 @@ run-dev:
 	APP_SECURE_COOKIES=False \
 	APP_PREFIX=/ \
 	gunicorn \
-		-w 3 \
+		-w 1 \
 		--worker-class=gevent \
 		--bind 0.0.0.0:5000 \
 		--access-logfile - entrypoint:app
-

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -3,8 +3,7 @@
 from kubeflow.kubeflow.crud_backend import api, logging
 from werkzeug.exceptions import NotFound
 
-from .. import utils
-from .. import status
+from .. import status, utils
 from . import bp
 
 log = logging.getLogger(__name__)
@@ -51,7 +50,7 @@ def get_poddefaults(namespace):
 
 @bp.route("/api/namespaces/<namespace>/notebooks")
 def get_notebooks(namespace):
-    notebooks = api.list_notebooks(namespace)["items"]
+    notebooks = api.list_notebooks(namespace)
     contents = [utils.notebook_dict_from_k8s_obj(nb) for nb in notebooks]
 
     return api.success_response("notebooks", contents)
@@ -71,8 +70,8 @@ def get_notebook_pod(notebook_name, namespace):
     # There should be only one Pod for each Notebook,
     # so we expect items to have length = 1
     pods = api.list_pods(namespace=namespace, label_selector=label_selector)
-    if pods.items:
-        pod = pods.items[0]
+    if pods:
+        pod = pods[0]
         return api.success_response(
             "pod", api.serialize(pod),
         )

--- a/components/crud-web-apps/jupyter/backend/entrypoint.py
+++ b/components/crud-web-apps/jupyter/backend/entrypoint.py
@@ -1,8 +1,11 @@
 import os
 import sys
 
-from apps import default
+import gevent
 from kubeflow.kubeflow.crud_backend import config, logging
+from kubeflow.kubeflow.crud_backend.api import notebook, pod, pvc
+
+from apps import default
 
 log = logging.getLogger(__name__)
 
@@ -41,6 +44,12 @@ if UI_FLAVOR == "default":
 else:
     log.error("No UI flavor for '%s'" % UI_FLAVOR)
     sys.exit(1)
+
+
+# Start the background watches
+gevent.spawn(notebook.watch_notebooks_all_namespaces)
+gevent.spawn(pod.watch_pods_all_namespaces)
+gevent.spawn(pvc.watch_pvcs_all_namespaces)
 
 if __name__ == "__main__":
     app.run()

--- a/components/crud-web-apps/tensorboards/backend/Makefile
+++ b/components/crud-web-apps/tensorboards/backend/Makefile
@@ -2,11 +2,15 @@ install-deps:
 	cd ../../common/backend && pip install -e .
 
 run:
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:_app
+	gunicorn -w 1 --bind 0.0.0.0:5000 --access-logfile - entrypoint:_app
 
 run-dev:
 	UI_FLAVOR=default \
 	BACKEND_MODE=dev \
 	APP_PREFIX=/ \
 	APP_SECURE_COOKIES=False \
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+	gunicorn \
+		-w 1 \
+		--worker-class=gevent \
+		--bind 0.0.0.0:5000 \
+		--access-logfile - entrypoint:app

--- a/components/crud-web-apps/tensorboards/backend/app/routes/get.py
+++ b/components/crud-web-apps/tensorboards/backend/app/routes/get.py
@@ -14,7 +14,7 @@ def get_tensorboards(namespace):
     )
     content = [
         utils.parse_tensorboard(tensorboard)
-        for tensorboard in tensorboards["items"]
+        for tensorboard in tensorboards
     ]
 
     return api.success_response("tensorboards", content)
@@ -24,7 +24,7 @@ def get_tensorboards(namespace):
 def get_pvcs(namespace):
     # Return the list of PVCs and the corresponding Viewer's state
     pvcs = api.list_pvcs(namespace)
-    content = [pvc.metadata.name for pvc in pvcs.items]
+    content = [pvc.metadata.name for pvc in pvcs]
 
     return api.success_response("pvcs", content)
 

--- a/components/crud-web-apps/volumes/backend/Makefile
+++ b/components/crud-web-apps/volumes/backend/Makefile
@@ -8,11 +8,19 @@ install-deps:
 
 run:
 	APP_PREFIX=/volumes \
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+	gunicorn \
+		-w 1 \
+		--worker-class=gevent \
+		--bind 0.0.0.0:5000 \
+		--access-logfile - entrypoint:app
 
 run-dev:
 	UI_FLAVOR=default \
 	BACKEND_MODE=dev \
 	APP_PREFIX=/ \
 	APP_SECURE_COOKIES=False \
-	gunicorn -w 3 --bind 0.0.0.0:5000 --access-logfile - entrypoint:app
+	gunicorn \
+		-w 1 \
+		--worker-class=gevent \
+		--bind 0.0.0.0:5000 \
+		--access-logfile - entrypoint:app

--- a/components/crud-web-apps/volumes/backend/apps/common/utils.py
+++ b/components/crud-web-apps/volumes/backend/apps/common/utils.py
@@ -68,7 +68,7 @@ def get_pods_using_pvc(pvc, namespace):
     pods = api.list_pods(namespace)
     mounted_pods = []
 
-    for pod in pods.items:
+    for pod in pods:
         pvcs = get_pod_pvcs(pod)
         if pvc in pvcs:
             mounted_pods.append(pod)

--- a/components/crud-web-apps/volumes/backend/entrypoint.py
+++ b/components/crud-web-apps/volumes/backend/entrypoint.py
@@ -1,8 +1,11 @@
 import os
 import sys
 
-from apps import default
+import gevent
 from kubeflow.kubeflow.crud_backend import config, logging
+from kubeflow.kubeflow.crud_backend.api import pod, pvc
+
+from apps import default
 
 log = logging.getLogger(__name__)
 
@@ -37,6 +40,11 @@ if UI_FLAVOR == "default":
 else:
     log.error("No UI flavor for '%s'", UI_FLAVOR)
     sys.exit(1)
+
+
+# Start the background watches
+gevent.spawn(pod.watch_pods_all_namespaces)
+gevent.spawn(pvc.watch_pvcs_all_namespaces)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This is the first work in the backend for having a cache in the backends and make some progress for https://github.com/kubeflow/kubeflow/issues/5201 https://github.com/kubeflow/kubeflow/issues/6454.

The proposed architecture is for the backend to:
1. do a K8s watch, and hadnle added/created/deleted events, just like Controllers do
2. have at any point in time the full list of resources cached

With this approach, while the frontend will keep on polling, the backend will only have a couple of persistent connections in K8s and act as a cache. Subsequent steps for the frontends will be to do effective pagination, where the frontend can ask for specific pages. I.e. give the the 3rd page where each page has 20 items. And the backend can support this since it contains the full list of objects.

Some technical notes on the implementation: 
* We expect each web app to perform a watch operation on a [greenlet](https://greenlet.readthedocs.io/en/latest/) (coroutines)
    * Keep in mind that we have worker processes (gunicorn) that spins up greenlets (for handling http requests and doing the watches)
    * If a web app create 3 greenlet threads for doing watches (i.e. on notebooks, pvcs and pods) then 3 persistent connections will be made for that worker process (that spins up greenlets)
* Since we are using green threads (one process switching tasks) we don't have to worry about locks
* Whenever a watch operation fails (in a greenlet) it will retry to create the cache
    * Until the cache is initialized if a list request is made then, since the cache is not ready, a request to K8s will be made instead
* To setup the cache the backend will do the following:
    1. Do an initial list request to get all the current objects
    2. Initialize the cache with this list (cache is considered initialized and can be used at that point)
    3. Perform a watch based on the resourceVersion of the fetched list
    4. Handle the incoming events from that watch and keep the cache up to date 

This implementation is relying on this K8s functionality https://kubernetes.io/docs/reference/using-api/api-concepts/#efficient-detection-of-changes