### PR TITLE
fix(crud-web-apps): fix condition checking when missing message

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -159,7 +159,9 @@ def get_status_from_conditions(notebook):
         # The status will be warning with a "reason: message" showing on hover
         if "reason" in condition:
             status_phase = status.STATUS_PHASE.WARNING
-            status_message = condition["reason"] + ': ' + condition["message"]
+            reason = condition["reason"]
+            message = condition.get("message", "No available message.") # noqa: E501
+            status_message = '%s: %s' % (reason, message)
             return status_phase, status_message
 
     return None, None

--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -160,7 +160,7 @@ def get_status_from_conditions(notebook):
         if "reason" in condition:
             status_phase = status.STATUS_PHASE.WARNING
             reason = condition["reason"]
-            message = condition.get("message", "No available message.") # noqa: E501
+            message = condition.get("message", "No available message.")
             status_message = '%s: %s' % (reason, message)
             return status_phase, status_message
 

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -54,8 +54,16 @@ class TestStatusFromContainerState(unittest.TestCase):
 class TestStatusFromConditions(unittest.TestCase):
     """Test the different cases of status from conditions"""
 
-    def test_no_conditions(self):
+    def test_no_status(self):
         conditions = {}
+
+        self.assertEqual(status.get_status_from_conditions(conditions),
+                         (None, None))
+
+    def test_no_conditions(self):
+        conditions = {
+            "status": {}
+        }
 
         self.assertEqual(status.get_status_from_conditions(conditions),
                          (None, None))

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -55,21 +55,21 @@ class TestStatusFromConditions(unittest.TestCase):
     """Test the different cases of status from conditions"""
 
     def test_no_status(self):
-        conditions = {}
+        notebook = {}
 
