### PR TITLE
fix: notebook server images with non-root SecurityContext

### DIFF
--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -25,9 +25,13 @@ ENV SHELL /bin/bash
 # see `s6/cont-init.d/01-copy-tmp-home`
 ENV HOME_TMP /tmp_home/$NB_USER
 
-# s3 only gives 5 seconds by default, which is too small for slow PVC storage backends
+# s6-overlay only gives 5 seconds by default, which is too small for slow PVC storage backends
 # when running `/etc/cont-inid.d/01-copy-tmp-home` (note, this is in milliseconds)
 ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME 300000
+
+# s6-overlay does not fail by default if the `/etc/cont-init.d/` or `/etc/services.d/` scripts fail
+# this is not the desired behavior, so we set it to fail
+ENV S6_BEHAVIOUR_IF_STAGE2_FAILS 2
 
 # args - software versions
 ARG KUBECTL_VERSION=v1.27.14

--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -10,6 +10,11 @@ ARG TARGETARCH
 # common environemnt variables
 ENV NB_USER jovyan
 ENV NB_UID 1000
+# WARNING: the GID of 'jovyan' MUST be 0!
+#          this allows any UID to be used as all important folders are owned by GID 0.
+#          some Kubernetes environments run containers as a random UID (e.g. OpenShift).
+#          note, having GID 0 (root) does NOT give you root permissions, so this is not a security issue.
+ENV NB_GID 0
 ENV NB_PREFIX /
 ENV HOME /home/$NB_USER
 ENV SHELL /bin/bash
@@ -26,7 +31,7 @@ ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME 300000
 
 # args - software versions
 ARG KUBECTL_VERSION=v1.27.14
-ARG S6_VERSION=v3.1.6.2
+ARG S6_VERSION=v3.2.0.0
 
 # set shell to bash
 SHELL ["/bin/bash", "-c"]
@@ -76,6 +81,10 @@ RUN case "${TARGETARCH}" in \
        /tmp/s6-overlay-${S6_ARCH}.tar.xz \
        /tmp/s6-overlay-${S6_ARCH}.tar.xz.sha256
 
+# fix permissions of '/run' folder for s6
+# https://github.com/just-containers/s6-overlay/blob/v3.2.0.0/layout/rootfs-overlay/package/admin/s6-overlay-%40VERSION%40/libexec/preinit#L86
+RUN chmod 0775 /run
+
 # install - kubectl
 RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" -o /usr/local/bin/kubectl \
  && curl -fsSL "https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl.sha256" -o /tmp/kubectl.sha256 \
@@ -84,12 +93,12 @@ RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETA
  && chmod +x /usr/local/bin/kubectl
 
 # create user and set required ownership
-RUN useradd -M -s /bin/bash -N -u ${NB_UID} ${NB_USER} \
+RUN useradd -M -s /bin/bash -N -u ${NB_UID} -g ${NB_GID} ${NB_USER} \
  && mkdir -p ${HOME} \
  && mkdir -p ${HOME_TMP} \
- && chown -R ${NB_USER}:users ${HOME} \
- && chown -R ${NB_USER}:users ${HOME_TMP} \
- && chown -R ${NB_USER}:users /usr/local/bin
+ && chown -R ${NB_USER}:${NB_GID} ${HOME} \
+ && chown -R ${NB_USER}:${NB_GID} ${HOME_TMP} \
+ && chown -R ${NB_USER}:${NB_GID} /usr/local/bin
 
 # set locale configs
 RUN echo "en_US.UTF-8 UTF-8" > /etc/locale.gen \
@@ -99,7 +108,7 @@ ENV LANGUAGE en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 
 # s6 - copy scripts
-COPY --chown=${NB_USER}:users --chmod=755 s6/ /etc
+COPY --chown=${NB_USER}:${NB_GID} --chmod=755 s6/ /etc
 
 USER $NB_UID
 

--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH
 # common environemnt variables
 ENV NB_USER jovyan
 ENV NB_UID 1000
-# WARNING: the GID of 'jovyan' MUST be 0!
+# WARNING: the primary GID of 'jovyan' MUST be 0!
 #          this allows any UID to be used as all important folders are owned by GID 0.
 #          some Kubernetes environments run containers as a random UID (e.g. OpenShift).
 #          note, having GID 0 (root) does NOT give you root permissions, so this is not a security issue.
@@ -18,6 +18,9 @@ ENV NB_GID 0
 ENV NB_PREFIX /
 ENV HOME /home/$NB_USER
 ENV SHELL /bin/bash
