### PR TITLE
Tensorboard Add start-stop UI function and culling controller

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/custom_resource.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/api/custom_resource.py
@@ -27,3 +27,9 @@ def get_custom_rsrc(group, version, kind, namespace, name):
 
     return custom_api.get_namespaced_custom_object(group, version, namespace,
                                                    kind, name)
+
+def patch_custom_rsrc(group, version, kind, namespace, name, body):
+    authz.ensure_authorized("patch", group, version, kind, namespace)
+
+    return custom_api.patch_namespaced_custom_object(group, version, namespace, 
+                                                     kind, name, body)

--- a/components/crud-web-apps/tensorboards/backend/app/routes/__init__.py
+++ b/components/crud-web-apps/tensorboards/backend/app/routes/__init__.py
@@ -2,4 +2,4 @@ from flask import Blueprint
 
 bp = Blueprint("base_routes", __name__)
 
-from . import get, post, delete  # noqa E402, F401
+from . import get, post, delete, patch  # noqa E402, F401

--- a/components/crud-web-apps/tensorboards/backend/app/routes/patch.py
+++ b/components/crud-web-apps/tensorboards/backend/app/routes/patch.py
@@ -1,0 +1,86 @@
+import datetime as dt
+
+from flask import request
+from werkzeug import exceptions
+
+from kubeflow.kubeflow.crud_backend import api, decorators, logging
+
+from .. import status
+from . import bp
+
+log = logging.getLogger(__name__)
+
+STOP_ATTR = "stopped"
+ATTRIBUTES = set([STOP_ATTR])
+
+
+# Routes
+@bp.route(
+    "/api/namespaces/<namespace>/tensorboards/<tensorboard>", methods=["PATCH"]
+)
+@decorators.request_is_json_type
+def patch_tensorboard(namespace, tensorboard):
+    request_body = request.get_json()
+    log.info("Got body: %s", request_body)
+
+    if request_body is None:
+        raise exceptions.BadRequest("Request doesn't have a body.")
+
+    # Ensure request has at least one valid command
+    if not any(attr in ATTRIBUTES for attr in request_body.keys()):
+        raise exceptions.BadRequest(
+            "Request body must include at least one supported key: %s"
+            % list(ATTRIBUTES)
+        )
+
+    # start/stop a notebook
+    if STOP_ATTR in request_body:
+        start_stop_tensorboard(namespace, tensorboard, request_body)
+
+    return api.success_response()
+
+
+# helper functions
+def start_stop_tensorboard(namespace, tensorboard, request_body):
+    stop = request_body[STOP_ATTR]
+
+    patch_body = {}
+    if stop:
+        if tensorboard_is_stopped(namespace, tensorboard):
+            raise exceptions.Conflict(
+                "Tensorboard %s/%s is already stopped." % (namespace, tensorboard)
+            )
+
+        log.info("Stopping tensorboard '%s/%s'", namespace, tensorboard)
+        now = dt.datetime.now(dt.timezone.utc)
+        timestamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        patch_body = {
+            "metadata": {"annotations": {status.STOP_ANNOTATION: timestamp}}
+        }
+    else:
+        log.info("Starting tensorboard '%s/%s'", namespace, tensorboard)
+        patch_body = {
+            "metadata": {"annotations": {status.STOP_ANNOTATION: None}}
+        }
+
+    log.info(
+        "Sending PATCH to tensorboard %s/%s: %s", namespace, tensorboard, patch_body
+    )
+
+    api.patch_custom_rsrc("tensorboard.kubeflow.org", "v1alpha1", "tensorboards", 
+                          namespace, tensorboard, patch_body)
+
+
+def tensorboard_is_stopped(namespace, tensorboard):
+    log.info(
+        "Checking if tensorboard %s/%s is already stopped", namespace, tensorboard,
+    )
+
+    tensorboard = api.get_custom_rsrc(
+        "tensorboard.kubeflow.org", "v1alpha1", "tensorboards", namespace, tensorboard
+    )
+    annotations = tensorboard.get("metadata", {}).get("annotations", {})
+
+    return status.STOP_ANNOTATION in annotations
+

--- a/components/crud-web-apps/tensorboards/backend/app/status.py
+++ b/components/crud-web-apps/tensorboards/backend/app/status.py
@@ -1,0 +1,112 @@
+import datetime as dt
+
+from kubeflow.kubeflow.crud_backend import status
+
+EVENT_TYPE_WARNING = "Warning"
+STOP_ANNOTATION = "kubeflow-resource-stopped"
+
+
+def process_status(tensorboard):
+    """
+    Return status and reason. Status may be [ready|waiting|warning|terminating|stopped]
+    """
+    # In case the Tb has no status
+    status_phase, status_message = get_empty_status(tensorboard)
+    if status_phase is not None:
+        return status.create_status(status_phase, status_message)
+
+    # In case the Tb is being stopped
+    status_phase, status_message = get_stopped_status(tensorboard)
+    if status_phase is not None:
+        return status.create_status(status_phase, status_message)
+
+    # In case the Tb is being deleted
+    status_phase, status_message = get_deleted_status(tensorboard)
+    if status_phase is not None:
+        return status.create_status(status_phase, status_message)
+
+    # In case the Tb is ready
+    status_phase, status_message = check_ready_tb(tensorboard)
+    if status_phase is not None:
+        return status.create_status(status_phase, status_message)
+
+    # Extract information about the status from the conditions of the Tb's status
+    status_phase, status_message = get_status_from_conditions(tensorboard)
+    if status_phase is not None:
+        return status.create_status(status_phase, status_message)
+
+    # In case there no status available, show a generic message
+    status_phase, status_message = status.STATUS_PHASE.WARNING, "Couldn't find any information for the status of this tensorboard."
+    return status.create_status(status_phase, status_message)
+
+
+def get_empty_status(tensorboard):
+    creation_timestamp = tensorboard["metadata"]["creationTimestamp"]
+    conditions = tensorboard["status"]["conditions"]
+
+    # Convert a date string of a format to datetime object
+    tb_creation_time = dt.datetime.strptime(
+        creation_timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    current_time = dt.datetime.utcnow().replace(microsecond=0)
+    delta = (current_time - tb_creation_time)
+
+    # If the tensorbord has no status, the status will be waiting (instead of warning) and we will
+    # show a generic message for the first 10 seconds
+    if not conditions and delta.total_seconds() <= 10:
+        status_phase, status_message = status.STATUS_PHASE.WAITING, "Waiting for deployment to create the underlying Pod."
+        return status_phase, status_message
+
+    return None, None
+
+
+def get_stopped_status(tensorboard):
+    ready_replicas = tensorboard.get("status", {}).get("readyReplicas", 0)
+    metadata = tensorboard.get("metadata", {})
+    annotations = metadata.get("annotations", {})
+
+    if STOP_ANNOTATION in annotations:
+        # If the tensorboard is stopped, the status will be stopped
+        if ready_replicas == 0:
+            status_phase, status_message = status.STATUS_PHASE.STOPPED, "No Pods are currently running for this tensorboard."
+            return status_phase, status_message
+        # If the tensorboard is being stopped, the status will be waiting
+        else:
+            status_phase, status_message = status.STATUS_PHASE.WAITING, "Tensorboard is stopping."
+            return status_phase, status_message
+
+    return None, None
+
+
+def get_deleted_status(tensorboard):
+    metadata = tensorboard.get("metadata", {})
+
+    # If the tensorboard is being deleted, the status will be terminating
+    if "deletionTimestamp" in metadata:
+        status_phase, status_message = status.STATUS_PHASE.TERMINATING, "Deleting this tensorboard."
+        return status_phase, status_message
+
+    return None, None
+
+
+def check_ready_tb(tensorboard):
+    ready_replicas = tensorboard.get("status", {}).get("readyReplicas", 0)
+
+    # If the tensorboard is running, the status will be ready
+    if ready_replicas == 1:
+        status_phase, status_message = status.STATUS_PHASE.READY, "Running"
+        return status_phase, status_message
+
+    return None, None
+
+
+def get_status_from_conditions(tensorboard):
+    conditions = tensorboard.get("status", {}).get("conditions", [])
+
+    for condition in conditions:
+        # The status will be warning with a "reason: message" showing on hover
+        if "reason" in condition:
+            status_phase, status_message = status.STATUS_PHASE.WARNING, condition[
+                "reason"] + ': ' + condition["message"]
+            return status_phase, status_message
+
+    return None, None

--- a/components/crud-web-apps/tensorboards/backend/app/utils.py
+++ b/components/crud-web-apps/tensorboards/backend/app/utils.py
@@ -1,4 +1,4 @@
-from kubeflow.kubeflow.crud_backend import status
+from .status import process_status
 from werkzeug.exceptions import BadRequest
 
 
@@ -6,22 +6,13 @@ def parse_tensorboard(tensorboard):
     """
     Process the Tensorboard object and format it as the UI expects it.
     """
-    if tensorboard.get("status", {}).get("readyReplicas", 0) == 1:
-        phase = status.STATUS_PHASE.READY
-        message = "The Tensorboard server is ready to connect"
-    else:
-        phase = status.STATUS_PHASE.UNAVAILABLE
-        message = "The Tensorboard server is currently unavailble"
-
-    parsed_tensorboard = {
+    return {
         "name": tensorboard["metadata"]["name"],
         "namespace": tensorboard["metadata"]["namespace"],
         "logspath": tensorboard["spec"]["logspath"],
         "age": tensorboard["metadata"]["creationTimestamp"],
-        "status": status.create_status(phase, message, "")
+        "status": process_status(tensorboard)
     }
-
-    return parsed_tensorboard
 
 
 def get_tensorboard_dict(namespace, body):

--- a/components/crud-web-apps/tensorboards/deploy/app-rbac.yaml
+++ b/components/crud-web-apps/tensorboards/deploy/app-rbac.yaml
@@ -38,6 +38,7 @@ rules:
   - watch
   - create
   - delete
+  - patch
 - apiGroups:
   - kubeflow.org
   resources:

--- a/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/pages/index/config.ts
@@ -7,6 +7,7 @@ import {
   TableColumn,
   TableConfig,
   DateTimeValue,
+  DialogConfig,
 } from 'kubeflow';
 
 const tableConfig: TableConfig = {
@@ -65,6 +66,15 @@ const actionsCol: TableColumn = {
       text: $localize`CONNECT`,
     }),
     new ActionIconValue({
+      name: 'start-stop',
+      tooltipInit: $localize`Stop this Tensorboard server`,
+      tooltipReady: $localize`Start this Tensorboard server`,
+      color: '',
+      field: 'startStopAction',
+      iconInit: 'material:stop',
+      iconReady: 'material:play_arrow',
+    }),
+    new ActionIconValue({
       name: 'delete',
       tooltip: $localize`Delete Tensorboard`,
       color: 'warn',
@@ -80,3 +90,17 @@ export const defaultConfig: TableConfig = {
   newButtonText: tableConfig.newButtonText,
   columns: tableConfig.columns.concat(actionsCol),
 };
+
+export function getStopDialogConfig(name: string): DialogConfig {
+  return {
+    title: $localize`Are you sure you want to stop this tensorboard? ${name}`,
+    message: $localize`Warning: Your data might be lost if the tensorboard
+                       is not backed by persistent storage.`,
+    accept: $localize`STOP`,
+    confirmColor: 'primary',
+    cancel: $localize`CANCEL`,
+    error: '',
+    applying: $localize`STOPPING`,
+    width: '600px',
+  };
+}

--- a/components/crud-web-apps/tensorboards/frontend/src/app/services/backend.service.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/services/backend.service.ts
@@ -88,4 +88,21 @@ export class TWABackendService extends BackendService {
       .delete<TWABackendResponse>(url)
       .pipe(catchError(error => this.handleError(error, false)));
   }
+
+  // PATCH
+  public startTensorboard(namespace: string, name: string): Observable<string> {
+    const url = `api/namespaces/${namespace}/tensorboards/${name}`;
+
+    return this.http
+      .patch<TWABackendResponse>(url, { stopped: false })
+      .pipe(catchError(error => this.handleError(error)), map(_ => 'started'),);
+  }
+
+  public stopTensorboard(namespace: string, name: string): Observable<string> {
+    const url = `api/namespaces/${namespace}/tensorboards/${name}`;
+
+    return this.http
+      .patch<TWABackendResponse>(url, { stopped: true })
+      .pipe(catchError(error => this.handleError(error, false)),map(_ => 'stopped'),);
+  }
 }

--- a/components/crud-web-apps/tensorboards/frontend/src/app/types.ts
+++ b/components/crud-web-apps/tensorboards/frontend/src/app/types.ts
@@ -10,6 +10,8 @@ import {
   V1VolumeMount,
 } from '@kubernetes/client-node';
 
+import { Params } from '@angular/router';
+
 export interface TWABackendResponse extends BackendResponse {
   tensorboards?: TensorboardResponseObject[];
   pvcs?: string[];
@@ -30,9 +32,15 @@ export interface TensorboardResponseObject {
 export interface TensorboardProcessedObject extends TensorboardResponseObject {
   deleteAction?: string;
   connectAction?: string;
+  startStopAction?: string;
   editAction?: string;
   ageValue?: string;
   ageTooltip?: string;
+  link: {
+    text: string;
+    url: string;
+    queryParams?: Params | null;
+  };
 }
 
 export interface TensorboardPostObject {

--- a/components/tensorboard-controller/Makefile
+++ b/components/tensorboard-controller/Makefile
@@ -59,6 +59,8 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test ./... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./controllers/... -coverprofile cover.out
+
 
 ##@ Build
 
@@ -68,6 +70,14 @@ build: generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
+	go run ./main.go
+
+# Run the controller locally with culling enabled
+.PHONY: run-culling
+run-culling: manifests generate fmt vet 
+	ENABLE_CULLING=true \
+	CULL_IDLE_TIME=10 \
+	IDLENESS_CHECK_PERIOD=1 \
 	go run ./main.go
 
 # Build the docker image

--- a/components/tensorboard-controller/config/base/kustomization.yaml
+++ b/components/tensorboard-controller/config/base/kustomization.yaml
@@ -9,6 +9,9 @@ configMapGenerator:
   - TENSORBOARD_IMAGE=tensorflow/tensorflow:2.5.1
   - ISTIO_GATEWAY=kubeflow/kubeflow-gateway
   - ISTIO_HOST=*
+  - ENABLE_CULLING="false"
+  - CULL_IDLE_TIME="1440"
+  - IDLENESS_CHECK_PERIOD="1"
 patchesStrategicMerge:
 - patches/add_controller_config.yaml
 images:

--- a/components/tensorboard-controller/config/manager/manager.yaml
+++ b/components/tensorboard-controller/config/manager/manager.yaml
@@ -31,6 +31,27 @@ spec:
             - /manager
           image: docker.io/kubeflownotebookswg/tensorboard-controller
           name: manager
+          env:
+            - name: ISTIO_GATEWAY
+              valueFrom:
+                configMapKeyRef:
+                  name: tensorboard-controller-config
+                  key: ISTIO_GATEWAY          
+            - name: ENABLE_CULLING
+              valueFrom:
+                configMapKeyRef:
+                  name: tensorboard-controller-config
+                  key: ENABLE_CULLING
+            - name: CULL_IDLE_TIME
+              valueFrom:
+                configMapKeyRef:
+                  name: tensorboard-controller-config
+                  key: CULL_IDLE_TIME
+            - name: IDLENESS_CHECK_PERIOD
+              valueFrom:
+                configMapKeyRef:
+                  name: tensorboard-controller-config
+                  key: IDLENESS_CHECK_PERIOD
           securityContext:
             allowPrivilegeEscalation: false
           livenessProbe:

--- a/components/tensorboard-controller/controllers/culling_controller.go
+++ b/components/tensorboard-controller/controllers/culling_controller.go
@@ -1,0 +1,341 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/kubeflow/kubeflow/components/tensorboard-controller/api/v1alpha1"
+)
+
+// The constants with name 'DEFAULT_{ENV_Var}' are the default values to be
+// used, if the respective ENV vars are not present.
+// All the time numbers correspond to minutes.
+
+const DEFAULT_CULL_IDLE_TIME = "1440" // One day
+const DEFAULT_IDLENESS_CHECK_PERIOD = "1"
+const DEFAULT_ENABLE_CULLING = "false"
+
+var CULL_IDLE_TIME = 0
+var ENABLE_CULLING = false
+var IDLENESS_CHECK_PERIOD = 0
+
+// When a Resource should be stopped/culled, then the controller should add this
+// annotation in the Resource's Metadata. Then, inside the reconcile loop,
+// the controller must check if this annotation is set and then apply the
+// respective culling logic for that Resource. The value of the annotation will
+// be a timestamp of when the Resource was stopped/culled.
+//
+// In case of TensorBoard, the controller will reduce the replicas to 0 if
+// this annotation is set. If it's not set, then it will make the replicas 1.
+const STOP_ANNOTATION = "kubeflow-resource-stopped"
+const LAST_ACTIVITY_ANNOTATION = "tensorboard.kubeflow.org/last-activity"
+const LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION = "tensorboard.kubeflow.org/last_activity_check_timestamp"
+
+// CullingReconciler : Type of a reconciler that will be culling idle tensorboard
+type CullingReconciler struct {
+	client.Client
+	Log logr.Logger
+}
+
+func (r *CullingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := r.Log.WithValues("culler", req.NamespacedName)
+	log.Info("Reconciliation loop started")
+
+	instance := &v1alpha1.Tensorboard{}
+	err := r.Get(ctx, req.NamespacedName, instance)
+	if err != nil && apierrs.IsNotFound(err) {
+		// we'll ignore not-found errors, since they can't be fixed by an immediate
+		// requeue (we'll need to wait for a new notification), and we can get them
+		// on deleted requests.
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Won't check for culling when a Tensorboard is being culled/stopped
+	// Remove LAST_ACTIVITY_ANNOTATION and LAST_ACTIVITY_TIMESTAMP_CHECK
+	// annotations for CR objects
+	if StopAnnotationIsSet(instance.ObjectMeta) {
+		log.Info("Tensorboard is already stopping")
+		removeAnnotations(&instance.ObjectMeta, r.Log)
+		err = r.Update(ctx, instance)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Ensure that the underlying Tensorboard Deployment exists
+	foundDeployment := &appsv1.Deployment{}
+	err = r.Get(ctx, types.NamespacedName{Name: instance.Name, Namespace: instance.Namespace}, foundDeployment)
+	if err != nil && apierrs.IsNotFound(err) {
+		log.Info("Deployment not found...Will remove last-activity annotation...")
+
+		removeAnnotations(&instance.ObjectMeta, r.Log)
+		err = r.Update(ctx, instance)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	} else if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Initialize culling (last-activity and last-activity-check-timestamp) annotations
+	if !annotationsExist(instance) {
+		log.Info("No annotations found. Initializing last-activity and last-activity-check-timestamp annotations")
+		initializeAnnotations(&instance.ObjectMeta)
+		err = r.Update(ctx, instance)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Check if culling period has passed (IDLENESS_CHECK_PERIOD ~ default 1 min)
+	if !cullingCheckPeriodHasPassed(instance.ObjectMeta, r.Log) {
+		log.Info("Not enough time has passed. Won't check for culling.")
+		return ctrl.Result{RequeueAfter: getRequeueTime()}, nil
+	}
+
+	// Update the LAST_ACTIVITY_ANNOTATION and LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION
+	updateTensorboardLastActivityAnnotation(&instance.ObjectMeta, foundDeployment, r.Log)
+	updateLastCullingCheckTimestampAnnotation(&instance.ObjectMeta, r.Log)
+	// Always keep track of the last time we checked for culling
+	err = r.Update(ctx, instance)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Check if the Tensorboard needs to be stopped
+	if tensorboardIsIdle(instance.ObjectMeta, r.Log) {
+		log.Info(fmt.Sprintf(
+			"Tensorboard %s/%s needs culling. Updating Tensorboard CR Annotations...",
+			instance.Namespace, instance.Name))
+
+		// Set Stop Annotation to the Tensorboard CR
+		setStopAnnotation(&instance.ObjectMeta, r.Log)
+		err = r.Update(ctx, instance)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{RequeueAfter: getRequeueTime()}, nil
+}
+
+// This function ensures that we run the culling checks every CULLING_CHECK_PERIOD
+// even if in the meantime an update/create/delete event occurs for a Tensorboard CR.
+func cullingCheckPeriodHasPassed(meta metav1.ObjectMeta, log logr.Logger) bool {
+	if _, ok := meta.GetAnnotations()[LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION]; !ok {
+		log.Info("No last-activity-check-timestamp found in the CR. Won't check for culling")
+		return false
+	}
+	storedTimestamp, _ := time.Parse(time.RFC3339, meta.Annotations[LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION])
+	nextCullingCheck := storedTimestamp.Add(getRequeueTime())
+	currentTime := time.Now()
+	return nextCullingCheck.Before(currentTime)
+}
+
+// Culling Logic
+func tensorboardIsIdle(meta metav1.ObjectMeta, log logr.Logger) bool {
+	// Being idle means that the Tensorboard can be culled/stopped
+	if meta.GetAnnotations() != nil {
+		if StopAnnotationIsSet(meta) {
+			log.Info("Tensorboard is already stopping")
+			return false
+		}
+		// Read the current LAST_ACTIVITY_ANNOTATION
+		tempLastActivity := meta.GetAnnotations()[LAST_ACTIVITY_ANNOTATION]
+		lastActivity, err := time.Parse(time.RFC3339, tempLastActivity)
+		if err != nil {
+			log.Error(err, "Error parsing last-activity time")
+			return false
+		}
+
+		timeCap := lastActivity.Add(time.Duration(CULL_IDLE_TIME) * time.Minute)
+		if time.Now().After(timeCap) {
+			return true
+		}
+	}
+	return false
+}
+
+// Update LAST_ACTIVITY_ANNOTATION
+func updateTensorboardLastActivityAnnotation(meta *metav1.ObjectMeta, deployment *appsv1.Deployment, log logr.Logger) {
+	var latestCondition *appsv1.DeploymentCondition
+	var latestTime metav1.Time
+
+	if deployment.Status.AvailableReplicas == 0 {
+		log.Info("No available replicas found in the Deployment. Will not update the annotation")
+		return
+	}
+
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == "Available" && (latestCondition == nil || condition.LastUpdateTime.Time.After(latestTime.Time)) {
+			latestCondition = &condition
+			latestTime = condition.LastUpdateTime
+		}
+	}
+
+	if latestCondition == nil {
+		log.Info("No conditions found in the Deployment of type 'Available'. Will not update the annotation")
+		return
+	}
+
+	lastActivityTime := latestCondition.LastUpdateTime
+	log.Info("Latest activity time: ", "time", lastActivityTime)
+
+	t := lastActivityTime.Format(time.RFC3339)
+
+	meta.Annotations[LAST_ACTIVITY_ANNOTATION] = t
+	log.Info(fmt.Sprintf("Successfully updated last-activity from latest kernel action, %s", t))
+}
+
+func updateLastCullingCheckTimestampAnnotation(meta *metav1.ObjectMeta, log logr.Logger) {
+	t := createTimestamp()
+	if _, ok := meta.GetAnnotations()[LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION]; !ok {
+		log.Info("No last-activity-check-timestamp annotation found. Will not update")
+	}
+	meta.Annotations[LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION] = t
+	log.Info("Successfully updated last-activity-check-timestamp annotation")
+}
+
+func annotationsExist(instance *v1alpha1.Tensorboard) bool {
+	meta := instance.ObjectMeta
+	if metav1.HasAnnotation(meta, LAST_ACTIVITY_ANNOTATION) &&
+		metav1.HasAnnotation(meta, LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION) {
+		return true
+	}
+	return false
+}
+
+func initializeAnnotations(meta *metav1.ObjectMeta) {
+	if len(meta.GetAnnotations()) == 0 {
+		meta.SetAnnotations(map[string]string{})
+	}
+	t := createTimestamp()
+	meta.Annotations[LAST_ACTIVITY_ANNOTATION] = t
+	meta.Annotations[LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION] = t
+}
+
+func removeAnnotations(meta *metav1.ObjectMeta, log logr.Logger) {
+	if meta == nil {
+		log.Info("Error: Metadata is Nil. Can't remove Annotations")
+		return
+	}
+
+	if _, ok := meta.GetAnnotations()[LAST_ACTIVITY_ANNOTATION]; ok {
+		log.Info("Removing last-activity annotation")
+		delete(meta.GetAnnotations(), LAST_ACTIVITY_ANNOTATION)
+	}
+	if _, ok := meta.GetAnnotations()[LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION]; ok {
+		log.Info("Removing last-activity-check-timestamp annotation")
+		delete(meta.GetAnnotations(), LAST_ACTIVITY_CHECK_TIMESTAMP_ANNOTATION)
+	}
+}
+
+// Stop Annotation handling functions
+func setStopAnnotation(meta *metav1.ObjectMeta, log logr.Logger) {
+	if meta == nil {
+		log.Info("Error: Metadata is Nil. Can't set Annotations")
+		return
+	}
+
+	log.Info("Setting stop timestamp annotation")
+	t := time.Now()
+	if len(meta.GetAnnotations()) == 0 {
+		meta.SetAnnotations(map[string]string{})
+	}
+	meta.Annotations[STOP_ANNOTATION] = t.Format(time.RFC3339)
+}
+
+func StopAnnotationIsSet(meta metav1.ObjectMeta) bool {
+	if meta.GetAnnotations() == nil {
+		return false
+	}
+	if metav1.HasAnnotation(meta, STOP_ANNOTATION) {
+		return true
+	}
+	return false
+}
+
+// Some Utility Functions
+func GetEnvDefault(variable string, defaultVal string) string {
+	envVar := os.Getenv(variable)
+	if len(envVar) == 0 {
+		return defaultVal
+	}
+	return envVar
+}
+
+// Time / Frequency Utility functions
+func createTimestamp() string {
+	now := time.Now()
+	return now.Format(time.RFC3339)
+}
+
+func getRequeueTime() time.Duration {
+	// The frequency in which we check if the Pod needs culling
+	// Uses ENV var: IDLENESS_CHECK_PERIOD
+	return time.Duration(IDLENESS_CHECK_PERIOD) * time.Minute
+}
+
+func initGlobalVars() error {
+	log := logf.Log.WithName("Culler")
+
+	idleTime := GetEnvDefault("CULL_IDLE_TIME", DEFAULT_CULL_IDLE_TIME)
+	realIdleTime, err := strconv.Atoi(idleTime)
+	if err != nil {
+		log.Info(fmt.Sprintf(
+			"CULL_IDLE_TIME should be Int. Got %s instead. Using default value.",
+			idleTime))
+		realIdleTime, _ = strconv.Atoi(DEFAULT_CULL_IDLE_TIME)
+	}
+	CULL_IDLE_TIME = realIdleTime
+
+	enableCulling := GetEnvDefault("ENABLE_CULLING", DEFAULT_ENABLE_CULLING)
+	if enableCulling == "true" {
+		ENABLE_CULLING = true
+	}
+
+	cullPeriod := GetEnvDefault("IDLENESS_CHECK_PERIOD", DEFAULT_IDLENESS_CHECK_PERIOD)
+	period, err := strconv.Atoi(cullPeriod)
+	if err != nil {
+		return err
+	}
+	IDLENESS_CHECK_PERIOD = period
+
+	return nil
+}
+
+// SetupWithManager : Add the culling controller to the manager
+func (r *CullingReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	log := r.Log.WithValues("Culler", "setup")
+
+	if err := initGlobalVars(); err != nil {
+		log.Error(err, "Could not initialize the global variables")
+		return err
+	}
+
+	controller := ctrl.NewControllerManagedBy(mgr).
+		For(&v1alpha1.Tensorboard{}).
+		Named("Culler")
+
+	err := controller.Complete(r)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/components/tensorboard-controller/controllers/culling_controller_test.go
+++ b/components/tensorboard-controller/controllers/culling_controller_test.go
@@ -1,0 +1,92 @@
+package controllers
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var TestLogger = logf.Log.WithName("test-logger")
+
+func TestSetStopAnnotation(t *testing.T) {
+	// Test if the annotation gets set
+	testCases := []struct {
+		testName string
+		meta     *metav1.ObjectMeta
+	}{
+		{
+			testName: "Nil Metadata",
+			meta:     nil,
+		},
+		{
+			testName: "No existing Annotations",
+			meta:     &metav1.ObjectMeta{},
+		},
+		{
+			testName: "Basic case",
+			meta: &metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+		},
+		{
+			testName: "Annotation is already set",
+			meta: &metav1.ObjectMeta{
+				Annotations: map[string]string{
+					STOP_ANNOTATION: createTimestamp(),
+				},
+			},
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.testName, func(t *testing.T) {
+			setStopAnnotation(c.meta, TestLogger)
+			if c.meta == nil {
+				return
+			}
+
+			if _, ok := c.meta.Annotations[STOP_ANNOTATION]; !ok {
+				t.Errorf("StopAnnotation not set for case: %+v", c)
+			}
+		})
+	}
+}
+
+func TestStopAnnotationIsSet(t *testing.T) {
+	testCases := []struct {
+		testName string
+		meta     metav1.ObjectMeta
+		result   bool
+	}{
+		{
+			testName: "No existing Annotations",
+			meta:     metav1.ObjectMeta{},
+			result:   false,
+		},
+		{
+			testName: "Stop Annotation not Set",
+			meta: metav1.ObjectMeta{
+				Annotations: map[string]string{},
+			},
+			result: false,
+		},
+		{
+			testName: "Annotation is already set",
+			meta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					STOP_ANNOTATION: createTimestamp(),
+				},
+			},
+			result: true,
+		},
+	}
+
+	for _, c := range testCases {
+		t.Run(c.testName, func(t *testing.T) {
+			if StopAnnotationIsSet(c.meta) != c.result {
+				t.Errorf("Wrong result for case: %+v", c)
+			}
+		})
+	}
+}

--- a/components/tensorboard-controller/controllers/tensorboard_controller.go
+++ b/components/tensorboard-controller/controllers/tensorboard_controller.go
@@ -253,13 +253,18 @@ func generateDeployment(tb *tensorboardv1alpha1.Tensorboard, log logr.Logger, r 
 	}
 	(podLabels)["app"] = tb.Name
 
+	replicas := int32(1)
+	if metav1.HasAnnotation(tb.ObjectMeta, "kubeflow-resource-stopped") {
+		replicas = 0
+	}
+
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      tb.Name,
 			Namespace: tb.Namespace,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: proto.Int32(1),
+			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"app": tb.Name,

--- a/components/tensorboard-controller/main.go
+++ b/components/tensorboard-controller/main.go
@@ -113,6 +113,16 @@ func main() {
 	}
 	//+kubebuilder:scaffold:builder
 
+	if controllers.GetEnvDefault("ENABLE_CULLING", controllers.DEFAULT_ENABLE_CULLING) == "true" {
+		if err = (&controllers.CullingReconciler{
+			Client: mgr.GetClient(),
+			Log:    ctrl.Log.WithName("controllers").WithName("Culler"),
+		}).SetupWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create controller", "controller", "Culler")
+			os.Exit(1)
+		}
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)


### PR DESCRIPTION
The idea of the PR is to replicate notebook server behavior.
Tensorboards are interactive workloads that should be stopped when not used or after a certain amount of seconds, just like notebook servers. This will free up resources but more importantly, tensorboards are constantly reading logs which can add significant cost when logs are stored on public cloud providers.

Few features
- Add start and stop button to the tensorboard dashboard --> UI backend adds stop resource annotation --> Controller changes deployment replica accordingly 
- Get tensorboard status and update UI
- Add tensorboard culler to stop (adds stop resource annotation) after x seconds
- Enabling culling and time for culling is configurable
- Add "patch" permission to the web app service account