### PR TITLE
fix: point to ~kubeflow/styles/fonts.scss

### DIFF
--- a/components/centraldashboard-angular/frontend/cypress/e2e/url-syncing.cy.ts
+++ b/components/centraldashboard-angular/frontend/cypress/e2e/url-syncing.cy.ts
@@ -26,7 +26,7 @@ describe('Browser and Iframe URL syncing', () => {
     cy.wait('@storageClassRequest');
     cy.equalUrls();
 
-    cy.getIframeBody().find('button').contains('keyboard_backspace').click();
+    cy.getIframeBody().find('button').contains('arrow_back').click();
     cy.wait('@notebooksRequest', { timeout: 10000 });
     cy.equalUrls();
 

--- a/components/centraldashboard-angular/frontend/src/styles/styles.scss
+++ b/components/centraldashboard-angular/frontend/src/styles/styles.scss
@@ -8,7 +8,7 @@ body {
   font-family: Roboto, 'Helvetica Neue', sans-serif;
 }
 
-@import '~kubeflow/lib/fonts.scss';
+@import '~kubeflow/styles/fonts.scss';
 
 // Use the material icons offline
 @import '~material-icons/iconfont/material-icons.scss';


### PR DESCRIPTION
It seems like the path to this file recently changed by #7062, which is now preventing the centraldashboard Docker image to build wich fails with a SassError when trying to import fonts.scss. This commit points to the right path.

This PR cherry picks the changes of #7352 to master.