### PR TITLE
fix: logout button for oauth2-proxy

### DIFF
--- a/components/centraldashboard/README.md
+++ b/components/centraldashboard/README.md
@@ -54,7 +54,7 @@ Make sure you have installed node 16!
     - Kubeflow Pipelines: `kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8087:80`
     - See [`webpack.config.js`](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/webpack.config.js) for more details.
 6. Open your browser to `http://localhost:8080` to see the dashboard:
-    - You will need to inject your requrests with a `kubeflow-userid` header
+    - You will need to inject your requests with a `kubeflow-userid` header
     - You can do this in Chrome by using the [Header Editor](https://chromewebstore.google.com/detail/eningockdidmgiojffjmkdblpjocbhgh) extension
     - For example, set the `kubeflow-userid` header to `user@example.com`
 

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: DASHBOARD_CONFIGMAP
           value: CD_CONFIGMAP_NAME_PLACEHOLDER
         - name: LOGOUT_URL
-          value: '/authservice/logout'
+          value: '/oauth2/sign_out'
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/components/centraldashboard/public/components/logout-button.css
+++ b/components/centraldashboard/public/components/logout-button.css
@@ -1,0 +1,3 @@
+a {
+    color: unset;
+}

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -1,5 +1,6 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '@polymer/paper-button/paper-button.js';
+import css from './logout-button.css';
 
 /**
  * Logout button component.
@@ -7,65 +8,24 @@ import '@polymer/paper-button/paper-button.js';
  */
 export class LogoutButton extends PolymerElement {
     static get template() {
-        return html`
-            <a href="{{logoutUrl}}" on-click="logout">
+        return html([`
+            <style>${css.toString()}</style>
+            <a href$="{{logoutUrl}}" on-tap="logout">
                 <paper-button id="logout-button">
                     <iron-icon icon="kubeflow:logout" 
                                title="Logout">
                     </iron-icon>
                 </paper-button>
             </a>
-        `;
-    }
-
-    static get properties() {
-        return {
-            /**
-             * The URL to trigger the logout process.
-             */
-            logoutUrl: {
-                type: String,
-                value: '', // Default to avoid undefined URL errors.
-            },
-            /**
-             * The URL to redirect to after a successful logout.
-             */
-            afterLogoutURL: {
-                type: String,
-                value: '/', // Default redirect if none is provided.
-            },
-        };
+        `]);
+        ;
     }
 
     /**
-     * Handles logout by navigating to the logout URL.
-     * If the backend returns an 'afterLogoutURL', the user is redirected there.
-     * Otherwise, it defaults to the provided `afterLogoutURL`.
-     *
-     * @param {Event} event - The click event triggered by the logout link.
+     * Set current page to logoutURL.
      */
-    logout(event) {
-        event.preventDefault(); // Prevent default anchor behavior.
-
-        // Perform the logout request via a GET request.
-        fetch(this.logoutUrl, {
-            method: 'GET',
-            credentials: 'include',
-        })
-            .then((response) => {
-                if (response.ok) {
-                    return response.json();
-                }
-                throw new Error('Logout failed');
-            })
-            .then((data) => {
-                const redirectUrl =
-                    data.afterLogoutURL || this.afterLogoutURL;
-                window.location.replace(redirectUrl);
-            })
-            .catch((error) => {
-                window.location.replace(this.afterLogoutURL);
-            });
+    logout() {
+        window.top.location.href = this.logoutUrl;
     }
 }
 

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -8,7 +8,7 @@ import '@polymer/paper-button/paper-button.js';
 export class LogoutButton extends PolymerElement {
     static get template() {
         return html`
-            <a href="#" on-click="logout">
+            <a href="{{logoutUrl}}" on-click="logout">
                 <paper-button id="logout-button">
                     <iron-icon icon="kubeflow:logout" 
                                title="Logout">


### PR DESCRIPTION
As suggested by @thesuperzapper [here ](https://github.com/kubeflow/manifests/issues/2895#issuecomment-2427184722) changed the login method to GET.  

Should fix #7624 and [Manifests #2895](https://github.com/kubeflow/manifests/issues/2895)

Testing:
- Built docker image for the dashboard
- Loaded the new image to kind cluster
- Changed name of docker image for central dashboard deployment to newly loaded image
- Tested logout functionality and it is working

