### PR TITLE
ci: read-only token-permissions for all workflows

### DIFF
--- a/.github/workflows/centraldb_angular_backend_test.yaml
+++ b/.github/workflows/centraldb_angular_backend_test.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/centraldashboard-angular/backend/**
 
+permissions:
+  contents: read
+
 jobs:
   run-backend-unittests:
     name: Unit tests

--- a/.github/workflows/centraldb_angular_docker_publish.yaml
+++ b/.github/workflows/centraldb_angular_docker_publish.yaml
@@ -8,6 +8,9 @@ on:
       - components/centraldashboard-angular/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/centraldashboard-angular

--- a/.github/workflows/centraldb_angular_frontend_test.yaml
+++ b/.github/workflows/centraldb_angular_frontend_test.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/centraldashboard-angular/frontend/**
 
+permissions:
+  contents: read
+
 jobs:
   frontend-format-lint-check:
     name: Check code format and lint

--- a/.github/workflows/centraldb_angular_intergration_test.yaml
+++ b/.github/workflows/centraldb_angular_intergration_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -8,6 +8,9 @@ on:
       - components/centraldashboard/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/centraldashboard

--- a/.github/workflows/centraldb_frontend_tests.yaml
+++ b/.github/workflows/centraldb_frontend_tests.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 jobs:
   frontend-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/centraldb_multi_arch_test.yaml
+++ b/.github/workflows/centraldb_multi_arch_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/common_frontend_tests.yaml
+++ b/.github/workflows/common_frontend_tests.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/crud-web-apps/common/frontend/kubeflow-common-lib/**
 
+permissions:
+  contents: read
+
 jobs:
   frontend-format-lint-check:
     name: Check code format and lint

--- a/.github/workflows/example_notebook_servers_publish.yaml
+++ b/.github/workflows/example_notebook_servers_publish.yaml
@@ -8,11 +8,16 @@ on:
       - components/example-notebook-servers/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 jobs:
   base_images:
     name: Build & Push - Base
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     secrets: inherit
+    permissions:
+      packages: write
     with:
       build_arch: linux/amd64,linux/arm64
       image_folders: |
@@ -23,6 +28,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ base_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       build_arch: linux/amd64,linux/arm64
       image_folders: |
@@ -34,6 +41,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ base_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       build_arch: linux/amd64,linux/arm64
       image_folders: |
@@ -45,6 +54,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ base_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       build_arch: linux/amd64,linux/arm64
       image_folders: |
@@ -55,6 +66,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ jupyter_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       build_arch: linux/amd64,linux/arm64
       image_folders: |
@@ -65,6 +78,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ jupyter_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       build_arch: linux/amd64,linux/arm64
       image_folders: |
@@ -76,6 +91,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ jupyter_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       # TODO: support 'linux/arm64' for PyTorch CUDA images
       build_arch: linux/amd64
@@ -88,6 +105,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ jupyter_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       build_arch: linux/amd64,linux/arm64
       image_folders: |
@@ -99,6 +118,8 @@ jobs:
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
     needs: [ jupyter_images ]
     secrets: inherit
+    permissions:
+      packages: write
     with:
       # TODO: support 'linux/arm64' for TensorFlow CUDA images
       build_arch: linux/amd64

--- a/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+++ b/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
@@ -11,6 +11,9 @@ on:
         description: "image folders to build, ordered by dependency, whitespace separated"
         type: string
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: docker.io/kubeflownotebookswg
   CACHE_IMAGE: ghcr.io/${{ github.repository }}/notebook-servers/build-cache
@@ -19,6 +22,8 @@ jobs:
   build_and_push_images:
     name: Build & Push Images
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/jwa_backend_unittests.yaml
+++ b/.github/workflows/jwa_backend_unittests.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/crud-web-apps/jupyter/backend/**
 
+permissions:
+  contents: read
+
 jobs:
   run-backend-unittests:
     name: Unittests

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -9,6 +9,9 @@ on:
       - components/crud-web-apps/common/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/jupyter-web-app

--- a/.github/workflows/jwa_frontend_tests.yaml
+++ b/.github/workflows/jwa_frontend_tests.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/crud-web-apps/jupyter/frontend/**
 
+permissions:
+  contents: read
+
 jobs:
   frontend-format-linting-check:
     name: Check code format and lint

--- a/.github/workflows/jwa_intergration_test.yaml
+++ b/.github/workflows/jwa_intergration_test.yaml
@@ -8,6 +8,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/jwa_multi_arch_test.yaml
+++ b/.github/workflows/jwa_multi_arch_test.yaml
@@ -8,6 +8,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -8,6 +8,9 @@ on:
       - components/access-management/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/kfam

--- a/.github/workflows/kfam_multi_arch_test.yaml
+++ b/.github/workflows/kfam_multi_arch_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -9,6 +9,9 @@ on:
       - components/common/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/notebook-controller

--- a/.github/workflows/nb_controller_intergration_test.yaml
+++ b/.github/workflows/nb_controller_intergration_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/nb_controller_multi_arch_test.yaml
+++ b/.github/workflows/nb_controller_multi_arch_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/notebook-controller/**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -8,6 +8,9 @@ on:
       - components/admission-webhook/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/poddefaults-webhook

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/poddefaults_multi_arch_test.yaml
+++ b/.github/workflows/poddefaults_multi_arch_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/poddefaults_unit_test.yaml
+++ b/.github/workflows/poddefaults_unit_test.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/admission-webhook/**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -8,6 +8,9 @@ on:
       - components/profile-controller/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/profile-controller

--- a/.github/workflows/prof_controller_multi_arch_test.yaml
+++ b/.github/workflows/prof_controller_multi_arch_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/prof_controller_unit_test.yaml
+++ b/.github/workflows/prof_controller_unit_test.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/profile-controller/**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/profiles_kfam_intergration_test.yaml
+++ b/.github/workflows/profiles_kfam_intergration_test.yaml
@@ -8,6 +8,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -9,6 +9,9 @@ on:
       - components/common/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/pvcviewer-controller

--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
+++ b/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/pvcviewer_controller_unit_test.yaml
+++ b/.github/workflows/pvcviewer_controller_unit_test.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/pvcviewer-controller/**
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python_lint.yaml
+++ b/.github/workflows/python_lint.yaml
@@ -7,6 +7,10 @@ on:
       - v*-branch
     paths:
       - "**.py"
+
+permissions:
+  contents: read
+
 jobs:
   flake8-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -8,6 +8,9 @@ on:
       - components/tensorboard-controller/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboard-controller

--- a/.github/workflows/tb_controller_intergration_test.yaml
+++ b/.github/workflows/tb_controller_intergration_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/tb_controller_multi_arch_test.yaml
+++ b/.github/workflows/tb_controller_multi_arch_test.yaml
@@ -7,6 +7,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/triage_issues.yaml
+++ b/.github/workflows/triage_issues.yaml
@@ -6,6 +6,9 @@ on:
     types: [opened, closed, reopened, transferred, labeled, unlabeled]
     # Issue is created, Issue is closed, Issue added or removed from projects, Labels added/removed
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -9,6 +9,9 @@ on:
       - components/crud-web-apps/common/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboards-web-app

--- a/.github/workflows/twa_frontend_tests.yaml
+++ b/.github/workflows/twa_frontend_tests.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/crud-web-apps/tensorboards/frontend/**
 
+permissions:
+  contents: read
+
 jobs:
   frontend-format-linting-check:
     name: Code format and lint

--- a/.github/workflows/twa_intergration_test.yaml
+++ b/.github/workflows/twa_intergration_test.yaml
@@ -8,6 +8,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/twa_multi_arch_test.yaml
+++ b/.github/workflows/twa_multi_arch_test.yaml
@@ -8,6 +8,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -9,6 +9,9 @@ on:
       - components/crud-web-apps/common/**
       - releasing/version/VERSION
 
+permissions:
+  contents: read
+
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/volumes-web-app

--- a/.github/workflows/vwa_frontend_tests.yaml
+++ b/.github/workflows/vwa_frontend_tests.yaml
@@ -4,6 +4,9 @@ on:
     paths:
       - components/crud-web-apps/volumes/frontend/**
 
+permissions:
+  contents: read
+
 jobs:
   frontend-format-lint-check:
     name: Check code format and lint

--- a/.github/workflows/vwa_intergration_test.yaml
+++ b/.github/workflows/vwa_intergration_test.yaml
@@ -8,6 +8,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true

--- a/.github/workflows/vwa_multi_arch_test.yaml
+++ b/.github/workflows/vwa_multi_arch_test.yaml
@@ -8,6 +8,9 @@ on:
       - master
       - v*-branch
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
   cancel-in-progress: true


### PR DESCRIPTION
Fixes kubeflow/notebooks#80.

This PR ensures all workflows run with read-only permissions.

From what I could tell, the `triage_issues.yml` workflow uses the secret PAT instead of the default workflow token, and as such doesn't require additional permissions.