### PR TITLE
fix: stop using gcr.io registry for kube-rbac-proxy

### DIFF
--- a/components/notebook-controller/config/default/manager_auth_proxy_patch.yaml
+++ b/components/notebook-controller/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.4.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.4.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/components/profile-controller/config/default/manager_auth_proxy_patch.yaml
+++ b/components/profile-controller/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.11.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.11.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/components/pvcviewer-controller/config/default/manager_auth_proxy_patch.yaml
+++ b/components/pvcviewer-controller/config/default/manager_auth_proxy_patch.yaml
@@ -31,7 +31,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
+        image: quay.io/brancz/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/components/tensorboard-controller/config/default/manager_auth_proxy_patch.yaml
+++ b/components/tensorboard-controller/config/default/manager_auth_proxy_patch.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       containers:
         - name: kube-rbac-proxy
-          image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+          image: quay.io/brancz/kube-rbac-proxy:v0.8.0
           args:
             - "--secure-listen-address=0.0.0.0:8443"
             - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
Resolves https://github.com/kubeflow/dashboard/issues/58

For now we are just updating the registry, but in the future it might be worth to replace it all together for https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/metrics/filters#WithAuthenticationAndAuthorization

/cc @thesuperzapper 