### PR TITLE
feat: add Intel Gaudi example notebook images

### DIFF
--- a/.github/workflows/example_notebook_servers_publish.yaml
+++ b/.github/workflows/example_notebook_servers_publish.yaml
@@ -83,6 +83,17 @@ jobs:
         jupyter-pytorch-cuda
         jupyter-pytorch-cuda-full
 
+  jupyter_pytorch_gaudi_images:
+    name: Build & Push - Jupyter (PyTorch + Gaudi)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64
+      image_folders: |
+        jupyter-pytorch-gaudi
+        jupyter-pytorch-gaudi-full
+
   jupyter_tensorflow_images:
     name: Build & Push - Jupyter (TensorFlow)
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -134,6 +134,8 @@ spawnerFormDefaults:
           uiName: "NVIDIA"
         - limitsKey: "amd.com/gpu"
           uiName: "AMD"
+        - limitsKey: "habana.ai/gaudi"
+          uiName: "Intel Gaudi"
 
       # the default value of the limit
       # (possible values: "none", "1", "2", "4", "8")

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -44,6 +44,7 @@ spawnerFormDefaults:
       - kubeflownotebookswg/jupyter-scipy:latest
       - kubeflownotebookswg/jupyter-pytorch-full:latest
       - kubeflownotebookswg/jupyter-pytorch-cuda-full:latest
+      - kubeflownotebookswg/jupyter-pytorch-gaudi-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-cuda-full:latest
 

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -134,6 +134,8 @@ spawnerFormDefaults:
           uiName: "NVIDIA"
         - limitsKey: "amd.com/gpu"
           uiName: "AMD"
+        - limitsKey: "habana.ai/gaudi"
+          uiName: "Intel Gaudi"
 
       # the default value of the limit
       # (possible values: "none", "1", "2", "4", "8")

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -44,6 +44,7 @@ spawnerFormDefaults:
       - kubeflownotebookswg/jupyter-scipy:latest
       - kubeflownotebookswg/jupyter-pytorch-full:latest
       - kubeflownotebookswg/jupyter-pytorch-cuda-full:latest
+      - kubeflownotebookswg/jupyter-pytorch-gaudi-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-cuda-full:latest
 

--- a/components/example-notebook-servers/Makefile
+++ b/components/example-notebook-servers/Makefile
@@ -9,6 +9,8 @@ IMAGE_FOLDERS ?= \
 	jupyter-pytorch-full \
 	jupyter-pytorch-cuda \
 	jupyter-pytorch-cuda-full \
+	jupyter-pytorch-gaudi \
+	jupyter-pytorch-gaudi-full \
 	jupyter-tensorflow \
 	jupyter-tensorflow-full \
 	jupyter-tensorflow-cuda \

