### PR TITLE
fix: remove superfluous space in docker builds

### DIFF
--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/jupyter-web-app
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/kfam
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/notebook-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/poddefaults-webhook
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/profile-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/pvcviewer-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -13,7 +13,7 @@ env:
   IMG: kubeflownotebookswg/tensorboard-controller
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/tensorboards-web-app
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -14,7 +14,7 @@ env:
   IMG: kubeflownotebookswg/volumes-web-app
   # If this is a PR, we ONLY build for AMD64. For PRs we only do a sanity check test to ensure Docker builds work.
   # If this is NOT a PR (e.g. a tag or merge commit), also build for ppc64le.
-  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ', linux/ppc64le' || '' }}
+  ARCH: linux/amd64${{ github.event_name != 'pull_request' && ',linux/ppc64le' || '' }}
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
Currently, all docker build pipelines are broken and GH actions are failing. Some examples:
* https://github.com/kubeflow/kubeflow/actions/runs/5717365930/job/15490946498
* https://github.com/kubeflow/kubeflow/actions/runs/5717283772/job/15490688661
* https://github.com/kubeflow/kubeflow/actions/runs/5718096836/job/15493211609

The error messages read: 
```
docker buildx build --platform linux/amd64, linux/ppc64le --tag kubeflownotebookswg/kfam:e706807 --push .
ERROR: "docker buildx build" requires exactly 1 argument.
```

Clearly, there's a superfluous space in `--platform`, which was, among others, just recently introduced in [3733989](https://github.com/kubeflow/kubeflow/commit/3733989a62b92b0751abef2c9da87f758128d487).

This PR removes the spaces.
The actions run fine in my repo after this change. 