### PR TITLE
Add GH action building pvcviewer controller

### DIFF
--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -1,0 +1,64 @@
+name: Build & Publish PVCViewer Controller Docker image
+on:
+  push:
+    branches:
+      - master
+      - v*-branch
+    paths:
+      - components/pvcviewer-controller/**
+      - components/common/**
+      - releasing/version/VERSION
+
+env:
+  DOCKER_USER: kubeflownotebookswg
+  IMG: kubeflownotebookswg/pvcviewer-controller
+  ARCH: linux/ppc64le,linux/amd64
+
+jobs:
+  push_to_registry:
+    name: Build & Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          version:
+            - 'releasing/version/VERSION'
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v2
+      with:
+        username: ${{ env.DOCKER_USER }}
+        password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: ppc64le
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build and push multi-arch docker image
+      run: |
+        cd components/pvcviewer-controller
+        make docker-build-push-multi-arch
+
+    - name: Build and push latest multi-arch docker image
+      if: github.ref == 'refs/heads/master'
+      run: |
+        export TAG=latest
+        cd components/pvcviewer-controller
+        make docker-build-push-multi-arch
+
+    - name: Build and push multi-arch docker image on Version change
+      id: version
+      if: steps.filter.outputs.version == 'true'
+      run: |
+        export TAG=$(cat releasing/version/VERSION)
+        cd components/pvcviewer-controller
+        make docker-build-push-multi-arch

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -12,7 +12,9 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/pvcviewer-controller
-  ARCH: linux/ppc64le,linux/amd64
+  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
+  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
As discussed in #6876, we're adding a GH action that builds and pushes the pvcviewer controller docker image.

The Action is untested and was copied off the notebook controller which works the same way.

This PR is part of three pvcviewer controller workflows. The others are:
* #7174
* #7175