### PR TITLE
ci: trigger tests on release + update release guide

### DIFF
--- a/.github/workflows/approve_gh_workflows.yaml
+++ b/.github/workflows/approve_gh_workflows.yaml
@@ -1,0 +1,48 @@
+name: Approve Workflow Runs
+
+permissions:
+  actions: write
+  contents: read
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  ok-to-test:
+    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Approve Pending Workflow Runs
+        uses: actions/github-script@v7
+        with:
+          retries: 3
+          script: |
+            const request = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: "pull_request",
+              status: "action_required",
+              head_sha: context.payload.pull_request.head.sha,
+            }
+            
+            core.info(`Getting workflow runs that need approval for commit ${request.head_sha}`)
+            const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, request)
+            
+            core.info(`Found ${runs.length} workflow runs that need approval`)
+            for (const run of runs) {
+              core.info(`Approving workflow run ${run.id}`)
+              const request = {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: run.id,
+              }
+              await github.rest.actions.approveWorkflowRun(request)
+            }

--- a/.github/workflows/centraldb_angular_backend_test.yaml
+++ b/.github/workflows/centraldb_angular_backend_test.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/centraldashboard-angular/backend/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   run-backend-unittests:

--- a/.github/workflows/centraldb_angular_frontend_test.yaml
+++ b/.github/workflows/centraldb_angular_frontend_test.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/centraldashboard-angular/frontend/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   frontend-format-lint-check:

--- a/.github/workflows/centraldb_angular_intergration_test.yaml
+++ b/.github/workflows/centraldb_angular_intergration_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/centraldashboard-angular/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/centraldb_frontend_tests.yaml
+++ b/.github/workflows/centraldb_frontend_tests.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/centraldashboard/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/centraldb_intergration_test.yaml
+++ b/.github/workflows/centraldb_intergration_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/centraldashboard/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/centraldb_multi_arch_test.yaml
+++ b/.github/workflows/centraldb_multi_arch_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/centraldashboard/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/common_frontend_tests.yaml
+++ b/.github/workflows/common_frontend_tests.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/common/frontend/kubeflow-common-lib/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   frontend-format-lint-check:

--- a/.github/workflows/jwa_backend_unittests.yaml
+++ b/.github/workflows/jwa_backend_unittests.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/jupyter/backend/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   run-backend-unittests:

--- a/.github/workflows/jwa_frontend_tests.yaml
+++ b/.github/workflows/jwa_frontend_tests.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/jupyter/frontend/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   frontend-format-linting-check:

