### PR TITLE
feat: update dashboard styles and links

### DIFF
--- a/components/centraldashboard/config/centraldashboard-config.yaml
+++ b/components/centraldashboard/config/centraldashboard-config.yaml
@@ -2,91 +2,118 @@ apiVersion: v1
 data:
   settings: |-
     {
-      DASHBOARD_FORCE_IFRAME: true
+      "DASHBOARD_FORCE_IFRAME": true
     }
   links: |-
     {
-      "menuLinks": [
-        {
-          "link": "/jupyter/",
-          "text": "Notebooks",
-          "icon": "book"
-        },
-        {
-          "link": "/tensorboards/",
-          "text": "Tensorboards",
-          "icon": "assessment"
-        },
-        {
-          "link": "/volumes/",
-          "text": "Volumes",
-          "icon": "device:storage"
-        },
-        {
-          "link": "/pipeline/",
-          "text": "Pipelines",
-          "icon": "kubeflow:pipeline-centered"
-        },
-        {
-          "link": "/katib/",
-          "text": "Katib"
-        }
-      ],
-      "externalLinks": [],
-      "quickLinks": [
-        {
-          "text": "Upload a pipeline",
-          "desc": "Pipelines",
-          "link": "/pipeline/"
-        },
-        {
-          "text": "View all pipeline runs",
-          "desc": "Pipelines",
-          "link": "/pipeline/#/runs"
-        },
-        {
-          "text": "Create a new Notebook server",
-          "desc": "Notebook Servers",
-          "link": "/jupyter/new?namespace=kubeflow"
-        },
-        {
-          "text": "View Katib Experiments",
-          "desc": "Katib",
-          "link": "/katib/"
-        }
-      ],
-      "documentationItems": [
-        {
-          "text": "Getting Started with Kubeflow",
-          "desc": "Get your machine-learning workflow up and running on Kubeflow",
-          "link": "https://www.kubeflow.org/docs/started/getting-started/"
-        },
-        {
-          "text": "MiniKF",
-          "desc": "A fast and easy way to deploy Kubeflow locally",
-          "link": "https://www.kubeflow.org/docs/distributions/minikf/"
-        },
-        {
-          "text": "Microk8s for Kubeflow",
-          "desc": "Quickly get Kubeflow running locally on native hypervisors",
-          "link": "https://www.kubeflow.org/docs/distributions/microk8s/kubeflow-on-microk8s/"
-        },
-        {
-          "text": "Kubeflow on GCP",
-          "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
-          "link": "https://www.kubeflow.org/docs/gke/"
-        },
-        {
-          "text": "Kubeflow on AWS",
-          "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
-          "link": "https://www.kubeflow.org/docs/aws/"
-        },
-        {
-          "text": "Requirements for Kubeflow",
-          "desc": "Get more detailed information about using Kubeflow and its components",
-          "link": "https://www.kubeflow.org/docs/started/requirements/"
-        }
-      ]
+        "menuLinks": [
+            {
+                "icon": "book",
+                "link": "/jupyter/",
+                "text": "Notebooks",
+                "type": "item"
+            },
+            {
+                "icon": "assessment",
+                "link": "/tensorboards/",
+                "text": "TensorBoards",
+                "type": "item"
+            },
+            {
+                "icon": "device:storage",
+                "link": "/volumes/",
+                "text": "Volumes",
+                "type": "item"
+            },
+            {
+                "icon": "kubeflow:katib",
+                "link": "/katib/",
+                "text": "Katib Experiments",
+                "type": "item"
+            },
+            {
+                "icon": "kubeflow:pipeline-centered",
+                "items": [
+                    {
+                        "link": "/pipeline/#/pipelines",
+                        "text": "Pipelines",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/experiments",
+                        "text": "Experiments",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/runs",
+                        "text": "Runs",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/recurringruns",
+                        "text": "Recurring Runs",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/artifacts",
+                        "text": "Artifacts",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/executions",
+                        "text": "Executions",
+                        "type": "item"
+                    }
+                ],
+                "text": "Pipelines",
+                "type": "section"
+            }
+        ],
+        "externalLinks": [],
+        "documentationItems": [
+            {
+                "desc": "The Kubeflow website",
+                "link": "https://www.kubeflow.org/",
+                "text": "Kubeflow Website"
+            },
+            {
+                "desc": "Documentation for Kubeflow Pipelines",
+                "link": "https://www.kubeflow.org/docs/components/pipelines/",
+                "text": "Kubeflow Pipelines Documentation"
+            },
+            {
+                "desc": "Documentation for Kubeflow Notebooks",
+                "link": "https://www.kubeflow.org/docs/components/notebooks/",
+                "text": "Kubeflow Notebooks Documentation"
+            },
+            {
+                "desc": "Documentation for Kubeflow Training Operator",
+                "link": "https://www.kubeflow.org/docs/components/training/",
+                "text": "Kubeflow Training Operator Documentation"
+            },
+            {
+                "desc": "Documentation for Katib",
+                "link": "https://www.kubeflow.org/docs/components/katib/",
+                "text": "Katib Documentation"
+            }
+        ],
+        "quickLinks": [
+            {
+                "desc": "Kubeflow Notebooks",
+                "link": "/jupyter/new",
+                "text": "Create a new Notebook"
+            },
+            {
+                "desc": "Kubeflow Pipelines",
+                "link": "/pipeline/#/pipelines",
+                "text": "Upload a Pipeline"
+            },
+            {
+                "desc": "Pipelines",
+                "link": "/pipeline/#/runs",
+                "text": "View Pipeline Runs"
+            }
+        ]
     }
 kind: ConfigMap
 metadata:

