### PR TITLE
ci: bump golang version 1.17->1.20

### DIFF
--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.17'
+        go-version: '1.20'
         check-latest: true
 
     - name: Run unit tests


### PR DESCRIPTION
Bump golang version in ci runners to correctly run tests. See https://github.com/kubeflow/kubeflow/pull/7338 for a similar issue.

This unblocks the CI for #7347 