### PR TITLE
fix(notebooks): correctly handle `status.containerState` messages

### DIFF
--- a/components/crud-web-apps/common/backend/setup.py
+++ b/components/crud-web-apps/common/backend/setup.py
@@ -8,7 +8,7 @@ REQUIRES = [
     "urllib3 >= 1.25.7",
     "Werkzeug >= 0.16.0",
     "Flask-Cors >= 3.0.8",
-    "gevent <= 22.10.2",
+    "gevent",
 ]
 
 setuptools.setup(

--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -143,8 +143,10 @@ def get_status_from_container_state(notebook):
         status_phase = status.STATUS_PHASE.WARNING
 
         reason = waiting_state.get("reason", "Undefined")
-        message = waiting_state.get("message",
-                                    "No available message for container state.")
+        message = waiting_state.get(
+            "message",
+            "No available message for container state."
+        )
         status_message = '%s: %s' % (reason, message)
         return status_phase, status_message
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -124,6 +124,7 @@ def check_ready_nb(notebook):
 
 
 def get_status_from_container_state(notebook):
+    # https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-states
     container_state = notebook.get("status", {}).get("containerState", {})
 
     if "waiting" not in container_state:
@@ -141,8 +142,7 @@ def get_status_from_container_state(notebook):
     else:
         status_phase = status.STATUS_PHASE.WARNING
 
-        reason = waiting_state.get("reason",
-                                   "No available reason for container state.")
+        reason = waiting_state.get("reason", "Undefined")
         message = waiting_state.get("message",
                                     "No avaiable message for container state.")
         status_message = '%s: %s' % (reason, message)

--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -134,7 +134,7 @@ def get_status_from_container_state(notebook):
     waiting_state = container_state["waiting"]
     if ["reason"] == 'PodInitializing':
         status_phase = status.STATUS_PHASE.WAITING
-        status_message = waiting_state.get("reason", "Undeternimed reason.")
+        status_message = waiting_state.get("reason", "Undetermined reason.")
         return status_phase, status_message
 
     # In any other case, the status will be warning with a "reason:
@@ -144,7 +144,7 @@ def get_status_from_container_state(notebook):
 
         reason = waiting_state.get("reason", "Undefined")
         message = waiting_state.get("message",
-                                    "No avaiable message for container state.")
+                                    "No available message for container state.")
         status_message = '%s: %s' % (reason, message)
         return status_phase, status_message
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -126,23 +126,27 @@ def check_ready_nb(notebook):
 def get_status_from_container_state(notebook):
     container_state = notebook.get("status", {}).get("containerState", {})
 
-    if "waiting" in container_state:
-        # If the Notebook is initializing, the status will be waiting
-        if container_state["waiting"]["reason"] == 'PodInitializing':
-            status_phase = status.STATUS_PHASE.WAITING
-            status_message = container_state["waiting"]["reason"]
-            return status_phase, status_message
-        # In any other case, the status will be warning with a "reason:
-        # message" showing on hover
-        else:
-            status_phase = status.STATUS_PHASE.WARNING
+    if "waiting" not in container_state:
+        return None, None
 
-            reason = container_state["waiting"]["reason"]
-            message = container_state["waiting"]["message"]
-            status_message = '%s: %s' % (reason, message)
-            return status_phase, status_message
+    # If the Notebook is initializing, the status will be waiting
+    waiting_state = container_state["waiting"]
+    if ["reason"] == 'PodInitializing':
+        status_phase = status.STATUS_PHASE.WAITING
+        status_message = waiting_state.get("reason", "Undeternimed reason.")
+        return status_phase, status_message
 
-    return None, None
+    # In any other case, the status will be warning with a "reason:
+    # message" showing on hover
+    else:
+        status_phase = status.STATUS_PHASE.WARNING
+
+        reason = waiting_state.get("reason",
+                                   "No available reason for container state.")
+        message = waiting_state.get("message",
+                                    "No avaiable message for container state.")
+        status_message = '%s: %s' % (reason, message)
+        return status_phase, status_message
 
 
 def get_status_from_conditions(notebook):

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -48,5 +48,5 @@ class TestStatusFromContainerState(unittest.TestCase):
         self.assertEqual(
             status.get_status_from_container_state(container_state),
             ("warning",
-             "PodInitializing: No available message for container state")
+             "PodInitializing: No available message for container state.")
         )

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -48,5 +48,5 @@ class TestStatusFromContainerState(unittest.TestCase):
         self.assertEqual(
             status.get_status_from_container_state(container_state),
             ("warning",
-             "PodInitializing: No avaiable message for container state.")
+             "PodInitializing: No available message for container state")
         )

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -47,5 +47,6 @@ class TestStatusFromContainerState(unittest.TestCase):
 
         self.assertEqual(
             status.get_status_from_container_state(container_state),
-            ("warning", "PodInitializing: No avaiable message for container state.")
+            ("warning",
+             "PodInitializing: No avaiable message for container state.")
         )

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -1,0 +1,51 @@
+import unittest
+
+from apps.common import status
+
+
+class TestStatusFromContainerState(unittest.TestCase):
+    """Test the different cases of status from containerState"""
+
+    def test_terminating_container_state(self):
+        container_state = {
+            "status": {
+                "containerState": {
+                    "terminating": {}
+                }
+            }
+        }
+
+        self.assertEqual(
+            status.get_status_from_container_state(container_state),
+            (None, None)
+        )
+
+    def test_ready_container_state(self):
+        container_state = {
+            "status": {
+                "containerState": {
+                    "running": {}
+                }
+            }
+        }
+
+        self.assertEqual(
+            status.get_status_from_container_state(container_state),
+            (None, None)
+        )
+
+    def test_no_message_container_state(self):
+        container_state = {
+            "status": {
+                "containerState": {
+                    "waiting": {
+                        "reason": "PodInitializing",
+                    }
+                }
+            }
+        }
+
+        self.assertEqual(
+            status.get_status_from_container_state(container_state),
+            ("warning", "PodInitializing: No avaiable message for container state.")
+        )


### PR DESCRIPTION
Fixes https://github.com/kubeflow/kubeflow/issues/7454

Update the backend code to gracefully handle the containerState and `message`, when it doesn't exist.

I also unpinned the `gevent` package, since it introduces a CVE in all the web apps.

/cc @thesuperzapper 