### PR TITLE
Make principals dynamic in Profiles Controller

### DIFF
--- a/.github/workflows/prof_controller_unit_test.yaml
+++ b/.github/workflows/prof_controller_unit_test.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.19'
         check-latest: true
 
     - name: Run unit tests

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -81,6 +81,10 @@ func getAuthorizationPolicy(binding *Binding, userIdHeader string, userIdPrefix 
 		"ISTIO_INGRESS_GATEWAY_PRINCIPAL",
 		"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
 
+	kfpUIPrincipal := GetEnvDefault(
+		"KFP_UI_PRINCIPAL",
+		"cluster.local/ns/kubeflow/sa/ml-pipeline-ui")
+
 	return istioSecurity.AuthorizationPolicy{
 		Rules: []*istioSecurity.Rule{
 			{
@@ -94,7 +98,10 @@ func getAuthorizationPolicy(binding *Binding, userIdHeader string, userIdPrefix 
 				},
 				From: []*istioSecurity.Rule_From{{
 					Source: &istioSecurity.Source{
-						Principals: []string{istioIGWPrincipal},
+						Principals: []string{
+							istioIGWPrincipal,
+							kfpUIPrincipal,
+						},
 					},
 				}},
 			},

--- a/components/access-management/kfam/bindings.go
+++ b/components/access-management/kfam/bindings.go
@@ -77,6 +77,10 @@ func getBindingName(binding *Binding) (string, error) {
 }
 
 func getAuthorizationPolicy(binding *Binding, userIdHeader string, userIdPrefix string) istioSecurity.AuthorizationPolicy {
+	istioIGWPrincipal := GetEnvDefault(
+		"ISTIO_INGRESS_GATEWAY_PRINCIPAL",
+		"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+
 	return istioSecurity.AuthorizationPolicy{
 		Rules: []*istioSecurity.Rule{
 			{
@@ -90,9 +94,7 @@ func getAuthorizationPolicy(binding *Binding, userIdHeader string, userIdPrefix 
 				},
 				From: []*istioSecurity.Rule_From{{
 					Source: &istioSecurity.Source{
-						Principals: []string{
-							"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account",
-						},
+						Principals: []string{istioIGWPrincipal},
 					},
 				}},
 			},

--- a/components/access-management/kfam/utils.go
+++ b/components/access-management/kfam/utils.go
@@ -13,3 +13,13 @@
 // limitations under the License.
 
 package kfam
+
+import "os"
+
+func GetEnvDefault(variable string, defaultVal string) string {
+	envVar := os.Getenv(variable)
+	if len(envVar) == 0 {
+		return defaultVal
+	}
+	return envVar
+}

--- a/components/profile-controller/config/manager/kustomization.yaml
+++ b/components/profile-controller/config/manager/kustomization.yaml
@@ -10,4 +10,5 @@ configMapGenerator:
   - USERID_PREFIX=
   - ISTIO_INGRESS_GATEWAY_PRINCIPAL="cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
   - NOTEBOOK_CONTROLLER_PRINCIPAL="cluster.local/ns/kubeflow/sa/notebook-controller-service-account")
+  - KFP_UI_PRINCIPAL="cluster.local/ns/kubeflow/sa/ml-pipeline-ui"
   name: config

--- a/components/profile-controller/config/manager/kustomization.yaml
+++ b/components/profile-controller/config/manager/kustomization.yaml
@@ -8,4 +8,6 @@ configMapGenerator:
   - WORKLOAD_IDENTITY=
   - USERID_HEADER="kubeflow-userid"
   - USERID_PREFIX=
+  - ISTIO_INGRESS_GATEWAY_PRINCIPAL="cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
+  - NOTEBOOK_CONTROLLER_PRINCIPAL="cluster.local/ns/kubeflow/sa/notebook-controller-service-account")
   name: config

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -449,20 +449,10 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 					Source: &istioSecurity.Source{
 						Principals: []string{
 							istioIGWPrincipal,
+							kfpUIPrincipal,
 						},
 					},
 				}},
-			},
-			{
-				From: []*istioSecurity.Rule_From{
-					{
-						// KFP UI needs to talk to ml-pipeline-ui-artifact pods
-						// in each profile namespace
-						Source: &istioSecurity.Source{
-							Principals: []string{kfpUIPrincipal},
-						},
-					},
-				},
 			},
 			{
 				When: []*istioSecurity.Condition{

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -417,12 +417,13 @@ func (r *ProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile) istioSecurity.AuthorizationPolicy {
+	nbControllerPrincipal := GetEnvDefault(
+		"NOTEBOOK_CONTROLLER_PRINCIPAL",
+		"cluster.local/ns/kubeflow/sa/notebook-controller-service-account")
 
-	clusterDomain := "cluster.local"
-	if clusterDomainFromEnv, ok := os.LookupEnv("CLUSTER_DOMAIN"); ok {
-		clusterDomain = clusterDomainFromEnv
-	}
-	principals := fmt.Sprintf("%s/ns/kubeflow/sa/notebook-controller-service-account", clusterDomain)
+	istioIGWPrincipal := GetEnvDefault(
+		"ISTIO_INGRESS_GATEWAY_PRINCIPAL",
+		"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
 
 	return istioSecurity.AuthorizationPolicy{
 		Action: istioSecurity.AuthorizationPolicy_ALLOW,
@@ -443,7 +444,7 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 				From: []*istioSecurity.Rule_From{{
 					Source: &istioSecurity.Source{
 						Principals: []string{
-							"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account",
+							istioIGWPrincipal,
 						},
 					},
 				}},
@@ -480,7 +481,7 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 				From: []*istioSecurity.Rule_From{
 					{
 						Source: &istioSecurity.Source{
-							Principals: []string{principals},
+							Principals: []string{nbControllerPrincipal},
 						},
 					},
 				},
@@ -781,4 +782,12 @@ func (r *ProfileReconciler) readDefaultLabelsFromFile(path string) map[string]st
 		os.Exit(1)
 	}
 	return labels
+}
+
+func GetEnvDefault(variable string, defaultVal string) string {
+	envVar := os.Getenv(variable)
+	if len(envVar) == 0 {
+		return defaultVal
+	}
+	return envVar
 }

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -425,6 +425,10 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 		"ISTIO_INGRESS_GATEWAY_PRINCIPAL",
 		"cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
 
+	kfpUIPrincipal := GetEnvDefault(
+		"KFP_UI_PRINCIPAL",
+		"cluster.local/ns/kubeflow/sa/ml-pipeline-ui")
+
 	return istioSecurity.AuthorizationPolicy{
 		Action: istioSecurity.AuthorizationPolicy_ALLOW,
 		// Empty selector == match all workloads in namespace
@@ -448,6 +452,17 @@ func (r *ProfileReconciler) getAuthorizationPolicy(profileIns *profilev1.Profile
 						},
 					},
 				}},
+			},
+			{
+				From: []*istioSecurity.Rule_From{
+					{
+						// KFP UI needs to talk to ml-pipeline-ui-artifact pods
+						// in each profile namespace
+						Source: &istioSecurity.Source{
+							Principals: []string{kfpUIPrincipal},
+						},
+					},
+				},
 			},
 			{
 				When: []*istioSecurity.Condition{


### PR DESCRIPTION
This is a follow-up to address https://github.com/kubeflow/kubeflow/pull/7032#issuecomment-1682614698

This PR will make all principals in Profile Controller configurable, so they should be changed from any distribution that deploys the components in different namespaces.

/cc @thesuperzapper 