### PR TITLE
fix: Missing Styles in kubeflow-common-lib Affecting KServe Models Web Application

### DIFF
--- a/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/ng-package.json
+++ b/components/crud-web-apps/common/frontend/kubeflow-common-lib/projects/kubeflow/ng-package.json
@@ -3,5 +3,6 @@
   "dest": "../../dist/kubeflow",
   "lib": {
     "entryFile": "src/public-api.ts"
-  }
+  },
+  "assets": ["src/styles"]
 }


### PR DESCRIPTION
## Issue: Missing styles in kubeflow-common-lib breaking KServe Models Web Application

### Description
The KServe Models Web Application is unable to properly import styles from the kubeflow-common-lib package. While the styles are referenced in `ng-package.json` as assets, there appears to be an issue with how they're being packaged and distributed.

### Current Configuration
In `ng-package.json`, styles are listed in assets:
```json
{
  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
  "dest": "../../dist/kubeflow",
  "lib": {
    "entryFile": "src/public-api.ts"
  },
  "assets": ["src/styles"]
}
```
When trying to import the styles in the KServe Models Web Application like:
```json
@import 'kubeflow/src/styles/styles.scss';
```
The application fails to build because it cannot locate these styles.