+
+# the GID of the 'users' group
+ENV USERS_GID 100
 
 # we copy the contents of $HOME_TMP to $HOME on startup
 # this is to work around the fact that a PVC will be mounted to $HOME
@@ -97,11 +100,21 @@ RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETA
  && chmod +x /usr/local/bin/kubectl
 
 # create user and set required ownership
-RUN useradd -M -s /bin/bash -N -u ${NB_UID} -g ${NB_GID} ${NB_USER} \
- && mkdir -p ${HOME} \
- && mkdir -p ${HOME_TMP} \
- && chown -R ${NB_USER}:${NB_GID} ${HOME} \
- && chown -R ${NB_USER}:${NB_GID} ${HOME_TMP} \
+RUN useradd -M -N \
+    --shell /bin/bash \
+    --home ${HOME} \
+    --uid ${NB_UID} \
+    --gid ${NB_GID} \
+    --groups ${USERS_GID} \
+    ${NB_USER} \
+ && mkdir -pv ${HOME} \
+ && mkdir -pv ${HOME_TMP} \
+    # in the interest of backwards compatibility we have the 'users' group owns the home directory
+    # we also set the SGID bit so that new files and directories are created with the 'users' group
+ && chmod 2775 ${HOME} \
+ && chmod 2775 ${HOME_TMP} \
+ && chown -R ${NB_USER}:${USERS_GID} ${HOME} \
+ && chown -R ${NB_USER}:${USERS_GID} ${HOME_TMP} \
  && chown -R ${NB_USER}:${NB_GID} /usr/local/bin
 
 # set locale configs

--- a/components/example-notebook-servers/base/s6/cont-init.d/01-copy-tmp-home
+++ b/components/example-notebook-servers/base/s6/cont-init.d/01-copy-tmp-home
@@ -1,5 +1,9 @@
 #!/command/with-contenv bash
 
+# setting umask to 0002 makes copied files/folders writable by group
+# this is needed to run the container as an arbitrary UID
+umask 0002
+
 # the home directory is usually a PVC
 # we need to copy the contents of $HOME_TMP that we populated during the build
 # NOTE: -n prevents overwriting existing files

--- a/components/example-notebook-servers/codeserver-python/Dockerfile
+++ b/components/example-notebook-servers/codeserver-python/Dockerfile
@@ -18,13 +18,14 @@ ARG PYTHON_VERSION=3.11.9
 # setup environment for conda
 ENV CONDA_DIR /opt/conda
 ENV PATH "${CONDA_DIR}/bin:${PATH}"
-RUN mkdir -p ${CONDA_DIR} \
+RUN mkdir -pv ${CONDA_DIR} \
+ && chmod 2775 ${CONDA_DIR} \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> ${HOME}/.bashrc \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/profile \
  && echo "conda activate base" >> ${HOME}/.bashrc \
  && echo "conda activate base" >> /etc/profile \
  && chown -R ${NB_USER}:${NB_GID} ${CONDA_DIR} \
- && chown -R ${NB_USER}:${NB_GID} ${HOME}
+ && chown -R ${NB_USER}:${USERS_GID} ${HOME}
 
 USER $NB_UID
 
@@ -63,4 +64,6 @@ RUN code-server --install-extension "ms-python.python@${CODESERVER_PYTHON_VERSIO
 # NOTE: the contents of $HOME_TMP are copied to $HOME at runtime
 #       this is a workaround because a PVC will be mounted at $HOME
 #       and the contents of $HOME will be hidden
-RUN cp -r -T "${HOME}" "${HOME_TMP}"
+RUN cp -p -r -T "${HOME}" "${HOME_TMP}" \
+    # give group same access as user (needed for OpenShift)
+ && chmod -R g=u "${HOME_TMP}"

--- a/components/example-notebook-servers/codeserver-python/Dockerfile
+++ b/components/example-notebook-servers/codeserver-python/Dockerfile
@@ -23,8 +23,8 @@ RUN mkdir -p ${CONDA_DIR} \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/profile \
  && echo "conda activate base" >> ${HOME}/.bashrc \
  && echo "conda activate base" >> /etc/profile \
- && chown -R ${NB_USER}:users ${CONDA_DIR} \
- && chown -R ${NB_USER}:users ${HOME}
+ && chown -R ${NB_USER}:${NB_GID} ${CONDA_DIR} \
+ && chown -R ${NB_USER}:${NB_GID} ${HOME}
 
 USER $NB_UID
 
