### PR TITLE
chore: cleanup inactive owners

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -1,7 +1,8 @@
 approvers:
+  - kimwnasptd
+  - thesuperzapper
+emeritus_approvers:
   - DavidSpek
   - elikatsis
-  - kimwnasptd
   - StefanoFioravanzo
-  - thesuperzapper
   - yanniszark

--- a/components/OWNERS
+++ b/components/OWNERS
@@ -1,6 +1,7 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
+  - elikatsis
+  - StefanoFioravanzo
   - yanniszark

--- a/components/access-management/OWNERS
+++ b/components/access-management/OWNERS
@@ -1,7 +1,7 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
+  - elikatsis
+  - StefanoFioravanzo
   - yanniszark
-reviewers:

--- a/components/admission-webhook/OWNERS
+++ b/components/admission-webhook/OWNERS
@@ -1,8 +1,8 @@
 approvers:
-  - discordianfish
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
+  - elikatsis
+  - discordianfish
+  - StefanoFioravanzo
   - yanniszark
-reviewers:

--- a/components/centraldashboard-angular/OWNERS
+++ b/components/centraldashboard-angular/OWNERS
@@ -1,5 +1,6 @@
 approvers:
   - orfeas-k
-  - tasos-ale
 reviewers:
   - kimwnasptd
+emeritus_approvers:
+  - tasos-ale

--- a/components/centraldashboard/OWNERS
+++ b/components/centraldashboard/OWNERS
@@ -1,9 +1,7 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
+  - elikatsis
+  - StefanoFioravanzo
   - yanniszark
-reviewers:
-  - avdaredevil
-  - SachinVarghese

--- a/components/crud-web-apps/OWNERS
+++ b/components/crud-web-apps/OWNERS
@@ -1,6 +1,6 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
-reviewers:
+emeritus_approvers:
+  - elikatsis
+  - StefanoFioravanzo

--- a/components/crud-web-apps/common/frontend/OWNERS
+++ b/components/crud-web-apps/common/frontend/OWNERS
@@ -1,4 +1,5 @@
 approvers:
-- elenzio9
-- orfeas-k
-- tasos-ale
+  - elenzio9
+  - orfeas-k
+emeritus_approvers:
+  - tasos-ale

--- a/components/crud-web-apps/jupyter/frontend/OWNERS
+++ b/components/crud-web-apps/jupyter/frontend/OWNERS
@@ -1,4 +1,5 @@
 approvers:
-- elenzio9
-- orfeas-k
-- tasos-ale
+  - elenzio9
+  - orfeas-k
+emeritus_approvers:
+  - tasos-ale

--- a/components/crud-web-apps/tensorboards/frontend/OWNERS
+++ b/components/crud-web-apps/tensorboards/frontend/OWNERS
@@ -1,4 +1,5 @@
 approvers:
-- elenzio9
-- orfeas-k
-- tasos-ale
+  - elenzio9
+  - orfeas-k
+emeritus_approvers:
+  - tasos-ale

--- a/components/crud-web-apps/volumes/frontend/OWNERS
+++ b/components/crud-web-apps/volumes/frontend/OWNERS
@@ -1,4 +1,5 @@
 approvers:
-- elenzio9
-- orfeas-k
-- tasos-ale
+  - elenzio9
+  - orfeas-k
+emeritus_approvers:
+  - tasos-ale

--- a/components/example-notebook-servers/OWNERS
+++ b/components/example-notebook-servers/OWNERS
@@ -1,7 +1,7 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
   - DavidSpek
-reviewers:
+  - elikatsis
+  - StefanoFioravanzo

--- a/components/notebook-controller/OWNERS
+++ b/components/notebook-controller/OWNERS
@@ -1,8 +1,7 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
+  - elikatsis
+  - StefanoFioravanzo
   - yanniszark
-reviewers:
-  - MartinForReal

--- a/components/profile-controller/OWNERS
+++ b/components/profile-controller/OWNERS
@@ -1,8 +1,8 @@
 approvers:
-  - elikatsis
   - kimwnasptd
+  - thesuperzapper
+emeritus_approvers:
+  - elikatsis
   - kunmingg
   - StefanoFioravanzo
-  - thesuperzapper
   - yanniszark
-reviewers:

--- a/components/tensorboard-controller/OWNERS
+++ b/components/tensorboard-controller/OWNERS
@@ -1,5 +1,0 @@
-approvers:
-  - elikatsis
-  - kandrio98
-  - kimwnasptd
-reviewers:

--- a/py/OWNERS
+++ b/py/OWNERS
@@ -1,7 +1,8 @@
 approvers:
-  - elikatsis
   - kimwnasptd
+  - thesuperzapper
+emeritus_approvers:
+  - elikatsis
   - PatrickXYS
   - StefanoFioravanzo
-  - thesuperzapper
   - yanniszark

--- a/releasing/OWNERS
+++ b/releasing/OWNERS
@@ -1,6 +1,7 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
+  - elikatsis
+  - StefanoFioravanzo
   - yanniszark

--- a/testing/gh-actions/OWNERS
+++ b/testing/gh-actions/OWNERS
@@ -1,6 +1,7 @@
 approvers:
-  - elikatsis
   - kimwnasptd
-  - StefanoFioravanzo
   - thesuperzapper
+emeritus_approvers:
+  - elikatsis
+  - StefanoFioravanzo
   - yanniszark


### PR DESCRIPTION
This PR is an important cleanup of the OWNERS files.

It will reduce the project's exposure to potentially compromised GitHub accounts by removing access from users who no longer need it.

I have removed reviewers and approvers who have not interacted with the `kubeflow/kubeflow` repo in the last year, or who are no longer associated with the project due to moving companies.

To pay respect to historical approvers, I have moved them to the `emeritus_approvers` section, which does not convey any permission, but denotes that they once had approver access. (Read more about this in the [Kubernetes OWNERs docs](https://www.kubernetes.dev/docs/guide/owners/#emeritus)).

---

This PR will also reduce the frustration of people who make PRs because it will prevent inactive members from being assigned/tagged to review/approve them.


