### PR TITLE
fix: remove extra ) from env variables

### DIFF
--- a/components/profile-controller/config/manager/kustomization.yaml
+++ b/components/profile-controller/config/manager/kustomization.yaml
@@ -8,7 +8,7 @@ configMapGenerator:
   - WORKLOAD_IDENTITY=
   - USERID_HEADER="kubeflow-userid"
   - USERID_PREFIX=
-  - ISTIO_INGRESS_GATEWAY_PRINCIPAL="cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account")
-  - NOTEBOOK_CONTROLLER_PRINCIPAL="cluster.local/ns/kubeflow/sa/notebook-controller-service-account")
+  - ISTIO_INGRESS_GATEWAY_PRINCIPAL="cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+  - NOTEBOOK_CONTROLLER_PRINCIPAL="cluster.local/ns/kubeflow/sa/notebook-controller-service-account"
   - KFP_UI_PRINCIPAL="cluster.local/ns/kubeflow/sa/ml-pipeline-ui"
   name: config


### PR DESCRIPTION
The ISTIO_INGRESS_GATEWAY_PRINCIPAL and NOTEBOOK_CONTROLLER_PRINCIPAL had an extra ) at the end of the value.

Fixes #7374 in v1.8-branch