### PR TITLE
fix: Use of externally-controlled format string

### DIFF
--- a/components/centraldashboard-angular/backend/app/api_workgroup.ts
+++ b/components/centraldashboard-angular/backend/app/api_workgroup.ts
@@ -109,7 +109,7 @@ const surfaceProfileControllerErrors = (info: {res: Response, msg: string, err: 
     const code = (err.response && err.response.statusCode) || 400;
     const devError = err.body || '';
     // Msg is the developer reason of what happened, devError is the technical details as to why
-    console.error(msg+(devError?` ${devError}`:''), err.stack?err:'');
+    console.error('%s%s', msg, devError ? ` ${devError}` : '', err.stack ? err : '');
     apiError({res, code, error: devError || msg});
 };
 

--- a/components/centraldashboard-angular/backend/app/k8s_service.ts
+++ b/components/centraldashboard-angular/backend/app/k8s_service.ts
@@ -63,7 +63,7 @@ export class KubernetesService {
       return body.items;
     } catch (err) {
       console.error(
-          `Unable to fetch Events for ${namespace}:`, err.body || err);
+          'Unable to fetch Events for %s:', namespace, err.body || err);
       return [];
     }
   }

--- a/components/centraldashboard/app/api_workgroup.ts
+++ b/components/centraldashboard/app/api_workgroup.ts
@@ -111,7 +111,7 @@ const surfaceProfileControllerErrors = (info: {res: Response, msg: string, err: 
     const code = (err.response && err.response.statusCode) || 400;
     const devError = err.body || '';
     // Msg is the developer reason of what happened, devError is the technical details as to why
-    console.error(msg+(devError?` ${devError}`:''), err.stack?err:'');
+    console.error('%s%s', msg, devError ? ` ${devError}` : '', err.stack ? err : '');
     apiError({res, code, error: devError || msg});
 };
 


### PR DESCRIPTION
https://github.com/kubeflow/kubeflow/blob/41ee8e7cb7cf57fa73b45362e67915c6a438c4aa/components/centraldashboard/app/api_workgroup.ts#L114-L114

https://github.com/kubeflow/kubeflow/blob/41ee8e7cb7cf57fa73b45362e67915c6a438c4aa/components/centraldashboard-angular/backend/app/api_workgroup.ts#L112-L112

https://github.com/kubeflow/kubeflow/blob/c856728c59115f62baa65b2eccfc37409eee69e6/components/centraldashboard-angular/backend/app/k8s_service.ts#L66-L66

Functions like the standard library function util.format accept a format string that is used to format the remaining arguments by providing inline format specifiers. If the format string contains unsanitized input from an untrusted source, then that string may contain unexpected format specifiers that cause garbled output.


fix the issue, we will modify the `console.error` statement on line 66 of `k8s_service.ts` to use a `%s` format specifier and pass the `namespace` parameter as a separate argument. This approach ensures that the `namespace` value is treated as a string and prevents any unintended behavior caused by special characters or malicious input. No additional imports or dependencies are required for this fix.


[util.format](https://nodejs.org/api/util.html#util_util_format_format_args) 
