### PR TITLE
Fix (profile controller): Profile controller fails to update profile owner, fixes #6576 and #5449

### DIFF
--- a/.github/workflows/prof_controller_unit_test.yaml
+++ b/.github/workflows/prof_controller_unit_test.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.21'
         check-latest: true
 
     - name: Run unit tests

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -701,9 +701,15 @@ func (r *ProfileReconciler) updateRoleBinding(profileIns *profilev1.Profile,
 			return err
 		}
 	} else {
+		update := updateAnnotations(&roleBinding.Annotations, &found.Annotations, []string{ROLE, USER})
+
 		if !(reflect.DeepEqual(roleBinding.RoleRef, found.RoleRef) && reflect.DeepEqual(roleBinding.Subjects, found.Subjects)) {
 			found.RoleRef = roleBinding.RoleRef
 			found.Subjects = roleBinding.Subjects
+			update = true
+		}
+
+		if update {
 			logger.Info("Updating RoleBinding", "namespace", roleBinding.Namespace, "name", roleBinding.Name)
 			err = r.Update(context.TODO(), found)
 			if err != nil {

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -579,8 +579,15 @@ func (r *ProfileReconciler) updateIstioAuthorizationPolicy(profileIns *profilev1
 			return err
 		}
 	} else {
+
+		update := updateAnnotations(&istioAuth.Annotations, &foundAuthorizationPolicy.Annotations, []string{ROLE, USER})
+
 		if !reflect.DeepEqual(*istioAuth.Spec.DeepCopy(), *foundAuthorizationPolicy.Spec.DeepCopy()) {
 			foundAuthorizationPolicy.Spec = *istioAuth.Spec.DeepCopy()
+			update = true
+		}
+
+		if update {
 			logger.Info("Updating Istio AuthorizationPolicy", "namespace", istioAuth.ObjectMeta.Namespace,
 				"name", istioAuth.ObjectMeta.Name)
 			err = r.Update(context.TODO(), foundAuthorizationPolicy)


### PR DESCRIPTION
Fixes issue #6576
Fixes issue #5449

This PR fixes the problem, described in issue #6576. Currently, the profile-controller fails to update the owner as it cannot verify the namespace owner. The PR implements solutions, suggested in the issue.  

Additional logic is added, to address issue #5449. If the namespace already exist, and it is not owned by any other profile - check if the namespace has annotation `transferToKubeflow: true`. If there is such annotation, take the ownership of that namespace and use it for the profile.