### PR TITLE
centraldashboard: removed critical vulnerabilities from centraldashboard image Fixes #7098

### DIFF
--- a/components/centraldashboard/Dockerfile
+++ b/components/centraldashboard/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Builds and tests
-FROM node:12.22.12-bullseye AS build
+FROM node:14.21.3-bullseye AS build
 
 ARG kubeflowversion
 ARG commit
@@ -24,7 +24,9 @@ RUN BUILDARCH="$(dpkg --print-architecture)" &&  npm rebuild && \
     npm prune --production
 
 # Step 2: Packages assets for serving
-FROM node:12.22.12-alpine AS serve
+FROM node:14.21.3-alpine3.17 AS serve
+
+USER node
 
 ENV NODE_ENV=production
 WORKDIR /app

--- a/components/centraldashboard/package-lock.json
+++ b/components/centraldashboard/package-lock.json
@@ -3203,28 +3203,21 @@
             "dev": true
         },
         "chart.js": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.8.0.tgz",
-            "integrity": "sha512-Di3wUL4BFvqI5FB5K26aQ+hvWh8wnP9A3DWGvXHVkO13D3DSnaSsdZx29cXlEsYKVkn1E2az+ZYFS4t0zi8x0w==",
+            "version": "2.9.4",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-2.9.4.tgz",
+            "integrity": "sha512-B07aAzxcrikjAPyV+01j7BmOpxtQETxTSlQ26BEYJ+3iUkbNKaOJ/nDbT6JjyqYxseM0ON12COHYdU2cTIjC7A==",
             "requires": {
                 "chartjs-color": "^2.1.0",
                 "moment": "^2.10.2"
             }
         },
         "chartjs-color": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.3.0.tgz",
