### PR TITLE
feat(profile_controller): add option to pass default AWS Role ARN to add profiles

### DIFF
--- a/components/profile-controller/README.md
+++ b/components/profile-controller/README.md
@@ -109,6 +109,8 @@ Plugin owners have full control over plugin spec struct and implementation.
         ### Boolean which defaults to false. If set to true IAM roles and policy will not be mutated
         annotateOnly: true 
   ```
+  To attach default role ARN to all profiles that don't have the AWS plugin provide Environment variable with name "DEFAULT_AWS_IAM_ROLE_ARN" and value of the Role ARN.
+
 # Deployment
 
 Install the `profiles.kubeflow.org` CRD:


### PR DESCRIPTION
/kind feature

In our deployment, at some point, we needed to assign the default AWS Role to all new profiles.

Solves the feature request [Add option to attach default AWS Role ARN to all profiles that don't have attached role](https://github.com/kubeflow/dashboard/issues/66).

Tested on the clean deployment.