### PR TITLE
Prevent S6 timeouts on container start by setting S6_CMD_WAIT_FOR_SER…

### DIFF
--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -13,6 +13,8 @@ ENV NB_UID 1000
 ENV NB_PREFIX /
 ENV HOME /home/$NB_USER
 ENV SHELL /bin/bash
+# Might be needed for slow storage see https://github.com/pi-hole/docker-pi-hole/pull/1192
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME 0 
 
 # args - software versions
 ARG KUBECTL_VERSION=v1.27.6


### PR DESCRIPTION
…VICES_MAXTIME to 0

Might be needed for slow storage see https://github.com/pi-hole/docker-pi-hole/pull/1192

@thesuperzapper i did not yet test this.

Fixes https://github.com/kubeflow/kubeflow/issues/7370#issuecomment-1830802354