### PR TITLE
Update  PVCViewer manifests

### DIFF
--- a/components/pvcviewer-controller/config/crd/bases/kubeflow.org_pvcviewers.yaml
+++ b/components/pvcviewer-controller/config/crd/bases/kubeflow.org_pvcviewers.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.10.0
-  creationTimestamp: null
   name: pvcviewers.kubeflow.org
 spec:
   group: kubeflow.org

--- a/components/pvcviewer-controller/config/default/cainjection_patch.yaml
+++ b/components/pvcviewer-controller/config/default/cainjection_patch.yaml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -26,4 +26,11 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: CERTIFICATE_NAMESPACE/CERTIFICATE_NAME
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+  name: pvcviewers.kubeflow.org

--- a/components/pvcviewer-controller/config/default/dnsnames_patch.yaml
+++ b/components/pvcviewer-controller/config/default/dnsnames_patch.yaml
@@ -1,0 +1,9 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: serving-cert
+  namespace: system
+spec:
+  dnsNames:
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
+  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local

--- a/components/pvcviewer-controller/config/default/kustomization.yaml
+++ b/components/pvcviewer-controller/config/default/kustomization.yaml
@@ -32,102 +32,139 @@ patchesStrategicMerge:
 # endpoint w/o any authn/z, please comment the following line.
 - manager_auth_proxy_patch.yaml
 - manager_webhook_patch.yaml
-- webhookcainjection_patch.yaml
+- cainjection_patch.yaml
+- dnsnames_patch.yaml
 
-replacements:
- - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
-     kind: Certificate
-     group: cert-manager.io
-     version: v1
-     name: serving-cert # this name should match the one in certificate.yaml
-     fieldPath: .metadata.namespace # namespace of the certificate CR
-   targets:
-     - select:
-         kind: ValidatingWebhookConfiguration
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 0
-         create: true
-     - select:
-         kind: MutatingWebhookConfiguration
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 0
-         create: true
-     - select:
-         kind: CustomResourceDefinition
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 0
-         create: true
- - source:
-     kind: Certificate
-     group: cert-manager.io
-     version: v1
-     name: serving-cert # this name should match the one in certificate.yaml
-     fieldPath: .metadata.name
-   targets:
-     - select:
-         kind: ValidatingWebhookConfiguration
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 1
-         create: true
-     - select:
-         kind: MutatingWebhookConfiguration
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 1
-         create: true
-     - select:
-         kind: CustomResourceDefinition
-       fieldPaths:
-         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-       options:
-         delimiter: '/'
-         index: 1
-         create: true
- - source: # Add cert-manager annotation to the webhook Service
-     kind: Service
-     version: v1
-     name: webhook-service
-     fieldPath: .metadata.name # namespace of the service
-   targets:
-     - select:
-         kind: Certificate
-         group: cert-manager.io
-         version: v1
-       fieldPaths:
-         - .spec.dnsNames.0
-         - .spec.dnsNames.1
-       options:
-         delimiter: '.'
-         index: 0
-         create: true
- - source:
-     kind: Service
-     version: v1
-     name: webhook-service
-     fieldPath: .metadata.namespace # namespace of the service
-   targets:
-     - select:
-         kind: Certificate
-         group: cert-manager.io
-         version: v1
-       fieldPaths:
-         - .spec.dnsNames.0
-         - .spec.dnsNames.1
-       options:
-         delimiter: '.'
-         index: 1
-         create: true
+vars:
+- name: CERTIFICATE_NAMESPACE 
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert 
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+- name: SERVICE_NAMESPACE
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+
+# the following config is for teaching kustomize how to replace vars in Certificates.
+configurations:
+- kustomizeconfig.yaml
+
+# Note: the kustomize version that's being used to execute integration tests currently doesn't support replacemens.
+# Thus, we're using the deprecated vars feature above.
+# Once the kustomize version is updated, we can use the following config instead of the vars feature.
+# Can be removed then: cainjection_patch.yaml, dnsnames_patch.yaml, kustomizeconfig.yaml, their references here and the vars section above.
+# replacements:
+#  - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1
+#      name: serving-cert # this name should match the one in certificate.yaml
+#      fieldPath: .metadata.namespace # namespace of the certificate CR
+#    targets:
+#      - select:
+#          kind: ValidatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#      - select:
+#          kind: MutatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#      - select:
+#          kind: CustomResourceDefinition
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#  - source:
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1
+#      name: serving-cert # this name should match the one in certificate.yaml
+#      fieldPath: .metadata.name
+#    targets:
+#      - select:
+#          kind: ValidatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: MutatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: CustomResourceDefinition
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#  - source: # Add cert-manager annotation to the webhook Service
+#      kind: Service
+#      version: v1
+#      name: webhook-service
+#      fieldPath: .metadata.name # namespace of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 0
+#          create: true
+#  - source:
+#      kind: Service
+#      version: v1
+#      name: webhook-service
+#      fieldPath: .metadata.namespace # namespace of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 1
+#          create: true

--- a/components/pvcviewer-controller/config/default/kustomization.yaml
+++ b/components/pvcviewer-controller/config/default/kustomization.yaml
@@ -12,10 +12,8 @@ namespace: kubeflow
 namePrefix: pvcviewer-
 
 # Labels to add to all resources and selectors.
-labels:
-- includeSelectors: true
-  pairs:
-    app: pvcviewer
+commonLabels:
+  app: pvcviewer
 
 resources:
 - ../crd

--- a/components/pvcviewer-controller/config/default/kustomizeconfig.yaml
+++ b/components/pvcviewer-controller/config/default/kustomizeconfig.yaml
@@ -1,0 +1,4 @@
+varReference:
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/dnsNames

--- a/components/pvcviewer-controller/config/rbac/role.yaml
+++ b/components/pvcviewer-controller/config/rbac/role.yaml
@@ -2,7 +2,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  creationTimestamp: null
   name: role
 rules:
 - apiGroups:

--- a/components/pvcviewer-controller/config/rbac/role_binding.yaml
+++ b/components/pvcviewer-controller/config/rbac/role_binding.yaml
@@ -12,7 +12,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: manager-role
+  name: role
 subjects:
 - kind: ServiceAccount
   name: controller-manager

--- a/components/pvcviewer-controller/config/webhook/manifests.yaml
+++ b/components/pvcviewer-controller/config/webhook/manifests.yaml
@@ -2,7 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -29,7 +28,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
* roleRef.name now matches role.metadata.name. 
  Without this change, kustomize build doesn't correctly bind the resulting clusterrolebinding.
* Remove creationTimestamp: null as noted by @axel7083 
* Use commonLabels over labels to comply with old kustomize version. Also, I had to introduce the deprecated vars feature as replacements aren't supported with the current kustomize version used by the build pipeline

See #6876 for initial PR.