### PR TITLE
fix(notebooks): add CRD validation for empty image and container

### DIFF
--- a/components/notebook-controller/config/crd/kustomization.yaml
+++ b/components/notebook-controller/config/crd/kustomization.yaml
@@ -21,3 +21,12 @@ patchesStrategicMerge:
 # the following config is for teaching kustomize how to do kustomization for CRDs.
 configurations:
 - kustomizeconfig.yaml
+
+patchesJson6902:
+  - target:
+      group: apiextensions.k8s.io
+      version: v1
+      kind: CustomResourceDefinition
+      name: notebooks.kubeflow.org
+    path: patches/validation_patches.yaml
+

--- a/components/notebook-controller/config/crd/patches/validation_patches.yaml
+++ b/components/notebook-controller/config/crd/patches/validation_patches.yaml
@@ -1,0 +1,29 @@
+- op: replace
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/template/properties/spec/properties/containers/items/required
+  value: 
+    - name
+    - image
+
+- op: replace
+  path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/template/properties/spec/properties/containers/items/required
+  value: 
+    - name
+    - image
+
+- op: replace
+  path: /spec/versions/2/schema/openAPIV3Schema/properties/spec/properties/template/properties/spec/properties/containers/items/required
+  value: 
+    - name
+    - image
+
+- op: add
+  path: /spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/template/properties/spec/properties/containers/minItems
+  value: 1
+
+- op: add
+  path: /spec/versions/1/schema/openAPIV3Schema/properties/spec/properties/template/properties/spec/properties/containers/minItems
+  value: 1
+
+- op: add
+  path: /spec/versions/2/schema/openAPIV3Schema/properties/spec/properties/template/properties/spec/properties/containers/minItems
+  value: 1


### PR DESCRIPTION
#### Related Issues/Tickets
Closes #6886

#### Changes
- Added json6902 patch for adding cel validation on notebooks crd to avoid
  - empty image names
  - at least 1 container objects in container array

#### Comments
Tested locally by running kustomize locally