### PR TITLE
fix: remove creationTimestamp line

### DIFF
--- a/components/profile-controller/Makefile
+++ b/components/profile-controller/Makefile
@@ -137,7 +137,8 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.2.0
-CONTROLLER_TOOLS_VERSION ?= v0.8.0
+# CONTROLLER_TOOLS_VERSION ?= v0.8.0
+CONTROLLER_TOOLS_VERSION ?= v0.13.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/components/profile-controller/Makefile
+++ b/components/profile-controller/Makefile
@@ -137,8 +137,7 @@ ENVTEST ?= $(LOCALBIN)/setup-envtest
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.2.0
-# CONTROLLER_TOOLS_VERSION ?= v0.8.0
-CONTROLLER_TOOLS_VERSION ?= v0.13.0
+CONTROLLER_TOOLS_VERSION ?= v0.8.0
 
 KUSTOMIZE_INSTALL_SCRIPT ?= "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"
 .PHONY: kustomize

--- a/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
+++ b/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.13.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   name: profiles.kubeflow.org
 spec:
   group: kubeflow.org

--- a/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
+++ b/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: profiles.kubeflow.org
 spec:
   group: kubeflow.org

--- a/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
+++ b/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
@@ -4,7 +4,6 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
-  creationTimestamp: null
   name: profiles.kubeflow.org
 spec:
   group: kubeflow.org

--- a/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
+++ b/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.13.0
   name: profiles.kubeflow.org
 spec:
   group: kubeflow.org
@@ -60,6 +60,7 @@ spec:
                 - kind
                 - name
                 type: object
+                x-kubernetes-map-type: atomic
               plugins:
                 items:
                   description: Plugin is for customize actions on different platform.
@@ -133,6 +134,7 @@ spec:
                           type: object
                         type: array
                     type: object
+                    x-kubernetes-map-type: atomic
                   scopes:
                     description: A collection of filters that must match each object
                       tracked by a quota. If not specified, the quota matches all
@@ -210,6 +212,7 @@ spec:
                 - kind
                 - name
                 type: object
+                x-kubernetes-map-type: atomic
               plugins:
                 items:
                   description: Plugin is for customize actions on different platform.
@@ -283,6 +286,7 @@ spec:
                           type: object
                         type: array
                     type: object
+                    x-kubernetes-map-type: atomic
                   scopes:
                     description: A collection of filters that must match each object
                       tracked by a quota. If not specified, the quota matches all
@@ -314,9 +318,3 @@ spec:
     storage: false
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []


### PR DESCRIPTION
Replacement of https://github.com/kubeflow/manifests/pull/2509, due to https://github.com/kubeflow/manifests/ is a mirror of part of this repo.

**Which issue is resolved by this Pull Request:**
Resolves https://github.com/kubeflow/kubeflow/issues/7041, https://github.com/GoogleCloudPlatform/kubeflow-distribution/issues/431


**Description of your changes:**
When deploying KF 1.7 on GCP, this line,
```
creationTimestamp: null
```
 caused the following error in deployment:
```
error: unable to decode "apps/profiles/build/apiextensions.k8s.io_v1_customresourcedefinition_profiles.kubeflow.org.yaml": parsing time "null" as "2006-01-02T15:04:05Z07:00": cannot parse "null" as "2006"
```
This seems to be due to golang being unable to handle `null` when unmarshalling timestamp. Currently, users have to manually remove this line every time for the deployment to succeed.

