### PR TITLE
fix: downgrade filebrowser to v2.23.0

### DIFF
--- a/components/crud-web-apps/volumes/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         - name: APP_SECURE_COOKIES
           value: $(VWA_APP_SECURE_COOKIES)
         - name: VOLUME_VIEWER_IMAGE
-          value: filebrowser/filebrowser:v2.24.2
+          value: filebrowser/filebrowser:v2.23.0
         volumeMounts: 
         - name: viewer-spec
           mountPath: /etc/config/viewer-spec.yaml


### PR DESCRIPTION
Cloudflare users are having issues with the newest filebrowser release.
This PR downgrades filebrowser to v2.23.0 have uploads work for everyone. 
Unfortunately, this removes chunked uploads until we're upgrading to a fixed filebrowser version.