### PR TITLE
feat: Add support to run notebooks on its own subdomains in Istio

### DIFF
--- a/components/notebook-controller/README.md
+++ b/components/notebook-controller/README.md
@@ -34,7 +34,17 @@ All other fields will be filled in with default value if not specified.
 | --- | --- |
 |ADD_FSGROUP| If the value is true or unset, fsGroup: 100 will be included in the pod's security context. If this value is present and set to false, it will suppress the automatic addition of fsGroup: 100 to the security context of the pod.|
 |DEV| If the value is false or unset, then the default implementation of the Notebook Controller will be used. If the admins want to use a custom implementation from their local machine, they should set this value to true.|
-
+|USE_ISTIO| If the value is set to true, Istio will be used to route traffic. If set to false, Istio routing will be disabled.|
+|ISTIO_GATEWAY|Name of the Istio Gateway resource used to route traffic to notebook servers. Only used if ``USE_ISTIO`` is enabled.|
+|ISTIO_HOST|Specifies the host to use in the Istio VirtualService. Default is ``*``. Only used if ``USE_ISTIO`` is enabled.|
+|ISTIO_USE_NOTEBOOK_SUBDOMAINS| If the value is true, notebooks hosted on a subdomain. This is recommended for security reasons but has some technical dependencies. If the value is set to false, secure subdomain feature is not enabled. Disabled by default.|
+|ISTIO_HOST_NOTEBOOK| Domain template used by Istio to host notebooks (e.g., `${NAMESPACE}-notebook.kubeflow.example.com`). Required if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
+|ISTIO_HOST_AUTH| Host used by Istio for handling authentication callbacks or login flows (e.g., `kubeflow.example.com`). Required if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
+|ISTIO_AUTH_PATH|Specifies the path used for authentication callbacks or redirection when integrating with an identity provider through Istio. Default is ``/oauth2/``. Only used if ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is enabled. |
+|ENABLE_CULLING|If the value is true, the controller will do culling on idle notebooks. Not enabled by default.|
+|CULL_IDLE_TIME|Specifies minutes until an idle notebook will be stopped. Default is 1 day.|
+|IDLENESS_CHECK_PERIOD|Specifies minutes for the idleness check period. Default is 1 minute.|
+|CLUSTER_DOMAIN| Specifies the Kubernetes internal cluster domain. Default is ``cluster.local``|
 
 
 ## Commandline parameters


### PR DESCRIPTION
This PR is a draft at the moment, see [Open Tasks](#open-tasks) for details.

This PR makes it possible to host notebooks on their own subdomains when Istio is used by adding this feature to the Kubeflow ``notebook-controller``. This isolates the notebook's origin from the dashboard / Kubeflow API origin in the browser and addresses a security problem that allows session hijacking through a malicious notebook.

## Motivation / Why this change is needed

This change addresses a security problem that allows session hijacking through a malicious notebook:

An attacker can log session cookies by misusing the Notebook feature: An attacker can create a Notebook with a custom image that logs the cookies / trigger API requests. Afterwards, they must convince the victim to visit the URL of the Notebook (a phishing attack). This is a classic phishing attack scenario.

Disallowing custom images wouldn't be sufficient because you can achieve the same thing with a few extra steps using one of default images.

The problem relies on the fact that the Notebooks and the Kubeflow Dashboard / APIs are in the Browser's [same origin](https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy). Thus, any attacker-controlled site would be able to access the Kubeflow API in the context of the victim.

To prevent this attack, the [authenticating cookies need to be removed](https://istio.io/latest/docs/reference/config/networking/virtual-service/#Headers-HeaderOperations) from requests forwarded to Notebook's Pods, and the notebooks need to be hosted on a different domain. This PR accomplishes this.

A proof of concept that demonstrates the problem is available but will not be disclosed until the problem is fixed.

## Request for Feedback

At the moment, we are removing all cookie headers for security reasons before the request is forwarded to the notebook container. This breaks the functionality in some notebook images. So the goal is to remove only the authenticating cookie and keep the remaining cookies.

Our idea is to use a [Istio Wasm Plugin](https://istio.io/latest/docs/reference/config/proxy_extensions/wasm-plugin/) that accomplishes this.

@kimwnasptd @juliusvonkohout @thesuperzapper What do you think?

## What this PR accomplishes

1. Set individual hosts based on the environment variable ``ISTIO_HOST_NOTEBOOK`` in the notebook's VirtualServices when ``ISTIO_USE_NOTEBOOK_SUBDOMAINS`` is set to prevent access to the dashboard / APIs from attacker-controlled notebooks through the browser.
2. Implementing the authentication flow on the subdomains by redirecting unauthenticated requests to the host configured in ``ISTIO_HOST_AUTH`` for the ``ISTIO_AUTH_PATH``.
3. Remove authenticating cookies from the request before it is forwarded to the notebook container (WIP) to prevent session token stealing.

## Open Tasks

This PR is a draft at the moment because the following parts are work in progress:

1. [ ] At the moment, we are removing all cookie headers for security reasons before the request is forwarded to the notebook container. This breaks the functionality in some notebook images. So the goal is to remove only the authenticating cookie and keep the remaining cookies. See [Request for Feedback](#request-for-feedback)
2. [ ] The subdomain feature requires additional configuration in the Kubeflow installation to make it fully functional (see configuration below). This will be documented and provided in a separate pull request in the [manifests repository](https://github.com/kubeflow/manifests).
3. [ ] Unit test code for the new feature

## Configuration

The subdomain feature is disabled by default as the setup has some prerequisites and is a breaking change. It requires a wildcard domain and wildcard TLS certificate or automated domain and certificate management.

To enable the feature, do the following configuration steps:

1. Configure the following environment variables in the ``notebook-controller``:

```sh
ISTIO_USE_NOTEBOOK_SUBDOMAINS: true
ISTIO_HOST: "${NAMESPACE}-notebook-${NAME}.kubeflow.example.com"
ISTIO_HOST_NOTEBOOK: "${NAMESPACE}-notebook.kubeflow.example.com"
ISTIO_HOST_AUTH: "kubeflow.example.com"
ISTIO_HOST_AUTH_PATH: "/oauth2/"
```

2. The `configmap` of `oauth2` must also be adjusted by enabling cookies for subdomains. Edit the ``oauth2_proxy.cfg`` configuration of the ``oauth2-proxy-hk55gm96k4`` ConfigMap in the ``oauth2-proxy`` namespace and add the following setting:

```sh
cookie_domains = "kubeflow.example.com"
```


/assign @juliusvonkohout
/label area/security
