### PR TITLE
Change LOGOUT_URL from central dashboard to oauth2 proxy

### DIFF
--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: DASHBOARD_CONFIGMAP
           value: CD_CONFIGMAP_NAME_PLACEHOLDER
         - name: LOGOUT_URL
-          value: '/authservice/logout'
+          value: '/oauth2/logout'
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
Since kubeflow switched to oauth2 proxy we have to adjust the logout url from the central dashboard