@@ -51,7 +51,7 @@ RUN case "${TARGETARCH}" in \
  && conda clean -a -f -y
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt
 

--- a/components/example-notebook-servers/codeserver/Dockerfile
+++ b/components/example-notebook-servers/codeserver/Dockerfile
@@ -18,7 +18,7 @@ RUN curl -fsSL "https://github.com/coder/code-server/releases/download/${CODESER
  && rm -f /tmp/code-server.deb
 
 # s6 - copy scripts
-COPY --chown=${NB_USER}:users --chmod=755 s6/ /etc
+COPY --chown=${NB_USER}:${NB_GID} --chmod=755 s6/ /etc
 
 USER $NB_UID
 

--- a/components/example-notebook-servers/codeserver/s6/services.d/code-server/run
+++ b/components/example-notebook-servers/codeserver/s6/services.d/code-server/run
@@ -1,5 +1,8 @@
 #!/command/with-contenv bash
+
 cd "${HOME}"
+echo "INFO: starting code-server..."
+exec 2>&1
 exec /usr/bin/code-server \
   --bind-addr 0.0.0.0:8888 \
   --disable-telemetry \

--- a/components/example-notebook-servers/jupyter-pytorch-cuda-full/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-cuda-full/Dockerfile
@@ -23,6 +23,6 @@ RUN mamba install -y -q \
  && mamba clean -a -f -y
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp/requirements.txt
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-cuda/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-cuda/Dockerfile
@@ -23,6 +23,6 @@ RUN python3 -m pip install --quiet --no-cache-dir --index-url https://download.p
     torchvision==${TORCHVISION_VERSION}
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-full/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-full/Dockerfile
@@ -23,6 +23,6 @@ RUN mamba install -y -q \
  && mamba clean -a -f -y
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp/requirements.txt
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch/Dockerfile
@@ -17,6 +17,6 @@ RUN python3 -m pip install --quiet --no-cache-dir --index-url https://download.p
     torchvision==${TORCHVISION_VERSION}
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-scipy/Dockerfile
+++ b/components/example-notebook-servers/jupyter-scipy/Dockerfile
@@ -52,6 +52,6 @@ RUN mamba install -y -q \
  && mamba clean -a -f -y
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-cuda-full/Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-cuda-full/Dockerfile
@@ -23,6 +23,6 @@ RUN mamba install -y -q \
  && mamba clean -a -f -y
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp/requirements.txt
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-cuda/Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-cuda/Dockerfile
@@ -45,6 +45,6 @@ RUN ln -s ${TENSORRT_LIBS}/libnvinfer.so.${TENSORRT_LIBS_VERSION%%.*} ${TENSORRT
 ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}/nvidia/cudnn/lib:${TENSORRT_LIBS}
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow-full/Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow-full/Dockerfile
@@ -23,6 +23,6 @@ RUN mamba install -y -q \
  && mamba clean -a -f -y
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp/requirements.txt
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-tensorflow/Dockerfile
+++ b/components/example-notebook-servers/jupyter-tensorflow/Dockerfile
@@ -20,6 +20,6 @@ RUN python3 -m pip install --quiet --no-cache-dir \
     tensorflow==${TENSORFLOW_VERSION}
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter/Dockerfile
+++ b/components/example-notebook-servers/jupyter/Dockerfile
@@ -35,13 +35,13 @@ RUN mkdir -p ${CONDA_DIR} \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/profile \
  && echo "conda activate base" >> ${HOME}/.bashrc \
  && echo "conda activate base" >> /etc/profile \
- && chown -R ${NB_USER}:users ${CONDA_DIR} \
- && chown -R ${NB_USER}:users ${HOME}
+ && chown -R ${NB_USER}:${NB_GID} ${CONDA_DIR} \
+ && chown -R ${NB_USER}:${NB_GID} ${HOME}
 
 # create the SYSTEM_CONFIG_PATH for jupyter, and make it owned by NB_USER
 # this is needed for jupyter to write `--level=system` configs
 RUN mkdir -p /usr/local/etc/jupyter \
- && chown -R ${NB_USER}:users /usr/local/etc/jupyter
+ && chown -R ${NB_USER}:${NB_GID} /usr/local/etc/jupyter
 
 # switch to NB_UID for installs
 USER $NB_UID
@@ -77,12 +77,12 @@ RUN echo "jupyterlab ==${JUPYTERLAB_VERSION}" >> ${CONDA_DIR}/conda-meta/pinned 
  && conda clean -a -f -y
 
 # install - requirements.txt
