### PR TITLE
fix(notebooks): fixed missing reference in volumes backend

### DIFF
--- a/components/crud-web-apps/volumes/backend/apps/default/routes/delete.py
+++ b/components/crud-web-apps/volumes/backend/apps/default/routes/delete.py
@@ -37,7 +37,7 @@ def delete_pvc(pvc, namespace):
                 "required to identify its parent",
                 namespace,
                 viewer_pod.metadata.name,
-                viewer_utils.VIEWER_LABEL,
+                viewer_utils.POD_PARENT_VIEWER_LABEL_KEY,
             )
         delete_viewer(viewer, namespace)
 


### PR DESCRIPTION
I noticed that the "delete_pvc" endpoint was referencing a missing value from the "viewer_utils" import.

When running this code, it would result in this error:
```
Traceback (most recent call last):
  File "/home/marcoma/Documents/upstreams/kubeflow/components/crud-web-apps/volumes/backend/web-apps-dev/lib/python3.10/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/marcoma/Documents/upstreams/kubeflow/components/crud-web-apps/volumes/backend/web-apps-dev/lib/python3.10/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
  File "/home/marcoma/Documents/upstreams/kubeflow/components/crud-web-apps/volumes/backend/apps/default/routes/delete.py", line 30, in delete_pvc
    viewer_utils.VIEWER_LABEL,
AttributeError: module 'apps.common.viewer' has no attribute 'VIEWER_LABEL'
```

So I replaced it for a value that does exist. Please confirm if this was the original intent for this warning log.