### PR TITLE
Pin env-test for Profiles Controller

### DIFF
--- a/components/profile-controller/Makefile
+++ b/components/profile-controller/Makefile
@@ -37,7 +37,7 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
-	
+
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.
@@ -59,7 +59,7 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./main.go -namespace-labels-path ./config/base/namespace-labels.yaml 
+	go run ./main.go -namespace-labels-path ./config/base/namespace-labels.yaml
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
@@ -75,7 +75,7 @@ docker-build-multi-arch: ##  Build multi-arch docker images with docker buildx
 	docker buildx build --load --platform ${ARCH} --tag ${IMG}:${TAG} .
 
 .PHONY: docker-build-push-multi-arch
-docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry 
+docker-build-push-multi-arch: ## Build multi-arch docker images with docker buildx and push to docker registry
 	docker buildx build --platform ${ARCH} --tag ${IMG}:${TAG} --push .
 
 .PHONY: image
@@ -134,6 +134,7 @@ $(LOCALBIN):
 KUSTOMIZE ?= $(LOCALBIN)/kustomize
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
+ENVTEST_VERSION?=release-0.12
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v3.2.0
@@ -153,4 +154,4 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)

--- a/components/profile-controller/api/v1/groupversion_info.go
+++ b/components/profile-controller/api/v1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1 contains API Schema definitions for the  v1 API group
-//+kubebuilder:object:generate=true
-//+groupName=kubeflow.org
+// +kubebuilder:object:generate=true
+// +groupName=kubeflow.org
 package v1
 
 import (

--- a/components/profile-controller/api/v1beta1/groupversion_info.go
+++ b/components/profile-controller/api/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the  v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=kubeflow.org
+// +kubebuilder:object:generate=true
+// +groupName=kubeflow.org
 package v1beta1
 
 import (

--- a/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
+++ b/components/profile-controller/config/crd/bases/kubeflow.org_profiles.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
   name: profiles.kubeflow.org
 spec:
   group: kubeflow.org
@@ -60,7 +61,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-map-type: atomic
               plugins:
                 items:
                   description: Plugin is for customize actions on different platform.
@@ -134,7 +134,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                    x-kubernetes-map-type: atomic
                   scopes:
                     description: A collection of filters that must match each object
                       tracked by a quota. If not specified, the quota matches all
@@ -212,7 +211,6 @@ spec:
                 - kind
                 - name
                 type: object
-                x-kubernetes-map-type: atomic
               plugins:
                 items:
                   description: Plugin is for customize actions on different platform.
@@ -286,7 +284,6 @@ spec:
                           type: object
                         type: array
                     type: object
-                    x-kubernetes-map-type: atomic
                   scopes:
                     description: A collection of filters that must match each object
                       tracked by a quota. If not specified, the quota matches all
@@ -318,3 +315,9 @@ spec:
     storage: false
     subresources:
       status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/components/profile-controller/controllers/plugin_iam_test.go
+++ b/components/profile-controller/controllers/plugin_iam_test.go
@@ -307,7 +307,6 @@ func TestIsAnnotateOnly(t *testing.T) {
 	// Check that the result is true
 	assert.True(t, aws.isAnnotateOnly())
 
-
 	aws = &AwsIAMForServiceAccount{AnnotateOnly: false}
 	// Check that the result is true
 	assert.False(t, aws.isAnnotateOnly())


### PR DESCRIPTION
This is a follow-up from
https://github.com/kubeflow/kubeflow/pull/7589

Which should also unblock the following PRs
- https://github.com/kubeflow/kubeflow/pull/7586
- https://github.com/kubeflow/kubeflow/pull/7152

In this PR we pin the `env-test` to `release-0.12`, which reflects the `controller-runtime` version in this component

/cc @thesuperzapper 