-        self.assertEqual(status.get_status_from_conditions(conditions),
+        self.assertEqual(status.get_status_from_conditions(notebook),
                          (None, None))
 
     def test_no_conditions(self):
-        conditions = {
+        notebook = {
             "status": {}
         }
 
-        self.assertEqual(status.get_status_from_conditions(conditions),
+        self.assertEqual(status.get_status_from_conditions(notebook),
                          (None, None))
 
     def test_no_reason_conditions(self):
-        conditions = {
+        notebook = {
             "status": {
                 "conditions": [{
                     "status": "True",
@@ -78,11 +78,11 @@ class TestStatusFromConditions(unittest.TestCase):
             }
         }
 
-        self.assertEqual(status.get_status_from_conditions(conditions),
+        self.assertEqual(status.get_status_from_conditions(notebook),
                          (None, None))
 
     def test_conditions_with_reason_and_message(self):
-        conditions = {
+        notebook = {
             "status": {
                 "conditions": [{
                     "status": "False",
@@ -94,11 +94,11 @@ class TestStatusFromConditions(unittest.TestCase):
         }
 
         self.assertEqual(
-            status.get_status_from_conditions(conditions),
+            status.get_status_from_conditions(notebook),
             ("warning", "FailedScheduling: 0/1 nodes are available."))
 
     def test_conditions_with_reason_no_message(self):
-        conditions = {
+        notebook = {
             "status": {
                 "conditions": [{
                     "status": "False",
@@ -108,5 +108,5 @@ class TestStatusFromConditions(unittest.TestCase):
             }
         }
 
-        self.assertEqual(status.get_status_from_conditions(conditions),
+        self.assertEqual(status.get_status_from_conditions(notebook),
                          ("warning", "PodFailed: No available message."))

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -50,3 +50,52 @@ class TestStatusFromContainerState(unittest.TestCase):
             ("warning",
              "PodInitializing: No available message for container state.")
         )
+
+class TestStatusFromConditions(unittest.TestCase):
+    """Test the different cases of status from conditions"""
+
+    def test_no_conditions(self):
+        conditions = []
+
+        self.assertEqual(
+            status.get_status_from_conditions(conditions),
+            (None, None)
+        )
+
+    def test_no_reason_conditions(self):
+        conditions = [
+            {
+            "status": "True",
+            "type": "Initialized",
+            }
+        ]
+
+        self.assertEqual(
+            status.get_status_from_conditions(conditions),
+            (None, None)
+        )
+
+    def test_conditions_with_reason_and_message(self):
+        conditions = {
+            "status": "False",
+            "type": "Warning",
+            "reason": "FailedScheduling",
+            "message": "0/1 nodes are available."
+        }
+
+        self.assertEqual(
+            status.get_status_from_conditions(conditions),
+            ("warning", "FailedScheduling: 0/1 nodes are available.")
+        )
+    
+    def test_conditions_with_reason_no_message(self):
+        conditions = {
+            "status": "False",
+            "type": "Ready",
+            "reason": "PodFailed",
+        }
+
+        self.assertEqual(
+            status.get_status_from_conditions(conditions),
+            ("warning", "PodFailed: No available message.")
+        )

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -7,32 +7,18 @@ class TestStatusFromContainerState(unittest.TestCase):
     """Test the different cases of status from containerState"""
 
     def test_terminating_container_state(self):
-        container_state = {
-            "status": {
-                "containerState": {
-                    "terminating": {}
-                }
-            }
-        }
+        container_state = {"status": {"containerState": {"terminating": {}}}}
 
         self.assertEqual(
             status.get_status_from_container_state(container_state),
-            (None, None)
-        )
+            (None, None))
 
     def test_ready_container_state(self):
-        container_state = {
-            "status": {
-                "containerState": {
-                    "running": {}
-                }
-            }
-        }
+        container_state = {"status": {"containerState": {"running": {}}}}
 
         self.assertEqual(
             status.get_status_from_container_state(container_state),
-            (None, None)
-        )
+            (None, None))
 
     def test_no_message_container_state(self):
         container_state = {
@@ -48,54 +34,57 @@ class TestStatusFromContainerState(unittest.TestCase):
         self.assertEqual(
             status.get_status_from_container_state(container_state),
             ("warning",
-             "PodInitializing: No available message for container state.")
-        )
+             "PodInitializing: No available message for container state."))
+
 
 class TestStatusFromConditions(unittest.TestCase):
     """Test the different cases of status from conditions"""
 
     def test_no_conditions(self):
-        conditions = []
+        conditions = {}
 
-        self.assertEqual(
-            status.get_status_from_conditions(conditions),
-            (None, None)
-        )
+        self.assertEqual(status.get_status_from_conditions(conditions),
+                         (None, None))
 
     def test_no_reason_conditions(self):
-        conditions = [
-            {
-            "status": "True",
-            "type": "Initialized",
+        conditions = {
+            "status": {
+                "conditions": [{
+                    "status": "True",
+                    "type": "Initialized",
+                }]
             }
-        ]
+        }
 
-        self.assertEqual(
-            status.get_status_from_conditions(conditions),
-            (None, None)
-        )
+        self.assertEqual(status.get_status_from_conditions(conditions),
+                         (None, None))
 
     def test_conditions_with_reason_and_message(self):
         conditions = {
-            "status": "False",
-            "type": "Warning",
-            "reason": "FailedScheduling",
-            "message": "0/1 nodes are available."
+            "status": {
+                "conditions": [{
+                    "status": "False",
+                    "type": "Warning",
+                    "reason": "FailedScheduling",
+                    "message": "0/1 nodes are available."
+                }]
+            }
         }
 
         self.assertEqual(
             status.get_status_from_conditions(conditions),
-            ("warning", "FailedScheduling: 0/1 nodes are available.")
-        )
-    
+            ("warning", "FailedScheduling: 0/1 nodes are available."))
+
     def test_conditions_with_reason_no_message(self):
         conditions = {
-            "status": "False",
-            "type": "Ready",
-            "reason": "PodFailed",
+            "status": {
+                "conditions": [{
+                    "status": "False",
+                    "type": "Ready",
+                    "reason": "PodFailed",
+                }]
+            }
         }
 
-        self.assertEqual(
-            status.get_status_from_conditions(conditions),
-            ("warning", "PodFailed: No available message.")
-        )
+        self.assertEqual(status.get_status_from_conditions(conditions),
+                         ("warning", "PodFailed: No available message."))

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -7,18 +7,32 @@ class TestStatusFromContainerState(unittest.TestCase):
     """Test the different cases of status from containerState"""
 
     def test_terminating_container_state(self):
-        container_state = {"status": {"containerState": {"terminating": {}}}}
+        container_state = {
+            "status": {
+                "containerState": {
+                    "terminating": {}
+                }
+            }
+        }
 
         self.assertEqual(
             status.get_status_from_container_state(container_state),
-            (None, None))
+            (None, None)
+        )
 
     def test_ready_container_state(self):
-        container_state = {"status": {"containerState": {"running": {}}}}
+        container_state = {
+            "status": {
+                "containerState": {
+                    "running": {}
+                }
+            }
+        }
 
         self.assertEqual(
             status.get_status_from_container_state(container_state),
-            (None, None))
+            (None, None)
+        )
 
     def test_no_message_container_state(self):
         container_state = {
@@ -34,8 +48,8 @@ class TestStatusFromContainerState(unittest.TestCase):
         self.assertEqual(
             status.get_status_from_container_state(container_state),
             ("warning",
-             "PodInitializing: No available message for container state."))
-
+             "PodInitializing: No available message for container state.")
+        )
 
 class TestStatusFromConditions(unittest.TestCase):
     """Test the different cases of status from conditions"""


### PR DESCRIPTION
In the current code of `get_status_from_conditions` it is assumed that "reason" and "message" will always co-exist in a `condition`
https://github.com/kubeflow/kubeflow/blob/78969ee8246a6f11295378fc61273b1f2dbe07a8/components/crud-web-apps/jupyter/backend/apps/common/status.py#L160-L163

This is in fact a wrong assumption and thus a condition with "reason" without "message" like one below will trigger a `KeyError` and break the notebook UI.

```
    - lastProbeTime: '2025-01-10T17:14:30Z'
      lastTransitionTime: '2025-01-10T16:47:33Z'
      reason: PodFailed
      status: 'False'
      type: ContainersReady
```

/cc @thesuperzapper



