### PR TITLE
poddefaults: Bump golang to 1.20

### DIFF
--- a/.github/workflows/poddefaults_unit_test.yaml
+++ b/.github/workflows/poddefaults_unit_test.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.20'
         check-latest: true
 
     - name: Run unit tests

--- a/components/admission-webhook/go.mod
+++ b/components/admission-webhook/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/kubeflow/components/admission-webhook
 
-go 1.17
+go 1.20
 
 require (
 	github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a


### PR DESCRIPTION
During https://github.com/kubeflow/kubeflow/pull/7322 the tests were not triggered so we missed the failing unit-tests action. We found this out during cherry-picking https://github.com/kubeflow/kubeflow/pull/7337

This is because it needed golang at least 1.20 during the unit tests, to install one of the dependencies.

I also went and updated the golang version of the component and am testing to make sure we didn't miss something

/assign @tzstoyanov @thesuperzapper 