### PR TITLE
fix(test): Remove redundant go test call scoped to controllers

### DIFF
--- a/components/notebook-controller/Makefile
+++ b/components/notebook-controller/Makefile
@@ -67,7 +67,6 @@ vet: ## Run go vet against code.
 .PHONY: test
 test: manifests generate fmt vet envtest ## Run tests.
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./... -coverprofile cover.out
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) -p path)" go test -v ./controllers/... -coverprofile cover.out
 
 .PHONY: manager
 manager: generate fmt vet ## Build manager binary.


### PR DESCRIPTION
A [prior commit](https://github.com/kubeflow/kubeflow/commit/909559a836fafc9f03643c011cbfeea6d47bd73a) introduced the following line to the `make test` target of `notebook-controller` :
- https://github.com/kubeflow/kubeflow/blob/master/components/notebook-controller/Makefile#L70

This then conflicts with the prior line:
- https://github.com/kubeflow/kubeflow/blob/master/components/notebook-controller/Makefile#L69

As L69 scopes `go test` to `./...` - that inherently will cover the specific `./controllers/...` scope of L70.

Furthermore, as the same `cover.out` `-coverprofile` value is used across both these invocations - the more verbose initial invocation gets overwritten.

Admittedly, as of now, `./controllers` is the only directory that contains `*_test.go` files - but it seems the proper configuration here should be the initial test call that searches the entire `notebook-controller` directory for tests to run.