### PR TITLE
Move gpusCount to spawner config

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/form.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/form.py
@@ -238,7 +238,7 @@ def set_notebook_gpus(notebook, body, defaults):
 
     # set the gpus annotation
     container = notebook["spec"]["template"]["spec"]["containers"][0]
-    vendor = gpus["vendor"]
+    vendor = gpus["vendor"]["limitsKey"]
     try:
         num = str(gpus["num"])
     except ValueError:

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -129,15 +129,22 @@ spawnerFormDefaults:
       # the list of available vendors in the dropdown
       #  `limitsKey` - what will be set as the actual limit
       #  `uiName` - what will be displayed in the dropdown UI
-      vendors: []
-      #vendors:
-      #  - limitsKey: "nvidia.com/gpu"
-      #    uiName: "NVIDIA"
-      #  - limitsKey: "amd.com/gpu"
-      #    uiName: "AMD"
-
-      # the default value of the limit
-      # (possible values: "none", "1", "2", "4", "8")
+      # Determines what the UI will show and send to the backend
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+          # Options in gpusCount indicate the number of GPUs available for each type
+          gpusCount:
+          - "1"
+          - "2"
+          - "4"
+          - "8"
+        - limitsKey: "amd.com/gpu"
+          uiName: "AMD"
+          gpusCount:
+          - "1"
+          - "2"
+          - "4"
       num: "none"
 
   ################################################################
@@ -305,3 +312,4 @@ spawnerFormDefaults:
   environment:
     readOnly: false
     value: {}
+    

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.html
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.html
@@ -1,15 +1,5 @@
 <lib-form-section title="GPUs" i18n-title>
   <div class="row" [formGroup]="parentForm.get('gpus')">
-    <!--GPUs Number-->
-    <mat-form-field class="column" appearance="outline">
-      <mat-label i18n>Number of GPUs</mat-label>
-      <mat-select matNativeControl formControlName="num">
-        <mat-option value="none" i18n="option None">None</mat-option>
-        <mat-option *ngFor="let v of gpusCount" [value]="v">
-          {{ v }}
-        </mat-option>
-      </mat-select>
-    </mat-form-field>
 
     <!--GPUs Vendor-->
     <mat-form-field class="column" appearance="outline">
@@ -17,10 +7,24 @@
       <mat-select matNativeControl formControlName="vendor" id="gpu-vendor">
         <mat-option
           *ngFor="let v of vendors"
-          [value]="v.limitsKey"
+          [value]="v"
           [matTooltip]="vendorTooltip(v)"
         >
           {{ v.uiName }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+    
+     <!--GPUs Number -->
+    <mat-form-field class="column" appearance="outline">
+      <mat-label i18n>Number of GPUs</mat-label>
+      <mat-select matNativeControl formControlName="num">
+        <mat-option value="none" i18n="option None">None</mat-option>
+        <mat-option
+          *ngFor="let v of counts"
+          [value]="v"
+        >
+          {{ v }}
         </mat-option>
       </mat-select>
       <mat-error>{{ getVendorError() }}</mat-error>

--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-gpus/form-gpus.component.ts
@@ -15,28 +15,29 @@ export class FormGpusComponent implements OnInit {
 
   private gpuCtrl: FormGroup;
   public installedVendors = new Set<string>();
+  public counts: string[] = [];
 
   subscriptions = new Subscription();
   maxGPUs = 16;
-  gpusCount = ['1', '2', '4', '8'];
 
   constructor(public backend: JWABackendService) {}
 
   ngOnInit() {
     this.gpuCtrl = this.parentForm.get('gpus') as FormGroup;
 
-    // Vendor should not be empty if the user selects GPUs num
+    // GPUCount should not be empty if the user selects GPU Vendor
     this.parentForm
       .get('gpus')
-      .get('vendor')
+      .get('num')
       .setValidators([this.vendorWithNum()]);
 
     this.subscriptions.add(
-      this.gpuCtrl.get('num').valueChanges.subscribe((n: string) => {
-        if (n === 'none') {
-          this.gpuCtrl.get('vendor').disable();
+      this.gpuCtrl.get('vendor').valueChanges.subscribe((n: GPUVendor) => {
+        if (!n) {
+          this.gpuCtrl.get('num').disable();
         } else {
-          this.gpuCtrl.get('vendor').enable();
+          this.counts = n.gpusCount;
+          this.gpuCtrl.get('num').enable();
         }
       }),
     );
@@ -55,10 +56,10 @@ export class FormGpusComponent implements OnInit {
 
   // Custom Validation
   public getVendorError() {
-    const vendorCtrl = this.parentForm.get('gpus').get('vendor');
+    const vendorCtrl = this.parentForm.get('gpus').get('num');
 
     if (vendorCtrl.hasError('vendorNullName')) {
-      return $localize`You must also specify the GPU Vendor for the assigned GPUs`;
+      return $localize`You must specify the number of GPUs for the chosen Vendor`;
     }
   }
 
@@ -69,7 +70,7 @@ export class FormGpusComponent implements OnInit {
       const num = this.parentForm.get('gpus').get('num').value;
       const vendor = this.parentForm.get('gpus').get('vendor').value;
 
-      if (num !== 'none' && vendor === '') {
+      if (vendor.limitsKey  !== 'none' && num == 'none') {
         return { vendorNullName: true };
       } else {
         return null;

--- a/components/crud-web-apps/jupyter/frontend/src/app/types/gpu.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/types/gpu.ts
@@ -1,6 +1,7 @@
 export interface GPUVendor {
   limitsKey: string;
   uiName: string;
+  gpusCount: string[];
 }
 
 export interface GPU {

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -129,15 +129,21 @@ spawnerFormDefaults:
       # the list of available vendors in the dropdown
       #  `limitsKey` - what will be set as the actual limit
       #  `uiName` - what will be displayed in the dropdown UI
-      vendors: []
-      #vendors:
-      #  - limitsKey: "nvidia.com/gpu"
-      #    uiName: "NVIDIA"
-      #  - limitsKey: "amd.com/gpu"
-      #    uiName: "AMD"
-
-      # the default value of the limit
-      # (possible values: "none", "1", "2", "4", "8")
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+          # Options in gpusCount indicate the number of GPUs available for each type
+          gpusCount:
+          - "1"
+          - "2"
+          - "4"
+          - "8"
+        - limitsKey: "amd.com/gpu"
+          uiName: "AMD"
+          gpusCount:
+          - "1"
+          - "2"
+          - "4"
       num: "none"
 
   ################################################################


### PR DESCRIPTION
Currently the notebook UI has a dropdown to select the number of GPUs required . However the options are hardcoded to ['1', '2', '4', '8'] . Moving these settings to spawner_ui_config.yaml will give users the flexibility to show GPU options that are relevant to their underlying cluster 

Address https://github.com/kubeflow/kubeflow/pull/6550 