### PR TITLE
fix: viewer-spec.yaml and trigger build

### DIFF
--- a/components/crud-web-apps/volumes/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         - name: APP_SECURE_COOKIES
           value: $(VWA_APP_SECURE_COOKIES)
         - name: VOLUME_VIEWER_IMAGE
-          value: filebrowser/filebrowser:latest
+          value: filebrowser/filebrowser:v2.24.2
         volumeMounts: 
         - name: viewer-spec
           mountPath: /etc/config/viewer-spec.yaml

--- a/components/crud-web-apps/volumes/manifests/base/viewer-spec.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/viewer-spec.yaml
@@ -3,7 +3,8 @@
 # Additionally, 'PVC_NAME', 'NAME' and 'NAMESPACE' are defined
 # Name of the pvc is set by the volumes web app
 pvc: $NAME
-podTemplate:
+podSpec:
+  serviceAccountName: default-editor
   containers:
     - name: main
       image: $VOLUME_VIEWER_IMAGE
@@ -28,7 +29,6 @@ podTemplate:
         - name: viewer-volume
           mountPath: /data
       workingDir: /data
-      serviceAccountName: default-editor
 networking:
   targetPort: 8080
   basePrefix: "/pvcviewers"

--- a/components/crud-web-apps/volumes/manifests/base/viewer-spec.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/viewer-spec.yaml
@@ -29,6 +29,10 @@ podSpec:
         - name: viewer-volume
           mountPath: /data
       workingDir: /data
+  volumes:
+    - name: viewer-volume
+      persistentVolumeClaim:
+        claimName: $NAME
 networking:
   targetPort: 8080
   basePrefix: "/pvcviewers"

--- a/components/crud-web-apps/volumes/manifests/base/viewer-spec.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/viewer-spec.yaml
@@ -27,8 +27,13 @@ podSpec:
       # viewer-volume is provided automatically by the volumes web app
       volumeMounts:
         - name: viewer-volume
-          mountPath: /data
-      workingDir: /data
+          mountPath: /srv
+      workingDir: /srv
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
   volumes:
     - name: viewer-volume
       persistentVolumeClaim:

--- a/components/pvcviewer-controller/README.md
+++ b/components/pvcviewer-controller/README.md
@@ -55,10 +55,10 @@ You may change the defaults by having the manager mount a config file with defau
 This is especially useful, when you can't control the creation of the `PVCViewer` object, e.g. since it's automatically created by another component such as the volumes UI.
 
 ## How it works
-This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/).
 
-It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/) 
-which provides a reconcile function responsible for synchronizing resources until the desired state is reached on the cluster 
+It uses [controllers](https://kubernetes.io/docs/concepts/architecture/controller/) to watch all changes to viewer objects and react accordingly. 
+Technically, this is implemented by the reconcile loop: it syncs resources until the desired state is reached on the cluster.
 
 ## Modifying the API definitions
 If you are editing the API definitions, generate the manifests such as CRs or CRDs using:


### PR DESCRIPTION
The [pvcviewer pipeline](https://github.com/kubeflow/kubeflow/actions/workflows/pvcviewer_controller_docker_publish.yaml) has not yet run successfully.
Thus, there is no public image that could be used to test the manifests.
As far as I can tell, this should be the last effort to get the volumes viewer working. 

Also, I snuck in another commit, fixing two fields of the viewer-spec.yaml