### PR TITLE
ci: fix version tagging of notebook server images

### DIFF
--- a/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+++ b/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
@@ -56,12 +56,11 @@ jobs:
           SHOULD_TAG_LATEST: ${{ github.ref == 'refs/heads/master' }}
           SHOULD_TAG_VERSION: ${{ steps.filter.outputs.version == 'true' }}
         run: |
-          cd components/example-notebook-servers/
-          
           if [[ "$SHOULD_TAG_LATEST" = "true" ]]; then
             export ALSO_TAG_LATEST=1
           fi
           if [[ "$SHOULD_TAG_VERSION" = "true" ]]; then
               export ALSO_TAG_VERSION=$(cat releasing/version/VERSION)
           fi
+          cd components/example-notebook-servers/
           make docker-build-push-multi-arch


### PR DESCRIPTION
There was a small bug in the CI from https://github.com/kubeflow/kubeflow/pull/7357, which cause the release version tags to not be created (when the `releasing/version/VERSION` file is updated).

It was simply doing the `cd` too early, so the relative path was not correct.

We will probably need to quickly do a `1.8.0-rc.5` after cherry-picking this pr into the `v1.8-branch`.