### PR TITLE
Add GH action unit testing pvcviewer controller

### DIFF
--- a/.github/workflows/pvcviewer_controller_unit_test.yaml
+++ b/.github/workflows/pvcviewer_controller_unit_test.yaml
@@ -1,0 +1,23 @@
+name: Run PVCViewer Controller unit tests
+on:
+  pull_request:
+    paths:
+      - components/pvcviewer-controller/**
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.20'
+        check-latest: true
+
+    - name: Run unit tests
+      run: |
+        cd components/pvcviewer-controller
+        make test


### PR DESCRIPTION
As discussed in https://github.com/kubeflow/kubeflow/pull/6876, we're adding a GH action that runs the pvcviewer controller's unit tests.

The Action is untested and was copied off the notebook controller which works the same way.

This PR is part of three pvcviewer controller workflows. The others are:
* #7173
* #7175