### PR TITLE
Handle edge case when node capacity is undefined gracefully. Closes #7280.

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -117,7 +117,9 @@ def get_gpu_vendors():
         if node.status.capacity:
             installed_resources.update(status.capacity.keys())
         else:
-            log.debug("Capacity was not available for node {node.metadata.name}")
+            log.debug(
+                "Capacity was not available for node {node.metadata.name}"
+                )
 
     # Keep the vendors the key of which exists in at least one node
     available_vendors = installed_resources.intersection(config_vendor_keys)

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -119,7 +119,7 @@ def get_gpu_vendors():
         else:
             log.debug(
                 "Capacity was not available for node {node.metadata.name}"
-                )
+            )
 
     # Keep the vendors the key of which exists in at least one node
     available_vendors = installed_resources.intersection(config_vendor_keys)

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -117,7 +117,7 @@ def get_gpu_vendors():
         if node.status.capacity:
             installed_resources.update(status.capacity.keys())
         else:
-            log.warn("Status was not available for node {node.metadata.name}")
+            log.warn("Capacity was not available for node {node.metadata.name}")
 
     # Keep the vendors the key of which exists in at least one node
     available_vendors = installed_resources.intersection(config_vendor_keys)

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -117,7 +117,7 @@ def get_gpu_vendors():
         if node.status.capacity:
             installed_resources.update(status.capacity.keys())
         else:
-            log.warn("Capacity was not available for node {node.metadata.name}")
+            log.debug("Capacity was not available for node {node.metadata.name}")
 
     # Keep the vendors the key of which exists in at least one node
     available_vendors = installed_resources.intersection(config_vendor_keys)

--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -114,7 +114,10 @@ def get_gpu_vendors():
     installed_resources = set()
     nodes = api.list_nodes().items
     for node in nodes:
-        installed_resources.update(node.status.capacity.keys())
+        if node.status.capacity:
+            installed_resources.update(status.capacity.keys())
+        else:
+            log.warn("Status was not available for node {node.metadata.name}")
 
     # Keep the vendors the key of which exists in at least one node
     available_vendors = installed_resources.intersection(config_vendor_keys)

--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -14,7 +14,9 @@ log = logging.getLogger(__name__)
 
 FILE_ABS_PATH = os.path.abspath(os.path.dirname(__file__))
 
-NOTEBOOK_TEMPLATE_YAML = os.path.join(FILE_ABS_PATH, "yaml/notebook_template.yaml")
+NOTEBOOK_TEMPLATE_YAML = os.path.join(
+    FILE_ABS_PATH, "yaml/notebook_template.yaml"
+)
 LAST_ACTIVITY_ANNOTATION = "notebooks.kubeflow.org/last-activity"
 
 # The production configuration is mounted on the app's pod via a configmap
@@ -97,7 +99,9 @@ def pvc_from_dict(vol, namespace):
         spec=client.V1PersistentVolumeClaimSpec(
             access_modes=[vol["mode"]],
             storage_class_name=get_storage_class(vol),
-            resources=client.V1ResourceRequirements(requests={"storage": vol["size"]}),
+            resources=client.V1ResourceRequirements(
+                requests={"storage": vol["size"]}
+            ),
         ),
     )
 


### PR DESCRIPTION
The node.status.capacity attribute can be None. In this event the call to /api/gpus fails with Nonetype does not have keys attribute. This results in the entire request failing if a single node in the cluster doesn't have the node.status.capacity attribute defined. This happens in situations where a node reaches a bad state (very rare). 

My proposed solution checks if node.status.capacity is defined for a node and then adds capacity keys to the list of vendors. In the event that node.status.capacity is not defined for a node a warning message is logged to inform the user that the node.status.capacity for node.metadata.name is not available.