--- a/components/centraldashboard/manifests/base/configmap.yaml
+++ b/components/centraldashboard/manifests/base/configmap.yaml
@@ -6,128 +6,113 @@ data:
     }
   links: |-
     {
-      "menuLinks": [
-        {
-          "type": "item",
-          "link": "/jupyter/",
-          "text": "Notebooks",
-          "icon": "book"
-        },
-        {
-          "type": "item",
-          "link": "/tensorboards/",
-          "text": "Tensorboards",
-          "icon": "assessment"
-        },
-        {
-          "type": "item",
-          "link": "/volumes/",
-          "text": "Volumes",
-          "icon": "device:storage"
-        },
-        {
-          "type": "item",
-          "link": "/models/",
-          "text": "Endpoints",
-          "icon": "kubeflow:models"
-        },
-        {
-          "type": "item",
-          "link": "/katib/",
-          "text": "Experiments (AutoML)",
-          "icon": "kubeflow:katib"
-        },
-        {
-          "type": "item",
-          "text": "Experiments (KFP)",
-          "link": "/pipeline/#/experiments",
-          "icon": "done-all"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/pipelines",
-          "text": "Pipelines",
-          "icon": "kubeflow:pipeline-centered"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/runs",
-          "text": "Runs",
-          "icon": "maps:directions-run"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/recurringruns",
-          "text": "Recurring Runs",
-          "icon": "device:access-alarm"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/artifacts",
-          "text": "Artifacts",
-          "icon": "editor:bubble-chart"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/executions",
-          "text": "Executions",
-          "icon": "av:play-arrow"
-        }
-      ],
-      "externalLinks": [ ],
-        "quickLinks": [
-          {
-            "text": "Upload a pipeline",
-            "desc": "Pipelines",
-            "link": "/pipeline/"
-          },
-          {
-            "text": "View all pipeline runs",
-            "desc": "Pipelines",
-            "link": "/pipeline/#/runs"
-          },
-          {
-            "text": "Create a new Notebook server",
-            "desc": "Notebook Servers",
-            "link": "/jupyter/new?namespace=kubeflow"
-          },
-          {
-            "text": "View Katib Experiments",
-            "desc": "Katib",
-            "link": "/katib/"
-          }
+        "menuLinks": [
+            {
+                "icon": "book",
+                "link": "/jupyter/",
+                "text": "Notebooks",
+                "type": "item"
+            },
+            {
+                "icon": "assessment",
+                "link": "/tensorboards/",
+                "text": "TensorBoards",
+                "type": "item"
+            },
+            {
+                "icon": "device:storage",
+                "link": "/volumes/",
+                "text": "Volumes",
+                "type": "item"
+            },
+            {
+                "icon": "kubeflow:katib",
+                "link": "/katib/",
+                "text": "Katib Experiments",
+                "type": "item"
+            },
+            {
+                "icon": "kubeflow:pipeline-centered",
+                "items": [
+                    {
+                        "link": "/pipeline/#/pipelines",
+                        "text": "Pipelines",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/experiments",
+                        "text": "Experiments",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/runs",
+                        "text": "Runs",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/recurringruns",
+                        "text": "Recurring Runs",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/artifacts",
+                        "text": "Artifacts",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/executions",
+                        "text": "Executions",
+                        "type": "item"
+                    }
+                ],
+                "text": "Pipelines",
+                "type": "section"
+            }
         ],
+        "externalLinks": [],
         "documentationItems": [
-          {
-            "text": "Getting Started with Kubeflow",
-            "desc": "Get your machine-learning workflow up and running on Kubeflow",
-            "link": "https://www.kubeflow.org/docs/started/getting-started/"
-          },
-          {
-            "text": "MiniKF",
-            "desc": "A fast and easy way to deploy Kubeflow locally",
-            "link": "https://www.kubeflow.org/docs/distributions/minikf/"
-          },
-          {
-            "text": "Microk8s for Kubeflow",
-            "desc": "Quickly get Kubeflow running locally on native hypervisors",
-            "link": "https://www.kubeflow.org/docs/distributions/microk8s/kubeflow-on-microk8s/"
-          },
-          {
-            "text": "Kubeflow on GCP",
-            "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
-            "link": "https://www.kubeflow.org/docs/gke/"
-          },
-          {
-            "text": "Kubeflow on AWS",
-            "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
-            "link": "https://www.kubeflow.org/docs/aws/"
-          },
-          {
-            "text": "Requirements for Kubeflow",
-            "desc": "Get more detailed information about using Kubeflow and its components",
-            "link": "https://www.kubeflow.org/docs/started/requirements/"
-          }
+            {
+                "desc": "The Kubeflow website",
+                "link": "https://www.kubeflow.org/",
+                "text": "Kubeflow Website"
+            },
+            {
+                "desc": "Documentation for Kubeflow Pipelines",
+                "link": "https://www.kubeflow.org/docs/components/pipelines/",
+                "text": "Kubeflow Pipelines Documentation"
+            },
+            {
+                "desc": "Documentation for Kubeflow Notebooks",
+                "link": "https://www.kubeflow.org/docs/components/notebooks/",
+                "text": "Kubeflow Notebooks Documentation"
+            },
+            {
+                "desc": "Documentation for Kubeflow Training Operator",
+                "link": "https://www.kubeflow.org/docs/components/training/",
+                "text": "Kubeflow Training Operator Documentation"
+            },
+            {
+                "desc": "Documentation for Katib",
+                "link": "https://www.kubeflow.org/docs/components/katib/",
+                "text": "Katib Documentation"
+            }
+        ],
+        "quickLinks": [
+            {
+                "desc": "Kubeflow Notebooks",
+                "link": "/jupyter/new",
+                "text": "Create a new Notebook"
+            },
+            {
+                "desc": "Kubeflow Pipelines",
+                "link": "/pipeline/#/pipelines",
+                "text": "Upload a Pipeline"
+            },
+            {
+                "desc": "Pipelines",
+                "link": "/pipeline/#/runs",
+                "text": "View Pipeline Runs"
+            }
         ]
     }
 kind: ConfigMap

--- a/components/centraldashboard/manifests/overlays/kserve/patches/configmap.yaml
+++ b/components/centraldashboard/manifests/overlays/kserve/patches/configmap.yaml
@@ -6,128 +6,119 @@ data:
     }
   links: |-
     {
-      "menuLinks": [
-        {
-          "type": "item",
-          "link": "/jupyter/",
-          "text": "Notebooks",
-          "icon": "book"
-        },
-        {
-          "type": "item",
-          "link": "/tensorboards/",
-          "text": "Tensorboards",
-          "icon": "assessment"
-        },
-        {
-          "type": "item",
-          "link": "/volumes/",
-          "text": "Volumes",
-          "icon": "device:storage"
-        },
-        {
-          "type": "item",
-          "link": "/kserve-endpoints/",
-          "text": "Endpoints",
-          "icon": "kubeflow:models"
-        },
-        {
-          "type": "item",
-          "link": "/katib/",
-          "text": "Experiments (AutoML)",
-          "icon": "kubeflow:katib"
-        },
-        {
-          "type": "item",
-          "text": "Experiments (KFP)",
-          "link": "/pipeline/#/experiments",
-          "icon": "done-all"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/pipelines",
-          "text": "Pipelines",
-          "icon": "kubeflow:pipeline-centered"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/runs",
-          "text": "Runs",
-          "icon": "maps:directions-run"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/recurringruns",
-          "text": "Recurring Runs",
-          "icon": "device:access-alarm"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/artifacts",
-          "text": "Artifacts",
-          "icon": "editor:bubble-chart"
-        },
-        {
-          "type": "item",
-          "link": "/pipeline/#/executions",
-          "text": "Executions",
-          "icon": "av:play-arrow"
-        }
-      ],
-      "externalLinks": [ ],
-        "quickLinks": [
-          {
-            "text": "Upload a pipeline",
-            "desc": "Pipelines",
-            "link": "/pipeline/"
-          },
-          {
-            "text": "View all pipeline runs",
-            "desc": "Pipelines",
-            "link": "/pipeline/#/runs"
-          },
-          {
-            "text": "Create a new Notebook server",
-            "desc": "Notebook Servers",
-            "link": "/jupyter/new?namespace=kubeflow"
-          },
-          {
-            "text": "View Katib Experiments",
-            "desc": "Katib",
-            "link": "/katib/"
-          }
+        "menuLinks": [
+            {
+                "icon": "book",
+                "link": "/jupyter/",
+                "text": "Notebooks",
+                "type": "item"
+            },
+            {
+                "icon": "assessment",
+                "link": "/tensorboards/",
+                "text": "TensorBoards",
+                "type": "item"
+            },
+            {
+                "icon": "device:storage",
+                "link": "/volumes/",
+                "text": "Volumes",
+                "type": "item"
+            },
+            {
+                "icon": "kubeflow:katib",
+                "link": "/katib/",
+                "text": "Katib Experiments",
+                "type": "item"
+            },
+            {
+                "type": "item",
+                "link": "/models/",
+                "text": "KServe Endpoints",
+                "icon": "kubeflow:models"
+            },
+            {
+                "icon": "kubeflow:pipeline-centered",
+                "items": [
+                    {
+                        "link": "/pipeline/#/pipelines",
+                        "text": "Pipelines",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/experiments",
+                        "text": "Experiments",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/runs",
+                        "text": "Runs",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/recurringruns",
+                        "text": "Recurring Runs",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/artifacts",
+                        "text": "Artifacts",
+                        "type": "item"
+                    },
+                    {
+                        "link": "/pipeline/#/executions",
+                        "text": "Executions",
+                        "type": "item"
+                    }
+                ],
+                "text": "Pipelines",
+                "type": "section"
+            }
         ],
+        "externalLinks": [],
         "documentationItems": [
-          {
-            "text": "Getting Started with Kubeflow",
-            "desc": "Get your machine-learning workflow up and running on Kubeflow",
-            "link": "https://www.kubeflow.org/docs/started/getting-started/"
-          },
-          {
-            "text": "MiniKF",
-            "desc": "A fast and easy way to deploy Kubeflow locally",
-            "link": "https://www.kubeflow.org/docs/distributions/minikf/"
-          },
-          {
-            "text": "Microk8s for Kubeflow",
-            "desc": "Quickly get Kubeflow running locally on native hypervisors",
-            "link": "https://www.kubeflow.org/docs/distributions/microk8s/kubeflow-on-microk8s/"
-          },
-          {
-            "text": "Kubeflow on GCP",
-            "desc": "Running Kubeflow on Kubernetes Engine and Google Cloud Platform",
-            "link": "https://www.kubeflow.org/docs/gke/"
-          },
-          {
-            "text": "Kubeflow on AWS",
-            "desc": "Running Kubeflow on Elastic Container Service and Amazon Web Services",
-            "link": "https://www.kubeflow.org/docs/aws/"
-          },
-          {
-            "text": "Requirements for Kubeflow",
-            "desc": "Get more detailed information about using Kubeflow and its components",
-            "link": "https://www.kubeflow.org/docs/started/requirements/"
-          }
+            {
+                "desc": "The Kubeflow website",
+                "link": "https://www.kubeflow.org/",
+                "text": "Kubeflow Website"
+            },
+            {
+                "desc": "Documentation for Kubeflow Pipelines",
+                "link": "https://www.kubeflow.org/docs/components/pipelines/",
+                "text": "Kubeflow Pipelines Documentation"
+            },
+            {
+                "desc": "Documentation for Kubeflow Notebooks",
+                "link": "https://www.kubeflow.org/docs/components/notebooks/",
+                "text": "Kubeflow Notebooks Documentation"
+            },
+            {
+                "desc": "Documentation for Kubeflow Training Operator",
+                "link": "https://www.kubeflow.org/docs/components/training/",
+                "text": "Kubeflow Training Operator Documentation"
+            },
+            {
+                "desc": "Documentation for Katib",
+                "link": "https://www.kubeflow.org/docs/components/katib/",
+                "text": "Katib Documentation"
+            }
+        ],
+        "quickLinks": [
+            {
+                "desc": "Kubeflow Notebooks",
+                "link": "/jupyter/new",
+                "text": "Create a new Notebook"
+            },
+            {
+                "desc": "Kubeflow Pipelines",
+                "link": "/pipeline/#/pipelines",
+                "text": "Upload a Pipeline"
+            },
+            {
+                "desc": "Pipelines",
+                "link": "/pipeline/#/runs",
+                "text": "View Pipeline Runs"
+            }
         ]
     }
 kind: ConfigMap

--- a/components/centraldashboard/public/components/main-page.css
+++ b/components/centraldashboard/public/components/main-page.css
@@ -58,13 +58,6 @@ app-drawer-layout[narrow] #MainDrawer {
     }
 }
 
