### PR TITLE
fix: point to ~kubeflow/styles/fonts.scss

### DIFF
--- a/components/centraldashboard-angular/frontend/cypress/e2e/url-syncing.cy.ts
+++ b/components/centraldashboard-angular/frontend/cypress/e2e/url-syncing.cy.ts
@@ -26,7 +26,7 @@ describe('Browser and Iframe URL syncing', () => {
     cy.wait('@storageClassRequest');
     cy.equalUrls();
 
-    cy.getIframeBody().find('button').contains('keyboard_backspace').click();
+    cy.getIframeBody().find('button').contains('arrow_back').click();
     cy.wait('@notebooksRequest', { timeout: 10000 });
     cy.equalUrls();
 

--- a/components/centraldashboard-angular/frontend/src/styles/styles.scss
+++ b/components/centraldashboard-angular/frontend/src/styles/styles.scss
@@ -8,7 +8,7 @@ body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
-@import '~kubeflow/lib/fonts.scss';
+@import '~kubeflow/styles/fonts.scss';
 
 // Use the material icons offline
 @import '~material-icons/iconfont/material-icons.scss';


### PR DESCRIPTION
It seems like the path to this file recently changed by #7062, which is now preventing the centraldashboard Docker image to build wich fails with a SassError when trying to import fonts.scss. This commit points to the right path.

Error log for reference:

```
 #27 90.64 ./src/styles/styles.scss - Error: Module build failed (from ./node_modules/mini-css-extract-plugin/dist/loader.js):
#27 90.64 ModuleBuildError: Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
#27 90.64 SassError: Can't find stylesheet to import.
#27 90.64    ╷
#27 90.64 11 │ @import '~kubeflow/lib/fonts.scss';
#27 90.64    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^
#27 90.64    ╵
#27 90.64   src/styles/styles.scss 11:9  root stylesheet
```

See [this build](https://github.com/kubeflow/kubeflow/actions/runs/6531881039/job/17733960649#step:5:721) for more information.