### PR TITLE
docs: update example notebooks spec

### DIFF
--- a/components/notebook-controller/README.md
+++ b/components/notebook-controller/README.md
@@ -22,18 +22,6 @@ spec:
       containers:
         - name: my-notebook
           image: kubeflownotebookswg/jupyter:master
-          args:
-            [
-              "start.sh",
-              "lab",
-              "--LabApp.token=''",
-              "--LabApp.allow_remote_access='True'",
-              "--LabApp.allow_root='True'",
-              "--LabApp.ip='*'",
-              "--LabApp.base_url=/test/my-notebook/",
-              "--port=8888",
-              "--no-browser",
-            ]
 ```
 
 The required fields are `containers[0].image` and (`containers[0].command` and/or `containers[0].args`).


### PR DESCRIPTION
It looks like the notebook images no longer rely on start.sh.

It looks like the Docker images now use the init system to run jupyterlab with the correct arguments https://github.com/kubeflow/kubeflow/blob/master/components/example-notebook-servers/jupyter/Dockerfile

I could find no start.sh script in the repo