### PR TITLE
Only load spawner_ui_config.yaml once every 10 minutes. closes #7259

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -2,6 +2,7 @@ import os
 import random
 import string
 
+from cachetools.func import ttl_cache
 from kubernetes import client
 from werkzeug import exceptions
 
@@ -13,9 +14,7 @@ log = logging.getLogger(__name__)
 
 FILE_ABS_PATH = os.path.abspath(os.path.dirname(__file__))
 
-NOTEBOOK_TEMPLATE_YAML = os.path.join(
-    FILE_ABS_PATH, "yaml/notebook_template.yaml"
-)
+NOTEBOOK_TEMPLATE_YAML = os.path.join(FILE_ABS_PATH, "yaml/notebook_template.yaml")
 LAST_ACTIVITY_ANNOTATION = "notebooks.kubeflow.org/last-activity"
 
 # The production configuration is mounted on the app's pod via a configmap
@@ -41,6 +40,7 @@ def load_notebook_template(**kwargs):
     return helpers.load_param_yaml(NOTEBOOK_TEMPLATE_YAML, **kwargs)
 
 
+@ttl_cache(ttl=60 * 10)
 def load_spawner_ui_config():
     for config in CONFIGS:
         config_dict = helpers.load_yaml(config)
@@ -90,13 +90,14 @@ def pvc_from_dict(vol, namespace):
         return None
 
     return client.V1PersistentVolumeClaim(
-        metadata=client.V1ObjectMeta(name=vol["name"], namespace=namespace,),
+        metadata=client.V1ObjectMeta(
+            name=vol["name"],
+            namespace=namespace,
+        ),
         spec=client.V1PersistentVolumeClaimSpec(
             access_modes=[vol["mode"]],
             storage_class_name=get_storage_class(vol),
-            resources=client.V1ResourceRequirements(
-                requests={"storage": vol["size"]}
-            ),
+            resources=client.V1ResourceRequirements(requests={"storage": vol["size"]}),
         ),
     )
 
@@ -139,5 +140,5 @@ def notebook_dict_from_k8s_obj(notebook):
         "memory": cntr["resources"]["requests"]["memory"],
         "volumes": [v["name"] for v in cntr["volumeMounts"]],
         "status": status.process_status(notebook),
-        "metadata": notebook["metadata"]
+        "metadata": notebook["metadata"],
     }

--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -40,7 +40,7 @@ def load_notebook_template(**kwargs):
     return helpers.load_param_yaml(NOTEBOOK_TEMPLATE_YAML, **kwargs)
 
 
-@ttl_cache(ttl=60 * 10)
+@ttl_cache(ttl=60)
 def load_spawner_ui_config():
     for config in CONFIGS:
         config_dict = helpers.load_yaml(config)


### PR DESCRIPTION
The process_gpus function calls load_spawner_ui_config for every notebook in a namespace when the get_notebooks endpoint is called. This change updates so the call is made once every 10 minutes. 

I was unsure if the expectation with this component is that users will be able to change the configmap without restarting the deployment. If not it would be better to load this config once at initialization. 

If that route is preferred I'd be happy to update this PR with those changes.