--- a/components/example-notebook-servers/README.md
+++ b/components/example-notebook-servers/README.md
@@ -13,11 +13,11 @@ graph TD
   Base[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/base'>Base</a>] --> Jupyter[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter'>Jupyter</a>]
   Base --> Code-Server[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/codeserver'>code-server</a>]
   Base --> RStudio[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/rstudio'>RStudio</a>]
-  
+
   Jupyter --> PyTorch[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch'>PyTorch</a>]
   Jupyter --> SciPy[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-scipy'>SciPy</a>]
   Jupyter --> TensorFlow[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-tensorflow'>TensorFlow</a>]
-  
+
   Code-Server --> Code-Server-Conda-Python[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/codeserver-python'>Conda Python</a>]
   RStudio --> Tidyverse[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/rstudio-tidyverse'>Tidyverse</a>]
 
@@ -29,6 +29,10 @@ graph TD
 
   PyTorchCuda --> PyTorchCudaFull[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch-cuda-full'>PyTorch CUDA Full</a>]
   TensorFlowCuda --> TensorFlowCudaFull[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-tensorflow-cuda-full'>TensorFlow CUDA Full</a>]
+
+  Jupyter --> PyTorchGaudi[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch-gaudi'>PyTorch Gaudi</a>]
+  PyTorchGaudi --> PyTorchGaudiFull[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch-gaudi-full'>PyTorch Gaudi Full</a>]
+
 ```
 
 ### Base Images
@@ -54,6 +58,8 @@ Dockerfile | Container Registry | Notes
 [`./jupyter-pytorch-full`](./jupyter-pytorch-full) | [`kubeflownotebookswg/jupyter-pytorch-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-full) | JupyterLab + PyTorch + Common Packages
 [`./jupyter-pytorch-cuda`](./jupyter-pytorch-cuda) | [`kubeflownotebookswg/jupyter-pytorch-cuda`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-cuda) | JupyterLab + PyTorch + CUDA
 [`./jupyter-pytorch-cuda-full`](./jupyter-pytorch-cuda-full) | [`kubeflownotebookswg/jupyter-pytorch-cuda-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-cuda-full) | JupyterLab + PyTorch + CUDA + Common Packages
+[`./jupyter-pytorch-gaudi`](./jupyter-pytorch-gaudi) | [`kubeflownotebookswg/jupyter-pytorch-gaudi`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-gaudi) | JupyterLab + PyTorch + Intel Gaudi
+[`./jupyter-pytorch-gaudi-full`](./jupyter-pytorch-gaudi-full) | [`kubeflownotebookswg/jupyter-pytorch-gaudi-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-gaudi-full) | JupyterLab + PyTorch + Intel Gaudi + Common Packages
 [`./jupyter-scipy`](./jupyter-scipy) | [`kubeflownotebookswg/jupyter-scipy`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-scipy) | JupyterLab + Common Packages
 [`./jupyter-tensorflow`](./jupyter-tensorflow) | [`kubeflownotebookswg/jupyter-tensorflow`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-tensorflow) | JupyterLab + TensorFlow
 [`./jupyter-tensorflow-full`](./jupyter-tensorflow-full) | [`kubeflownotebookswg/jupyter-tensorflow-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-tensorflow-full) | JupyterLab + TensorFlow + Common Packages

--- a/components/example-notebook-servers/jupyter-pytorch-gaudi-full/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-gaudi-full/Dockerfile
@@ -1,0 +1,28 @@
+#
+# NOTE: Use the Makefiles to build this image correctly.
+#
+
+ARG BASE_IMG=<jupyter-pytorch-gaudi>
+FROM $BASE_IMG
+
+# install - conda packages
+# NOTE: we use mamba to speed things up
+RUN mamba install -y -q \
+    bokeh==3.3.4 \
+    cloudpickle==2.2.1 \
+    dill==0.3.8 \
+    ipympl==0.9.4 \
+    matplotlib==3.8.4 \
+    numpy==1.24.4 \
+    pandas==2.1.4 \
+    scikit-image==0.22.0 \
+    scikit-learn==1.3.2 \
+    scipy==1.11.3 \
+    seaborn==0.13.2 \
+    xgboost==1.7.6 \
+ && mamba clean -a -f -y
+
+# install - requirements.txt
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-gaudi-full/Makefile
+++ b/components/example-notebook-servers/jupyter-pytorch-gaudi-full/Makefile
@@ -1,0 +1,35 @@
+#
+# This Makefile is templated, the following targets are provided:
+#  - Current Architecture:
+#     - docker-build:     build the docker image
+#     - docker-build-dep: build the docker image (and any base images)
+#     - docker-push:      push the docker image
+#     - docker-push-dep:  push the docker image (and any base images)
+#  - Multi-Architecture:
+#     - docker-build-multi-arch:          build the docker image
+#     - docker-build-multi-arch-dep:      build the docker image (and any base images)
+#     - docker-build-push-multi-arch:     build AND push the docker image
+#     - docker-build-push-multi-arch-dep: build AND push the docker image (and any base images)
+#
+
+GIT_COMMIT     := $(shell git rev-parse HEAD)
+GIT_TREE_STATE := $(shell test -n "`git status --porcelain`" && echo "-dirty" || echo "")
+
+REGISTRY ?= docker.io/kubeflownotebookswg
+TAG      ?= sha-$(GIT_COMMIT)$(GIT_TREE_STATE)
+
+IMAGE_NAME := jupyter-pytorch-gaudi-full
+
+BASE_IMAGE         := $(REGISTRY)/jupyter-pytorch-gaudi:$(TAG)
+BASE_IMAGE_FOLDERS := jupyter-pytorch-gaudi
+
+# we use a separate registry-type cache to keep the main registry clean
+# https://docs.docker.com/build/cache/backends/
+CACHE_IMAGE ?= ghcr.io/kubeflow/kubeflow/notebook-servers/build-cache
+CACHE_TAG   ?= $(IMAGE_NAME)
+
+# https://docs.docker.com/engine/reference/commandline/buildx_build/#platform
+ARCH ?= linux/amd64
+
+# include build targets from common
+include ../common.mk

--- a/components/example-notebook-servers/jupyter-pytorch-gaudi-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-pytorch-gaudi-full/requirements.txt
@@ -1,0 +1,5 @@
+# kubeflow packages
+kfp==2.7.0
+
+# jupyterlab extensions
+jupyterlab-git==0.50.1

--- a/components/example-notebook-servers/jupyter-pytorch-gaudi/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-gaudi/Dockerfile
@@ -164,6 +164,9 @@ COPY --chown=${NB_USER}:users requirements.txt /tmp
 RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
  && rm -f /tmp/requirements.txt
 
+# install - note about Gaudi workloads and hugepages
+COPY README.md "${HOME}"
+
 # s6 - 01-copy-tmp-home
 # NOTE: the contents of $HOME_TMP are copied to $HOME at runtime
 #       this is a workaround because a PVC will be mounted at $HOME

--- a/components/example-notebook-servers/jupyter-pytorch-gaudi/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-gaudi/Dockerfile
@@ -1,0 +1,173 @@
+#
+# NOTE: Use the Makefiles to build this image correctly.
+#
+
+ARG BASE_IMG=<jupyter>
+FROM $BASE_IMG
+
+# Content below is based on the scripts/Dockerfiles here:
+# https://github.com/HabanaAI/Setup_and_Install/blob/1.17.1/dockerfiles/base/Dockerfile.ubuntu22.04
+# https://github.com/HabanaAI/Setup_and_Install/blob/1.17.1/dockerfiles/pytorch/Dockerfile.ubuntu
+
+# args - gaudi version
+ARG GAUDI_VERSION=1.17.1
+ARG GAUDI_REVISION=40
+
+# args - software versions
+# see this support matrix for compatible versions:
+# https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html
+ARG AWS_EFA_VERSION=1.29.0
+ARG HCCL_OFI_WRAPPER_VERSION=1.18.0
+ARG LIBFABRIC_VERSION=1.20.0
+ARG PYTORCH_VERSION=2.3.1
+
+# Gaudi 1.17 does not currently support Python 3.11, so we downgrade to 3.10
+# https://docs.habana.ai/en/latest/Support_Matrix/Support_Matrix.html
+ARG PYTHON_VERSION=3.10.14
+RUN sed -i "s/python ==.*/python ==${PYTHON_VERSION}/" ${CONDA_DIR}/conda-meta/pinned \
+ && conda install -y -q \
+    python==${PYTHON_VERSION} \
+ && conda clean -a -f -y
+
+USER root
+
+# install - support libraries
+RUN export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update -yq \
+ && apt-get install -yq --no-install-recommends \
+    apt-utils \
+    bc \
+    build-essential \
+    graphviz \
+    iproute2 \
+    libcairo2-dev \
+    libgl1 \
+    libglib2.0-dev \
+    libgnutls30 \
+    libgoogle-glog0v5 \
+    libgoogle-perftools-dev \
+    libhdf5-dev \
+    libjemalloc2 \
+    libjpeg-dev \
+    liblapack-dev \
+    libmkl-dev \
+    libnuma-dev \
+    libopenblas-dev \
+    libpcre2-dev \
+    libpq-dev \
+    libselinux1-dev \
+    lsof \
+    moreutils \
+    numactl \
+    protobuf-compiler \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV LD_PRELOAD=/lib/x86_64-linux-gnu/libtcmalloc.so.4
+
+# install - elastic fabric adapter
+# NOTE: we use a temporary GNUPGHOME to avoid polluting the user's HOME with root-owned files
+RUN export GNUPGHOME=$(mktemp -d) \
+ && curl -fsSL "https://efa-installer.amazonaws.com/aws-efa-installer-$AWS_EFA_VERSION.tar.gz" -o /tmp/aws-efa-installer.tar.gz \
+ && curl -fsSL "https://efa-installer.amazonaws.com/aws-efa-installer-$AWS_EFA_VERSION.tar.gz.sig" -o /tmp/aws-efa-installer.tar.gz.sig \
+ && curl -fsSL "https://efa-installer.amazonaws.com/aws-efa-installer.key" | gpg --import \
+ && gpg --verify /tmp/aws-efa-installer.tar.gz.sig /tmp/aws-efa-installer.tar.gz \
+ && tar xzf /tmp/aws-efa-installer.tar.gz -C /tmp \
+ && cd /tmp/aws-efa-installer \
+ && export DEBIAN_FRONTEND=noninteractive \
+ && apt-get -yq update \
+ && ./efa_installer.sh -y --skip-kmod --skip-limit-conf --no-verify \
+ && rm -rf /etc/ld.so.conf.d/efa.conf /etc/profile.d/efa.sh \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/* \
+ && rm -rf /tmp/aws-efa-installer.tar.gz /tmp/aws-efa-installer.tar.gz.sig /tmp/aws-efa-installer \
+ && rm -rf "${GNUPGHOME}"
+
+# config - fabric adapter and mpi variables
+ENV MPI_ROOT=/opt/amazon/openmpi
+ENV PATH=${MPI_ROOT}/bin:${PATH}
+ENV MPICC=${MPI_ROOT}/bin/mpicc
+ENV OPAL_PREFIX=${MPI_ROOT}
+ENV RDMAV_FORK_SAFE=1
+ENV FI_EFA_USE_DEVICE_RDMA=1
+ENV LD_LIBRARY_PATH=${MPI_ROOT}/lib
+
+# install - habana packages
+RUN curl -fsSL "https://vault.habana.ai/artifactory/api/gpg/key/public" | gpg --dearmor -o /usr/share/keyrings/habana-artifactory.gpg \
+ && chown root:root /usr/share/keyrings/habana-artifactory.gpg \
+ && chmod 644 /usr/share/keyrings/habana-artifactory.gpg \
+ && echo "deb [signed-by=/usr/share/keyrings/habana-artifactory.gpg] https://vault.habana.ai/artifactory/debian jammy main" | tee /etc/apt/sources.list.d/habana.list \
+ && export DEBIAN_FRONTEND=noninteractive \
+ && apt-get update -yq \
+ && apt-get install -yq --no-install-recommends \
+    habanalabs-firmware-tools="${GAUDI_VERSION}"-"${GAUDI_REVISION}" \
+    habanalabs-graph="${GAUDI_VERSION}"-"${GAUDI_REVISION}" \
+    habanalabs-rdma-core="${GAUDI_VERSION}"-"${GAUDI_REVISION}" \
+    habanalabs-thunk="${GAUDI_VERSION}"-"${GAUDI_REVISION}" \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# config - habana variables
+ENV RDMA_CORE_ROOT=/opt/habanalabs/rdma-core/src
+ENV RDMA_CORE_LIB=${RDMA_CORE_ROOT}/build/lib
+ENV GC_KERNEL_PATH=/usr/lib/habanalabs/libtpc_kernels.so
+ENV HABANA_LOGS=/var/log/habana_logs/
+ENV HABANA_SCAL_BIN_PATH=/opt/habanalabs/engines_fw
+ENV HABANA_PLUGINS_LIB_PATH=/opt/habanalabs/habana_plugins
+ENV DATA_LOADER_AEON_LIB_PATH=/usr/lib/habanalabs/libaeon.so
+ENV LD_LIBRARY_PATH=/usr/lib/habanalabs:${LD_LIBRARY_PATH}
+
+# install - libfabric
+ENV LIBFABRIC_ROOT="/opt/habanalabs/libfabric-${LIBFABRIC_VERSION}"
+RUN curl -fsSL "https://github.com/ofiwg/libfabric/releases/download/v${LIBFABRIC_VERSION}/libfabric-${LIBFABRIC_VERSION}.tar.bz2" -o /tmp/libfabric-${LIBFABRIC_VERSION}.tar.bz2 \
+ && tar xjf /tmp/libfabric-${LIBFABRIC_VERSION}.tar.bz2 -C /tmp \
+ && cd /tmp/libfabric-${LIBFABRIC_VERSION} \
+ && ./configure --prefix=${LIBFABRIC_ROOT} --enable-psm3-verbs --enable-verbs=yes --with-synapseai=/usr \
+ && make -j \
+ && make install \
+ && cd / \
+ && rm -rf /tmp/libfabric-${LIBFABRIC_VERSION}.tar.bz2 /tmp/libfabric-${LIBFABRIC_VERSION}
+
+# config - add libfabric to loadable libraries
+ENV LD_LIBRARY_PATH="/opt/habanalabs/libfabric-${LIBFABRIC_VERSION}/lib:${LD_LIBRARY_PATH}"
+ENV PATH="/opt/habanalabs/libfabric-${LIBFABRIC_VERSION}/bin:${PATH}"
+
+# install - hccl wrapper for ofi
+RUN curl -fsSL "https://github.com/HabanaAI/hccl_ofi_wrapper/archive/refs/tags/v${HCCL_OFI_WRAPPER_VERSION}.tar.gz" -o /tmp/hccl_ofi_wrapper.tar.gz \
+ && tar xzf /tmp/hccl_ofi_wrapper.tar.gz -C /tmp \
+ && cd /tmp/hccl_ofi_wrapper-${HCCL_OFI_WRAPPER_VERSION} \
+ && make \
+ && cp -f libhccl_ofi_wrapper.so /usr/lib/habanalabs/libhccl_ofi_wrapper.so \
+ && cd / \
+ && rm -rf /tmp/hccl_ofi_wrapper.tar.gz /tmp/hccl_ofi_wrapper-v${HCCL_OFI_WRAPPER_VERSION} \
+ && /sbin/ldconfig
+
+# config - add habana modules to PYTHONPATH
+ENV PYTHONPATH=/usr/lib/habanalabs
+
+USER $NB_UID
+
+# install - habana pytorch media modules
+RUN python3 -m pip install --quiet --no-cache \
+    habana_media_loader=="${GAUDI_VERSION}.${GAUDI_REVISION}"
+
+# install - habana pytorch modules
+RUN curl -fsSL "https://vault.habana.ai/artifactory/gaudi-pt-modules/${GAUDI_VERSION}/${GAUDI_REVISION}/pytorch/ubuntu2204/pytorch_modules-v${PYTORCH_VERSION}_${GAUDI_VERSION}_${GAUDI_REVISION}.tgz" -o /tmp/gaudi-pt-modules.tgz \
+ && mkdir -p /tmp/gaudi-pt-modules \
+ && tar xzf /tmp/gaudi-pt-modules.tgz -C /tmp/gaudi-pt-modules \
+ && cd /tmp/gaudi-pt-modules \
+ && PIP_QUIET=1 PIP_NO_CACHE_DIR=1 PYTHON_VERSION=3 bash install.sh ${GAUDI_VERSION} ${GAUDI_REVISION} \
+ && rm -rf /tmp/gaudi-pt-modules.tgz /tmp/gaudi-pt-modules
+
+# install - requirements.txt
+COPY --chown=${NB_USER}:users requirements.txt /tmp
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt
+
+# s6 - 01-copy-tmp-home
+# NOTE: the contents of $HOME_TMP are copied to $HOME at runtime
+#       this is a workaround because a PVC will be mounted at $HOME
+#       and the contents of $HOME will be hidden
+RUN cp -p -r -T "${HOME}" "${HOME_TMP}" \
+    # give group same access as user (needed for OpenShift)
+ && chmod -R g=u "${HOME_TMP}"

--- a/components/example-notebook-servers/jupyter-pytorch-gaudi/Makefile
+++ b/components/example-notebook-servers/jupyter-pytorch-gaudi/Makefile
@@ -1,0 +1,35 @@
+#
+# This Makefile is templated, the following targets are provided:
+#  - Current Architecture:
+#     - docker-build:     build the docker image
+#     - docker-build-dep: build the docker image (and any base images)
+#     - docker-push:      push the docker image
+#     - docker-push-dep:  push the docker image (and any base images)
+#  - Multi-Architecture:
+#     - docker-build-multi-arch:          build the docker image
+#     - docker-build-multi-arch-dep:      build the docker image (and any base images)
+#     - docker-build-push-multi-arch:     build AND push the docker image
+#     - docker-build-push-multi-arch-dep: build AND push the docker image (and any base images)
+#
+
+GIT_COMMIT     := $(shell git rev-parse HEAD)
+GIT_TREE_STATE := $(shell test -n "`git status --porcelain`" && echo "-dirty" || echo "")
+
+REGISTRY ?= docker.io/kubeflownotebookswg
+TAG      ?= sha-$(GIT_COMMIT)$(GIT_TREE_STATE)
+
+IMAGE_NAME := jupyter-pytorch-gaudi
+
+BASE_IMAGE         := $(REGISTRY)/jupyter:$(TAG)
+BASE_IMAGE_FOLDERS := jupyter
+
+# we use a separate registry-type cache to keep the main registry clean
+# https://docs.docker.com/build/cache/backends/
+CACHE_IMAGE ?= ghcr.io/kubeflow/kubeflow/notebook-servers/build-cache
+CACHE_TAG   ?= $(IMAGE_NAME)
+
+# https://docs.docker.com/engine/reference/commandline/buildx_build/#platform
+ARCH ?= linux/amd64
+
+# include build targets from common
+include ../common.mk

--- a/components/example-notebook-servers/jupyter-pytorch-gaudi/README.md
+++ b/components/example-notebook-servers/jupyter-pytorch-gaudi/README.md
@@ -1,0 +1,9 @@
+# A note about Gaudi workloads
+
+Some Gaudi workloads require hugepages to run correctly. One can find a list of workloads listed [here](https://console.cloud.intel.com/docs/guides/k8s_guide.html#hugepages-settings-by-model). As of now, Kubeflow Notebooks lack the capability to request hugepages resources for individual notebooks.
+
+To add hugepages resources for the Notebook Pod, there are a couple of options:
+* Use [Limit Ranges](https://kubernetes.io/docs/concepts/policy/limit-range/) to set default hugepages amount for all Pods in the namespace.
+* Edit the Kubeflow's notebook object after it has been created and add the hugepages resources to the pod template.
+
+The upcoming Notebooks 2.0 release will improve the situation with its `podTemplate` feature.


### PR DESCRIPTION
closes: https://github.com/kubeflow/kubeflow/issues/7541

Hello,

This pull request adds initial support for Intel Gaudi use with Kubeflow's notebooks. The patches add two things:
1) Intel Gaudi option to the Notebook creation UI
2) Intel Gaudi pytorch jupyter Dockerfiles

The Gaudi containers downgrade the python version from `3.11` to `3.10` as the Habana pytorch stack does not yet support `3.11`. Support for `3.11` is planned and we will update the Dockerfiles once the `3.11` version is released.
