### PR TITLE
ci: downgrade qemu, fix arm64 build segfaults

### DIFF
--- a/.github/workflows/centraldb_docker_publish.yaml
+++ b/.github/workflows/centraldb_docker_publish.yaml
@@ -37,6 +37,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/centraldb_multi_arch_test.yaml
+++ b/.github/workflows/centraldb_multi_arch_test.yaml
@@ -24,6 +24,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
+++ b/.github/workflows/example_notebook_servers_publish_TEMPLATE.yaml
@@ -33,6 +33,10 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          # see: https://github.com/tonistiigi/binfmt/issues/215
+          # see: https://github.com/docker/setup-qemu-action/issues/198
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/jwa_docker_publish.yaml
+++ b/.github/workflows/jwa_docker_publish.yaml
@@ -38,6 +38,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/jwa_multi_arch_test.yaml
+++ b/.github/workflows/jwa_multi_arch_test.yaml
@@ -25,6 +25,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/kfam_docker_publish.yaml
+++ b/.github/workflows/kfam_docker_publish.yaml
@@ -37,6 +37,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/kfam_multi_arch_test.yaml
+++ b/.github/workflows/kfam_multi_arch_test.yaml
@@ -24,6 +24,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/nb_controller_docker_publish.yaml
+++ b/.github/workflows/nb_controller_docker_publish.yaml
@@ -38,6 +38,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/nb_controller_multi_arch_test.yaml
+++ b/.github/workflows/nb_controller_multi_arch_test.yaml
@@ -24,6 +24,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/poddefaults_docker_publish.yaml
+++ b/.github/workflows/poddefaults_docker_publish.yaml
@@ -37,6 +37,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/poddefaults_multi_arch_test.yaml
+++ b/.github/workflows/poddefaults_multi_arch_test.yaml
@@ -24,6 +24,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/prof_controller_docker_publish.yaml
+++ b/.github/workflows/prof_controller_docker_publish.yaml
@@ -37,6 +37,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/prof_controller_multi_arch_test.yaml
+++ b/.github/workflows/prof_controller_multi_arch_test.yaml
@@ -24,6 +24,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
+++ b/.github/workflows/pvcviewer_controller_multi_arch_test.yaml
@@ -24,6 +24,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/tb_controller_docker_publish.yaml
+++ b/.github/workflows/tb_controller_docker_publish.yaml
@@ -37,6 +37,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/tb_controller_multi_arch_test.yaml
+++ b/.github/workflows/tb_controller_multi_arch_test.yaml
@@ -24,6 +24,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/twa_docker_publish.yaml
+++ b/.github/workflows/twa_docker_publish.yaml
@@ -38,6 +38,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/twa_multi_arch_test.yaml
+++ b/.github/workflows/twa_multi_arch_test.yaml
@@ -25,6 +25,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/vwa_docker_publish.yaml
+++ b/.github/workflows/vwa_docker_publish.yaml
@@ -38,6 +38,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/.github/workflows/vwa_multi_arch_test.yaml
+++ b/.github/workflows/vwa_multi_arch_test.yaml
@@ -25,6 +25,10 @@ jobs:
 
     - name: Setup QEMU
       uses: docker/setup-qemu-action@v3
+      with:
+        # see: https://github.com/tonistiigi/binfmt/issues/215
+        # see: https://github.com/docker/setup-qemu-action/issues/198
+        image: tonistiigi/binfmt:qemu-v7.0.0-28
 
     - name: Setup Docker Buildx
       uses: docker/setup-buildx-action@v3

--- a/components/example-notebook-servers/README.md
+++ b/components/example-notebook-servers/README.md
@@ -4,6 +4,7 @@
 > <br>
 > Contributions are greatly appreciated.
 
+
 ## Images
 
 This chart shows how the images are related to each other (the nodes are clickable links to the Dockerfiles):


### PR DESCRIPTION
There is some kind of calamity going on regarding emulated ARM64 builds, it seems like the only way to fix it is pinning QEMU to `tonistiigi/binfmt:qemu-v7.0.0-28` and Ubuntu to `22.04` (already done in https://github.com/kubeflow/kubeflow/pull/7681).

Without this change, our `example-notebook-servers` are failing to build with a segmentation fault every time:
- https://github.com/kubeflow/kubeflow/actions/runs/13365536962/job/37350738903

Upstream issues:

- https://github.com/tonistiigi/binfmt/issues/215
- https://github.com/docker/setup-qemu-action/issues/198
