### PR TITLE
Updating OWNERS for 2025 KSC members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,8 +2,8 @@
 # Approvers listed here is just a backup in case someone is out.
 approvers:
   - andreyvelich
-  - james-jwu
-  - jbottum
+  - franciscojavierarceo
+  - juliusvonkohout 
   - johnugeorge
   - terrytangyuan
   - zijianjoy


### PR DESCRIPTION
Updating OWNERS for 2025 KSC members

As required by https://github.com/kubeflow/community/issues/812