### PR TITLE
fix: return waiting on no pvcviewer status

### DIFF
--- a/components/crud-web-apps/volumes/backend/apps/common/status.py
+++ b/components/crud-web-apps/volumes/backend/apps/common/status.py
@@ -51,15 +51,14 @@ def viewer_status(viewer):
     Return a string representing the status of that viewer. If a deletion
     timestamp is set we want to return a `Terminating` state.
     """
-    try:
-        ready = viewer["status"]["ready"]
-    except KeyError:
+    if viewer is None or not viewer:
         return status.STATUS_PHASE.UNINITIALIZED
 
-    if "deletionTimestamp" in viewer["metadata"]:
+    metadata = viewer.get("metadata", {})
+    if "deletionTimestamp" in metadata:
         return status.STATUS_PHASE.TERMINATING
 
-    if not ready:
-        return status.STATUS_PHASE.WAITING
+    if viewer.get("status", {}).get("ready", False):
+        return status.STATUS_PHASE.READY
 
-    return status.STATUS_PHASE.READY
+    return status.STATUS_PHASE.WAITING


### PR DESCRIPTION
In some cases, a PVCViewer object has no status as it was just created or is having issues starting a pod.  In those cases, we should rather return waiting than uninitialized, which would appear to the users as if no viewer was started.