### PR TITLE
Add GH action integration testing pvcviewer controller

### DIFF
--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -1,0 +1,58 @@
+name: PVCViewer Controller Integration Test
+on:
+  pull_request:
+    paths:
+      - components/pvcviewer-controller/**
+    branches:
+      - master
+      - v*-branch
+
+env:
+  IMG: pvcviewer-controller
+  TAG: intergration-test
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build PVCViewer Controller Image 
+      run: |
+        cd components/pvcviewer-controller
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+
+    - name: Install KinD
+      run: ./components/testing/gh-actions/install_kind.sh
+
+    - name: Create KinD Cluster
+      run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
+
+    - name: Load Images into KinD Cluster 
+      run: |
+        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+
+    - name: Install kustomize
+      run: ./components/testing/gh-actions/install_kustomize.sh
+
+    - name: Install Istio
+      run: ./components/testing/gh-actions/install_istio.sh
+
+    - name: Build & Apply manifests
+      run: |
+        cd components/pvcviewer-controller/config
+        kubectl create ns kubeflow
+
+        export CURRENT_PVCVIEWER_IMG=docker.io/kubeflownotebookswg/pvcviewer-controller:latest
+        export PR_PVCVIEWER_IMG=${{env.IMG}}:${{env.TAG}}
+
+        kustomize build base | sed "s#$CURRENT_PVCVIEWER_IMG#$PR_PVCVIEWER_IMG#g" | kubectl apply -f -
+        kubectl wait pods -n kubeflow -l app=pvcviewer --for=condition=Ready --timeout=300s


### PR DESCRIPTION
As discussed in https://github.com/kubeflow/kubeflow/pull/6876, we're adding a GH action that integration tests the pvcviewer controller / its manifests.

The Action is untested and was copied off the notebook controller which works the same way.

This PR is part of three pvcviewer controller workflows. The others are: 
* #7173
* #7174