### PR TITLE
chore: fix typo in release guide

### DIFF
--- a/releasing/README.md
+++ b/releasing/README.md
@@ -53,7 +53,7 @@ git push origin $RELEASE_BRANCH
 ```sh
 VERSION="v1.10.0-rc.0" # for a release candidate
 # VERSION="v1.10.0" # for a final release
-releasing/update-manifests-images $TAG
+releasing/update-manifests-images $VERSION
 ```
 
 2. Bump version in `releasing/version/VERSION` file:


### PR DESCRIPTION
There was a slight typo in the release guide after https://github.com/kubeflow/kubeflow/pull/7684