### PR TITLE
chore: update filebrowser image to v2.32.0

### DIFF
--- a/components/crud-web-apps/volumes/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/deployment.yaml
@@ -21,7 +21,7 @@ spec:
         - name: APP_SECURE_COOKIES
           value: $(VWA_APP_SECURE_COOKIES)
         - name: VOLUME_VIEWER_IMAGE
-          value: filebrowser/filebrowser:v2.25.0
+          value: filebrowser/filebrowser:v2.32.0
         - name: METRICS
           value: $(VWA_APP_ENABLE_METRICS)
         volumeMounts: 


### PR DESCRIPTION
Updating to the most recent v2.32.0. The current default image is from September 2023.