### PR TITLE
feat(notebooks): only display allocatable GPU configuration when creating notebook

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/pod.py
@@ -15,3 +15,6 @@ def get_pod_logs(namespace, pod, container, auth=True):
     return v1_core.read_namespaced_pod_log(
         namespace=namespace, name=pod, container=container
     )
+
+def list_all_pods(field_selector: str):
+    return v1_core.list_pod_for_all_namespaces(field_selector=field_selector)

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.html
@@ -1,16 +1,5 @@
 <lib-form-section title="GPUs" i18n-title>
   <div class="row" [formGroup]="parentForm.get('gpus')">
-    <!--GPUs Number-->
-    <mat-form-field class="column" appearance="outline">
-      <mat-label i18n>Number of GPUs</mat-label>
-      <mat-select matNativeControl formControlName="num">
-        <mat-option value="none" i18n="option None">None</mat-option>
-        <mat-option *ngFor="let v of gpusCount" [value]="v">
-          {{ v }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
-
     <!--GPUs Vendor-->
     <mat-form-field class="column" appearance="outline">
       <mat-label i18n>GPU Vendor</mat-label>
@@ -24,6 +13,17 @@
         </mat-option>
       </mat-select>
       <mat-error>{{ getVendorError() }}</mat-error>
+    </mat-form-field>
+
+    <!--GPUs Number-->
+    <mat-form-field class="column" appearance="outline">
+      <mat-label i18n>Number of GPUs</mat-label>
+      <mat-select matNativeControl formControlName="num">
+        <mat-option value="none" i18n="option None">None</mat-option>
+        <mat-option *ngFor="let v of gpusCount" [value]="v">
+          {{ v }}
+        </mat-option>
+      </mat-select>
     </mat-form-field>
   </div>
 </lib-form-section>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.spec.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.spec.ts
@@ -11,7 +11,7 @@ import { FormGpusComponent } from './form-gpus.component';
 import { CommonModule } from '@angular/common';
 
 const JWABackendServiceStub: Partial<JWABackendService> = {
-  getGPUVendors: () => of(),
+  getGPUAllocatable: () => of(),
 };
 
 const SnackBarServiceStub: Partial<SnackBarService> = {

--- a/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/services/backend.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
-import { BackendService, SnackBarService, SnackType } from 'kubeflow';
+import { BackendService, SnackBarService } from 'kubeflow';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { Observable, throwError } from 'rxjs';
+import { Observable } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
 import {
   NotebookResponseObject,
@@ -10,8 +10,8 @@ import {
   Config,
   PodDefault,
   NotebookFormObject,
-  NotebookProcessedObject,
   PvcResponseObject,
+  AllocatableGPU,
 } from '../types';
 import { V1Pod } from '@kubernetes/client-node';
 import { EventObject } from '../types/event';
@@ -130,13 +130,13 @@ export class JWABackendService extends BackendService {
     );
   }
 
-  public getGPUVendors(): Observable<string[]> {
+  public getGPUAllocatable(): Observable<AllocatableGPU> {
     // Get installed GPU vendors
     const url = `api/gpus`;
 
     return this.http.get<JWABackendResponse>(url).pipe(
       catchError(error => this.handleError(error)),
-      map(data => data.vendors),
+      map(data => data.allocatable),
     );
   }
 

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/notebook.ts
@@ -80,3 +80,7 @@ export interface NotebookRawObject {
     readyReplicas: number;
   };
 }
+
+export interface AllocatableGPU {
+  [vendor: string]: number;
+}

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/responses.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/responses.ts
@@ -2,7 +2,7 @@ import { V1Pod } from '@kubernetes/client-node';
 import { BackendResponse } from 'kubeflow';
 import { Config } from './config';
 import { EventObject } from './event';
-import { NotebookRawObject, NotebookResponseObject } from './notebook';
+import {AllocatableGPU, NotebookRawObject, NotebookResponseObject} from './notebook';
 import { PodDefault } from './poddefault';
 import { PvcResponseObject } from './volume';
 
@@ -13,7 +13,7 @@ export interface JWABackendResponse extends BackendResponse {
   pvcs?: PvcResponseObject[];
   config?: Config;
   poddefaults?: PodDefault[];
-  vendors?: string[];
+  allocatable?: AllocatableGPU;
   pod?: V1Pod;
   events?: EventObject[];
 }


### PR DESCRIPTION
## Description

When creating a notebook, the number of GPU displayed does not correspond to the real hardware allocatable. This PR change the behavior of the `/jupyter/api/gpus` to return the maximum number of GPUs allocatable based on Node resources. 

<details>
  <summary> <strong>/jupyter/api/gpus </strong> response example</summary>
The following response state that we can create a notebook with a maximum of 3 NVIDIA GPUs simultaneously. it <strong>does not</strong> mean only 3 GPUs are available on the cluster, it mean the node with the most GPUs available has 3.

  ```json
  {
    "allocatable": {
      "amd.com/gpu": 0,
      "nvidia.com/gpu": 3
    },
    "status": 200,
    "success": true,
    "user": "email@email.com"
  }
  ```
  
</details>

In the gpus `formGroup`, the order of the following field: `num` and `vendors` have been inverted, since the number of GPUs is depending on the vendor, it makes sense to choose the vendor first.

This could be extended to `memory` and `cpu` but those resources are usually less an issue.

## Related issues
- https://github.com/kubeflow/notebooks/issues/90
- https://github.com/kubeflow/notebooks/issues/97
