### PR TITLE
fix: running code-server notebook behind proxy

### DIFF
--- a/components/example-notebook-servers/codeserver/s6/services.d/code-server/run
+++ b/components/example-notebook-servers/codeserver/s6/services.d/code-server/run
@@ -10,4 +10,5 @@ exec /usr/bin/code-server \
   --disable-workspace-trust \
   --disable-getting-started-override \
   --auth none \
+  --trusted-origins "*" \
   "${HOME}"


### PR DESCRIPTION
## What's the problem?

Currently, the code-server notebook image (VSCode) will not work properly when behind a proxy that changes the hostname, as code-server requires that the x-forwarded-for match the actual HTTP host header otherwise it gives an error like this:

```text
The workbench failed to connect to the server (Error: WebSocket close with status code 1006)
```

![image](https://github.com/user-attachments/assets/c467b4ad-821f-4731-9a99-ecec508ed01a)

## What's the solution?

As documented upstream in https://github.com/coder/code-server/issues/4443, the solution is to start code-server with the `--trusted-origins "*"` parameter.