-COPY --chown=${NB_USER}:users requirements.txt /tmp
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt
 
 # s6 - copy scripts
-COPY --chown=${NB_USER}:users --chmod=755 s6/ /etc
+COPY --chown=${NB_USER}:${NB_GID} --chmod=755 s6/ /etc
 
 # configure - jupyter
 # NOTE: we use `--level=system` to write these configs at `/usr/local/etc/jupyter` because it defaults

--- a/components/example-notebook-servers/jupyter/Dockerfile
+++ b/components/example-notebook-servers/jupyter/Dockerfile
@@ -30,17 +30,18 @@ RUN export DEBIAN_FRONTEND=noninteractive \
 # setup environment for conda
 ENV CONDA_DIR /opt/conda
 ENV PATH "${CONDA_DIR}/bin:${PATH}"
-RUN mkdir -p ${CONDA_DIR} \
+RUN mkdir -pv ${CONDA_DIR} \
+ && chmod 2775 ${CONDA_DIR} \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> ${HOME}/.bashrc \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/profile \
  && echo "conda activate base" >> ${HOME}/.bashrc \
  && echo "conda activate base" >> /etc/profile \
  && chown -R ${NB_USER}:${NB_GID} ${CONDA_DIR} \
- && chown -R ${NB_USER}:${NB_GID} ${HOME}
+ && chown -R ${NB_USER}:${USERS_GID} ${HOME}
 
 # create the SYSTEM_CONFIG_PATH for jupyter, and make it owned by NB_USER
 # this is needed for jupyter to write `--level=system` configs
-RUN mkdir -p /usr/local/etc/jupyter \
+RUN mkdir -pv /usr/local/etc/jupyter \
  && chown -R ${NB_USER}:${NB_GID} /usr/local/etc/jupyter
 
 # switch to NB_UID for installs
@@ -94,6 +95,8 @@ RUN jupyter labextension disable --level=system "@jupyterlab/apputils-extension:
 # NOTE: the contents of $HOME_TMP are copied to $HOME at runtime
 #       this is a workaround because a PVC will be mounted at $HOME
 #       and the contents of $HOME will be hidden
-RUN cp -r -T "${HOME}" "${HOME_TMP}"
+RUN cp -p -r -T "${HOME}" "${HOME_TMP}" \
+    # give group same access as user (needed for OpenShift)
+ && chmod -R g=u "${HOME_TMP}"
 
 EXPOSE 8888

--- a/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
+++ b/components/example-notebook-servers/jupyter/s6/services.d/jupyterlab/run
@@ -5,6 +5,8 @@
 export JUPYTER_RUNTIME_DIR="/tmp/jupyter_runtime"
 
 cd "${HOME}"
+echo "INFO: starting jupyter..."
+exec 2>&1
 exec /opt/conda/bin/jupyter lab \
   --notebook-dir="${HOME}" \
   --ip=0.0.0.0 \

--- a/components/example-notebook-servers/rstudio/Dockerfile
+++ b/components/example-notebook-servers/rstudio/Dockerfile
@@ -40,13 +40,14 @@ RUN apt-get -yq update \
 # setup environment for conda
 ENV CONDA_DIR /opt/conda
 ENV PATH "${CONDA_DIR}/bin:${PATH}"
-RUN mkdir -p ${CONDA_DIR} \
+RUN mkdir -pv ${CONDA_DIR} \
+ && chmod 2775 ${CONDA_DIR} \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> ${HOME}/.bashrc \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/profile \
  && echo "conda activate base" >> ${HOME}/.bashrc \
  && echo "conda activate base" >> /etc/profile \
  && chown -R ${NB_USER}:${NB_GID} ${CONDA_DIR} \
- && chown -R ${NB_USER}:${NB_GID} ${HOME}
+ && chown -R ${NB_USER}:${USERS_GID} ${HOME}
 
 # setup environment for R
 ENV R_HOME ${CONDA_DIR}/lib/R
@@ -115,7 +116,12 @@ RUN case "${TARGETARCH}" in \
  && chown -R ${NB_USER}:${NB_GID} /etc/rstudio \
  && chown -R ${NB_USER}:${NB_GID} /run/rstudio-server* \
  && chown -R ${NB_USER}:${NB_GID} /usr/lib/rstudio-server \
