### PR TITLE
wa(front): Make the background white of all webapps

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles/styles.scss
@@ -96,6 +96,7 @@ mat-form-field .mat-form-field {
 html,
 body {
   margin: 0;
+  background: white;
 }
 
 .flex {


### PR DESCRIPTION
Right now the web-apps all become grey, because of a transparency change introduced by d4b6dff8
![image](https://github.com/kubeflow/kubeflow/assets/11134742/760a7743-45df-4570-bd7f-54232646be99)

/assign @thesuperzapper 