### PR TITLE
ci: fix test image replacement

### DIFF
--- a/.github/workflows/centraldb_angular_intergration_test.yaml
+++ b/.github/workflows/centraldb_angular_intergration_test.yaml
@@ -50,8 +50,15 @@ jobs:
         cd components/centraldashboard-angular/manifests
         kubectl create ns kubeflow
 
-        export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard-angular:latest
-        export PR_CENTRALDB_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build overlays/kserve | sed "s#$CURRENT_CENTRALDB_IMG#$PR_CENTRALDB_IMG#g" | kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/kserve \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=centraldashboard-angular --for=condition=Ready --timeout=300s

--- a/.github/workflows/centraldb_angular_intergration_test.yaml
+++ b/.github/workflows/centraldb_angular_intergration_test.yaml
@@ -7,6 +7,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: centraldashboard-angular
   TAG: intergration-test
@@ -33,7 +37,7 @@ jobs:
 
     - name: Load Images into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -47,7 +51,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard-angular:latest
-        export PR_CENTRALDB_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_CENTRALDB_IMG="${IMG}:${TAG}"
 
         kustomize build overlays/kserve | sed "s#$CURRENT_CENTRALDB_IMG#$PR_CENTRALDB_IMG#g" | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=centraldashboard-angular --for=condition=Ready --timeout=300s

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -7,6 +7,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: centraldashboard
   TAG: intergration-test
@@ -38,7 +42,7 @@ jobs:
 
     - name: Load Images into KinD Cluster
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -52,7 +56,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard:latest
-        export PR_CENTRALDB_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_CENTRALDB_IMG="${IMG}:${TAG}"
 
         kustomize build overlays/kserve | sed "s#$CURRENT_CENTRALDB_IMG#$PR_CENTRALDB_IMG#g" | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=centraldashboard --for=condition=Ready --timeout=300s

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -55,8 +55,15 @@ jobs:
         cd components/centraldashboard/manifests
         kubectl create ns kubeflow
 
-        export CURRENT_CENTRALDB_IMG=docker.io/kubeflownotebookswg/centraldashboard:latest
-        export PR_CENTRALDB_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build overlays/kserve | sed "s#$CURRENT_CENTRALDB_IMG#$PR_CENTRALDB_IMG#g" | kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/kserve \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=centraldashboard --for=condition=Ready --timeout=300s

--- a/.github/workflows/jwa_intergration_test.yaml
+++ b/.github/workflows/jwa_intergration_test.yaml
@@ -8,6 +8,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: jupyter-web-app
   TAG: intergration-test
@@ -39,7 +43,7 @@ jobs:
 
     - name: Load Image into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -53,7 +57,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_JWA_IMG=docker.io/kubeflownotebookswg/jupyter-web-app:latest
-        export PR_JWA_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_JWA_IMG="${IMG}:${TAG}"
 
         kustomize build overlays/istio | sed "s#$CURRENT_JWA_IMG#$PR_JWA_IMG#g" | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=jupyter-web-app --for=condition=Ready --timeout=300s

--- a/.github/workflows/jwa_intergration_test.yaml
+++ b/.github/workflows/jwa_intergration_test.yaml
@@ -56,8 +56,15 @@ jobs:
         cd components/crud-web-apps/jupyter/manifests
         kubectl create ns kubeflow
 
-        export CURRENT_JWA_IMG=docker.io/kubeflownotebookswg/jupyter-web-app:latest
-        export PR_JWA_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build overlays/istio | sed "s#$CURRENT_JWA_IMG#$PR_JWA_IMG#g" | kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/istio \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=jupyter-web-app --for=condition=Ready --timeout=300s

--- a/.github/workflows/nb_controller_intergration_test.yaml
+++ b/.github/workflows/nb_controller_intergration_test.yaml
@@ -55,8 +55,15 @@ jobs:
         cd components/notebook-controller/config
         kubectl create ns kubeflow
 
-        export CURRENT_NOTEBOOK_IMG=docker.io/kubeflownotebookswg/notebook-controller:latest
-        export PR_NOTEBOOK_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build overlays/kubeflow | sed "s#$CURRENT_NOTEBOOK_IMG#$PR_NOTEBOOK_IMG#g" | kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/kubeflow \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=notebook-controller --for=condition=Ready --timeout=300s

--- a/.github/workflows/nb_controller_intergration_test.yaml
+++ b/.github/workflows/nb_controller_intergration_test.yaml
@@ -7,6 +7,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: notebook-controller
   TAG: intergration-test
