### PR TITLE
ci: Build ARM images for core components

### DIFF
--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -11,7 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/centraldashboard
-  ARCH: linux/ppc64le,linux/amd64
+  ARCH: linux/ppc64le,linux/amd64,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -33,7 +33,7 @@ jobs:
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
-        
+
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
 

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -22,16 +22,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
-
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
     - name: Build CentralDashboard Image
       run: |
         cd components/centraldashboard
-        ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/amd64 make docker-build-multi-arch
 
     - name: Install KinD

--- a/.github/workflows/centraldb_multi_arch_test.yaml
+++ b/.github/workflows/centraldb_multi_arch_test.yaml
@@ -1,0 +1,35 @@
+name: CentralDashboard Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/centraldashboard/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: centraldashboard
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/centraldashboard
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -12,9 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/jupyter-web-app
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/jupyter-web-app
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:
@@ -42,13 +42,13 @@ jobs:
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
-    
+
     - name: Build and push multi-arch docker image
       run: |
         cd components/crud-web-apps/jupyter
         make docker-build-push-multi-arch
 
-    - name: Build and push latest multi-arch docker image 
+    - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'
       run: |
         export TAG=latest

--- a/.github/workflows/jwa_intergration_test.yaml
+++ b/.github/workflows/jwa_intergration_test.yaml
@@ -22,18 +22,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Build JWA Image 
+    - name: Build JWA Image
       run: |
         cd components/crud-web-apps/jupyter
-        ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch 
+        make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -41,7 +37,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Image into KinD Cluster 
+    - name: Load Image into KinD Cluster
       run: |
         kind load docker-image "${IMG}:${TAG}"
 

