### PR TITLE
feature(notebook): Adding creator user-id to annotation

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -7,6 +7,7 @@ metadata:
     app: {name}
   annotations:
     notebooks.kubeflow.org/server-type: ""
+    notebooks.kubeflow.org/creator: {creator}
 spec:
   template:
     spec:

--- a/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
+++ b/components/crud-web-apps/jupyter/backend/apps/default/routes/post.py
@@ -1,6 +1,6 @@
 from flask import request
 
-from kubeflow.kubeflow.crud_backend import api, decorators, helpers, logging
+from kubeflow.kubeflow.crud_backend import api, decorators, helpers, logging, authn
 
 from ...common import form, utils, volumes
 from . import bp
@@ -14,12 +14,14 @@ log = logging.getLogger(__name__)
 def post_pvc(namespace):
     body = request.get_json()
     log.info("Got body: %s" % body)
+    user = authn.get_username()
 
     notebook = helpers.load_param_yaml(
         utils.NOTEBOOK_TEMPLATE_YAML,
         name=body["name"],
         namespace=namespace,
         serviceAccount="default-editor",
+        creator=user if user is not None else "anonymous@kubeflow.org"
     )
 
     defaults = utils.load_spawner_ui_config()

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/notebook-page/overview/overview.component.ts
@@ -151,6 +151,17 @@ export class OverviewComponent implements OnInit, OnDestroy {
     }
   }
 
+  get notebookCreator(): string {
+    return this.getNotebookCreator(this.notebook);
+  }
+
+  getNotebookCreator(notebook: NotebookRawObject): string {
+    if (!notebook?.metadata?.annotations) {
+      return null;
+    }
+    return notebook.metadata.annotations["notebooks.kubeflow.org/creator"];
+  }
+
   get cpuRequests(): string {
     return this.getCpuRequest(this.notebook);
   }


### PR DESCRIPTION
## Description

This will add the user-id (from the `USERID_HEADER`) to the notebook annotation under `notebooks.kubeflow.org/creator`.
This allows to keep track of the creator of the notebook. I added in the frontend in the `Notebook details` section a creator section.