@@ -38,7 +42,7 @@ jobs:
 
     - name: Load Images into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -52,7 +56,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_NOTEBOOK_IMG=docker.io/kubeflownotebookswg/notebook-controller:latest
-        export PR_NOTEBOOK_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_NOTEBOOK_IMG="${IMG}:${TAG}"
 
         kustomize build overlays/kubeflow | sed "s#$CURRENT_NOTEBOOK_IMG#$PR_NOTEBOOK_IMG#g" | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=notebook-controller --for=condition=Ready --timeout=300s

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -7,6 +7,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: poddefaults-webhook
   TAG: intergration-test
@@ -39,7 +43,7 @@ jobs:
 
     - name: Load Images into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -56,7 +60,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_PODDEFAULTS_IMG=docker.io/kubeflownotebookswg/poddefaults-webhook:latest
-        export PR_PODDEFAULTS_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_PODDEFAULTS_IMG="${IMG}:${TAG}"
 
 
         kustomize build overlays/cert-manager | sed "s#$CURRENT_PODDEFAULTS_IMG#$PR_PODDEFAULTS_IMG#g" | kubectl apply -f -

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -59,9 +59,15 @@ jobs:
         cd components/admission-webhook/manifests
         kubectl create ns kubeflow
 
-        export CURRENT_PODDEFAULTS_IMG=docker.io/kubeflownotebookswg/poddefaults-webhook:latest
-        export PR_PODDEFAULTS_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
 
-        kustomize build overlays/cert-manager | sed "s#$CURRENT_PODDEFAULTS_IMG#$PR_PODDEFAULTS_IMG#g" | kubectl apply -f -
+        kustomize build overlays/cert-manager \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=poddefaults --for=condition=Ready --timeout=300s

--- a/.github/workflows/profiles_kfam_intergration_test.yaml
+++ b/.github/workflows/profiles_kfam_intergration_test.yaml
@@ -64,10 +64,21 @@ jobs:
         cd components/profile-controller/config
         kubectl create ns kubeflow
 
-        export CURRENT_PROFILE_IMG=docker.io/kubeflownotebookswg/profile-controller:latest
-        export CURRENT_KFAM_IMG=docker.io/kubeflownotebookswg/kfam:latest
-        export PR_PROFILE_IMG="${PROFILE_IMG}:${TAG}"
-        export PR_KFAM_IMG="${KFAM_IMG}:${TAG}"
+        export CURRENT_PROFILE_IMAGE="docker.io/kubeflownotebookswg/${PROFILE_IMG}"
+        export PR_PROFILE_IMAGE="${PROFILE_IMG}:${TAG}"
 
