### PR TITLE
fix: KeyError on KF 1.8

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -58,9 +58,10 @@ def process_status(notebook):
 
 
 def get_empty_status(notebook):
-    creation_timestamp = notebook["metadata"]["creationTimestamp"]
-    container_state = notebook["status"]["containerState"]
-    conditions = notebook["status"]["conditions"]
+    creation_timestamp = notebook.get("metadata", {}).get("creationTimestamp")
+    status = notebook.get("status", {})
+    container_state = status.get("containerState")
+    conditions = status.get("conditions")
 
     # Convert a date string of a format to datetime object
     nb_creation_time = dt.datetime.strptime(

--- a/components/crud-web-apps/jupyter/backend/apps/common/utils.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/utils.py
@@ -14,7 +14,9 @@ log = logging.getLogger(__name__)
 
 FILE_ABS_PATH = os.path.abspath(os.path.dirname(__file__))
 
-NOTEBOOK_TEMPLATE_YAML = os.path.join(FILE_ABS_PATH, "yaml/notebook_template.yaml")
+NOTEBOOK_TEMPLATE_YAML = os.path.join(
+    FILE_ABS_PATH, "yaml/notebook_template.yaml"
+)
 LAST_ACTIVITY_ANNOTATION = "notebooks.kubeflow.org/last-activity"
 
 # The production configuration is mounted on the app's pod via a configmap
@@ -97,7 +99,9 @@ def pvc_from_dict(vol, namespace):
         spec=client.V1PersistentVolumeClaimSpec(
             access_modes=[vol["mode"]],
             storage_class_name=get_storage_class(vol),
-            resources=client.V1ResourceRequirements(requests={"storage": vol["size"]}),
+            resources=client.V1ResourceRequirements(
+                requests={"storage": vol["size"]}
+            ),
         ),
     )
 


### PR DESCRIPTION
This change fixes an error 500 on notebook creation in Kubeflow 1.8.

Background: the frontend may be faster accessing the status of the newly created Notebook than the controller can create it. This causes the user to see an empty Notebook page and an error 500. 