### PR TITLE
fix(crud-web-apps/jupyter): dict variable reference for `node.status.capacity`

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py
@@ -115,10 +115,10 @@ def get_gpu_vendors():
     nodes = api.list_nodes().items
     for node in nodes:
         if node.status.capacity:
-            installed_resources.update(status.capacity.keys())
+            installed_resources.update(node.status.capacity.keys())
         else:
             log.debug(
-                "Capacity was not available for node {node.metadata.name}"
+                f"Capacity was not available for node {node.metadata.name}"
             )
 
     # Keep the vendors the key of which exists in at least one node


### PR DESCRIPTION
#### Related Issues/PRs
Fixes #7441

#### Changes
* Corrected node status reference
* Converted string to f-string

#### Comments

Previous known working version
https://github.com/kubeflow/kubeflow/blob/0c0c76300d8df28f0b7cac95099c286e4dab3288/components/crud-web-apps/jupyter/backend/apps/common/routes/get.py#L117