- && chown -R ${NB_USER}:${NB_GID} /var/lib/rstudio-server
+ && chown -R ${NB_USER}:${NB_GID} /var/lib/rstudio-server \
+    # give group same access as user (needed for OpenShift)
+ && chmod -R g=u /etc/rstudio \
+ && chmod -R g=u /run/rstudio-server* \
+ && chmod -R g=u /usr/lib/rstudio-server \
+ && chmod -R g=u /var/lib/rstudio-server
 
 # tell rstudio to use conda python by setting `RETICULATE_PYTHON` with `--rsession-path=/opt/rsession.sh`
 COPY --chown=${NB_USER}:${NB_GID} --chmod=755 rsession.sh /opt
@@ -128,8 +134,9 @@ COPY --chown=${NB_USER}:${NB_GID} --chmod=755 s6/ /etc
 # NOTE: the contents of $HOME_TMP are copied to $HOME at runtime
 #       this is a workaround because a PVC will be mounted at $HOME
 #       and the contents of $HOME will be hidden
-RUN cp -r -T "${HOME}" "${HOME_TMP}" \
- && chown -R ${NB_USER}:${NB_GID} ${HOME_TMP}
+RUN cp -p -r -T "${HOME}" "${HOME_TMP}" \
+    # give group same access as user (needed for OpenShift)
+ && chmod -R g=u "${HOME_TMP}"
 
 USER $NB_UID
 

--- a/components/example-notebook-servers/rstudio/Dockerfile
+++ b/components/example-notebook-servers/rstudio/Dockerfile
@@ -52,6 +52,15 @@ RUN mkdir -pv ${CONDA_DIR} \
 # setup environment for R
 ENV R_HOME ${CONDA_DIR}/lib/R
 
+# rstudio logs to a file by default, but we need to see them in the container logs
+ENV RS_LOG_LEVEL WARN
+ENV RS_LOGGER_TYPE stderr
+
+# rstudio must run as a named user.
+# we change the UID of 'jovyan' at runtime to match the UID of the container.
+# this is important for environments like OpenShift where the container has a random UID.
+RUN chmod g+w /etc/passwd
+
 USER $NB_UID
 
 # install - conda, pip, python
@@ -101,27 +110,36 @@ RUN case "${TARGETARCH}" in \
       *) echo "Unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
     esac \
  && curl -fsSL "${RSTUDIO_DEB_URL}" -o /tmp/rstudio-server.deb \
-    # add rstudio public code-signing keys
+    # validate the build signature
+ && export GNUPGHOME="$(mktemp -d)" \
  && gpg --keyserver keys.gnupg.net --keyserver pgp.surfnet.nl --recv-keys 3F32EE77E331692F \
  && gpg --keyserver keys.openpgp.org --recv-keys 51C0B5BB19F92D60 \
-    # validate the build signature
  && dpkg-sig --verify /tmp/rstudio-server.deb \
+ && rm -rf "${GNUPGHOME}" \
+    # install rstudio-server
  && dpkg -i /tmp/rstudio-server.deb \
  && rm -f /tmp/rstudio-server.deb \
+    # the default DB path '/var/lib/rstudio-server' causes permission issues when running as a random UID (like in OpenShift)
+ && echo "provider=sqlite" > /etc/rstudio/database.conf \
+ && echo "directory=/tmp/rstudio_db" >> /etc/rstudio/database.conf \
     # use advisory file-locks to improve PVC support
  && echo "lock-type=advisory" > /etc/rstudio/file-locks \
     # allow kubeflow to display rstudio in an iframe
  && echo "www-frame-origin=same" >> /etc/rstudio/rserver.conf \
     # allows the non-root NB_USER to run rstudio
+ && chown -R ${NB_USER}:${NB_GID} ${R_HOME} \
  && chown -R ${NB_USER}:${NB_GID} /etc/rstudio \
  && chown -R ${NB_USER}:${NB_GID} /run/rstudio-server* \
  && chown -R ${NB_USER}:${NB_GID} /usr/lib/rstudio-server \
  && chown -R ${NB_USER}:${NB_GID} /var/lib/rstudio-server \
+ && chown -R ${NB_USER}:${NB_GID} /var/log/rstudio \
     # give group same access as user (needed for OpenShift)
+ && chmod -R g=u ${R_HOME} \
  && chmod -R g=u /etc/rstudio \
  && chmod -R g=u /run/rstudio-server* \
  && chmod -R g=u /usr/lib/rstudio-server \
- && chmod -R g=u /var/lib/rstudio-server
+ && chmod -R g=u /var/lib/rstudio-server \
+ && chmod -R g=u /var/log/rstudio
 
 # tell rstudio to use conda python by setting `RETICULATE_PYTHON` with `--rsession-path=/opt/rsession.sh`
 COPY --chown=${NB_USER}:${NB_GID} --chmod=755 rsession.sh /opt

