### PR TITLE
fix(dashboard): Make buttons look clickable

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles/styles.scss
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/src/styles/styles.scss
@@ -55,7 +55,7 @@ $kubeflow-typography-config: mat.define-typography-config(
 $kubeflow-theme: mat.define-light-theme(
   (
     color: (
-      primary: mat.define-palette($kubeflow-primary-palette, 500),
+      primary: mat.define-palette($kubeflow-primary-palette, 700),
       accent: mat.define-palette(mat.$pink-palette, A200, A100, A400),
     ),
   )


### PR DESCRIPTION
Resolves https://github.com/kubeflow/dashboard/issues/98

This fix restores the main theme color to 700, which was unintentionally changed to 500 in #7637.

before:

![before1](https://github.com/user-attachments/assets/f07d3287-e85a-4e9d-8e3e-b456f3eb53ba)
![before2](https://github.com/user-attachments/assets/493cdf30-ed85-4f85-a959-140ded22d718)

after:

![after1](https://github.com/user-attachments/assets/620bd6be-5e1b-4f09-9780-0bcf0e417403)
![after2](https://github.com/user-attachments/assets/de78be34-9db7-466f-95a8-cee780db0360)