--- a/.github/workflows/jwa_intergration_test.yaml
+++ b/.github/workflows/jwa_intergration_test.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - components/crud-web-apps/jupyter/**
       - components/crud-web-apps/common/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/jwa_multi_arch_test.yaml
+++ b/.github/workflows/jwa_multi_arch_test.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - components/crud-web-apps/jupyter/**
       - components/crud-web-apps/common/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/kfam_multi_arch_test.yaml
+++ b/.github/workflows/kfam_multi_arch_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/access-management/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/nb_controller_intergration_test.yaml
+++ b/.github/workflows/nb_controller_intergration_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/notebook-controller/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/nb_controller_multi_arch_test.yaml
+++ b/.github/workflows/nb_controller_multi_arch_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/notebook-controller/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/notebook_controller_unit_test.yaml
+++ b/.github/workflows/notebook_controller_unit_test.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/notebook-controller/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   build:

--- a/.github/workflows/poddefaults_intergration_test.yaml
+++ b/.github/workflows/poddefaults_intergration_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/admission-webhook/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/poddefaults_multi_arch_test.yaml
+++ b/.github/workflows/poddefaults_multi_arch_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/admission-webhook/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/poddefaults_unit_test.yaml
+++ b/.github/workflows/poddefaults_unit_test.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/admission-webhook/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   build:

--- a/.github/workflows/prof_controller_multi_arch_test.yaml
+++ b/.github/workflows/prof_controller_multi_arch_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/profile-controller/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/prof_controller_unit_test.yaml
+++ b/.github/workflows/prof_controller_unit_test.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/profile-controller/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   build:

--- a/.github/workflows/profiles_kfam_intergration_test.yaml
+++ b/.github/workflows/profiles_kfam_intergration_test.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - components/profile-controller/**
       - components/access-management/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/pvcviewer_controller_intergration_test.yaml
+++ b/.github/workflows/pvcviewer_controller_intergration_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/pvcviewer-controller/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
+++ b/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/pvcviewer-controller/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/pvcviewer_controller_unit_test.yaml
+++ b/.github/workflows/pvcviewer_controller_unit_test.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/pvcviewer-controller/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   build:

--- a/.github/workflows/python_lint.yaml
+++ b/.github/workflows/python_lint.yaml
@@ -7,6 +7,7 @@ on:
       - v*-branch
     paths:
       - "**.py"
+
 jobs:
   flake8-lint:
     runs-on: ubuntu-22.04

--- a/.github/workflows/semantic_prs.yaml
+++ b/.github/workflows/semantic_prs.yaml
@@ -1,0 +1,43 @@
+name: Semantic PRs
+
+on:
+  pull_request_target:
+    types:
+      - edited
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate_title:
+    name: Validate Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            fix
+            feat
+            improve
+            refactor
+            revert
+            test
+            ci
+            docs
+            chore
+
+          scopes: |
+            dashboard
+            kfam
+            notebook
+            poddefault
+            profile
+            tensorboard
+            volume
+          requireScope: false

--- a/.github/workflows/tb_controller_intergration_test.yaml
+++ b/.github/workflows/tb_controller_intergration_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/tensorboard-controller/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/tb_controller_multi_arch_test.yaml
+++ b/.github/workflows/tb_controller_multi_arch_test.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     paths:
       - components/tensorboard-controller/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/twa_frontend_tests.yaml
+++ b/.github/workflows/twa_frontend_tests.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/tensorboards/frontend/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   frontend-format-linting-check:

--- a/.github/workflows/twa_intergration_test.yaml
+++ b/.github/workflows/twa_intergration_test.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - components/crud-web-apps/tensorboards/**
       - components/crud-web-apps/common/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/twa_multi_arch_test.yaml
+++ b/.github/workflows/twa_multi_arch_test.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - components/crud-web-apps/tensorboards/**
       - components/crud-web-apps/common/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/vwa_frontend_tests.yaml
+++ b/.github/workflows/vwa_frontend_tests.yaml
@@ -3,6 +3,10 @@ on:
   pull_request:
     paths:
       - components/crud-web-apps/volumes/frontend/**
+      - releasing/version/VERSION
+    branches:
+      - master
+      - v*-branch
 
 jobs:
   frontend-format-lint-check:

--- a/.github/workflows/vwa_intergration_test.yaml
+++ b/.github/workflows/vwa_intergration_test.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - components/crud-web-apps/volumes/**
       - components/crud-web-apps/common/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/.github/workflows/vwa_multi_arch_test.yaml
+++ b/.github/workflows/vwa_multi_arch_test.yaml
@@ -4,6 +4,7 @@ on:
     paths:
       - components/crud-web-apps/volumes/**
       - components/crud-web-apps/common/**
+      - releasing/version/VERSION
     branches:
       - master
       - v*-branch

--- a/releasing/README.md
+++ b/releasing/README.md
@@ -11,25 +11,96 @@ The Notebooks Working Group release process follows the Kubeflow [release timeli
 
 ## Steps for releasing
 
-1. Create a new release branch:
-    ```sh
-    VERSION="v1.3.0-rc.0"
-    RELEASE_BRANCH="v1.3-branch"
-    git checkout -b $RELEASE_BRANCH origin/master
-    ```
-2. Edit files under manifests (e.g., Deployments) to the release image tag:
-    ```sh
-    TAG=$VERSION
-    releasing/update-manifests-images $TAG
-    ```
-3. Bump version in `VERSION` file:
-    ```sh
-    echo "$VERSION" > VERSION
-    ```
-4. Commit changes to the release branch:
-    ```sh
-    git commit -s -a -m "Release $VERSION"
-    ```
-5. PR merged (after CI validates and builds all images for that commit).
-6. CI job (postsubmit) kicks in and builds the images for $VERSION.
-7. Tag commit as $VERSION.
+### Prepare (MINOR RELEASE)
+
+1. Create a new release branch from `master`:
+
+```sh
+RELEASE_BRANCH="v1.10-branch"
+git checkout -b $RELEASE_BRANCH origin/master
+# OR: git checkout -b $RELEASE_BRANCH upstream/master
+
+# push the release branch to the upstream repository
+git push origin $RELEASE_BRANCH
+# OR: git push upstream $RELEASE_BRANCH
+```
+
+### Prepare (PATCH RELEASE)
+
+1. Check out the release branch for the version you are releasing:
+
+```sh
+RELEASE_BRANCH="v1.10-branch"
+git checkout $RELEASE_BRANCH
+```
+
+2. Cherry-pick the changes you want to include in the patch release (if they have not been added via a PR):
+
+```sh
+# cherry-pick the commit
+# NOTE: you could also use an IDE to make this easier
+git cherry-pick HASH_OF_COMMIT
+
+# push the changes to the release branch
+git push origin $RELEASE_BRANCH
+# OR: git push upstream $RELEASE_BRANCH
+```
+
+### Create Release (ALL RELEASES)
+
+1. Update the image tags in the manifests to the new version:
+
+```sh
+VERSION="v1.10.0-rc.0" # for a release candidate
+# VERSION="v1.10.0" # for a final release
+releasing/update-manifests-images $TAG
+```
+
+2. Bump version in `releasing/version/VERSION` file:
+
+```sh
+echo "$VERSION" > releasing/version/VERSION
+```
+
+3. Create a PR into the release branch with the changes from steps 2 and 3:
+
+     - The PR should be titled `chore: Release vX.X.X-rc.X` or `chore: Release vX.X.X`.
+     - This is to trigger the GitHub Actions tests, and ensure a release is possible.
+     - The only changes should be the image tags in the manifests and the VERSION bump.
+     - __WARNING:__ the "example notebook servers" builds are not triggered on PRs (they need to push to a registry as they `FROM` each other).
+       Check the last commit which updated `components/example-notebook-servers/**` and ensure that its build succeeded.
+       If not, STOP, and fix the build for the "example notebook servers" before merging the release PR.
+     - Once the tests pass, merge the PR (this will trigger the release builds).
+
+4. Create a tag in the release branch:
+
+```sh
+# check out the release branch at the commit that was merged
+git checkout $RELEASE_BRANCH
+# NOTE: make sure you are at the current HEAD of the release branch
+#       which should be the commit from the PR merged in the previous step
+
+# create the tag
+# NOTE: this is a signed tag, so you must have set up your GPG key
+git tag -s "$VERSION" -m "$VERSION"
+
+# verify the tag signature
+git verify-tag "$VERSION"
+
+# push the tag
+git push origin "$VERSION"
+# OR: git push upstream "$VERSION"
+```
+
+5. Create a new release on GitHub:
+
+     - Go to the [releases page](https://github.com/kubeflow/kubeflow/releases).
+     - Click `"Draft a new release"`.
+     - Enter the tag you just created in the `"Coose a tag"` box.
+     - If this is an RC release:
+        - check the `"This is a pre-release"` box
+        - make a basic description of the release but don't include the full release notes.
+     - If this is a final release:
+        - Set the `"Previous tag"` to the previous non-RC release and click `"Generate release notes"`.
+        - Try and format the release notes like the previous releases.
+     - Click `"Publish release"`.


### PR DESCRIPTION
__This PR:__

- ensures that we run all unit/integration tests on release, to avoid cutting releases that fail tests
    - __NOTE:__ we now trigger the tests on PRs that bump `releasing/version/VERSION`.
    - __WARNING:__ we still don't test build the example notebooks servers, because they require us to push images to a repo (as they `FROM` each other). But this is less of a problem because we still attempt to build the images every time a commit is made that updates `components/example-notebook-servers/**` so before releasing, we can check the builds succeeded on the last commit which updated those files
- updates the releasing README, because it was very out of date and could result in an invalid release
- adds a workflow similar to https://github.com/kubeflow/notebooks/pull/204 so that PRs with `ok-to-test` run tests without needing someone with write access to approve them
- adds a workflow similar to https://github.com/kubeflow/notebooks/pull/14 so that we enforce semantic PR title names
