### PR TITLE
fix: set default GPU vendors list

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -129,12 +129,11 @@ spawnerFormDefaults:
       # the list of available vendors in the dropdown
       #  `limitsKey` - what will be set as the actual limit
       #  `uiName` - what will be displayed in the dropdown UI
-      vendors: []
-      #vendors:
-      #  - limitsKey: "nvidia.com/gpu"
-      #    uiName: "NVIDIA"
-      #  - limitsKey: "amd.com/gpu"
-      #    uiName: "AMD"
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+        - limitsKey: "amd.com/gpu"
+          uiName: "AMD"
 
       # the default value of the limit
       # (possible values: "none", "1", "2", "4", "8")

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -129,12 +129,11 @@ spawnerFormDefaults:
       # the list of available vendors in the dropdown
       #  `limitsKey` - what will be set as the actual limit
       #  `uiName` - what will be displayed in the dropdown UI
-      vendors: []
-      #vendors:
-      #  - limitsKey: "nvidia.com/gpu"
-      #    uiName: "NVIDIA"
-      #  - limitsKey: "amd.com/gpu"
-      #    uiName: "AMD"
+      vendors:
+        - limitsKey: "nvidia.com/gpu"
+          uiName: "NVIDIA"
+        - limitsKey: "amd.com/gpu"
+          uiName: "AMD"
 
       # the default value of the limit
       # (possible values: "none", "1", "2", "4", "8")


### PR DESCRIPTION
The change introduced by kubeflow/kubeflow#6736 removed the default GPU vendors list, which causes an issue when trying to select a vendor from the dropdown menu if the vendors list is not configured.
This commit can be reverted if proper documentation is provided for users/distributions to configure the dropdown menu.
Fixes #7273 in `master`