-            "integrity": "sha512-hEvVheqczsoHD+fZ+tfPUE+1+RbV6b+eksp2LwAhwRTVXEjCSEavvk+Hg3H6SZfGlPh/UfmWKGIvZbtobOEm3g==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chartjs-color/-/chartjs-color-2.4.1.tgz",
+            "integrity": "sha512-haqOg1+Yebys/Ts/9bLo/BqUcONQOdr/hoEr2LLTRl6C5LXctUdHxsCYfvQVg5JIxITrfCNUDr4ntqmQk9+/0w==",
             "requires": {
                 "chartjs-color-string": "^0.6.0",
-                "color-convert": "^0.5.3"
-            },
-            "dependencies": {
-                "color-convert": {
-                    "version": "0.5.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
-                    "integrity": "sha1-vbbGnOZg+t/+CwAHzER+G59ygr0="
-                }
+                "color-convert": "^1.9.3"
             }
         },
         "chartjs-color-string": {
@@ -3436,7 +3429,6 @@
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
             "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -8140,9 +8132,9 @@
             }
         },
         "moment": {
-            "version": "2.29.2",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-            "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+            "version": "2.29.4",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+            "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
         },
         "move-concurrently": {
             "version": "1.0.1",

--- a/components/centraldashboard/package.json
+++ b/components/centraldashboard/package.json
@@ -67,7 +67,7 @@
         "@types/dotenv": "^6.1.1",
         "@vaadin/vaadin-grid": "^5.4.9",
         "@webcomponents/webcomponentsjs": "^2.3.0",
-        "chart.js": "^2.8.0",
+        "chart.js": "^2.9.4",
         "chartjs-plugin-crosshair": "^1.1.4",
         "express": "^4.17.1",
         "node-fetch": "^2.6.7",


### PR DESCRIPTION
**Description of your changes:**
* Fixes https://github.com/kubeflow/kubeflow/issues/7098
* Switching to the 14.21.3 version of the node image, which is the next LTS version after 12.22.12
* changed user from root to `node` because of the compliance issue  `(CIS_Docker_CE_v1.1.0 - 4.1) Image should be created with a non-root user`

Before:
```
Vulnerabilities
===============
  CVE                 Package                 Version      Severity    Status                    CVSS
  ---                 -------                 -------      --------    ------                    ----
  CVE-2022-37434      zlib                    1.2.12-r0    critical    fixed in 1.2.12-r2        9.8
  CVE-2021-44906      minimist                1.2.5        critical    fixed in 1.2.6            9.8
  CVE-2020-7746       chart.js                2.8.0        critical    fixed in 2.9.4            9.8
  CVE-2023-0464       openssl                 1.1.1n-r0    high        fixed in 1.1.1t-r2        7.5
  CVE-2023-0215       openssl                 1.1.1n-r0    high        fixed in 1.1.1t-r0        7.5
  CVE-2022-4450       openssl                 1.1.1n-r0    high        fixed in 1.1.1t-r0        7.5
  CVE-2022-3517       minimatch               3.0.4        high        fixed in 3.0.5            7.5
  CVE-2022-31129      moment                  2.29.2       high        fixed in 2.29.4           7.5
  CVE-2022-25878      protobufjs              6.11.2       high        fixed in 6.11.3           7.5
  CVE-2022-24999      qs                      6.5.2        high        fixed in 6.10.3           7.5
  CVE-2022-24999      qs                      6.7.0        high        fixed in 6.10.3           7.5
  CVE-2021-3807       ansi-regex              4.1.0        high        fixed in 4.1.1            7.5
  CVE-2021-3807       ansi-regex              3.0.0        high        fixed in 4.1.1            7.5
  CVE-2021-23343      path-parse              1.0.6        high        fixed in 1.0.7            7.5
  CVE-2023-0286       openssl                 1.1.1n-r0    high        fixed in 1.1.1t-r0        7.4
  PRISMA-2022-0022    node-forge              0.10.0       high        fixed in 1.0.0            7
  CVE-2022-24772      node-forge              0.10.0       high        fixed in 1.3.0            7
  CVE-2022-24771      node-forge              0.10.0       high        fixed in 1.3.0            7
  CVE-2022-38778      decode-uri-component    0.2.0        medium      fixed in 0.2.1            6.5
  CVE-2022-0235       node-fetch              2.6.6        medium      fixed in 3.1.1, 2.6.7     6.1
  CVE-2022-4304       openssl                 1.1.1n-r0    medium      fixed in 1.1.1t-r0        5.9
  CVE-2020-28928      musl                    1.2.2-r7     medium      fixed in 1.2.2_pre2-r0    5.5
  CVE-2023-0465       openssl                 1.1.1n-r0    medium      fixed in 1.1.1t-r3        5.3
  CVE-2022-33987      got                     6.7.1        medium      fixed in 12.1.0           5.3
  CVE-2022-2097       openssl                 1.1.1n-r0    medium      fixed in 1.1.1q-r0        5.3
  CVE-2022-24773      node-forge              0.10.0       moderate    fixed in 1.3.0            4
  CVE-2022-0122       node-forge              0.10.0       moderate    fixed in 1.0.0            4
  CVE-2020-15366      ajv                     6.9.2        moderate    fixed in 6.12.3           4

Compliance
==========
  Severity    Description
  --------    -----------
  high        (CIS_Docker_CE_v1.1.0 - 4.1) Image should be created with a non-root user

Vulnerability
    Critical: 3
    High:     15
    Medium:   10
    Low:      0
    Total:    28

  Compliance
    Critical: 0
    High:     1
    Medium:   0
    Low:      0
    Total:    1
```

After: 

```
Vulnerabilities
===============
  CVE                 Package       Version    Severity    Status                   CVSS
  ---                 -------       -------    --------    ------                   ----
  CVE-2022-3517       minimatch     3.0.4      high        fixed in 3.0.5           7.5
  CVE-2022-25878      protobufjs    6.11.2     high        fixed in 6.11.3          7.5
  CVE-2022-24999      qs            6.5.2      high        fixed in 6.10.3          7.5
  CVE-2022-24999      qs            6.7.0      high        fixed in 6.10.3          7.5
  CVE-2021-3807       ansi-regex    4.1.0      high        fixed in 4.1.1           7.5
  CVE-2021-3807       ansi-regex    3.0.0      high        fixed in 4.1.1           7.5
  CVE-2021-23343      path-parse    1.0.6      high        fixed in 1.0.7           7.5
  PRISMA-2022-0022    node-forge    0.10.0     high        fixed in 1.0.0           7
  CVE-2022-24772      node-forge    0.10.0     high        fixed in 1.3.0           7
  CVE-2022-24771      node-forge    0.10.0     high        fixed in 1.3.0           7
  CVE-2022-0235       node-fetch    2.6.6      medium      fixed in 3.1.1, 2.6.7    6.1
  CVE-2022-33987      got           6.7.1      medium      fixed in 12.1.0          5.3
  CVE-2022-24773      node-forge    0.10.0     moderate    fixed in 1.3.0           4
  CVE-2022-0122       node-forge    0.10.0     moderate    fixed in 1.0.0           4
  CVE-2020-15366      ajv           6.9.2      moderate    fixed in 6.12.3          4

Compliance
==========
  No compliances issues found

  Vulnerability
    Critical: 0
    High:     10
    Medium:   5
    Low:      0
    Total:    15

  Compliance
    Critical: 0
    High:     0
    Medium:   0
    Low:      0
    Total:    0

```

Most of the existing severities are coming from 2 packages https://github.com/kubeflow/kubeflow/blob/d0df9b1124fac43b39ded88605466f9f3ed2d004/components/centraldashboard/package.json#L41 and https://github.com/kubeflow/kubeflow/blob/d0df9b1124fac43b39ded88605466f9f3ed2d004/components/centraldashboard/package.json#L42

I tried to upgrade `@google-cloud/monitoring` to latest version and looks like it have even more vulnerabilities, so i skipped that.

For `@kubernetes/client-node` looks like `0.8.2` is best we can do with current node and webpack version. I tried couple of different versions, but build was breaking because of compilation issues (some names have changed in new lib version),, even after fixing those i was getting webpack issues.