--- a/components/example-notebook-servers/rstudio/Dockerfile
+++ b/components/example-notebook-servers/rstudio/Dockerfile
@@ -45,8 +45,8 @@ RUN mkdir -p ${CONDA_DIR} \
  && echo ". /opt/conda/etc/profile.d/conda.sh" >> /etc/profile \
  && echo "conda activate base" >> ${HOME}/.bashrc \
  && echo "conda activate base" >> /etc/profile \
- && chown -R ${NB_USER}:users ${CONDA_DIR} \
- && chown -R ${NB_USER}:users ${HOME}
+ && chown -R ${NB_USER}:${NB_GID} ${CONDA_DIR} \
+ && chown -R ${NB_USER}:${NB_GID} ${HOME}
 
 # setup environment for R
 ENV R_HOME ${CONDA_DIR}/lib/R
@@ -112,24 +112,24 @@ RUN case "${TARGETARCH}" in \
     # allow kubeflow to display rstudio in an iframe
  && echo "www-frame-origin=same" >> /etc/rstudio/rserver.conf \
     # allows the non-root NB_USER to run rstudio
- && chown -R ${NB_USER}:users /etc/rstudio \
- && chown -R ${NB_USER}:users /run/rstudio-server* \
- && chown -R ${NB_USER}:users /usr/lib/rstudio-server \
- && chown -R ${NB_USER}:users /var/lib/rstudio-server
+ && chown -R ${NB_USER}:${NB_GID} /etc/rstudio \
+ && chown -R ${NB_USER}:${NB_GID} /run/rstudio-server* \
+ && chown -R ${NB_USER}:${NB_GID} /usr/lib/rstudio-server \
+ && chown -R ${NB_USER}:${NB_GID} /var/lib/rstudio-server
 
 # tell rstudio to use conda python by setting `RETICULATE_PYTHON` with `--rsession-path=/opt/rsession.sh`
-COPY --chown=${NB_USER}:users --chmod=755 rsession.sh /opt
+COPY --chown=${NB_USER}:${NB_GID} --chmod=755 rsession.sh /opt
 RUN chmod +x /opt/rsession.sh
 
 # s6 - copy scripts
-COPY --chown=${NB_USER}:users --chmod=755 s6/ /etc
+COPY --chown=${NB_USER}:${NB_GID} --chmod=755 s6/ /etc
 
 # s6 - 01-copy-tmp-home
 # NOTE: the contents of $HOME_TMP are copied to $HOME at runtime
 #       this is a workaround because a PVC will be mounted at $HOME
 #       and the contents of $HOME will be hidden
 RUN cp -r -T "${HOME}" "${HOME_TMP}" \
- && chown -R ${NB_USER}:users ${HOME_TMP}
+ && chown -R ${NB_USER}:${NB_GID} ${HOME_TMP}
 
 USER $NB_UID
 

--- a/components/example-notebook-servers/rstudio/s6/cont-init.d/02-rstudio-env-fix
+++ b/components/example-notebook-servers/rstudio/s6/cont-init.d/02-rstudio-env-fix
@@ -1,4 +1,5 @@
 #!/command/with-contenv bash
+
 # rstudio terminal cant see environment variables set by the container runtime
 # (which breaks kubectl, to fix this we store the KUBERNETES_* env vars in Renviron.site)
 env | grep KUBERNETES_ >> ${R_HOME}/etc/Renviron.site

--- a/components/example-notebook-servers/rstudio/s6/services.d/rstudio/finish
+++ b/components/example-notebook-servers/rstudio/s6/services.d/rstudio/finish
@@ -1,2 +1,0 @@
-#!/command/with-contenv bash
-exec rstudio-server stop

--- a/components/example-notebook-servers/rstudio/s6/services.d/rstudio/run
+++ b/components/example-notebook-servers/rstudio/s6/services.d/rstudio/run
@@ -1,9 +1,32 @@
 #!/command/with-contenv bash
