### PR TITLE
fix: don't require authentication for crud-web-apps metrics endpoints

### DIFF
--- a/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/metrics.py
+++ b/components/crud-web-apps/common/backend/kubeflow/kubeflow/crud_backend/metrics.py
@@ -4,6 +4,8 @@ import sys
 from flask import Flask
 from prometheus_flask_exporter import PrometheusMetrics
 
+from .authn import no_authentication
+
 log = logging.getLogger(__name__)
 
 
@@ -36,7 +38,10 @@ def enable_metrics(app: Flask) -> None:
     backend_version = _get_backend_version()
     log.debug("Backend version is %s", backend_version)
     metrics = PrometheusMetrics(
-        app, group_by="url_rule", default_labels={"app": app.name}
+        app,
+        group_by="url_rule",
+        default_labels={"app": app.name},
+        metrics_decorator=no_authentication,
     )
     # add default metrics with info about app
     metrics.info(


### PR DESCRIPTION
Currently you need to submit a request with a `kubeflow-userid` header to scrape web application metrics added in #7634.  Unfortunately, this makes it difficult to integrate using the existing Prometheus `PodMonitor`/`ServiceMonitor` resources as they only allow manipulation of simple HTTP authentication headers.