### PR TITLE
Add extra namespace labels option

### DIFF
--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -380,6 +380,7 @@ func (r *ProfileReconciler) ShutdownFileWatchers() {
 		// Exit if there are no file watchers configured
 		return
 	}
+	defer close(r.fileWatcherStopped)
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	for {

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -853,13 +853,13 @@ func (r *ProfileReconciler) readDefaultLabelsFromFiles(labelPaths []string) (map
 		logger := r.Log.WithName("read-config-file").WithValues("path", path)
 		dat, err := ioutil.ReadFile(path)
 		if err != nil {
-			logger.Error(err, fmt.Sprintf("unable to read default namespace labels file %s", path))
+			logger.Error(err, "unable to read default namespace labels file")
 			return nil, err
 		}
 		labels := map[string]string{}
 		err = yaml.Unmarshal(dat, &labels)
 		if err != nil {
-			logger.Error(err, fmt.Sprintf("unable to parse default namespace labels file %s.", path))
+			logger.Error(err, "unable to parse default namespace labels file")
 			return nil, err
 		}
 		for labelKey, labelVal := range labels {

--- a/components/profile-controller/controllers/profile_controller.go
+++ b/components/profile-controller/controllers/profile_controller.go
@@ -484,7 +484,8 @@ func (r *ProfileReconciler) setupFileWatchers(events chan event.GenericEvent, mg
 	return nil
 }
 
-func (r *ProfileReconciler) SetupWithManager(mgr ctrl.Manager, events chan event.GenericEvent) error {
+func (r *ProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	events := make(chan event.GenericEvent)
 	c := ctrl.NewControllerManagedBy(mgr).
 		For(&profilev1.Profile{}).
 		Owns(&corev1.Namespace{}).

--- a/components/profile-controller/controllers/profile_controller_test.go
+++ b/components/profile-controller/controllers/profile_controller_test.go
@@ -277,11 +277,6 @@ func TestReadDefaultLabelsFromFiles(t *testing.T) {
 	}
 }
 
-type SetupWatchersSuite struct {
-	name  string
-	files []string
-}
-
 type FakeManager struct {
 	ctrl.Manager
 	elected chan struct{}
@@ -291,7 +286,7 @@ func (f FakeManager) Elected() <-chan struct{} {
 	return f.elected
 }
 
-func TestSetupWatchers(t *testing.T) {
+func TestSetupFileWatchers(t *testing.T) {
 	// Setup file
 	fileName := "file.yaml"
 	dirName := "setup-watchers"
@@ -340,7 +335,7 @@ func TestSetupWatchers(t *testing.T) {
 	assert.False(t, <-eventReceived)
 }
 
-func TestSetupWatchersMissingFile(t *testing.T) {
+func TestSetupFileWatchersMissingFile(t *testing.T) {
 	events := make(chan event.GenericEvent)
 	defer close(events)
 	r := createMockReconciler()
@@ -353,7 +348,7 @@ func TestSetupWatchersMissingFile(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
-func TestSetupWatchersMissingSecondFile(t *testing.T) {
+func TestSetupFileWatchersMissingSecondFile(t *testing.T) {
 	// Set up file
 	fileName := "file.yaml"
 	dirName := "setup-watchers-missing-second"

--- a/components/profile-controller/main.go
+++ b/components/profile-controller/main.go
@@ -30,7 +30,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -116,9 +115,7 @@ func main() {
 		DefaultNamespaceLabelsPaths: namespaceLabelsPaths,
 	}
 
-	events := make(chan event.GenericEvent)
-
-	if err = r.SetupWithManager(mgr, events); err != nil {
+	if err = r.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Profile")
 		os.Exit(1)
 	}

--- a/components/profile-controller/main.go
+++ b/components/profile-controller/main.go
@@ -117,7 +117,6 @@ func main() {
 	}
 
 	events := make(chan event.GenericEvent)
-	defer close(events)
 
 	if err = r.SetupWithManager(mgr, events); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Profile")


### PR DESCRIPTION
This PR adds the ability to configure an additional file of labels for the profile controller to add to profiles by configuring the file in the env var `EXTRA_NAMESPACE_LABELS_PATH`. We need this additional file so that we can add pod security standards as part of @juliusvonkohout 's plan (https://github.com/kubeflow/manifests/blob/master/proposals/20200913-rootlessKubeflow.md) to increase security. We are currently unable to add to the existing configurable namespace labels file in a patch because Kustomize does not allow editing data in a configmap key value (only adding a new key).

This PR adds an additional fsnotify watcher instance for the new file and proper shutdown. Since we will have two watcher instances, I thought it was important to ensure proper resource clean up upon termination. I also added a fix to allow the file watcher code to work if in leader elect mode on a platform that follows symlinks. If these two additional updates seem like too much increasing scope for this PR, I can separate them into different PRs to submit later.