### PR TITLE
Disabling multiple architecture build for PRs

### DIFF
--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -11,7 +11,9 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboard-controller
-  ARCH: linux/ppc64le,linux/amd64
+  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
this PR ensures that PRs will only trigger an AMD64 build. The multiarc build will only occur when a PR is merged into the main or when a new tag is created.

There is unfortunately, no way to fully test this without merging this PR.