### PR TITLE
fix: jupyterlab runtime volume permissions

### DIFF
--- a/components/example-notebook-servers/jupyter/Dockerfile
+++ b/components/example-notebook-servers/jupyter/Dockerfile
@@ -79,16 +79,14 @@ RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
 # s6 - copy scripts
 COPY --chown=${NB_USER}:users --chmod=755 s6/ /etc
 
+# configure - jupyter
+RUN jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
+
 # s6 - 01-copy-tmp-home
 USER root
 RUN mkdir -p /tmp_home \
  && cp -r ${HOME} /tmp_home \
  && chown -R ${NB_USER}:users /tmp_home
 USER $NB_UID
-
-# generate jupyter config
-RUN jupyter notebook --generate-config \
- && jupyter lab --generate-config \
- && jupyter labextension disable "@jupyterlab/apputils-extension:announcements"
 
 EXPOSE 8888

--- a/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
+++ b/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
@@ -1,4 +1,9 @@
 #!/command/with-contenv bash
+
+# the runtime directory must be a path that is NOT a persistent volume
+# as volumes often cause permission issues https://github.com/jupyter/notebook/issues/5058
+export JUPYTER_RUNTIME_DIR="/tmp/jupyter_runtime"
+
 cd "${HOME}"
 exec /opt/conda/bin/jupyter lab \
   --notebook-dir="${HOME}" \
@@ -9,5 +14,6 @@ exec /opt/conda/bin/jupyter lab \
   --ServerApp.token="" \
   --ServerApp.password="" \
   --ServerApp.allow_origin="*" \
-  --ServerApp.base_url="${NB_PREFIX}" \
-  --ServerApp.authenticate_prometheus=False
+  --ServerApp.allow_remote_access=True \
+  --ServerApp.authenticate_prometheus=False \
+  --ServerApp.base_url="${NB_PREFIX}"


### PR DESCRIPTION
resolves #7370

This PR fixes a longstanding issue in the JupyterLab images, which can cause them to fail to start if the PVC mounted to the home directory has incorrect file permissions for the `/home/jovyan/.local/share/jupyter/runtime` folder. 

This issue often happens for NFS-based PVCs because they typically do not support Unix file permissions, so they often present everything as 755.

The runtime files should not be persisted between restarts, so this PR makes them be stored in the `/tmp` directory.

---

It also adds the `--ServerApp.allow_remote_access=True` argument, which is unrelated, but a good idea to prevent proxy issues.