### PR TITLE
Checksum verification kubectl without saving checksum file and add key --no-cache-dir for pip 

### DIFF
--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -45,11 +45,11 @@ FROM python:3.8-slim
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .
-RUN pip3 install .
+RUN pip3 install --no-cache-dir .
 
 WORKDIR /src
 COPY ./jupyter/backend/requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY ./jupyter/backend/apps/ ./apps
 COPY ./jupyter/backend/entrypoint.py .

--- a/components/crud-web-apps/tensorboards/Dockerfile
+++ b/components/crud-web-apps/tensorboards/Dockerfile
@@ -45,11 +45,11 @@ FROM python:3.8-slim
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .
-RUN pip3 install .
+RUN pip3 install --no-cache-dir .
 
 WORKDIR /src
 COPY ./tensorboards/backend/requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY ./tensorboards/backend/app/ ./app
 COPY ./tensorboards/backend/entrypoint.py .

--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -54,9 +54,7 @@ RUN export GNUPGHOME=/tmp/ \
 
 # install - kubectl
 RUN curl -sL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl" -o /usr/local/bin/kubectl \
- && curl -sL "https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl.sha256" -o /tmp/kubectl.sha256 \
- && echo "$(cat /tmp/kubectl.sha256) /usr/local/bin/kubectl" | sha256sum --check \
- && rm /tmp/kubectl.sha256 \
+ && echo $(curl -sL https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${KUBECTL_ARCH}/kubectl.sha256) /usr/local/bin/kubectl | sha256sum --check \
  && chmod +x /usr/local/bin/kubectl
 
 # create user and set required ownership

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -12,17 +12,15 @@ FROM golang:${GOLANG_VERSION} as builder
 WORKDIR /workspace
 
 # Copy the Go Modules manifests
-COPY notebook-controller /workspace/notebook-controller
-COPY common /workspace/common
+COPY notebook-controller ./notebook-controller
+COPY common ./common
 
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
-RUN cd /workspace/notebook-controller && go mod download
-
 WORKDIR /workspace/notebook-controller
-
-# Build
-RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod -o manager main.go
+RUN go mod download && \
+    # Build
+    CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
Checksum verification kubectl without saving checksum file allows you to reduce the number of commands for the dockerfile.
Add key --no-cache-dir for pip Allows you to reduce the size of images.