### PR TITLE
feat(dashboard): allow using `{ns}` template in `externalLinks`

### DIFF
--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -337,6 +337,25 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
     }
 
     /**
+     * Parse namespace in external links
+     * @param {string} href - external link
+     * @param {Object} queryParamsChange - queryParams updated on-the-fly
+     * @return {string}
+     */
+    _buildExternalHref(href, queryParamsChange) {
+        // The "queryParams" value from "queryParamsChange" is not updated as
+        // expected in the "iframe-link", but it works in anchor element.
+        // A temporary workaround is  to use "this.queryParams" as an input
+        // instead of "queryParamsChange.base".
+        // const queryParams = queryParamsChange.base;
+        const queryParams = this.queryParams;
+        if (!queryParams || !queryParams['ns']) {
+            return href.replace('{ns}', '');
+        }
+        return href.replace('{ns}', queryParams['ns']);
+    }
+
+    /**
      * Builds the new iframeSrc string based on the subroute path, current
      * hash fragment, and the query string parameters other than ns.
      */

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -38,7 +38,6 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         paper-item.menu-item
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]
-            aside.divider
             template(is='dom-repeat', items='[[externalLinks]]')
                 template(is='dom-if', if='[[item.iframe]]')
                     iframe-link(href$="[[buildHref(item.link, queryParams)]]")
@@ -46,7 +45,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]
                 template(is='dom-if', if='[[!item.iframe]]')
-                    a(href$="[[_buildExternalHref(item.link, queryParams.*)]]",tabindex='-1', target="_blank")
+                    a(href$="[[_buildExternalHref(item.link, queryParams.*)]]", tabindex='-1', target="_blank")
                         paper-item.menu-item
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -38,6 +38,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         paper-item.menu-item
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]
+            aside.divider
             template(is='dom-repeat', items='[[externalLinks]]')
                 template(is='dom-if', if='[[item.iframe]]')
                     iframe-link(href$="[[buildHref(item.link, queryParams)]]")
@@ -45,7 +46,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]
                 template(is='dom-if', if='[[!item.iframe]]')
-                    a(href$="[[item.link]]",tabindex='-1', target="_blank")
+                    a(href$="[[_buildExternalHref(item.link, queryParams.*)]]",tabindex='-1', target="_blank")
                         paper-item.menu-item
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]


### PR DESCRIPTION
This PR improves Centraldashboard by adding a possibility to parse Kubeflow namespaces with default selector (`{ns}`) in `externalLinks` when the element is not an `iframe`.

For example, this can be seamless for someone to dynamically pass a profile to an external service that uses Kubeflow-related features in that profile/namespace.
