### PR TITLE
[Add] Propogate labels from NB to StatefulSets

### DIFF
--- a/components/notebook-controller/controllers/notebook_controller.go
+++ b/components/notebook-controller/controllers/notebook_controller.go
@@ -368,6 +368,7 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      instance.Name,
 			Namespace: instance.Namespace,
+			Labels:    map[string]string{},
 		},
 		Spec: appsv1.StatefulSetSpec{
 			Replicas: &replicas,
@@ -387,6 +388,11 @@ func generateStatefulSet(instance *v1beta1.Notebook) *appsv1.StatefulSet {
 				Spec: *instance.Spec.Template.Spec.DeepCopy(),
 			},
 		},
+	}
+
+	sl := &ss.Labels
+	for k, v := range instance.Labels {
+		(*sl)[k] = v
 	}
 
 	// copy all of the Notebook labels to the pod including poddefault related labels


### PR DESCRIPTION
This commit propagates labels from Notebooks to statefulsets. This is required to enable NBs to be managed by Kueue. When a user adds the label to point a NB to the right LocalQueue where it needs to be admitted, it needs to propagate to the underlying StatefulSet, so that Kueue can manage it.