### PR TITLE
fix: downgrade jupyterlab to 3.6.6

### DIFF
--- a/components/example-notebook-servers/codeserver-python/Dockerfile
+++ b/components/example-notebook-servers/codeserver-python/Dockerfile
@@ -43,11 +43,9 @@ RUN case "${TARGETARCH}" in \
  && rm /tmp/Miniforge3.sh \
  && conda config --system --set auto_update_conda false \
  && conda config --system --set show_channel_urls true \
- && echo "conda ${MINIFORGE_VERSION:0:-2}" >> ${CONDA_DIR}/conda-meta/pinned \
- && echo "python ${PYTHON_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+ && echo "python ==${PYTHON_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
  && conda install -y -q \
     python=${PYTHON_VERSION} \
-    conda=${MINIFORGE_VERSION:0:-2} \
     pip=${PIP_VERSION} \
  && conda update -y -q --all \
  && conda clean -a -f -y

--- a/components/example-notebook-servers/codeserver-python/requirements.txt
+++ b/components/example-notebook-servers/codeserver-python/requirements.txt
@@ -1,3 +1,3 @@
 # kubeflow packages
-kfp==2.3.0
-kfp-server-api==2.0.2
+kfp==2.4.0
+kfp-server-api==2.0.3

--- a/components/example-notebook-servers/jupyter-pytorch-cuda-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-pytorch-cuda-full/requirements.txt
@@ -1,3 +1,6 @@
 # kubeflow packages
-kfp==2.3.0
-kfp-server-api==2.0.2
+kfp==2.4.0
+kfp-server-api==2.0.3
+
+# jupyterlab extensions
+jupyterlab-git==0.44.0

--- a/components/example-notebook-servers/jupyter-pytorch-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-pytorch-full/requirements.txt
@@ -1,3 +1,6 @@
 # kubeflow packages
-kfp==2.3.0
-kfp-server-api==2.0.2
+kfp==2.4.0
+kfp-server-api==2.0.3
+
+# jupyterlab extensions
+jupyterlab-git==0.44.0

--- a/components/example-notebook-servers/jupyter-scipy/requirements.txt
+++ b/components/example-notebook-servers/jupyter-scipy/requirements.txt
@@ -1,3 +1,6 @@
 # kubeflow packages
-kfp==2.3.0
-kfp-server-api==2.0.2
+kfp==2.4.0
+kfp-server-api==2.0.3
+
+# jupyterlab extensions
+jupyterlab-git==0.44.0

--- a/components/example-notebook-servers/jupyter-tensorflow-cuda-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-tensorflow-cuda-full/requirements.txt
@@ -1,3 +1,6 @@
 # kubeflow packages
-kfp==2.3.0
-kfp-server-api==2.0.2
+kfp==2.4.0
+kfp-server-api==2.0.3
+
+# jupyterlab extensions
+jupyterlab-git==0.44.0

--- a/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/requirements.txt
@@ -1,3 +1,6 @@
 # kubeflow packages
-kfp==2.3.0
-kfp-server-api==2.0.2
+kfp==2.4.0
+kfp-server-api==2.0.3
+
+# jupyterlab extensions
+jupyterlab-git==0.44.0

--- a/components/example-notebook-servers/jupyter/Dockerfile
+++ b/components/example-notebook-servers/jupyter/Dockerfile
@@ -10,8 +10,8 @@ ARG TARGETARCH
 USER root
 
 # args - software versions
-ARG JUPYTERLAB_VERSION=4.0.7
-ARG JUPYTER_VERSION=7.0.5
+ARG JUPYTERLAB_VERSION=3.6.6
+ARG JUPYTER_VERSION=6.5.6
 ARG MINIFORGE_VERSION=23.3.1-1
 ARG NODE_MAJOR_VERSION=18
 ARG PIP_VERSION=23.2.1
@@ -56,18 +56,16 @@ RUN case "${TARGETARCH}" in \
  && rm /tmp/Miniforge3.sh \
  && conda config --system --set auto_update_conda false \
  && conda config --system --set show_channel_urls true \
- && echo "conda ${MINIFORGE_VERSION:0:-2}" >> ${CONDA_DIR}/conda-meta/pinned \
- && echo "python ${PYTHON_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+ && echo "python ==${PYTHON_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
  && conda install -y -q \
     python=${PYTHON_VERSION} \
-    conda=${MINIFORGE_VERSION:0:-2} \
     pip=${PIP_VERSION} \
  && conda update -y -q --all \
  && conda clean -a -f -y
 
 # install - jupyter
-RUN echo "jupyterlab >=${JUPYTERLAB_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
- && echo "notebook >=${JUPYTER_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+RUN echo "jupyterlab ==${JUPYTERLAB_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+ && echo "notebook ==${JUPYTER_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
  && conda install -y -q \
     jupyterlab==${JUPYTERLAB_VERSION} \
     notebook==${JUPYTER_VERSION} \

--- a/components/example-notebook-servers/rstudio/Dockerfile
+++ b/components/example-notebook-servers/rstudio/Dockerfile
@@ -67,17 +67,15 @@ RUN case "${TARGETARCH}" in \
  && rm /tmp/Miniforge3.sh \
  && conda config --system --set auto_update_conda false \
  && conda config --system --set show_channel_urls true \
- && echo "conda ${MINIFORGE_VERSION:0:-2}" >> ${CONDA_DIR}/conda-meta/pinned \
- && echo "python ${PYTHON_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+ && echo "python ==${PYTHON_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
  && conda install -y -q \
     python=${PYTHON_VERSION} \
-    conda=${MINIFORGE_VERSION:0:-2} \
     pip=${PIP_VERSION} \
  && conda update -y -q --all \
  && conda clean -a -f -y
 
 # install - r packages
-RUN echo "r-base ${R_BASE_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
+RUN echo "r-base ==${R_BASE_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned \
  && conda install -y -q \
     r-base=${R_BASE_VERSION} \
     r-reticulate=${R_RETICULATE_VERSION} \


### PR DESCRIPTION
Follow up to https://github.com/kubeflow/kubeflow/pull/7357

This PR downgrades JupyterLab to 3.6.6 and Jupyter Notebooks to 6.5.6.

This is to ensure compatibility with JupyterLab extensions which have not supported JupyterLab 4.0 yet.

I have also re-added the `jupyterlab-git` extension, as this was one of the plugins that did not support 4.0.

Finally, I have updated the `kfp` version to `2.4.0`, as this version fixes a bug uncovered in Kubeflow 1.8.0-rc.4.

