### PR TITLE
feat: use rootless base image for nb-controller and pod-default

### DIFF
--- a/components/admission-webhook/Dockerfile
+++ b/components/admission-webhook/Dockerfile
@@ -12,8 +12,13 @@ ENV GO111MODULE=on
 # Build
 RUN CGO_ENABLED=0 GOOS=linux go build -o webhook -a . ;
     
-# Copy the controller-manager into a distroless image
-FROM gcr.io/distroless/static-debian10:fd0d99e8c54d7d7b2f3dd29f5093d030d192cbbc
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+
 WORKDIR /
 COPY --from=builder /go/src/github.com/kubeflow/kubeflow/components/admission-webhook/webhook .
+
+USER 65532:65532
+
 ENTRYPOINT ["/webhook"]

--- a/components/notebook-controller/Dockerfile
+++ b/components/notebook-controller/Dockerfile
@@ -26,9 +26,13 @@ RUN CGO_ENABLED=0 GOOS=linux GO111MODULE=on go build -a -mod=mod -o manager main
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM gcr.io/distroless/base:debug
+FROM gcr.io/distroless/static:nonroot
+
 WORKDIR /
 COPY --from=builder /workspace/notebook-controller/manager .
 COPY --from=builder /workspace/notebook-controller/third_party/license.txt third_party/license.txt
 COPY --from=builder /go/pkg/mod/github.com/hashicorp third_party/hashicorp
+
+USER 65532:65532
+
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
Currently, the admission-webhook and notebook-controller don't use the standard `gcr.io/distroless/static:nonroot` image, this PR updates both of them and makes them use `nonroot`. 

The notebook-controller is using the `debug` image for some reason (which adds `bash` and is a security risk for no reason).

The `admission-webhook` (PodDefaults) is using a very outdated `debian10` image.

