### PR TITLE
fix: resolve service name conflict for notebooks and tensorboards

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -449,7 +449,7 @@ func generateService(instance *v1beta1.Notebook) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     "ClusterIP",
-			Selector: map[string]string{"statefulset": instance.Name},
+			Selector: map[string]string{"statefulset": instance.Name, "notebook-name": instance.Name},
 			Ports: []corev1.ServicePort{
 				{
 					// Make port name follow Istio pattern so it can be managed by istio rbac

--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -444,7 +444,7 @@ func generateService(instance *v1beta1.Notebook) *corev1.Service {
 	}
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      instance.Name,
+			Name:      fmt.Sprintf("notebook-%s-%s", instance.Namespace, instance.Name),
 			Namespace: instance.Namespace,
 		},
 		Spec: corev1.ServiceSpec{

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -252,6 +252,7 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 		(podLabels)[k] = v
 	}
 	(podLabels)["app"] = tb.Name
+	(podLabels)["tensorboard-name"] = tb.Name
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -263,6 +264,7 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": tb.Name,
+					"tensorboard-name": tb.Name,
 				},
 			},
 			Template: corev1.PodTemplateSpec{
@@ -306,7 +308,7 @@ func generateService(tb *tensorboardv1alpha1.Tensorboard) *corev1.Service {
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     "ClusterIP",
-			Selector: map[string]string{"app": tb.Name},
+			Selector: map[string]string{"app": tb.Name, "tensorboard-name": tb.Name},
 			Ports: []corev1.ServicePort{
 				corev1.ServicePort{
 					Name:       "http-" + tb.Name,
@@ -409,8 +411,8 @@ func extractPVCSubPath(path string) string {
 	}
 }
 
-//Searches a corev1.PodList for running pods and returns
-//a running corev1.Pod (if exists)
+// Searches a corev1.PodList for running pods and returns
+// a running corev1.Pod (if exists)
 func findRunningPod(pods *corev1.PodList) corev1.Pod {
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == "Running" {
@@ -470,9 +472,9 @@ func generateNodeAffinity(affinity *corev1.Affinity, pvcname string, r *Tensorbo
 	return nil
 }
 
-//Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
-//'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
-//returned boolean is set to 'false', so that the scheduling functionality is off by default.
+// Checks the value of 'RWO_PVC_SCHEDULING' env var (if present in the environment) and returns
+// 'true' or 'false' accordingly. If 'RWO_PVC_SCHEDULING' is NOT present, then the value of the
+// returned boolean is set to 'false', so that the scheduling functionality is off by default.
 func rwoPVCScheduling() (error, bool) {
 	if value, exists := os.LookupEnv("RWO_PVC_SCHEDULING"); !exists || value == "false" || value == "False" || value == "FALSE" {
 		return nil, false

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -301,7 +301,7 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 func generateService(tb *tensorboardv1alpha1.Tensorboard) *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      tb.Name,
+			Name:      fmt.Sprintf("tensorboard-%s", tb.Name),
 			Namespace: tb.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
@@ -335,7 +335,7 @@ func generateVirtualService(tb *tensorboardv1alpha1.Tensorboard) (*unstructured.
 	vsvc := &unstructured.Unstructured{}
 	vsvc.SetAPIVersion("networking.istio.io/v1alpha3")
 	vsvc.SetKind("VirtualService")
-	vsvc.SetName(tb.Name)
+	vsvc.SetName(fmt.Sprintf("tensorboard-%s", tb.Name))
 	vsvc.SetNamespace(tb.Namespace)
 	if err := unstructured.SetNestedStringSlice(vsvc.Object, []string{istioHost}, "spec", "hosts"); err != nil {
 		return nil, fmt.Errorf("Set .spec.hosts error: %v", err)


### PR DESCRIPTION
#### Related Issues/PRs
Closes kubeflow/dashboard#50

#### Changes

###### Notebook Controller
* Update names of `service`, `virtualService` and `statefulset` resource to include
  * `nb-{notebook_name}-`  with `generateName` 
* Added a reconcile check for name length check as we are adding prefixes
* Added a function that deletes obsolete services, so as to not leave dangling services after folks update.
* * Added a function that deletes obsolete services, so as to not leave dangling services after folks update.
* Update `servicename` in `virtualService` after reconciliation of service
* Upated code and tests to check owner reference as the source of resource connection

###### Tensorboard Controller
* Update `name` of `service` and `virtualService` to `tb-{notebook-name}`
* Add label `tensorboard-name` in pods and for service label selector
* Add label `notebook-name` in service `selector`
* Added a reconcile check for name length check as we are adding prefixes

#### Comments
- This might be a breaking change, and if there are notebook servers with long names, they might fail to reconcile as we are adding name, and namespace prefix.