### PR TITLE
ci: Ensure we publish for all architectures

### DIFF
--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -11,6 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/centraldashboard
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -12,6 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/jupyter-web-app
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -11,6 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/kfam
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -12,6 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/notebook-controller
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -11,6 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/poddefaults-webhook
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -11,6 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/profile-controller
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -12,6 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/pvcviewer-controller
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -11,6 +11,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboard-controller
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -12,6 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/tensorboards-web-app
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -12,6 +12,7 @@ on:
 env:
   DOCKER_USER: kubeflownotebookswg
   IMG: kubeflownotebookswg/volumes-web-app
+  ARCH: linux/amd64,linux/ppc64le,linux/arm64/v8
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
there's another problem with ARM ci right now. In the end the image only for amd64 gets pushed, because
1. The step that actually pushes the image is not configured to build/push for all architectures https://github.com/kubeflow/kubeflow/blob/1a494d4ac35fc81c8571d2331f5f6a84432549b8/.github/workflows/centraldb_docker_publish.yaml#L54
2. It will use the default env var in the makefiles, which is `ARCH=amd64` https://github.com/kubeflow/kubeflow/blob/1a494d4ac35fc81c8571d2331f5f6a84432549b8/components/centraldashboard/Makefile#L5


To resolve this, this PR brings back the default ENV var with all architectures. This means that now the flow is
1. We build sequentially for each architecture by overriding the `ARCH` env var
2. Then build/push again but this time using the global `ARCH` env var
    * This will re-use the cached images and just push

/assign @thesuperzapper 