### PR TITLE
ci: wait for deployment instead of pods for test execution

### DIFF
--- a/.github/workflows/centraldb_angular_integration_test.yaml
+++ b/.github/workflows/centraldb_angular_integration_test.yaml
@@ -1,8 +1,8 @@
-name: Notebook Controller Intergration Test
+name: CentralDashboard-Angular Intergration Test
 on:
   pull_request:
     paths:
-      - components/notebook-controller/**
+      - components/centraldashboard-angular/**
     branches:
       - master
       - v*-branch
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMG: notebook-controller
+  IMG: centraldashboard-angular
   TAG: intergration-test
 
 jobs:
@@ -21,18 +21,13 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      with:
+        fetch-depth: 0
 
-    - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Build Notebook Controller Image 
+    - name: Build CentralDashboard-Angular Image 
       run: |
-        cd components/notebook-controller
-        ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch
+        cd components/centraldashboard-angular
+        make docker-build 
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -52,7 +47,7 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/notebook-controller/config
+        cd components/centraldashboard-angular/manifests
         kubectl create ns kubeflow
 
         export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
@@ -62,8 +57,9 @@ jobs:
         export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
         export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
 
-        kustomize build overlays/kubeflow \
+        kustomize build overlays/kserve \
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=notebook-controller --for=condition=Ready --timeout=300s
+        DEPLOYMENT=centraldashboard-angular
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/centraldb_integration_test.yaml
+++ b/.github/workflows/centraldb_integration_test.yaml
@@ -66,4 +66,5 @@ jobs:
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=centraldashboard --for=condition=Ready --timeout=300s
+        DEPLOYMENT=centraldashboard
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/jwa_integration_test.yaml
+++ b/.github/workflows/jwa_integration_test.yaml
@@ -1,8 +1,9 @@
-name: CentralDashboard-Angular Intergration Test
+name: JWA Intergration Test
 on:
   pull_request:
     paths:
-      - components/centraldashboard-angular/**
+      - components/crud-web-apps/jupyter/**
+      - components/crud-web-apps/common/**
     branches:
       - master
       - v*-branch
@@ -12,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMG: centraldashboard-angular
+  IMG: jupyter-web-app
   TAG: intergration-test
 
 jobs:
@@ -21,13 +22,18 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
 
-    - name: Build CentralDashboard-Angular Image 
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build JWA Image 
       run: |
-        cd components/centraldashboard-angular
-        make docker-build 
+        cd components/crud-web-apps/jupyter
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch 
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -35,7 +41,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Images into KinD Cluster 
+    - name: Load Image into KinD Cluster 
       run: |
         kind load docker-image "${IMG}:${TAG}"
 
@@ -47,7 +53,7 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/centraldashboard-angular/manifests
+        cd components/crud-web-apps/jupyter/manifests
         kubectl create ns kubeflow
 
         export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
@@ -57,8 +63,9 @@ jobs:
         export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
         export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
 
-        kustomize build overlays/kserve \
+        kustomize build overlays/istio \
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=centraldashboard-angular --for=condition=Ready --timeout=300s
+        DEPLOYMENT=jupyter-web-app-deployment
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/nb_controller_integration_test.yaml
+++ b/.github/workflows/nb_controller_integration_test.yaml
@@ -1,9 +1,8 @@
-name: TWA Intergration Test
+name: Notebook Controller Intergration Test
 on:
   pull_request:
     paths:
-      - components/crud-web-apps/tensorboards/**
-      - components/crud-web-apps/common/**
+      - components/notebook-controller/**
     branches:
       - master
       - v*-branch
@@ -13,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMG: tensorboards-web-app
+  IMG: notebook-controller
   TAG: intergration-test
 
 jobs:
@@ -22,11 +21,18 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
+      
+    - name: Setup QEMU
+      uses: docker/setup-qemu-action@v2
 
-    - name: Build TWA Image 
+    - name: Setup Docker Buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Build Notebook Controller Image 
       run: |
-        cd components/crud-web-apps/tensorboards
-        make docker-build 
+        cd components/notebook-controller
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -34,7 +40,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Image into KinD Cluster 
+    - name: Load Images into KinD Cluster 
       run: |
         kind load docker-image "${IMG}:${TAG}"
 
@@ -46,7 +52,7 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/crud-web-apps/tensorboards/manifests
+        cd components/notebook-controller/config
         kubectl create ns kubeflow
 
         export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
@@ -56,8 +62,9 @@ jobs:
         export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
         export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
 
-        kustomize build overlays/istio \
+        kustomize build overlays/kubeflow \
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=tensorboards-web-app --for=condition=Ready --timeout=300s
+        DEPLOYMENT=notebook-controller-deployment
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/poddefaults_integration_test.yaml
+++ b/.github/workflows/poddefaults_integration_test.yaml
@@ -1,9 +1,8 @@
-name: JWA Intergration Test
+name: PodDefaults Intergration Test
 on:
   pull_request:
     paths:
-      - components/crud-web-apps/jupyter/**
-      - components/crud-web-apps/common/**
+      - components/admission-webhook/**
     branches:
       - master
       - v*-branch
@@ -13,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMG: jupyter-web-app
+  IMG: poddefaults-webhook
   TAG: intergration-test
 
 jobs:
@@ -29,11 +28,12 @@ jobs:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-    - name: Build JWA Image 
+
+    - name: Build PodDefaults Image 
       run: |
-        cd components/crud-web-apps/jupyter
+        cd components/admission-webhook
         ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch 
+        ARCH=linux/amd64 make docker-build-multi-arch
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -41,7 +41,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Image into KinD Cluster 
+    - name: Load Images into KinD Cluster 
       run: |
         kind load docker-image "${IMG}:${TAG}"
 
@@ -51,9 +51,12 @@ jobs:
     - name: Install Istio
       run: ./components/testing/gh-actions/install_istio.sh
 
+    - name: Install cert-manager
+      run: ./components/testing/gh-actions/install_cert_manager.sh
+
     - name: Build & Apply manifests
       run: |
-        cd components/crud-web-apps/jupyter/manifests
+        cd components/admission-webhook/manifests
         kubectl create ns kubeflow
 
         export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
@@ -63,8 +66,9 @@ jobs:
         export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
         export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
 
-        kustomize build overlays/istio \
+        kustomize build overlays/cert-manager \
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=jupyter-web-app --for=condition=Ready --timeout=300s
+        DEPLOYMENT=admission-webhook-deployment
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/profiles_kfam_integration_test.yaml
+++ b/.github/workflows/profiles_kfam_integration_test.yaml
@@ -81,4 +81,5 @@ jobs:
           | sed "s|${CURRENT_KFAM_IMAGE}:[a-zA-Z0-9_.-]*|${PR_KFAM_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l kustomize.component=profiles --for=condition=Ready --timeout=300s
+        DEPLOYMENT=profiles-deployment
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/pvcviewer_controller_integration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_integration_test.yaml
@@ -69,4 +69,5 @@ jobs:
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=pvcviewer --for=condition=Ready --timeout=300s
+        DEPLOYMENT=pvcviewer-controller-manager
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/tb_controller_integration_test.yaml
+++ b/.github/workflows/tb_controller_integration_test.yaml
@@ -59,4 +59,5 @@ jobs:
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=tensorboard-controller --for=condition=Ready --timeout=300s
+        DEPLOYMENT=tensorboard-controller-deployment
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/twa_integration_test.yaml
+++ b/.github/workflows/twa_integration_test.yaml
@@ -1,8 +1,8 @@
-name: VWA Intergration Test
+name: TWA Intergration Test
 on:
   pull_request:
     paths:
-      - components/crud-web-apps/volumes/**
+      - components/crud-web-apps/tensorboards/**
       - components/crud-web-apps/common/**
     branches:
       - master
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMG: volumes-web-app
+  IMG: tensorboards-web-app
   TAG: intergration-test
 
 jobs:
@@ -22,18 +22,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v3
-      
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
 
-    - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
-
-    - name: Build VWA Image 
+    - name: Build TWA Image 
       run: |
-        cd components/crud-web-apps/volumes
-        ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch 
+        cd components/crud-web-apps/tensorboards
+        make docker-build 
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -53,7 +46,7 @@ jobs:
 
     - name: Build & Apply manifests
       run: |
-        cd components/crud-web-apps/volumes/manifests
+        cd components/crud-web-apps/tensorboards/manifests
         kubectl create ns kubeflow
 
         export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
@@ -67,4 +60,5 @@ jobs:
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=volumes-web-app --for=condition=Ready --timeout=300s
+        DEPLOYMENT=tensorboards-web-app-deployment
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s

--- a/.github/workflows/vwa_integration_test.yaml
+++ b/.github/workflows/vwa_integration_test.yaml
@@ -1,8 +1,9 @@
-name: PodDefaults Intergration Test
+name: VWA Intergration Test
 on:
   pull_request:
     paths:
-      - components/admission-webhook/**
+      - components/crud-web-apps/volumes/**
+      - components/crud-web-apps/common/**
     branches:
       - master
       - v*-branch
@@ -12,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  IMG: poddefaults-webhook
+  IMG: volumes-web-app
   TAG: intergration-test
 
 jobs:
@@ -28,12 +29,11 @@ jobs:
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v2
 
-
-    - name: Build PodDefaults Image 
+    - name: Build VWA Image 
       run: |
-        cd components/admission-webhook
+        cd components/crud-web-apps/volumes
         ARCH=linux/ppc64le make docker-build-multi-arch
-        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch 
 
     - name: Install KinD
       run: ./components/testing/gh-actions/install_kind.sh
@@ -41,7 +41,7 @@ jobs:
     - name: Create KinD Cluster
       run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
 
-    - name: Load Images into KinD Cluster 
+    - name: Load Image into KinD Cluster 
       run: |
         kind load docker-image "${IMG}:${TAG}"
 
@@ -51,12 +51,9 @@ jobs:
     - name: Install Istio
       run: ./components/testing/gh-actions/install_istio.sh
 
-    - name: Install cert-manager
-      run: ./components/testing/gh-actions/install_cert_manager.sh
-
     - name: Build & Apply manifests
       run: |
-        cd components/admission-webhook/manifests
+        cd components/crud-web-apps/volumes/manifests
         kubectl create ns kubeflow
 
         export CURRENT_IMAGE="docker.io/kubeflownotebookswg/${IMG}"
@@ -66,8 +63,9 @@ jobs:
         export CURRENT_IMAGE=$(echo "$CURRENT_IMAGE" | sed 's|\.|\\.|g')
         export PR_IMAGE=$(echo "$PR_IMAGE" | sed 's|\.|\\.|g')
 
-        kustomize build overlays/cert-manager \
+        kustomize build overlays/istio \
           | sed "s|${CURRENT_IMAGE}:[a-zA-Z0-9_.-]*|${PR_IMAGE}|g" \
           | kubectl apply -f -
 
-        kubectl wait pods -n kubeflow -l app=poddefaults --for=condition=Ready --timeout=300s
+        DEPLOYMENT=volumes-web-app-deployment
+        kubectl wait deploy -n kubeflow $DEPLOYMENT --for=jsonpath='{.status.readyReplicas}'=1 --timeout=300s


### PR DESCRIPTION
Wait for deployment state instead of pod during test execution.

Relates #7251 