### PR TITLE
fix: return notebook events error message

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -49,6 +49,7 @@ def process_status(notebook):
     status_event, reason_event = get_status_from_events(notebook_events)
     if status_event is not None:
         status_phase, status_message = status_event, reason_event
+        return status.create_status(status_phase, status_message)
 
     # In case there no Events available, show a generic message
     status_phase = status.STATUS_PHASE.WARNING


### PR DESCRIPTION
Fixes https://github.com/kubeflow/notebooks/issues/64

Notebook events are not currently returned resulting in the generic error message `Couldn't find any information for the status of this notebook.` when unsuccessfully creating a notebook. 

This is because the error message from notebook events is currently being overridden by the generic error message.