### PR TITLE
(frontend): Adding style for main drawer scrollbar

### DIFF
--- a/components/centraldashboard/public/components/main-page.css
+++ b/components/centraldashboard/public/components/main-page.css
@@ -27,6 +27,18 @@
     overflow: auto;
 }
 
+.scrollable::-webkit-scrollbar {
+    -webkit-appearance: none;
+    width: 7px;
+    height: 7px;
+}
+
+.scrollable::-webkit-scrollbar-thumb {
+    border-radius: 4px;
+    background-color: rgba(238, 238, 239, 0.5);
+    box-shadow: 0 0 1px rgba(255,255,255,.5);
+}
+
 #MainDrawer {
     color: white;
     --app-drawer-content-container: {


### PR DESCRIPTION

When we have a lot of item, on the maindrawer, the scrollbar appear, and the default one is pretty ugly and take a lot of space.
I simply copy past the style from kubeflow/pipeline elements and change the color to match the text.

| before | after |
|---|---|
| ![image](https://github.com/kubeflow/kubeflow/assets/42176370/c0897396-4bc1-4e3b-8c38-fd261257ecd0) | ![image](https://github.com/kubeflow/kubeflow/assets/42176370/607168c7-24ee-4379-be1f-c0b4c23469d2) |
