### PR TITLE
feat: remove default 'ubuntu' user on Ubuntu 23.04+

### DIFF
--- a/components/example-notebook-servers/base/Dockerfile
+++ b/components/example-notebook-servers/base/Dockerfile
@@ -102,7 +102,9 @@ RUN curl -fsSL "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETA
  && chmod +x /usr/local/bin/kubectl
 
 # create user and set required ownership
-RUN useradd -M -N \
+# Ubuntu 23.04 and later ship with a default user 'ubuntu' with UID 1000
+RUN userdel -r ubuntu || true \
+  && useradd -M -N \
     --shell /bin/bash \
     --home ${HOME} \
     --uid ${NB_UID} \


### PR DESCRIPTION
Starting from Ubuntu 23.04, the system includes a default 'ubuntu' user (UID 1000) to serve as a non-root OCI user. This cause errors when building the base image: `useradd: UID 1000 is not unique`.

Since we don't need the default 'ubuntu' user, this commit removes it.