### PR TITLE
fix(notebook): fix default workspace volume name to match default configs

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-workspace-volume/form-workspace-volume.component.ts
+++ b/components/crud-web-apps/jupyter/frontend/src/app/pages/form/form-new/form-workspace-volume/form-workspace-volume.component.ts
@@ -50,7 +50,9 @@ export class FormWorkspaceVolumeComponent implements OnInit, OnDestroy {
   }
 
   addNewVolume() {
-    this.volGroup.addControl('newPvc', createNewPvcFormGroup());
+    this.volGroup.addControl('newPvc', createNewPvcFormGroup(
+      '{notebook-name}-workspace'
+    ));
     this.volGroup.get('mount').setValue('/home/jovyan');
     this.volGroup.enable();
     this.volGroup.get('newPvc.spec.storageClassName').disable();


### PR DESCRIPTION
Small fix to improve consistency in the default workspace volume name when creating a new Notebook.

I noticed that on initial load of the crud-web-apps/jupyter form, the default workspace volume name was "{notebook-name}-workspace". 
But if you deleted that workspace volume, and then re-added a workspace volume to the Notebook you are creating, then the workspace volume name was "{notebook-name}-volume".

This PR is to **FIX** the default name of the workspace volume to always follow the same standard of "{notebook-name}-workspace" to match with the default configs.