### PR TITLE
fix ECONNREFUSED jupyter frontend

### DIFF
--- a/components/crud-web-apps/jupyter/frontend/src/proxy.conf.json
+++ b/components/crud-web-apps/jupyter/frontend/src/proxy.conf.json
@@ -1,6 +1,6 @@
 {
   "/api": {
-    "target": "http://localhost:5000",
+    "target": "http://0.0.0.0:5000",
     "secure": false
   },
   "/static": {


### PR DESCRIPTION
fix ECONNREFUSED when running jupyter frontend locally by `npm run serve`,
the jupyter backend is exposed by `--bind 0.0.0.0:5000`

<img width="1070" alt="image" src="https://github.com/user-attachments/assets/d477d1bd-a551-4fe9-820d-643866a47c10" />
