### PR TITLE
fix(jupyter backend): fixed function to get notebook status from container state

### DIFF
--- a/components/crud-web-apps/jupyter/backend/apps/common/status.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status.py
@@ -133,9 +133,9 @@ def get_status_from_container_state(notebook):
 
     # If the Notebook is initializing, the status will be waiting
     waiting_state = container_state["waiting"]
-    if ["reason"] == 'PodInitializing':
+    if waiting_state["reason"] == 'PodInitializing':
         status_phase = status.STATUS_PHASE.WAITING
-        status_message = waiting_state.get("reason", "Undetermined reason.")
+        status_message = waiting_state["reason"]
         return status_phase, status_message
 
     # In any other case, the status will be warning with a "reason:

--- a/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
+++ b/components/crud-web-apps/jupyter/backend/apps/common/status_test.py
@@ -47,6 +47,6 @@ class TestStatusFromContainerState(unittest.TestCase):
 
         self.assertEqual(
             status.get_status_from_container_state(container_state),
-            ("warning",
-             "PodInitializing: No available message for container state.")
+            ("waiting",
+             "PodInitializing")
         )


### PR DESCRIPTION
I noticed that the function `get_status_from_container_state` found in `status.go` under `crud-web-apps/jupyter/backend` had an issue in how one conditional was written.

It was doing a comparison between an array of a string with a completely different string, which will always result as `false`.

Tracked down where this issue was introduced to [this PR](https://github.com/kubeflow/kubeflow/pull/7585)

Additionally, I noticed that this exact test case was defined in `status_test.go`. But it seems like the test case was built from the broken code, because the assertion did not follow the logic of the function.