### PR TITLE
fix: incorrect references `DASHBOARD_LINKS_CONFIGMAP` env-var

### DIFF
--- a/components/centraldashboard-angular/manifests/base/deployment.yaml
+++ b/components/centraldashboard-angular/manifests/base/deployment.yaml
@@ -38,6 +38,6 @@ spec:
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
           value: $(CD_REGISTRATION_FLOW)
-        - name: DASHBOARD_LINKS_CONFIGMAP
+        - name: DASHBOARD_CONFIGMAP
           value: $(CD_CONFIGMAP_NAME)
       serviceAccountName: centraldashboard-angular

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
           value: CD_REGISTRATION_FLOW_PLACEHOLDER
-        - name: DASHBOARD_LINKS_CONFIGMAP
+        - name: DASHBOARD_CONFIGMAP
           value: CD_CONFIGMAP_NAME_PLACEHOLDER
         - name: LOGOUT_URL
           value: '/authservice/logout'


### PR DESCRIPTION
fix env name mismatch

https://github.com/kubeflow/kubeflow/blob/d1c40f916225ecb40826400595ea99096a2adbb7/components/centraldashboard/app/k8s_service.ts#L4-L7

https://github.com/kubeflow/kubeflow/blob/d1c40f916225ecb40826400595ea99096a2adbb7/components/centraldashboard-angular/backend/app/k8s_service.ts#L4-L9