### PR TITLE
chore: update default filebrowser version

### DIFF
--- a/components/crud-web-apps/volumes/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         - name: APP_SECURE_COOKIES
           value: $(VWA_APP_SECURE_COOKIES)
         - name: VOLUME_VIEWER_IMAGE
-          value: filebrowser/filebrowser:v2.23.0
+          value: filebrowser/filebrowser:v2.25.0
         volumeMounts: 
         - name: viewer-spec
           mountPath: /etc/config/viewer-spec.yaml


### PR DESCRIPTION
Filebrowser recently [released v2.25.0](https://github.com/filebrowser/filebrowser/releases/tag/v2.25.0).
Until now, we couldn't use v2.24.0, which brings chunked uploads, due to an issue with Cloudflare environments.  This got fixed in v2.25.0, so that chunked uploads should now work for every user.