### PR TITLE
ci: prevent triggering release builds accidentally

### DIFF
--- a/.github/workflows/centraldb_angular_docker_publish.yaml
+++ b/.github/workflows/centraldb_angular_docker_publish.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -24,6 +24,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+++ b/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: dorny/paths-filter@v2
         id: filter
         with:
+          base: ${{ github.ref }}
           filters: |
             version:
               - 'releasing/version/VERSION'

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -24,6 +24,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -24,6 +24,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -24,6 +24,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -24,6 +24,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: dorny/paths-filter@v2
       id: filter
       with:
+        base: ${{ github.ref }}
         filters: |
           version:
             - 'releasing/version/VERSION'


### PR DESCRIPTION
There is currently a serious bug in the CI which may result in image tags being re-pushed post-release.

The issue is that our current system to detect when the `releasing/version/VERSION` file has changed (and thus a new "release" image tag needs to be created) will trigger 100% of the time.

This is because, by default, the [`dorny/paths-filter@v2`](https://github.com/dorny/paths-filter) will compare against `master`, even if the push was to the `v1.8-branch`, and there will always be a different on the `releasing/version/VERSION` between master and release branches.

This PR simply uses `${{ github.ref }}` as the base of comparison, as [suggested by the author of `dorny/paths-filter`](https://github.com/dorny/paths-filter#change-detection-workflows) for long-lived branches.

