### PR TITLE
ci: update actions and revert to ubuntu-22.04

### DIFF
--- a/.github/workflows/centraldb_angular_backend_test.yaml
+++ b/.github/workflows/centraldb_angular_backend_test.yaml
@@ -7,12 +7,14 @@ on:
 jobs:
   run-backend-unittests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: 12
+
       - name: Run unit tests
         run: |
           cd components/centraldashboard-angular/backend/
@@ -21,12 +23,14 @@ jobs:
 
   run-backend-tslint:
     name: TSLint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: 12
+
       - name: Run tslint
         run: |
           cd components/centraldashboard-angular/backend/

--- a/.github/workflows/centraldb_angular_docker_publish.yaml
+++ b/.github/workflows/centraldb_angular_docker_publish.yaml
@@ -15,14 +15,14 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -31,7 +31,7 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}

--- a/.github/workflows/centraldb_angular_frontend_test.yaml
+++ b/.github/workflows/centraldb_angular_frontend_test.yaml
@@ -7,13 +7,13 @@ on:
 jobs:
   frontend-format-lint-check:
     name: Check code format and lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -31,19 +31,22 @@ jobs:
 
   run-frontend-unittests:
     name: Unit tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
         with:
           node-version: 16
+
       - name: Install Kubeflow common library dependecies
         run: |
           cd components/crud-web-apps/common/frontend/kubeflow-common-lib
           npm i
           npm run build
           npm link ./dist/kubeflow
+
       - name: Run unit tests
         run: |
           cd components/centraldashboard-angular/frontend/
@@ -53,12 +56,13 @@ jobs:
 
   run-ui-tests:
     name: UI tests in chrome and firefox
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 

--- a/.github/workflows/centraldb_angular_intergration_test.yaml
+++ b/.github/workflows/centraldb_angular_intergration_test.yaml
@@ -17,10 +17,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -16,12 +16,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -30,16 +30,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/centraldb_frontend_tests.yaml
+++ b/.github/workflows/centraldb_frontend_tests.yaml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   frontend-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Unit tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node version to 12
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 12
 

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -17,13 +17,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build CentralDashboard Image
       run: |

--- a/.github/workflows/centraldb_multi_arch_test.yaml
+++ b/.github/workflows/centraldb_multi_arch_test.yaml
@@ -16,16 +16,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/common_frontend_tests.yaml
+++ b/.github/workflows/common_frontend_tests.yaml
@@ -7,14 +7,14 @@ on:
 jobs:
   frontend-format-lint-check:
     name: Check code format and lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -23,6 +23,7 @@ jobs:
           cd components/crud-web-apps/common/frontend/kubeflow-common-lib
           npm i
           npm run format:check
+
       - name: Check frontend code linting
         run: |
           cd components/crud-web-apps/common/frontend/kubeflow-common-lib
@@ -30,13 +31,14 @@ jobs:
           npm run lint-check
 
   frontend-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Unit tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 

--- a/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+++ b/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
@@ -18,12 +18,12 @@ env:
 jobs:
   build_and_push_images:
     name: Build & Push Images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           base: ${{ github.ref }}
@@ -32,20 +32,20 @@ jobs:
               - 'releasing/version/VERSION'
 
       - name: Setup QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Login to DockerHub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: kubeflownotebookswg
           password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}

--- a/.github/workflows/jwa_backend_unittests.yaml
+++ b/.github/workflows/jwa_backend_unittests.yaml
@@ -7,21 +7,26 @@ on:
 jobs:
   run-backend-unittests:
     name: Unittests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Install KinD
         run: ./components/testing/gh-actions/install_kind.sh
+
       - name: Create KinD Cluster
         run: kind create cluster --config components/testing/gh-actions/kind-1-25.yaml
-      - uses: actions/setup-python@v4
+
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.7'
+          python-version: "3.7"
+
       - name: Setup Python environment
         run: |
           cd components/crud-web-apps/jupyter/backend
           make install-deps
+
       - name: Run unittests
         run: |
           cd components/crud-web-apps/jupyter/backend

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -17,12 +17,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -31,16 +31,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/jwa_frontend_tests.yaml
+++ b/.github/workflows/jwa_frontend_tests.yaml
@@ -7,14 +7,14 @@ on:
 jobs:
   frontend-format-linting-check:
     name: Check code format and lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -31,13 +31,14 @@ jobs:
           npm run lint-check
 
   frontend-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Unit tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -47,11 +48,13 @@ jobs:
           npm i
           npm run build
           npm link ./dist/kubeflow
+
       - name: Install JWA dependencies
         run: |
           cd components/crud-web-apps/jupyter/frontend
           npm i
           npm link kubeflow
