### PR TITLE
bump go from 1.22.2 to 1.22.4 due to CVE-2024-24790

### DIFF
--- a/.github/workflows/pvcviewer_controller_unit_test.yaml
+++ b/.github/workflows/pvcviewer_controller_unit_test.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.22.2'
+        go-version: '1.22.4'
         check-latest: true
 
     - name: Run unit tests

--- a/components/pvcviewer-controller/Dockerfile
+++ b/components/pvcviewer-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-ARG GOLANG_VERSION=1.22.2
+ARG GOLANG_VERSION=1.22.4
 FROM golang:${GOLANG_VERSION} as builder
 
 WORKDIR /workspace

--- a/components/pvcviewer-controller/go.mod
+++ b/components/pvcviewer-controller/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubeflow/kubeflow/components/pvc-viewer
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
Fixing CVE-2024-24790

<img width="896" alt="image" src="https://github.com/user-attachments/assets/d1099cd0-9948-4f50-8181-71f5fbf76a29">