--- a/.github/workflows/jwa_multi_arch_test.yaml
+++ b/.github/workflows/jwa_multi_arch_test.yaml
@@ -1,0 +1,36 @@
+name: JWA Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/crud-web-apps/jupyter/**
+      - components/crud-web-apps/common/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: jupyter-web-app
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/crud-web-apps/jupyter
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/kfam
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -11,9 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/kfam
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/kfam_multi_arch_test.yaml
+++ b/.github/workflows/kfam_multi_arch_test.yaml
@@ -1,0 +1,35 @@
+name: KFAM Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/access-management/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: kfam
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/access-management
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/notebook-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -12,9 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/notebook-controller
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -39,8 +37,6 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v2
-      with:
-        platforms: ppc64le
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/nb_controller_intergration_test.yaml
+++ b/.github/workflows/nb_controller_intergration_test.yaml
@@ -21,18 +21,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Build Notebook Controller Image 
+    - name: Build Notebook Controller Image
       run: |
         cd components/notebook-controller
-        ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch
+        make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -40,7 +36,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Images into KinD Cluster 
+    - name: Load Images into KinD Cluster
       run: |
         kind load docker-image "${IMG}:${TAG}"
 

--- a/.github/workflows/nb_controller_multi_arch_test.yaml
+++ b/.github/workflows/nb_controller_multi_arch_test.yaml
@@ -1,0 +1,35 @@
+name: Notebook Controller Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/notebook-controller/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: notebook-controller
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/notebook-controller
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -11,9 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/poddefaults-webhook
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/poddefaults-webhook
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -21,19 +21,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-
-    - name: Build PodDefaults Image 
+    - name: Build PodDefaults Image
       run: |
         cd components/admission-webhook
-        ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch
+        make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -41,7 +36,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Images into KinD Cluster 
+    - name: Load Images into KinD Cluster
       run: |
         kind load docker-image "${IMG}:${TAG}"
 

--- a/.github/workflows/poddefaults_multi_arch_test.yaml
+++ b/.github/workflows/poddefaults_multi_arch_test.yaml
@@ -1,0 +1,35 @@
+name: PodDefaults Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/admission-webhook/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: poddefaults-webhook
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/admission-webhook
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/profile-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -11,9 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/profile-controller
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/prof_controller_multi_arch_test.yaml
+++ b/.github/workflows/prof_controller_multi_arch_test.yaml
@@ -1,0 +1,35 @@
+name: Profile Controller Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/profile-controller/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: profile-controller
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/profile-controller
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/profiles_kfam_intergration_test.yaml
+++ b/.github/workflows/profiles_kfam_intergration_test.yaml
@@ -23,24 +23,19 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Build Profile Controller Image 
+    - name: Build Profile Controller Image
       run: |
         cd components/profile-controller
-        ARCH=linux/ppc64le make docker-build-multi-arch IMG="${PROFILE_IMG}"
-        ARCH=linux/amd64 make docker-build-multi-arch IMG="${PROFILE_IMG}"
+        make docker-build-multi-arch IMG="${PROFILE_IMG}"
 
     - name: Build Kfam Image
       run: |
         cd components/access-management
-        ARCH=linux/ppc64le make docker-build-multi-arch IMG="${KFAM_IMG}"
-        ARCH=linux/amd64 make docker-build-multi-arch IMG="${KFAM_IMG}"
+        make docker-build-multi-arch IMG="${KFAM_IMG}"
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -48,7 +43,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Images into KinD Cluster 
+    - name: Load Images into KinD Cluster
       run: |
         kind load docker-image "${PROFILE_IMG}:${TAG}"
         kind load docker-image "${KFAM_IMG}:${TAG}"

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/pvcviewer-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -12,9 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/pvcviewer-controller
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -36,11 +34,6 @@ jobs:
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
-
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: ppc64le
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -21,18 +21,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Build PVCViewer Controller Image 
+    - name: Build PVCViewer Controller Image
       run: |
         cd components/pvcviewer-controller
-        ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch
+        make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -40,7 +36,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Images into KinD Cluster 
+    - name: Load Images into KinD Cluster
       run: |
         kind load docker-image "${IMG}:${TAG}"
 
@@ -49,7 +45,7 @@ jobs:
 
     - name: Install Istio
       run: ./components/testing/gh-actions/install_istio.sh
-      
+
     - name: Install cert-manager
       run: ./components/testing/gh-actions/install_cert_manager.sh
 

--- a/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
+++ b/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
@@ -1,0 +1,35 @@
+name: PVCViewer Controller Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/pvcviewer-controller/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: pvcviewer-controller
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/pvcviewer-controller
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -11,9 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboard-controller
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/tensorboard-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/tb_controller_multi_arch_test.yaml
+++ b/.github/workflows/tb_controller_multi_arch_test.yaml
@@ -1,0 +1,35 @@
+name: TensorBoard Controller Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/tensorboard-controller/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: tensorboard-controller
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/tensorboard-controller
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/tensorboards-web-app
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -12,9 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboards-web-app
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/twa_intergration_test.yaml
+++ b/.github/workflows/twa_intergration_test.yaml
@@ -23,10 +23,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Build TWA Image 
+    - name: Build TWA Image
       run: |
         cd components/crud-web-apps/tensorboards
-        make docker-build 
+        make docker-build
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -34,7 +34,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Image into KinD Cluster 
+    - name: Load Image into KinD Cluster
       run: |
         kind load docker-image "${IMG}:${TAG}"
 

--- a/.github/workflows/twa_multi_arch_test.yaml
+++ b/.github/workflows/twa_multi_arch_test.yaml
@@ -1,0 +1,36 @@
+name: TWA Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/crud-web-apps/tensorboards/**
+      - components/crud-web-apps/common/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: tensorboards-web-app
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/crud-web-apps/tensorboards
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -12,9 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/volumes-web-app
-  # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
-  # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/volumes-web-app
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le,linux/arm64/v8' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/vwa_intergration_test.yaml
+++ b/.github/workflows/vwa_intergration_test.yaml
@@ -22,18 +22,14 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Build VWA Image 
+    - name: Build VWA Image
       run: |
         cd components/crud-web-apps/volumes
-        ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch 
+        make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -41,7 +37,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Image into KinD Cluster 
+    - name: Load Image into KinD Cluster
       run: |
         kind load docker-image "${IMG}:${TAG}"
 

--- a/.github/workflows/vwa_multi_arch_test.yaml
+++ b/.github/workflows/vwa_multi_arch_test.yaml
@@ -1,0 +1,36 @@
+name: VWA Multi-Arch Build Test
+on:
+  pull_request:
+    paths:
+      - components/crud-web-apps/volumes/**
+      - components/crud-web-apps/common/**
+    branches:
+      - master
+      - v*-branch
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+env:
+  IMG: volumes-web-app
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
+
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build multi-arch Image
+      run: |
+        cd components/crud-web-apps/volumes
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch

--- a/components/crud-web-apps/jupyter/Dockerfile
+++ b/components/crud-web-apps/jupyter/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build the backend kubeflow-wheel ---
-FROM python:3.8-slim AS backend-kubeflow-wheel
+FROM python:3.10-slim AS backend-kubeflow-wheel
 
 WORKDIR /src
 
@@ -41,7 +41,7 @@ COPY --from=frontend-kubeflow-lib /src/dist/kubeflow/ ./node_modules/kubeflow/
 RUN npm run build -- --output-path=./dist/default --configuration=production
 
 # Web App
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .

--- a/components/crud-web-apps/tensorboards/Dockerfile
+++ b/components/crud-web-apps/tensorboards/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build the backend kubeflow-wheel ---
-FROM python:3.8-slim AS backend-kubeflow-wheel
+FROM python:3.10-slim AS backend-kubeflow-wheel
 
 WORKDIR /src
 
@@ -41,7 +41,7 @@ COPY --from=frontend-kubeflow-lib /src/dist/kubeflow/ ./node_modules/kubeflow/
 RUN npm run build -- --output-path=./dist --configuration=production
 
 # Web App
-FROM python:3.8-slim
+FROM python:3.10-slim
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .

--- a/components/crud-web-apps/volumes/Dockerfile
+++ b/components/crud-web-apps/volumes/Dockerfile
@@ -1,5 +1,5 @@
 # --- Build the backend kubeflow-wheel ---
-FROM python:3.8 AS backend-kubeflow-wheel
+FROM python:3.10-slim AS backend-kubeflow-wheel
 
 WORKDIR /src
 
@@ -41,7 +41,7 @@ COPY --from=frontend-kubeflow-lib /src/dist/kubeflow/ ./node_modules/kubeflow/
 RUN npm run build -- --output-path=./dist/default --configuration=production
 
 # Web App
-FROM python:3.7-slim
+FROM python:3.10-slim
 
 WORKDIR /package
 COPY --from=backend-kubeflow-wheel /src .

--- a/releasing/update-manifests-images
+++ b/releasing/update-manifests-images
@@ -130,6 +130,16 @@ apps = [
         ],
     },
     {
+        "name": "PVCViewer Controller",
+        "kustomization": "components/pvcviewer-controller/config/base/kustomization.yaml",
+        "images": [
+            {
+                "name": "docker.io/kubeflownotebookswg/pvcviewer-controller",
+                "newName": "docker.io/kubeflownotebookswg/pvcviewer-controller",
+            },
+        ],
+    },
+    {
         "name": "Access Management",
         "kustomization": "components/profile-controller/config/overlays/kubeflow/kustomization.yaml",
         "images": [


### PR DESCRIPTION
This PR extends the GH Actions to also build the "core" images in kubeflow/kubeflow for ARM. This is for https://github.com/kubeflow/manifests/issues/2472 and https://github.com/kubeflow/kubeflow/issues/2337

The last step is to then modify the build system and makefiles for the example notebook images https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers