### PR TITLE
fix: kserve models link in sidebar of dashboard

### DIFF
--- a/components/centraldashboard/manifests/overlays/kserve/patches/configmap.yaml
+++ b/components/centraldashboard/manifests/overlays/kserve/patches/configmap.yaml
@@ -33,7 +33,7 @@ data:
             },
             {
                 "type": "item",
-                "link": "/models/",
+                "link": "/kserve-endpoints/",
                 "text": "KServe Endpoints",
                 "icon": "kubeflow:models"
             },


### PR DESCRIPTION
This is a follow-up to https://github.com/kubeflow/kubeflow/pull/7583.

I incorrectly put the link for the "KServe models-web-app" as `/models/` when it's `/kserve-endpoints/` which made that UI inaccessible. 

See here for the relevant manifests:

- https://github.com/kserve/models-web-app/blob/v0.10.0/config/base/istio.yaml#L14