+
+# the runtime state directory must be a path that is NOT a persistent volume
+# note, this env-var is not read by rstudio, but is used later in this script
+export RSTUDIO_RUNTIME_DIR="/tmp/rstudio_runtime"
+
+# rstudio needs a named user. if we are running as a user with no name,
+# change the 'jovyan' user to match the current UID. this is necessary
+# as some environments (e.g. OpenShift) run containers as a random UID.
+# note, '/etc/passwd' is writable by GID 0, which is why we can edit it.
+if ! whoami &> /dev/null; then
+  echo "INFO: container is running as UID $(id -u), changing 'jovyan' to match"
+  if [[ -w /etc/passwd ]]; then
+    TEMP_SED=$(sed "s/^${NB_USER}:x:${NB_UID}/${NB_USER}:x:$(id -u)/" /etc/passwd)
+    echo "${TEMP_SED}" > /etc/passwd
+  else
+    echo "ERROR: no permission to write /etc/passwd"
+    exit 1
+  fi
+fi
+
 # using rstudio with non-root and `--auth-none=1` inexplicably requires USER to be set
 export USER="${NB_USER}"
 
+echo "INFO: starting rstudio-server..."
+exec 2>&1
 exec /usr/lib/rstudio-server/bin/rserver \
   --server-daemonize=0 \
+  --server-data-dir="${RSTUDIO_RUNTIME_DIR}" \
   --server-working-dir="${HOME}" \
   --server-user="${NB_USER}" \
   --www-address=0.0.0.0 \


### PR DESCRIPTION
resolves https://github.com/kubeflow/kubeflow/issues/5808

# What does this PR do?

This PR makes the following changes to the `example-notebook-servers`:

