### PR TITLE
fix: :label: Ensure username is returned by `get_username` as a string

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {name}
   annotations:
     notebooks.kubeflow.org/server-type: ""
-    notebooks.kubeflow.org/creator: {creator}
+    notebooks.kubeflow.org/creator: "{creator}"
 spec:
   template:
     spec:


### PR DESCRIPTION
In order to maintain consistency and compatibility, explicitly convert the 'username' variable to a string using the str() function before returning it. This ensures that the function consistently provides a string representation of the username, addressing potential variations in the original data type.

https://github.com/kubeflow/kubeflow/issues/7456

Update notebook_template.yaml