### PR TITLE
Run build steps for multi-arch sequentially

### DIFF
--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/centraldashboard
-  ARCH: linux/ppc64le,linux/amd64,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -43,7 +42,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/centraldashboard
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -12,7 +12,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/jupyter-web-app
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -44,7 +43,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/crud-web-apps/jupyter
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/kfam
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -43,7 +42,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/access-management
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -12,7 +12,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/notebook-controller
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -44,7 +43,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/notebook-controller
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/poddefaults-webhook
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -43,7 +42,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/admission-webhook
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/profile-controller
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -43,7 +42,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/profile-controller
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -12,7 +12,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/pvcviewer-controller
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -41,7 +40,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/pvcviewer-controller
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -11,7 +11,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboard-controller
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -43,7 +42,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/tensorboard-controller
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -12,7 +12,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboards-web-app
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -44,7 +43,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/crud-web-apps/tensorboards
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -12,7 +12,6 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/volumes-web-app
-  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:
@@ -44,7 +43,9 @@ jobs:
     - name: Build and push multi-arch docker image
       run: |
         cd components/crud-web-apps/volumes
-        make docker-build-push-multi-arch
+        ARCH=linux/ppc64le make docker-build-multi-arch
+        ARCH=linux/amd64 make docker-build-multi-arch
+        ARCH=linux/arm64/v8 make docker-build-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
We saw that if we try to build using an ENV var containing all the architectures then docker buildx will run 3 parallel jobs.

This made the GH runners crash in some cases because they were over-utilizing the resources.

To mitigate this we'll sequentially build each image for each arch.

/assign @thesuperzapper 
cc @DnPlas 