-        kustomize build overlays/kubeflow | sed "s#$CURRENT_PROFILE_IMG#$PR_PROFILE_IMG#g" | sed "s#$CURRENT_KFAM_IMG#$PR_KFAM_IMG#g" | kubectl apply -f -
+        export CURRENT_KFAM_IMAGE="docker.io/kubeflownotebookswg/${KFAM_IMG}"
+        export PR_KFAM_IMAGE="${KFAM_IMG}:${TAG}"
+
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_PROFILE_IMAGE=$(echo "$CURRENT_PROFILE_IMAGE" | sed 's|\.|\\.|g')
+        export PR_PROFILE_IMAGE=$(echo "$PR_PROFILE_IMAGE" | sed 's|\.|\\.|g')
+        export CURRENT_KFAM_IMAGE=$(echo "$CURRENT_KFAM_IMAGE" | sed 's|\.|\\.|g')
+        export PR_KFAM_IMAGE=$(echo "$PR_KFAM_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/kubeflow \
+          | sed "s|${CURRENT_PROFILE_IMAGE}:[a-zA-Z0-9_.-]*|${PR_PROFILE_IMAGE}|g" \
+          | sed "s|${CURRENT_KFAM_IMAGE}:[a-zA-Z0-9_.-]*|${PR_KFAM_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l kustomize.component=profiles --for=condition=Ready --timeout=300s

--- a/.github/workflows/profiles_kfam_intergration_test.yaml
+++ b/.github/workflows/profiles_kfam_intergration_test.yaml
@@ -8,6 +8,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   PROFILE_IMG: profile-controller
   KFAM_IMG: kfam
@@ -29,14 +33,14 @@ jobs:
     - name: Build Profile Controller Image 
       run: |
         cd components/profile-controller
-        ARCH=linux/ppc64le make docker-build-multi-arch IMG=${{env.PROFILE_IMG}}
-        ARCH=linux/amd64 make docker-build-multi-arch IMG=${{env.PROFILE_IMG}}
+        ARCH=linux/ppc64le make docker-build-multi-arch IMG="${PROFILE_IMG}"
+        ARCH=linux/amd64 make docker-build-multi-arch IMG="${PROFILE_IMG}"
 
     - name: Build Kfam Image
       run: |
         cd components/access-management
-        ARCH=linux/ppc64le make docker-build-multi-arch IMG=${{env.KFAM_IMG}}
-        ARCH=linux/amd64 make docker-build-multi-arch IMG=${{env.KFAM_IMG}}
+        ARCH=linux/ppc64le make docker-build-multi-arch IMG="${KFAM_IMG}"
+        ARCH=linux/amd64 make docker-build-multi-arch IMG="${KFAM_IMG}"
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -46,8 +50,8 @@ jobs:
 
     - name: Load Images into KinD Cluster 
       run: |
-        kind load docker-image ${{env.PROFILE_IMG}}:${{env.TAG}}
-        kind load docker-image ${{env.KFAM_IMG}}:${{env.TAG}}
+        kind load docker-image "${PROFILE_IMG}:${TAG}"
+        kind load docker-image "${KFAM_IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -62,8 +66,8 @@ jobs:
 
         export CURRENT_PROFILE_IMG=docker.io/kubeflownotebookswg/profile-controller:latest
         export CURRENT_KFAM_IMG=docker.io/kubeflownotebookswg/kfam:latest
-        export PR_PROFILE_IMG=${{env.PROFILE_IMG}}:${{env.TAG}}
-        export PR_KFAM_IMG=${{env.KFAM_IMG}}:${{env.TAG}}
+        export PR_PROFILE_IMG="${PROFILE_IMG}:${TAG}"
+        export PR_KFAM_IMG="${KFAM_IMG}:${TAG}"
 
         kustomize build overlays/kubeflow | sed "s#$CURRENT_PROFILE_IMG#$PR_PROFILE_IMG#g" | sed "s#$CURRENT_KFAM_IMG#$PR_KFAM_IMG#g" | kubectl apply -f -
         kubectl wait pods -n kubeflow -l kustomize.component=profiles --for=condition=Ready --timeout=300s

--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -7,6 +7,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: pvcviewer-controller
   TAG: intergration-test
@@ -38,7 +42,7 @@ jobs:
 
     - name: Load Images into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -55,7 +59,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_PVCVIEWER_IMG=docker.io/kubeflownotebookswg/pvcviewer-controller:latest
-        export PR_PVCVIEWER_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_PVCVIEWER_IMG="${IMG}:${TAG}"
 
         kustomize build base | sed "s#$CURRENT_PVCVIEWER_IMG#$PR_PVCVIEWER_IMG#g" | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=pvcviewer --for=condition=Ready --timeout=300s

--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -58,8 +58,15 @@ jobs:
         cd components/pvcviewer-controller/config
         kubectl create ns kubeflow
 
-        export CURRENT_PVCVIEWER_IMG=docker.io/kubeflownotebookswg/pvcviewer-controller:latest
-        export PR_PVCVIEWER_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build base | sed "s#$CURRENT_PVCVIEWER_IMG#$PR_PVCVIEWER_IMG#g" | kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build base \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=pvcviewer --for=condition=Ready --timeout=300s

--- a/.github/workflows/tb_controller_intergration_test.yaml
+++ b/.github/workflows/tb_controller_intergration_test.yaml
@@ -7,6 +7,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: tensorboard-controller
   TAG: intergration-test
@@ -31,7 +35,7 @@ jobs:
 
     - name: Load Images into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -45,7 +49,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_TENSORBOARD_IMG=docker.io/kubeflownotebookswg/tensorboard-controller:latest
-        export export PR_TENSORBOARD_IMG=${{env.IMG}}:${{env.TAG}}
+        export export PR_TENSORBOARD_IMG="${IMG}:${TAG}"
 
         kustomize build overlays/kubeflow | sed "s#$CURRENT_TENSORBOARD_IMG#$PR_TENSORBOARD_IMG#g" | kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=tensorboard-controller --for=condition=Ready --timeout=300s

--- a/.github/workflows/tb_controller_intergration_test.yaml
+++ b/.github/workflows/tb_controller_intergration_test.yaml
@@ -48,8 +48,15 @@ jobs:
         cd components/tensorboard-controller/config
         kubectl create ns kubeflow
 
-        export CURRENT_TENSORBOARD_IMG=docker.io/kubeflownotebookswg/tensorboard-controller:latest
-        export export PR_TENSORBOARD_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build overlays/kubeflow | sed "s#$CURRENT_TENSORBOARD_IMG#$PR_TENSORBOARD_IMG#g" | kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/kubeflow \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=tensorboard-controller --for=condition=Ready --timeout=300s

--- a/.github/workflows/twa_intergration_test.yaml
+++ b/.github/workflows/twa_intergration_test.yaml
@@ -8,6 +8,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: tensorboards-web-app
   TAG: intergration-test
@@ -32,7 +36,7 @@ jobs:
 
     - name: Load Image into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -46,7 +50,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_TWA_IMG=docker.io/kubeflownotebookswg/tensorboards-web-app:latest
-        export PR_TWA_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_TWA_IMG="${IMG}:${TAG}"
 
         kustomize build overlays/istio | sed "s#$CURRENT_TWA_IMG#$PR_TWA_IMG#g" |  kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=tensorboards-web-app --for=condition=Ready --timeout=300s

--- a/.github/workflows/twa_intergration_test.yaml
+++ b/.github/workflows/twa_intergration_test.yaml
@@ -49,8 +49,15 @@ jobs:
         cd components/crud-web-apps/tensorboards/manifests
         kubectl create ns kubeflow
 
-        export CURRENT_TWA_IMG=docker.io/kubeflownotebookswg/tensorboards-web-app:latest
-        export PR_TWA_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build overlays/istio | sed "s#$CURRENT_TWA_IMG#$PR_TWA_IMG#g" |  kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/istio \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=tensorboards-web-app --for=condition=Ready --timeout=300s

--- a/.github/workflows/vwa_intergration_test.yaml
+++ b/.github/workflows/vwa_intergration_test.yaml
@@ -8,6 +8,10 @@ on:
       - master
       - v*-branch
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 env:
   IMG: volumes-web-app
   TAG: intergration-test
@@ -39,7 +43,7 @@ jobs:
 
     - name: Load Image into KinD Cluster 
       run: |
-        kind load docker-image ${{env.IMG}}:${{env.TAG}}
+        kind load docker-image "${IMG}:${TAG}"
 
     - name: Install kustomize
       run: ./components/testing/gh-actions/install_kustomize.sh
@@ -53,7 +57,7 @@ jobs:
         kubectl create ns kubeflow
 
         export CURRENT_VWA_IMG=docker.io/kubeflownotebookswg/volumes-web-app:latest
-        export PR_VWA_IMG=${{env.IMG}}:${{env.TAG}}
+        export PR_VWA_IMG="${IMG}:${TAG}"
 
         kustomize build overlays/istio | sed "s#$CURRENT_VWA_IMG#$PR_VWA_IMG#g" |  kubectl apply -f -
         kubectl wait pods -n kubeflow -l app=volumes-web-app --for=condition=Ready --timeout=300s

--- a/.github/workflows/vwa_intergration_test.yaml
+++ b/.github/workflows/vwa_intergration_test.yaml
@@ -56,8 +56,15 @@ jobs:
         cd components/crud-web-apps/volumes/manifests
         kubectl create ns kubeflow
 
-        export CURRENT_VWA_IMG=docker.io/kubeflownotebookswg/volumes-web-app:latest
-        export PR_VWA_IMG="${IMG}:${TAG}"
+        export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
+        export PR_IMAGE="${IMG}:${TAG}"
 
-        kustomize build overlays/istio | sed "s#$CURRENT_VWA_IMG#$PR_VWA_IMG#g" |  kubectl apply -f -
+        # escape "." in the image names, as it is a special characters in sed
+        export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
+        export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
+
+        kustomize build overlays/istio \
+          | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
+          | kubectl apply -f -
+
         kubectl wait pods -n kubeflow -l app=volumes-web-app --for=condition=Ready --timeout=300s


### PR DESCRIPTION
Supersedes https://github.com/kubeflow/kubeflow/pull/7252

Fixes https://github.com/kubeflow/kubeflow/pull/7234

This PR does the following:

- ensures that only one instance of the integration test jobs can run at a time (per pr)
- replaces all redundant references like `${{env.TAG}}`, with their safer equivalents in bash, e.g. `${TAG}`
- fixes how we are replacing images, to support arbitrary tags, rather than assuming they are `latest`:
    - this was causing https://github.com/kubeflow/kubeflow/pull/7234 to fail its tests