### PR TITLE
fix: add container securityContext to profile-controller and kfam

### DIFF
--- a/components/access-management/Dockerfile
+++ b/components/access-management/Dockerfile
@@ -17,11 +17,14 @@ RUN chmod a+rx access-management
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:latest as serve
+FROM gcr.io/distroless/static:nonroot as serve
+
 WORKDIR /
 COPY third_party third_party
 COPY --from=builder /workspace/access-management .
 COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/library/
+
+USER 65532:65532
 
 EXPOSE 8081
 

--- a/components/profile-controller/Dockerfile
+++ b/components/profile-controller/Dockerfile
@@ -20,13 +20,15 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -o manager main.go;
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:latest as serve
+FROM gcr.io/distroless/static:nonroot as serve
+
 WORKDIR /
 COPY --from=builder /workspace/dash /bin/dash
-
 COPY third_party third_party
 COPY --from=builder /workspace/manager .
 COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/library/
+
+USER 65532:65532
 
 EXPOSE 8080
 

--- a/components/profile-controller/config/base/patches/manager.yaml
+++ b/components/profile-controller/config/base/patches/manager.yaml
@@ -18,8 +18,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
           capabilities:
             drop:
             - ALL

--- a/components/profile-controller/config/base/patches/manager.yaml
+++ b/components/profile-controller/config/base/patches/manager.yaml
@@ -13,6 +13,16 @@ spec:
             name: namespace-labels-data
       containers:
       - name: manager
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 0
+          capabilities:
+            drop:
+            - ALL
         volumeMounts:
         - name: namespace-labels
           mountPath: /etc/profile-controller

--- a/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
@@ -33,4 +33,14 @@ spec:
         - containerPort: 8081
           name: kfam-http
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          seccompProfile:
+            type: RuntimeDefault
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 0
+          capabilities:
+            drop:
+            - ALL
       serviceAccountName: controller-service-account

--- a/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/patches/kfam.yaml
@@ -38,8 +38,6 @@ spec:
           seccompProfile:
             type: RuntimeDefault
           runAsNonRoot: true
-          runAsUser: 1000
-          runAsGroup: 0
           capabilities:
             drop:
             - ALL


### PR DESCRIPTION
upstream what we have in https://github.com/kubeflow/manifests/tree/master/contrib/security/PSS to make PSS enforcable
and enjoy a rootless Kubeflow https://github.com/kubeflow/manifests/issues/2528