+
       - name: Run unit tests
         run: |
           cd components/crud-web-apps/jupyter/frontend
@@ -59,12 +62,13 @@ jobs:
 
   run-ui-tests:
     name: UI tests with Playwright
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -74,11 +78,13 @@ jobs:
           npm i
           npm run build
           npm link ./dist/kubeflow
+
       - name: Install JWA dependencies
         run: |
           cd components/crud-web-apps/jupyter/frontend
           npm i
           npm link kubeflow
+
       - name: Serve UI & run Playwright tests in Chrome and Firefox
         run: |
           cd components/crud-web-apps/jupyter/frontend

--- a/.github/workflows/jwa_intergration_test.yaml
+++ b/.github/workflows/jwa_intergration_test.yaml
@@ -18,13 +18,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build JWA Image
       run: |

--- a/.github/workflows/jwa_multi_arch_test.yaml
+++ b/.github/workflows/jwa_multi_arch_test.yaml
@@ -17,16 +17,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -16,12 +16,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -30,16 +30,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/kfam_multi_arch_test.yaml
+++ b/.github/workflows/kfam_multi_arch_test.yaml
@@ -16,16 +16,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -17,12 +17,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -31,16 +31,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/nb_controller_intergration_test.yaml
+++ b/.github/workflows/nb_controller_intergration_test.yaml
@@ -17,13 +17,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build Notebook Controller Image
       run: |

--- a/.github/workflows/nb_controller_multi_arch_test.yaml
+++ b/.github/workflows/nb_controller_multi_arch_test.yaml
@@ -16,16 +16,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -6,15 +6,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.17'
+        go-version: "1.17"
         check-latest: true
 
     - name: Run unit tests

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -16,12 +16,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -30,16 +30,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -17,13 +17,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build PodDefaults Image
       run: |

--- a/.github/workflows/poddefaults_multi_arch_test.yaml
+++ b/.github/workflows/poddefaults_multi_arch_test.yaml
@@ -16,16 +16,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/poddefaults_unit_test.yaml
+++ b/.github/workflows/poddefaults_unit_test.yaml
@@ -6,15 +6,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.20'
+        go-version: "1.20"
         check-latest: true
 
     - name: Run unit tests

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -16,12 +16,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -30,16 +30,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: kubeflownotebookswg
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/prof_controller_multi_arch_test.yaml
+++ b/.github/workflows/prof_controller_multi_arch_test.yaml
@@ -16,16 +16,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/prof_controller_unit_test.yaml
+++ b/.github/workflows/prof_controller_unit_test.yaml
@@ -6,15 +6,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.19'
+        go-version: "1.19"
         check-latest: true
 
     - name: Run unit tests

--- a/.github/workflows/profiles_kfam_intergration_test.yaml
+++ b/.github/workflows/profiles_kfam_intergration_test.yaml
@@ -19,13 +19,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build Profile Controller Image
       run: |

--- a/.github/workflows/pvcviewer_controller_docker_publish.yaml
+++ b/.github/workflows/pvcviewer_controller_docker_publish.yaml
@@ -17,12 +17,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -31,13 +31,13 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -17,13 +17,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build PVCViewer Controller Image
       run: |

--- a/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
+++ b/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
@@ -16,16 +16,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/pvcviewer_controller_unit_test.yaml
+++ b/.github/workflows/pvcviewer_controller_unit_test.yaml
@@ -6,15 +6,15 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.22.2'
+        go-version: "1.22.2"
         check-latest: true
 
     - name: Run unit tests

--- a/.github/workflows/python_lint.yaml
+++ b/.github/workflows/python_lint.yaml
@@ -9,16 +9,18 @@ on:
       - "**.py"
 jobs:
   flake8-lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Check
     steps:
       - name: Checkout source repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Set up Python environment 3.8
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: "3.8"
+
       - name: flake8 Lint
-        uses: py-actions/flake8@v1
+        uses: py-actions/flake8@v2
         with:
           exclude: "docs"

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -16,12 +16,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -30,16 +30,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/tb_controller_intergration_test.yaml
+++ b/.github/workflows/tb_controller_intergration_test.yaml
@@ -17,10 +17,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build Tensorboard Controller Image 
       run: |

--- a/.github/workflows/tb_controller_multi_arch_test.yaml
+++ b/.github/workflows/tb_controller_multi_arch_test.yaml
@@ -16,16 +16,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/triage_issues.yaml
+++ b/.github/workflows/triage_issues.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Update Kanban
         uses: kubeflow/code-intelligence/Issue_Triage/action@master

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -17,12 +17,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -31,16 +31,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/twa_frontend_tests.yaml
+++ b/.github/workflows/twa_frontend_tests.yaml
@@ -7,14 +7,14 @@ on:
 jobs:
   frontend-format-linting-check:
     name: Code format and lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -31,13 +31,14 @@ jobs:
           npm run lint-check
 
   frontend-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Unit tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -62,9 +63,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -74,11 +76,13 @@ jobs:
           npm i
           npm run build
           npm link ./dist/kubeflow