-app-drawer-layout[bleed] #MainDrawer {
-    background: var(--primary-background-color);
-    --app-drawer-content-container: {
-        background: transparent !important;
-    }
-}
-
 #PageLoader {
     @apply --layout-fullbleed;
     @apply --layout-center-center;
@@ -107,7 +100,7 @@ app-drawer-layout[bleed] #MainDrawer {
 }
 
 #MainDrawer .inner-menu-item {
-    padding-left: 65px;
+    padding-left: 60px;
     margin: 0;
     font-size: 13px;
     min-height: 30px;

--- a/components/centraldashboard/public/components/main-page.js
+++ b/components/centraldashboard/public/components/main-page.js
@@ -444,7 +444,16 @@ export class MainPage extends utilitiesMixin(PolymerElement) {
     }
 
     _toggleMenuSection(e) {
-        e.target.nextElementSibling.toggle();
+        // look upwards until we find <paper-item>
+        let el = e.target;
+        while (el && el.tagName !== 'PAPER-ITEM') {
+            el = el.parentElement;
+        }
+
+        // if we found paper-item, the next sibling is the section
+        if (el) {
+            el.nextElementSibling.toggle();
+        }
     }
 
     /**

--- a/components/centraldashboard/public/components/main-page.pug
+++ b/components/centraldashboard/public/components/main-page.pug
@@ -32,7 +32,8 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                     iron-collapse
                         template(is='dom-repeat', items='[[item.items]]')
                             iframe-link(href$="[[_buildHref(item.link, queryParams.*)]]")
-                                paper-item.menu-item.inner-menu-item [[item.text]]
+                                paper-item.menu-item.inner-menu-item
+                                    | [[item.text]]
                 template(is='dom-if', if='[[!equals(item.type, "section")]]')
                     iframe-link(href$="[[_buildHref(item.link, queryParams.*)]]")
                         paper-item.menu-item
@@ -49,6 +50,7 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                         paper-item.menu-item
                             iron-icon(icon='[[item.icon]]')
                             | [[item.text]]
+                            iron-icon.external(icon="launch")
             template(is='dom-if', if='[[equals(isolationMode, "multi-user")]]')
                 aside.divider
                 a(href$='[[_buildHref("/manage-users", queryParams.*)]]', tabindex='-1')
@@ -63,12 +65,11 @@ app-drawer-layout.flex(narrow='{{narrowMode}}',
                 paper-item.menu-item Documentation
                     iron-icon.external(icon="launch")
         footer.footer
-            section.information
-                a.privacy(title='Kubeflow Privacy Policy', target='_blank', href='https://policies.google.com/privacy') Privacy
-                .bullet
-                a.usage(title='Kubeflow Usage Reporting', target='_blank', href='https://www.kubeflow.org/docs/other-guides/usage-reporting/') Usage Reporting
-            section.build build version&nbsp;
-                span(title="Build: [[buildVersion]] | Dashboard: v[[dashVersion]] | Isolation-Mode: [[isolationMode]]") [[buildVersion]]
+            section.build
+                | build version -
+                |
+                span(title="Build: [[buildVersion]] | Dashboard: v[[dashVersion]] | Isolation-Mode: [[isolationMode]]")
+                    | [[buildVersion]]
     app-header-layout(fullbleed)
         app-header(slot='header', hides, hidden$='[[notFoundInIframe]]')
             app-toolbar


### PR DESCRIPTION
This PR does the following things:

1. __Updates the homepage links:__
     - Removes all 404 links to the Kubeflow website
     - Adds docs links for all Kubeflow components
1. __Updates the sidebar links:__
     - Groups all Kubeflow Pipelines links into one collapsable "section" 
     - Removes the "Privacy Policy" and "Usage Reporting" links as these are from many years ago when there was an optional usage reporting system, which no longer exists. Also, the "Usage Reporting" link was 404.
1. __Improves the styling of the sidebar links:__
     - Fixes an issue with the "section" `menuLinks` type where clicking on the icon would not collapse the section
     - De-indents the "section" elements slightly
     - Ensures that all "external" (i.e. non-iframe) links have an indicator ![Screenshot 2024-05-20 at 21 46 09](https://github.com/kubeflow/kubeflow/assets/5735406/d5e4bb57-a32e-4166-b747-8fc8c27fcc1e)
1. __Fixes other style issues:__
      -  Previously, if the user had a very narrow screen, the sidebar would take up the entire screen.

# Screenshots

## Homepage

This is a screenshot of the updated homepage, with new documentation links.

![KF_homepage](https://github.com/kubeflow/kubeflow/assets/5735406/19bad8d1-0fa3-4b88-bfa6-b5dadf56b7ed)

## Pipelines - Runs

This is a screenshot of the Kubeflow Pipelines - Runs page, showing the new collapsible sidebar section:

![KF_Pipeline-Runs](https://github.com/kubeflow/kubeflow/assets/5735406/b3fbc711-327b-4c72-889e-644c80508ed7)


