### PR TITLE
tests(notebook-controller): use the direct (uncached) client to drive tests

### DIFF
--- a/components/notebook-controller/controllers/suite_test.go
+++ b/components/notebook-controller/controllers/suite_test.go
@@ -92,7 +92,6 @@ var _ = BeforeSuite(func() {
 		Expect(err).ToNot(HaveOccurred(), "failed to run manager")
 	}()
 
-	k8sClient = k8sManager.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
 
 }, 60)


### PR DESCRIPTION
## Description

This is in accordance with the recommendations in the Kubebuilder Book.

> Note that we set up both a "live" k8s client and a separate client from the manager.
> This is because when making assertions in tests, you generally want to assert against the live state of the API server.
> If you use the client from the manager (`k8sManager.GetClient`), you'd end up asserting against the contents of the cache instead, which is slower and can introduce flakiness into your tests.
> We could use the manager's `APIReader` to accomplish the same thing, but that would leave us with two clients in our test assertions and setup (one for reading, one for writing), and it'd be easy to make mistakes.
>
> Note that we keep the reconciler running against the manager's cache client, though – we want our controller to behave as it would in production, and we use features of the cache (like indices) in our controller which aren't available when talking directly to the API server.

(https://book.kubebuilder.io/cronjob-tutorial/writing-tests)

And also in this discusion
* https://github.com/kubernetes-sigs/controller-runtime/issues/343#issuecomment-469435686