### PR TITLE
tests(notebook-controller): fix unintended shadowing of `cfg` variable

### DIFF
--- a/components/notebook-controller/controllers/suite_test.go
+++ b/components/notebook-controller/controllers/suite_test.go
@@ -59,7 +59,8 @@ var _ = BeforeSuite(func() {
 		ErrorIfCRDPathMissing: true,
 	}
 
-	cfg, err := testEnv.Start()
+	var err error
+	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 


### PR DESCRIPTION
This is a nasty Go gotcha, and we aren't the first to have trouble with it https://temporal.io/blog/go-shadowing-bad-choices#the-bug

## Description

`cfg` is first declared here

https://github.com/kubeflow/kubeflow/blob/e7980b146e0d62779e019de95a6faabc45c439cf/components/odh-notebook-controller/controllers/suite_test.go#L57-L64

and then the `:=` operator shadows it, and the `cfg` we are setting is a different `cfg`. The top `cfg` remains `nil`.

https://github.com/kubeflow/kubeflow/blob/e7980b146e0d62779e019de95a6faabc45c439cf/components/odh-notebook-controller/controllers/suite_test.go#L101