+
       - name: Install TWA dependencies
         run: |
           cd components/crud-web-apps/tensorboards/frontend
           npm i
           npm link kubeflow
+
       - name: Serve UI & run Cypress tests in Chrome and Firefox
         run: |
           cd components/crud-web-apps/tensorboards/frontend

--- a/.github/workflows/twa_intergration_test.yaml
+++ b/.github/workflows/twa_intergration_test.yaml
@@ -18,10 +18,10 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Build TWA Image
       run: |

--- a/.github/workflows/twa_multi_arch_test.yaml
+++ b/.github/workflows/twa_multi_arch_test.yaml
@@ -17,16 +17,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -17,12 +17,12 @@ env:
 jobs:
   push_to_registry:
     name: Build & Push Docker image to Docker Hub
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - uses: dorny/paths-filter@v2
+    - uses: dorny/paths-filter@v3
       id: filter
       with:
         base: ${{ github.ref }}
@@ -31,16 +31,16 @@ jobs:
             - 'releasing/version/VERSION'
 
     - name: Login to DockerHub
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ env.DOCKER_USER }}
         password: ${{ secrets.KUBEFLOWNOTEBOOKSWG_DOCKER_TOKEN }}
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build and push multi-arch docker image
       run: |

--- a/.github/workflows/vwa_frontend_tests.yaml
+++ b/.github/workflows/vwa_frontend_tests.yaml
@@ -7,14 +7,13 @@ on:
 jobs:
   frontend-format-lint-check:
     name: Check code format and lint
-    runs-on: ubuntu-latest
-
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -23,6 +22,7 @@ jobs:
           cd components/crud-web-apps/volumes/frontend
           npm i
           npm run format:check
+
       - name: Check frontend code linting
         run: |
           cd components/crud-web-apps/volumes/frontend
@@ -30,13 +30,14 @@ jobs:
           npm run lint-check
 
   frontend-unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Unit tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -46,11 +47,13 @@ jobs:
           npm i
           npm run build
           npm link ./dist/kubeflow
+
       - name: Install VWA dependencies
         run: |
           cd components/crud-web-apps/volumes/frontend
           npm i
           npm link kubeflow
+
       - name: Run unit tests
         run: |
           cd components/crud-web-apps/volumes/frontend
@@ -58,12 +61,13 @@ jobs:
 
   run-tests-in-chrome:
     name: UI tests in chrome
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -73,13 +77,15 @@ jobs:
           npm i
           npm run build
           npm link ./dist/kubeflow
+
       - name: Install VWA dependencies
         run: |
           cd components/crud-web-apps/volumes/frontend
           npm i
           npm link kubeflow
+
       - name: Serve UI & run Cypress tests in Chrome
-        uses: cypress-io/github-action@v4.2.0
+        uses: cypress-io/github-action@v6
         with:
           working-directory: components/crud-web-apps/volumes/frontend
           start: npm run serve
@@ -89,12 +95,13 @@ jobs:
 
   run-tests-in-firefox:
     name: UI tests in firefox
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Setup node version to 16
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16
 
@@ -104,13 +111,15 @@ jobs:
           npm i
           npm run build
           npm link ./dist/kubeflow
+
       - name: Install VWA dependencies
         run: |
           cd components/crud-web-apps/volumes/frontend
           npm i
           npm link kubeflow
+
       - name: Serve UI & run Cypress tests in Firefox
-        uses: cypress-io/github-action@v4.2.0
+        uses: cypress-io/github-action@v6
         with:
           working-directory: components/crud-web-apps/volumes/frontend
           start: npm run serve

--- a/.github/workflows/vwa_intergration_test.yaml
+++ b/.github/workflows/vwa_intergration_test.yaml
@@ -18,13 +18,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build VWA Image
       run: |

--- a/.github/workflows/vwa_multi_arch_test.yaml
+++ b/.github/workflows/vwa_multi_arch_test.yaml
@@ -17,16 +17,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Setup QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
 
     - name: Build multi-arch Image
       run: |


### PR DESCRIPTION
We are having a lot of problems with the GitHub actions (especially around ARM/PPC emulation builds), and it's partially because many are really old, but it's also because the meaning of `ubuntu-latest` has changed to `ubuntu-24.04` at some point in the last year.

Because I don't have time to track down every compatibility issue, I am going to hard code them all at `ubuntu-22.04` for now, until 24.04 has been out for so long that everyone else has run into the problems.