### PR TITLE
Add error log for YAML parsing

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/helpers.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/helpers.py
@@ -51,7 +51,8 @@ def load_yaml(f):
         else:
             # YAML exists and is not empty
             return contents
-    except yaml.YAMLError:
+    except yaml.YAMLError as e:
+        log.error("Error parsing: %s, %s", f, e)
         return None
 
 
@@ -80,7 +81,8 @@ def load_param_yaml(f, **kwargs):
         else:
             # YAML exists and is not empty
             return contents
-    except yaml.YAMLError:
+    except yaml.YAMLError as e:
+        log.error("Error parsing: %s, %s", f, e)
         return None
 
 


### PR DESCRIPTION
Currently, when a YAML parsing error occurs in `load_yaml` and `load_param_yaml`, no error log is output.

This is useful for troubleshooting problems such as when `spawner_ui_config.yaml` is not reflected.