### PR TITLE
ARM docker images for kubeflow components

### DIFF
--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/centraldashboard
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -29,6 +29,7 @@ jobs:
         cd components/centraldashboard
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64 make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -12,7 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/jupyter-web-app
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/kfam
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -12,7 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/notebook-controller
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/poddefaults-webhook
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/profile-controller
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboard-controller
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -12,7 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboards-web-app
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -12,7 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/volumes-web-app
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
/kind feature

**Why you need this feature:**
Support for ARM VMs
With KF 1.7 we have Istio 1.16 which supports ARM,  **but** sadly kubeflow images don't have an ARM platform build so that one can run kubeflow locally on Apple M1 Mac **or**  on cloud  ARM based nodes  such as AWS Graviton


**Describe the solution you'd like:**
Updated github actions section that uses multi arch docker publish steps to support linux/arm64 platform


**Anything else you would like to add:**
I have tested it locally by building and pushing docker to my personal repo at https://hub.docker.com/repositories/vinaychandran 
It would be great if docker hub registry that kubeflow uses by default had these ARM variants. 