- updates the version of [`s6-overlay`](https://github.com/just-containers/s6-overlay) to [`v3.2.0.0`](https://github.com/just-containers/s6-overlay/releases/tag/v3.2.0.0)
- changes the primary GID of the `jovyan` user from `100` to `0`: 
    - for backwards-compatibility, `jovyan` is still a member of `100`
- fixed the fact that the IDEs could fail to start, but the container would stay running:
    - sets `S6_BEHAVIOUR_IF_STAGE2_FAILS` to `2` 
- fixed the fact that the STDERR of the IDEs was not being captured in the Pod logs:
    - runs `exec 2>&1` in the s6 `run` scripts
- fixed the fact that RStudio would not print its logs to the container:
    - set `RS_LOGGER_TYPE` to `stderr`
- removed the `finish` s6 script for RStudio, as this is no longer needed:
    - RStudio now catches the TERM signal and gracefully saves user work.
- fixed running the container images under a random UID (e.g. OpenShift):
    - see "What is left to do?" for future work to make this even better.

# What is left to do?

In a future PR we can address the following:

- Make the default container SecutiryContext of the Pods more restrictive:
    - Because our images now support running with a more restrictive SecurityContext, we should make this the default.
        - `allowPrivilegeEscalation: false`
        - `capabilities ... drop ... ALL`
    - However, as this will prevent older notebooks from running, we need to make a public migration plan, perhaps even only doing this on Notebooks 2.0
- While I have made it possible to start all the example notebooks with a random UID (e.g. in OpenShift), the files created in the `/home/jovyan` PVC are sometimes are not writable by the group:
    - This mean when the Notebook restarts with a new UID, it will not be able to write these files.
    - I wonder if this is something to do with the UMASK not being set to `002` the s6 services?

# How can I test the fix?

If you would like to test some of these images I have pushed them (in X86 only) to:

- VSCode (Python): [`ghcr.io/thesuperzapper/kubeflow/notebook-servers/rstudio-tidyverse:sha-665708b0ad39da0f2a152a2aec860726c01ab160`](https://github.com/thesuperzapper/kubeflow/pkgs/container/kubeflow%2Fnotebook-servers%2Fcodeserver-python/238311326?tag=sha-665708b0ad39da0f2a152a2aec860726c01ab160)
- RStudio (Tidyverse): [`ghcr.io/thesuperzapper/kubeflow/notebook-servers/rstudio-tidyverse:sha-665708b0ad39da0f2a152a2aec860726c01ab160`](https://github.com/thesuperzapper/kubeflow/pkgs/container/kubeflow%2Fnotebook-servers%2Frstudio-tidyverse/238309972?tag=sha-665708b0ad39da0f2a152a2aec860726c01ab160)
- Jupyter (SciPy): [`ghcr.io/thesuperzapper/kubeflow/notebook-servers/jupyter-scipy:sha-665708b0ad39da0f2a152a2aec860726c01ab160`](https://github.com/thesuperzapper/kubeflow/pkgs/container/kubeflow%2Fnotebook-servers%2Fjupyter-scipy/238311943?tag=sha-665708b0ad39da0f2a152a2aec860726c01ab160)
- Jupyter (PyTorch) [`ghcr.io/thesuperzapper/kubeflow/notebook-servers/jupyter-pytorch-cuda-full:sha-665708b0ad39da0f2a152a2aec860726c01ab160`](https://github.com/thesuperzapper/kubeflow/pkgs/container/kubeflow%2Fnotebook-servers%2Fjupyter-pytorch-cuda-full/238316746?tag=sha-665708b0ad39da0f2a152a2aec860726c01ab160)
- Jupyter (Tensorflow) [`ghcr.io/thesuperzapper/kubeflow/notebook-servers/jupyter-tensorflow-cuda-full:sha-665708b0ad39da0f2a152a2aec860726c01ab160`](https://github.com/thesuperzapper/kubeflow/pkgs/container/kubeflow%2Fnotebook-servers%2Fjupyter-tensorflow-cuda-full/238320627?tag=sha-665708b0ad39da0f2a152a2aec860726c01ab160)

# The Problem

Currently, setting a typical `securityContext` on Notebooks, will cause them to fail to start with the following error:

```text
test-jupyter3 s6-overlay-suexec: warning: unable to gain root privileges (is the suid bit set?)                                                                                                  
test-jupyter3 s6-mkdir: warning: unable to mkdir /run/s6: Permission denied                                                                                                                      
test-jupyter3 s6-mkdir: warning: unable to mkdir /run/service: Permission denied                                                                                                                 
test-jupyter3 s6-overlay-suexec: fatal: child failed with exit code 111  
```

What I mean by a "typical" container `securityContext` is one that drops all permissions prevents privilege escalation:

```yaml
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            runAsNonRoot: true
```


For example, here is a Notebook which has this error that uses the `kubeflownotebookswg/jupyter-scipy:v1.9.0-rc.1` image:


```yaml
apiVersion: kubeflow.org/v1
kind: Notebook
metadata:
  name: my-notebook
  namespace: team-1
  annotations:
    notebooks.kubeflow.org/server-type: jupyter
spec:
  template:
    spec:
      containers:
        - env: []
          image: kubeflownotebookswg/jupyter-scipy:v1.9.0-rc.1
          imagePullPolicy: IfNotPresent
          name: test-jupyter3
          resources:
            limits:
              cpu: "0.6"
              memory: 1.2Gi
            requests:
              cpu: "0.5"
              memory: 1Gi

          ## \/ THIS PART IS THE PROBLEM \/ ##
          securityContext:
            allowPrivilegeEscalation: false
            capabilities:
              drop:
                - ALL
            runAsNonRoot: true
          ## /\ THIS PART IS THE PROBLEM /\ ##

          volumeMounts:
            - mountPath: /dev/shm
              name: dshm
            - mountPath: /home/jovyan
              name: my-notebook-volume
      serviceAccountName: default-editor
      tolerations: []
      volumes:
        - name: dshm
          emptyDir:
            medium: Memory
        - name: my-notebook-volume
          persistentVolumeClaim:
            claimName: my-notebook-volume
            readOnly: false
```

# The solution

Luckily, the [`s6-overlay`](https://github.com/just-containers/s6-overlay) project (which we depend on in our example images) released [`v3.2.0.0`](https://github.com/just-containers/s6-overlay/releases/tag/v3.2.0.0) recently which addresses this very issue.

To make this work we must also change the primary `GID` of the `jovyan` user to `0`. While this might look like giving the Pod root, it actually does nothing, because being in the `root` group does not confer any extra permissions. 

This is extremely common practice in the Kubernetes world (setting the GID of non-root users as `0`), for example, this is what __Apache Airflow__ does in their Docker container, which you can read more about [here](https://airflow.apache.org/docs/docker-stack/entrypoint.html#allowing-arbitrary-user-to-run-the-container).

The reason for choosing `0` is just that its the industry standard, the only important thing is to have a common GID so that we can make all important files in the Docker container be owned by this group (which allows for deployment on Kubernetes clusters that randomize container's UIDs, like OpenShift)

# How do I set `securityContext` anyway?

You might be wondering how this would be done in the real world, as Notebooks 1.0 does NOT provide a way to set a `securityContext` other than manually creating `Notebook` CRDs.

It turns out that you can override the [default `notebook_template.yaml`](https://github.com/kubeflow/kubeflow/blob/v1.8.0/components/crud-web-apps/jupyter/backend/apps/common/yaml/notebook_template.yaml) by mounting a file at `/src/apps/common/yaml/notebook_template.yaml` in the `Deployment/jupyter-web-app-deployment` Pod. 

See the [deployKF docs](https://www.deploykf.org/guides/tools/kubeflow-notebooks/#override-notebook-template) for more information about this.