### PR TITLE
fix: increase S6_CMD_WAIT_FOR_SERVICES_MAXTI…

### DIFF
--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -14,7 +14,8 @@ ENV NB_PREFIX /
 ENV HOME /home/$NB_USER
 ENV SHELL /bin/bash
 # Might be needed for slow storage see https://github.com/pi-hole/docker-pi-hole/pull/1192
-ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME 0 
+# Value is in milliseconds and 300000 is 5 minutes
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME 300000
 
 # args - software versions
 ARG KUBECTL_VERSION=v1.27.6


### PR DESCRIPTION
#### Related Issues/PRs
Related to #7421

#### Changes
- Updated the default to 5 mins, instead of infinity.
- Default is 5000 (ms) https://github.com/just-containers/s6-overlay/blob/941fbd88c809a591367cd4acb520a97c47d4f882/README.md?plain=1#L876
