### PR TITLE
feat(notebooks): add rocm support

### DIFF
--- a/.github/workflows/example_notebook_servers_publish.yaml
+++ b/.github/workflows/example_notebook_servers_publish.yaml
@@ -94,6 +94,17 @@ jobs:
         jupyter-pytorch-gaudi
         jupyter-pytorch-gaudi-full
 
+  jupyter_pytorch_rocm_images:
+    name: Build & Push - Jupyter (PyTorch + ROCm)
+    uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+    needs: [ jupyter_images ]
+    secrets: inherit
+    with:
+      build_arch: linux/amd64
+      image_folders: |
+        jupyter-pytorch-rocm
+        jupyter-pytorch-rocm-full
+
   jupyter_tensorflow_images:
     name: Build & Push - Jupyter (TensorFlow)
     uses: ./.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml

--- a/components/centraldashboard/README.md
+++ b/components/centraldashboard/README.md
@@ -54,7 +54,7 @@ Make sure you have installed node 16!
     - Kubeflow Pipelines: `kubectl port-forward -n kubeflow svc/ml-pipeline-ui 8087:80`
     - See [`webpack.config.js`](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/webpack.config.js) for more details.
 6. Open your browser to `http://localhost:8080` to see the dashboard:
-    - You will need to inject your requrests with a `kubeflow-userid` header
+    - You will need to inject your requests with a `kubeflow-userid` header
     - You can do this in Chrome by using the [Header Editor](https://chromewebstore.google.com/detail/eningockdidmgiojffjmkdblpjocbhgh) extension
     - For example, set the `kubeflow-userid` header to `user@example.com`
 

--- a/components/centraldashboard/manifests/base/deployment.yaml
+++ b/components/centraldashboard/manifests/base/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: DASHBOARD_CONFIGMAP
           value: CD_CONFIGMAP_NAME_PLACEHOLDER
         - name: LOGOUT_URL
-          value: '/authservice/logout'
+          value: '/oauth2/sign_out'
         - name: POD_NAMESPACE
           valueFrom:
             fieldRef:

--- a/components/centraldashboard/public/components/logout-button.css
+++ b/components/centraldashboard/public/components/logout-button.css
@@ -1,0 +1,3 @@
+a {
+    color: unset;
+}

--- a/components/centraldashboard/public/components/logout-button.js
+++ b/components/centraldashboard/public/components/logout-button.js
@@ -1,79 +1,31 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-
-import '@polymer/iron-ajax/iron-ajax.js';
+import { html, PolymerElement } from '@polymer/polymer/polymer-element.js';
 import '@polymer/paper-button/paper-button.js';
+import css from './logout-button.css';
 
 /**
  * Logout button component.
- * Handles the logout requests and post-logout redirects.
- *
+ * Triggers a GET request to the logout URL and handles post-logout redirection.
  */
-
 export class LogoutButton extends PolymerElement {
     static get template() {
-        return html`
-            <paper-button id="logout-button" on-tap="logout">
-                <iron-icon icon='kubeflow:logout' title="Logout">
-                </iron-icon>
-            </paper-button>
-            <iron-ajax
-                    id='logout'
-                    url$='{{logoutUrl}}'
-                    method='post'
-                    handle-as='json'
-                    headers='{{headers}}'
-                    on-response='_postLogout'>
-            </iron-ajax>
-        `;
-    }
-
-    static get properties() {
-        return {
-            headers: {
-                type: Object,
-                computed: '_setHeaders()',
-            },
-            logoutUrl: {
-                type: String,
-            },
-        };
+        return html([`
+            <style>${css.toString()}</style>
+            <a href$="{{logoutUrl}}" on-tap="logout">
+                <paper-button id="logout-button">
+                    <iron-icon icon="kubeflow:logout" 
+                               title="Logout">
+                    </iron-icon>
+                </paper-button>
+            </a>
+        `]);
+        ;
     }
 
     /**
-     * After successful logout, redirects user to `afterLogoutURL`,
-     * received from the backend.
-     *
-     * @param {{Event}} event
-     * @private
-     */
-    _postLogout(event) {
-        window.location.replace(event.detail.response['afterLogoutURL']);
-    }
-
-    /**
-     * Call logout endpoint.
+     * Set current page to logoutURL.
      */
     logout() {
-        // call iron-ajax
-        this.$.logout.generateRequest();
-    }
-
-    /**
-     * Set 'Authorization' header based on the existing cookie.
-     * Currently, the logout method only accepts authorization header, see:
-     * https://github.com/arrikto/oidc-authservice/blob/master/server.go#L386
-     *
-     * @return {{Object}} headers
-     * @private
-     */
-    _setHeaders() {
-        const cookie = ('; ' + document.cookie)
-            .split(`; authservice_session=`)
-            .pop()
-            .split(';')[0];
-        return {
-            'Authorization': `Bearer ${cookie}`,
-        };
+        window.top.location.href = this.logoutUrl;
     }
 }
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -49,6 +49,7 @@ def process_status(notebook):
     status_event, reason_event = get_status_from_events(notebook_events)
     if status_event is not None:
         status_phase, status_message = status_event, reason_event
+        return status.create_status(status_phase, status_message)
 
     # In case there no Events available, show a generic message
     status_phase = status.STATUS_PHASE.WARNING

--- a/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/backend/apps/common/yaml/spawner_ui_config.yaml
@@ -45,6 +45,7 @@ spawnerFormDefaults:
       - kubeflownotebookswg/jupyter-pytorch-full:latest
       - kubeflownotebookswg/jupyter-pytorch-cuda-full:latest
       - kubeflownotebookswg/jupyter-pytorch-gaudi-full:latest
+      - kubeflownotebookswg/jupyter-pytorch-rocm-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-cuda-full:latest
 

--- a/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/configs/spawner_ui_config.yaml
@@ -45,6 +45,7 @@ spawnerFormDefaults:
       - kubeflownotebookswg/jupyter-pytorch-full:latest
       - kubeflownotebookswg/jupyter-pytorch-cuda-full:latest
       - kubeflownotebookswg/jupyter-pytorch-gaudi-full:latest
+      - kubeflownotebookswg/jupyter-pytorch-rocm-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-full:latest
       - kubeflownotebookswg/jupyter-tensorflow-cuda-full:latest
 

--- a/components/example-notebook-servers/Makefile
+++ b/components/example-notebook-servers/Makefile
@@ -11,6 +11,8 @@ IMAGE_FOLDERS ?= \
 	jupyter-pytorch-cuda-full \
 	jupyter-pytorch-gaudi \
 	jupyter-pytorch-gaudi-full \
+	jupyter-pytorch-rocm \
+	jupyter-pytorch-rocm-full \
 	jupyter-tensorflow \
 	jupyter-tensorflow-full \
 	jupyter-tensorflow-cuda \

--- a/components/example-notebook-servers/README.md
+++ b/components/example-notebook-servers/README.md
@@ -33,6 +33,9 @@ graph TD
   Jupyter --> PyTorchGaudi[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch-gaudi'>PyTorch Gaudi</a>]
   PyTorchGaudi --> PyTorchGaudiFull[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch-gaudi-full'>PyTorch Gaudi Full</a>]
 
+  Jupyter --> PyTorchRocm[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch-rocm'>PyTorch ROCm</a>]
+  PyTorchRocm --> PyTorchRocmFull[<a href='https://github.com/kubeflow/kubeflow/tree/master/components/example-notebook-servers/jupyter-pytorch-rocm-full'>PyTorch ROCm Full</a>]
+
 ```
 
 ### Base Images
@@ -60,6 +63,8 @@ Dockerfile | Container Registry | Notes
 [`./jupyter-pytorch-cuda-full`](./jupyter-pytorch-cuda-full) | [`kubeflownotebookswg/jupyter-pytorch-cuda-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-cuda-full) | JupyterLab + PyTorch + CUDA + Common Packages
 [`./jupyter-pytorch-gaudi`](./jupyter-pytorch-gaudi) | [`kubeflownotebookswg/jupyter-pytorch-gaudi`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-gaudi) | JupyterLab + PyTorch + Intel Gaudi
 [`./jupyter-pytorch-gaudi-full`](./jupyter-pytorch-gaudi-full) | [`kubeflownotebookswg/jupyter-pytorch-gaudi-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-gaudi-full) | JupyterLab + PyTorch + Intel Gaudi + Common Packages
+[`./jupyter-pytorch-rocm`](./jupyter-pytorch-rocm) | [`kubeflownotebookswg/jupyter-pytorch-rocm`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-rocm) | JupyterLab + PyTorch + AMD ROCm
+[`./jupyter-pytorch-rocm-full`](./jupyter-pytorch-rocm-full) | [`kubeflownotebookswg/jupyter-pytorch-rocm-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-pytorch-rocm-full) | JupyterLab + PyTorch + AMD ROCm + Common Packages
 [`./jupyter-scipy`](./jupyter-scipy) | [`kubeflownotebookswg/jupyter-scipy`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-scipy) | JupyterLab + Common Packages
 [`./jupyter-tensorflow`](./jupyter-tensorflow) | [`kubeflownotebookswg/jupyter-tensorflow`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-tensorflow) | JupyterLab + TensorFlow
 [`./jupyter-tensorflow-full`](./jupyter-tensorflow-full) | [`kubeflownotebookswg/jupyter-tensorflow-full`](https://hub.docker.com/r/kubeflownotebookswg/jupyter-tensorflow-full) | JupyterLab + TensorFlow + Common Packages

--- a/components/example-notebook-servers/jupyter-pytorch-rocm-full/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-rocm-full/Dockerfile
@@ -1,0 +1,28 @@
+#
+# NOTE: Use the Makefiles to build this image correctly.
+#
+
+ARG BASE_IMG=<jupyter-pytorch-rocm>
+FROM $BASE_IMG
+
+# install - conda packages
+# NOTE: we use mamba to speed things up
+RUN mamba install -y -q \
+    bokeh==3.3.4 \
+    cloudpickle==2.2.1 \
+    dill==0.3.8 \
+    ipympl==0.9.4 \
+    matplotlib==3.8.4 \
+    numpy==1.24.4 \
+    pandas==2.1.4 \
+    scikit-image==0.22.0 \
+    scikit-learn==1.3.2 \
+    scipy==1.11.3 \
+    seaborn==0.13.2 \
+    xgboost==1.7.6 \
+ && mamba clean -a -f -y
+
+# install - requirements.txt
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp/requirements.txt
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-rocm-full/Makefile
+++ b/components/example-notebook-servers/jupyter-pytorch-rocm-full/Makefile
@@ -1,0 +1,35 @@
+#
+# This Makefile is templated, the following targets are provided:
+#  - Current Architecture:
+#     - docker-build:     build the docker image
+#     - docker-build-dep: build the docker image (and any base images)
+#     - docker-push:      push the docker image
+#     - docker-push-dep:  push the docker image (and any base images)
+#  - Multi-Architecture:
+#     - docker-build-multi-arch:          build the docker image
+#     - docker-build-multi-arch-dep:      build the docker image (and any base images)
+#     - docker-build-push-multi-arch:     build AND push the docker image
+#     - docker-build-push-multi-arch-dep: build AND push the docker image (and any base images)
+#
+
+GIT_COMMIT     := $(shell git rev-parse HEAD)
+GIT_TREE_STATE := $(shell test -n "`git status --porcelain`" && echo "-dirty" || echo "")
+
+REGISTRY ?= docker.io/kubeflownotebookswg
+TAG      ?= sha-$(GIT_COMMIT)$(GIT_TREE_STATE)
+
+IMAGE_NAME := jupyter-pytorch-rocm-full
+
+BASE_IMAGE         := $(REGISTRY)/jupyter-pytorch-rocm:$(TAG)
+BASE_IMAGE_FOLDERS := jupyter-pytorch-rocm
+
+# we use a separate registry-type cache to keep the main registry clean
+# https://docs.docker.com/build/cache/backends/
+CACHE_IMAGE ?= ghcr.io/kubeflow/kubeflow/notebook-servers/build-cache
+CACHE_TAG   ?= $(IMAGE_NAME)
+
+# https://docs.docker.com/engine/reference/commandline/buildx_build/#platform
+ARCH ?= linux/amd64
+
+# include build targets from common
+include ../common.mk

--- a/components/example-notebook-servers/jupyter-pytorch-rocm-full/requirements.txt
+++ b/components/example-notebook-servers/jupyter-pytorch-rocm-full/requirements.txt
@@ -1,0 +1,5 @@
+# kubeflow packages
+kfp==2.7.0
+
+# jupyterlab extensions
+jupyterlab-git==0.50.1

--- a/components/example-notebook-servers/jupyter-pytorch-rocm/Dockerfile
+++ b/components/example-notebook-servers/jupyter-pytorch-rocm/Dockerfile
@@ -1,0 +1,51 @@
+#
+# NOTE: Use the Makefiles to build this image correctly.
+#
+
+ARG BASE_IMG=<jupyter>
+FROM $BASE_IMG
+
+# args - software versions
+# https://github.com/pytorch/pytorch/releases
+# https://github.com/pytorch/audio/releases
+# https://github.com/pytorch/vision/releases
+ARG PYTORCH_VERSION=2.3.1
+ARG TORCHAUDIO_VERSION=2.3.1
+ARG TORCHVISION_VERSION=0.18.1
+
+# args - rocm versions
+ARG ROCM_VERSION=6.0
+ARG AMDGPU_VERSION=6.0
+
+# install - rocm & support libraries
+USER root
+ARG APT_PREF="Package: *\\nPin: release o=repo.radeon.com\\nPin-Priority: 600"
+RUN echo -e "$APT_PREF" > /etc/apt/preferences.d/rocm-pin-600
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends ca-certificates curl libnuma-dev gnupg \
+  && curl -sL https://repo.radeon.com/rocm/rocm.gpg.key | apt-key add - \
+  && printf "deb [arch=amd64] https://repo.radeon.com/rocm/apt/$ROCM_VERSION/ jammy main" | tee /etc/apt/sources.list.d/rocm.list \
+  && printf "deb [arch=amd64] https://repo.radeon.com/amdgpu/$AMDGPU_VERSION/ubuntu jammy main" | tee /etc/apt/sources.list.d/amdgpu.list \
+  && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+  libelf1 \
+  kmod \
+  file \
+  rocm-dev \
+  build-essential && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
+
+# config - user permissions
+RUN usermod -aG video $NB_USER
+
+USER $NB_UID
+
+# install - pytorch (rocm)
+RUN python3 -m pip install --quiet --no-cache-dir --index-url https://download.pytorch.org/whl/rocm6.0/ \
+    torch==${PYTORCH_VERSION} \
+    torchaudio==${TORCHAUDIO_VERSION} \
+    torchvision==${TORCHVISION_VERSION}
+
+# install - requirements.txt
+COPY --chown=${NB_USER}:${NB_GID} requirements.txt /tmp
+RUN python3 -m pip install -r /tmp/requirements.txt --quiet --no-cache-dir \
+ && rm -f /tmp/requirements.txt

--- a/components/example-notebook-servers/jupyter-pytorch-rocm/Makefile
+++ b/components/example-notebook-servers/jupyter-pytorch-rocm/Makefile
@@ -1,0 +1,35 @@
+#
+# This Makefile is templated, the following targets are provided:
+#  - Current Architecture:
+#     - docker-build:     build the docker image
+#     - docker-build-dep: build the docker image (and any base images)
+#     - docker-push:      push the docker image
+#     - docker-push-dep:  push the docker image (and any base images)
+#  - Multi-Architecture:
+#     - docker-build-multi-arch:          build the docker image
+#     - docker-build-multi-arch-dep:      build the docker image (and any base images)
+#     - docker-build-push-multi-arch:     build AND push the docker image
+#     - docker-build-push-multi-arch-dep: build AND push the docker image (and any base images)
+#
+
+GIT_COMMIT     := $(shell git rev-parse HEAD)
+GIT_TREE_STATE := $(shell test -n "`git status --porcelain`" && echo "-dirty" || echo "")
+
+REGISTRY ?= docker.io/kubeflownotebookswg
+TAG      ?= sha-$(GIT_COMMIT)$(GIT_TREE_STATE)
+
+IMAGE_NAME := jupyter-pytorch-rocm
+
+BASE_IMAGE         := $(REGISTRY)/jupyter:$(TAG)
+BASE_IMAGE_FOLDERS := jupyter
+
+# we use a separate registry-type cache to keep the main registry clean
+# https://docs.docker.com/build/cache/backends/
+CACHE_IMAGE ?= ghcr.io/kubeflow/kubeflow/notebook-servers/build-cache
+CACHE_TAG   ?= $(IMAGE_NAME)
+
+# https://docs.docker.com/engine/reference/commandline/buildx_build/#platform
+ARCH ?= linux/amd64
+
+# include build targets from common
+include ../common.mk


### PR DESCRIPTION
/kind feature

This PR adds ROCm pytorch images to Kubeflow with one caveat, a udev change required on the hosts on which these containers/pods run so that any user besides `root` can access and use the devices. This is due to the group id of the render group being dynamic. This was raised to AMD upstream and their input was to do the following as we cannot bake the render group into the image. For the issue see:
https://github.com/ROCm/ROCm-docker/issues/90 and https://github.com/ROCm/k8s-device-plugin/issues/39

Doing the following on the host:

Create a new file (if it doesn't exist) `/etc/udev/rules.d/70-amdgpu.rules` with the following content:

`KERNEL=="kfd", MODE="0666" SUBSYSTEM=="drm", KERNEL=="renderD*", MODE="0666"`

Reload the udev rules with:

`sudo udevadm control --reload-rules && sudo udevadm trigger`

With these changes the `jovyan` user has access to the devices and can run workloads on AMD GPUs.

These images were tested on a node of 8 MI300X AMD GPUs both on k3s (with the amd k8s device plugin) and docker.

