### PR TITLE
fix: Remove and replace unwanted information from test case

### DIFF
--- a/components/access-management/kfam/bindings_test.go
+++ b/components/access-management/kfam/bindings_test.go
@@ -30,11 +30,11 @@ func TestGetBindingName(t *testing.T) {
 		out      string
 		hasError bool
 	}{
-		{"letters", getBindingObject("lalith.vaka@zq.msds.kp.org"), "user-lalith-vaka-zq-msds-kp-org-clusterrole-edit", false},
-		{"numbers", getBindingObject("397401@zq.msds.kp.org"), "user-397401-zq-msds-kp-org-clusterrole-edit", false},
-		{"letters-numbers", getBindingObject("lalith.397401@zq.msds.kp.org"), "user-lalith-397401-zq-msds-kp-org-clusterrole-edit", false},
-		{"numbers-letters", getBindingObject("397401.vaka@zq.msds.kp.org"), "user-397401-vaka-zq-msds-kp-org-clusterrole-edit", false},
-		{"lettersnumbers", getBindingObject("i397401@zq.msds.kp.org"), "user-i397401-zq-msds-kp-org-clusterrole-edit", false},
+		{"letters", getBindingObject("lalith.vaka@xyz.msds.abc.com"), "user-lalith-vaka-xyz-msds-abc-com-clusterrole-edit", false},
+		{"numbers", getBindingObject("111111@xyz.msds.abc.com"), "user-111111-xyz-msds-abc-com-clusterrole-edit", false},
+		{"letters-numbers", getBindingObject("lalith.111111@xyz.msds.abc.com"), "user-lalith-111111-xyz-msds-abc-com-clusterrole-edit", false},
+		{"numbers-letters", getBindingObject("111111.vaka@xyz.msds.abc.com"), "user-111111-vaka-xyz-msds-abc-com-clusterrole-edit", false},
+		{"lettersnumbers", getBindingObject("a111111@xyz.msds.abc.com"), "user-a111111-xyz-msds-abc-com-clusterrole-edit", false},
 	}
 
 	//format := "--- %s: %s (%s)\n"


### PR DESCRIPTION
Description:
I previously contributed PR #4979 and recently noticed I accidentally included some unwanted/sensitive information in one of the test cases. This PR removes that information.

Changes:
- Removed unwanted information from /components/access-management/kfam/bindings_test.go
- No functional changes to the code or tests

I've verified that all tests continue to pass after this change.

This is a straightforward cleanup with no impact on functionality.