### PR TITLE
ci: Push the multi-arch image for specific tag

### DIFF
--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -46,6 +46,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -47,6 +47,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -46,6 +46,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -47,6 +47,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -46,6 +46,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -46,6 +46,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -44,6 +44,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -46,6 +46,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -47,6 +47,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -47,6 +47,7 @@ jobs:
         ARCH=linux/amd64 make docker-build-multi-arch
         ARCH=linux/ppc64le make docker-build-multi-arch
         ARCH=linux/arm64/v8 make docker-build-multi-arch
+        make docker-build-push-multi-arch
 
     - name: Build and push latest multi-arch docker image
       if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
https://github.com/kubeflow/kubeflow/pull/7333 made the CI to only build the images for different archs, but not push for the tag value of the commit.

This is because the code replaced
```bash
# make docker-build-push-multi-arch
ARCH=amd64 make docker-build-multi-arch
```

While pushing the `latest` tag or a release version tag will work we still want to ensure we push an image with a tag.

You can find a [docker image](https://hub.docker.com/layers/kimwnasptd/notebook-controller/cb2590a/images/sha256-88e7248ee86db27f78b14537bcb1820de74881f37996839bc73f314d266ef5c6?context=repo) built with the above action , and the workflow that produced it in 
https://github.com/kimwnasptd/kubeflow/actions/runs/6526089745/job/17719463473