### PR TITLE
Add cert-manager install to pvcviewer tests

### DIFF
--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -45,6 +45,9 @@ jobs:
 
     - name: Install Istio
       run: ./components/testing/gh-actions/install_istio.sh
+      
+    - name: Install cert-manager
+      run: ./components/testing/gh-actions/install_cert_manager.sh
 
     - name: Build & Apply manifests
       run: |


### PR DESCRIPTION
The PVCViewer controller relies on the cert-manager for its webhooks. 
We need to install cert-manager in for its GH action integration tests to run.

See [here](https://github.com/kubeflow/kubeflow/actions/runs/5631528605/job/15258576432#step:11:32) for a failed workflow.