### PR TITLE
chore: Refactor kustomize manifests to improve installation UX

### DIFF
--- a/components/admission-webhook/manifests/base/kustomization.yaml
+++ b/components/admission-webhook/manifests/base/kustomization.yaml
@@ -1,0 +1,54 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- mutating-webhook-configuration.yaml
+- service-account.yaml
+- service.yaml
+- crd.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: poddefaults
+    kustomize.component: poddefaults
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+images:
+- name: ghcr.io/kubeflow/kubeflow/poddefaults-webhook
+  newName: ghcr.io/kubeflow/kubeflow/poddefaults-webhook
+  newTag: v1.10.0
+namespace: kubeflow
+generatorOptions:
+  disableNameSuffixHash: true
+vars:
+# These vars are used to substitute in the namespace, service name and
+# deployment name into the mutating WebHookConfiguration.
+# Since its a CR kustomize isn't aware of those fields and won't
+# transform them.
+# We need the var names to be relatively unique so that when we
+# compose with other applications they won't conflict.
+- fieldref:
+    fieldPath: metadata.namespace
+  name: podDefaultsNamespace
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: metadata.name
+  name: podDefaultsServiceName
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: metadata.name
+  name: podDefaultsDeploymentName
+  objref:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: deployment
+configurations:
+- params.yaml

--- a/components/admission-webhook/manifests/overlays/cert-manager/kustomization.yaml
+++ b/components/admission-webhook/manifests/overlays/cert-manager/kustomization.yaml
@@ -1,0 +1,48 @@
+# This overlay uses CertManager to provision a certificate for the
+# PodDefaults admission controller. This is preferred over the old
+# way of using "bootstrap" which was running a shell script to create
+# the certificate.
+# TODO(jlewi): We should eventually refactor the manifests to delete
+# bootstrap and use certmanager by default.
+
+resources:
+- certificate.yaml
+- ../../base
+
+namespace: kubeflow
+
+namePrefix: admission-webhook-
+
+labels:
+- includeSelectors: true
+  pairs:
+    app: poddefaults
+    kustomize.component: poddefaults
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+patches:
+- path: mutating-webhook-configuration.yaml
+- path: deployment.yaml
+
+
+generatorOptions:
+  disableNameSuffixHash: true
+
+vars:
+# These vars are used to substitute in the namespace, service name and
+# deployment name into the mutating WebHookConfiguration.
+# Since its a CR kustomize isn't aware of those fields and won't
+# transform them.
+# We need the var names to be relatively unique so that when we
+# compose with other applications they won't conflict.
+- name: podDefaultsCertName
+  objref:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: cert
+  fieldref:
+    fieldpath: metadata.name
+
+configurations:
+- params.yaml

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -1,0 +1,94 @@
+# TODO(https://github.com/kubeflow/manifests/issues/774):
+# This is a legacy package. Hopefully we can get rid of it once
+# 774 is complete.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+# TODO(jlewi): We can't depend on base because of the deployment_patch.
+# but maybe if we changed that to use ConfigMapRef then the patch would correctly
+# override the patch applied in base_v3
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- role-binding.yaml
+- role.yaml
+- service-account.yaml
+- service.yaml
+- configs/logos-configmap.yaml
+namePrefix: jupyter-web-app-
+namespace: kubeflow
+labels:
+- includeSelectors: true
+  pairs:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
+images:
+- name: ghcr.io/kubeflow/kubeflow/jupyter-web-app
+  newName: ghcr.io/kubeflow/kubeflow/jupyter-web-app
+  newTag: v1.10.0
+# We need the name to be unique without the suffix because the original name is what
+# gets used with patches
+configMapGenerator:
+- envs:
+  - params.env
+  name: parameters
+- files:
+  - configs/spawner_ui_config.yaml
+  name: config
+vars:
+- fieldref:
+    fieldPath: data.JWA_CLUSTER_DOMAIN
+  name: JWA_CLUSTER_DOMAIN
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: metadata.namespace
+  name: JWA_NAMESPACE
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: data.JWA_USERID_HEADER
+  name: JWA_USERID_HEADER
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.JWA_USERID_PREFIX
+  name: JWA_USERID_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.JWA_UI
+  name: JWA_UI
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.JWA_PREFIX
+  name: JWA_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- name: JWA_APP_SECURE_COOKIES
+  fieldref:
+    fieldPath: data.JWA_APP_SECURE_COOKIES
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- name: JWA_APP_ENABLE_METRICS
+  fieldref:
+    fieldPath: data.JWA_APP_ENABLE_METRICS
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- virtual-service.yaml
+- authorization-policy.yaml
+- destination-rule.yaml
+namespace: kubeflow
+labels:
+- includeSelectors: true
+  pairs:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
+configurations:
+- params.yaml

--- a/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
@@ -1,0 +1,75 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- service-account.yaml
+- service.yaml
+namePrefix: tensorboards-web-app-
+namespace: kubeflow
+labels:
+- includeSelectors: true
+  pairs:
+    app: tensorboards-web-app
+    kustomize.component: tensorboards-web-app
+images:
+- name: ghcr.io/kubeflow/kubeflow/tensorboards-web-app
+  newName: ghcr.io/kubeflow/kubeflow/tensorboards-web-app
+  newTag: v1.10.0
+# We need the name to be unique without the suffix because the original name is what
+# gets used with patches
+configMapGenerator:
+- envs:
+  - params.env
+  name: parameters
+vars:
+- fieldref:
+    fieldPath: data.TWA_CLUSTER_DOMAIN
+  name: TWA_CLUSTER_DOMAIN
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: metadata.namespace
+  name: TWA_NAMESPACE
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: data.TWA_USERID_HEADER
+  name: TWA_USERID_HEADER
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.TWA_USERID_PREFIX
+  name: TWA_USERID_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.TWA_PREFIX
+  name: TWA_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.TWA_APP_SECURE_COOKIES
+  name: TWA_APP_SECURE_COOKIES
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- name: TWA_APP_ENABLE_METRICS
+  fieldref:
+    fieldPath: data.TWA_APP_ENABLE_METRICS
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- virtual-service.yaml
+- authorization-policy.yaml
+- destination-rule.yaml
+namespace: kubeflow
+labels:
+- includeSelectors: true
+  pairs:
+    app: tensorboards-web-app
+    kustomize.component: tensorboards-web-app
+configurations:
+- params.yaml

--- a/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
@@ -1,0 +1,78 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- cluster-role-binding.yaml
+- cluster-role.yaml
+- deployment.yaml
+- service-account.yaml
+- service.yaml
+namePrefix: volumes-web-app-
+namespace: kubeflow
+labels:
+- includeSelectors: true
+  pairs:
+    app: volumes-web-app
+    kustomize.component: volumes-web-app
+images:
+- name: ghcr.io/kubeflow/kubeflow/volumes-web-app
+  newName: ghcr.io/kubeflow/kubeflow/volumes-web-app
+  newTag: v1.10.0
+# We need the name to be unique without the suffix because the original name is what
+# gets used with patches
+configMapGenerator:
+- envs:
+  - params.env
+  name: parameters
+- files:
+  - viewer-spec.yaml
+  name: viewer-spec
+vars:
+- fieldref:
+    fieldPath: data.VWA_CLUSTER_DOMAIN
+  name: VWA_CLUSTER_DOMAIN
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: metadata.namespace
+  name: VWA_NAMESPACE
+  objref:
+    apiVersion: v1
+    kind: Service
+    name: service
+- fieldref:
+    fieldPath: data.VWA_USERID_HEADER
+  name: VWA_USERID_HEADER
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.VWA_USERID_PREFIX
+  name: VWA_USERID_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- fieldref:
+    fieldPath: data.VWA_PREFIX
+  name: VWA_PREFIX
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- name: VWA_APP_SECURE_COOKIES
+  fieldref:
+    fieldPath: data.VWA_APP_SECURE_COOKIES
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters
+- name: VWA_APP_ENABLE_METRICS
+  fieldref:
+    fieldPath: data.VWA_APP_ENABLE_METRICS
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: parameters

--- a/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+- virtual-service.yaml
+- authorization-policy.yaml
+- destination-rule.yaml
+namespace: kubeflow
+labels:
+- includeSelectors: true
+  pairs:
+    app: volumes-web-app
+    kustomize.component: volumes-web-app
+configurations:
+- params.yaml

--- a/components/notebook-controller/config/crd/kustomization.yaml
+++ b/components/notebook-controller/config/crd/kustomization.yaml
@@ -1,0 +1,31 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/kubeflow.org_notebooks.yaml
+# +kubebuilder:scaffold:crdkustomizeresource
+
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+#- patches/webhook_in_notebooks.yaml
+# +kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- patches/cainjection_in_notebooks.yaml
+# +kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml
+
+patches:
+- path: patches/trivial_conversion_patch.yaml
+- path: patches/validation_patches.yaml
+  target:
+    group: apiextensions.k8s.io
+    kind: CustomResourceDefinition
+    name: notebooks.kubeflow.org
+    version: v1
+

--- a/components/notebook-controller/config/default/kustomization.yaml
+++ b/components/notebook-controller/config/default/kustomization.yaml
@@ -1,0 +1,75 @@
+# Adds namespace to all resources.
+namespace: notebook-controller-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: notebook-controller-
+
+# Labels to add to all resources and selectors.
+labels:
+- includeSelectors: true
+  pairs:
+    app: notebook-controller
+    kustomize.component: notebook-controller
+resources:
+- ../rbac
+- ../manager
+- ../crd
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+
+#patchesStrategicMerge:
+#- manager_image_patch.yaml
+  # Protect the /metrics endpoint by putting it behind auth.
+  # Only one of manager_auth_proxy_patch.yaml and
+  # manager_prometheus_metrics_patch.yaml should be enabled.
+#- manager_auth_proxy_patch.yaml
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, uncomment the following line and
+  # comment manager_auth_proxy_patch.yaml.
+  # Only one of manager_auth_proxy_patch.yaml and
+  # manager_prometheus_metrics_patch.yaml should be enabled.
+#- manager_prometheus_metrics_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+# vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#   objref:
+#     kind: Certificate
+#     group: certmanager.k8s.io
+#     version: v1alpha1
+#     name: serving-cert # this name should match the one in certificate.yaml
+#   fieldref:
+#     fieldpath: metadata.namespace
+# - name: CERTIFICATE_NAME
+#   objref:
+#     kind: Certificate
+#     group: certmanager.k8s.io
+#     version: v1alpha1
+#     name: serving-cert # this name should match the one in certificate.yaml
+# - name: SERVICE_NAMESPACE # namespace of the service
+#   objref:
+#     kind: Service
+#     version: v1
+#     name: webhook-service
+#   fieldref:
+#     fieldpath: metadata.namespace
+# - name: SERVICE_NAME
+#   objref:
+#     kind: Service
+#     version: v1
+#     name: webhook-service

--- a/components/notebook-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/kubeflow/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+namespace: kubeflow
+patches:
+- path: patches/remove-namespace.yaml
+configMapGenerator:
+- name: config
+  behavior: merge
+  literals:
+  - USE_ISTIO=true
+  - ISTIO_GATEWAY=kubeflow/kubeflow-gateway

--- a/components/profile-controller/config/base/kustomization.yaml
+++ b/components/profile-controller/config/base/kustomization.yaml
@@ -1,0 +1,20 @@
+# TODO(jlewi): This kustomization.yaml is deprecated. We want the
+# base_v3 version. This version uses a bunch of problematic patterns e.g.
+# i) Using vars to do command line substitution
+# ii) Not using a configmap to make application and global config available
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../default
+patches:
+- path: patches/manager.yaml
+
+images:
+- name: ghcr.io/kubeflow/kubeflow/profile-controller
+  newName: ghcr.io/kubeflow/kubeflow/profile-controller
+  newTag: v1.10.0
+
+configMapGenerator:
+- name: namespace-labels-data
+  files:
+  - namespace-labels.yaml

--- a/components/profile-controller/config/crd/kustomization.yaml
+++ b/components/profile-controller/config/crd/kustomization.yaml
@@ -1,0 +1,21 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/kubeflow.org_profiles.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+patches:
+- path: patches/trivial_conversion_patch.yaml
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+#- patches/webhook_in_profiles.yaml
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- patches/cainjection_in_profiles.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml

--- a/components/profile-controller/config/default/kustomization.yaml
+++ b/components/profile-controller/config/default/kustomization.yaml
@@ -1,0 +1,77 @@
+# Adds namespace to all resources.
+namespace: profiles-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: profiles-
+
+# Labels to add to all resources and selectors.
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: profiles
+resources:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+# patchesStrategicMerge:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+# - manager_auth_proxy_patch.yaml
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, uncomment the following line and
+  # comment manager_auth_proxy_patch.yaml.
+  # Only one of manager_auth_proxy_patch.yaml and
+  # manager_prometheus_metrics_patch.yaml should be enabled.
+#- manager_prometheus_metrics_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+# vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/components/profile-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/kustomization.yaml
@@ -1,0 +1,34 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kubeflow
+resources:
+- ../../base
+- service.yaml
+- virtual-service.yaml
+- authorizationpolicy.yaml
+
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: profiles
+
+patches:
+- path: patches/kfam.yaml
+- path: patches/remove-namespace.yaml
+
+configurations:
+- params.yaml
+
+vars:
+- name: PROFILES_NAMESPACE
+  fieldref:
+    fieldpath: metadata.namespace
+  objref:
+    name: profiles-kfam
+    kind: Service
+    apiVersion: v1
+
+images:
+- name: ghcr.io/kubeflow/kubeflow/kfam
+  newName: ghcr.io/kubeflow/kubeflow/kfam
+  newTag: v1.10.0

--- a/components/pvcviewer-controller/config/crd/kustomization.yaml
+++ b/components/pvcviewer-controller/config/crd/kustomization.yaml
@@ -1,0 +1,15 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/kubeflow.org_pvcviewers.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+patches:
+- path: patches/webhook_in_pvcviewers.yaml
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
+- path: patches/cainjection_in_pvcviewers.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml

--- a/components/pvcviewer-controller/config/default/kustomization.yaml
+++ b/components/pvcviewer-controller/config/default/kustomization.yaml
@@ -1,0 +1,170 @@
+# Adds namespace to all resources.
+# Note: the namespace name needs to be changed here and cannot be changed in an overlay
+# This is because certmanager and webhook use kustomize names to configure resources.
+# Setting another namespace here as in the overlay will lead to e.g. wrong DNSNames being generated.
+namespace: kubeflow
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: pvcviewer-
+
+# Labels to add to all resources and selectors.
+labels:
+- includeSelectors: true
+  pairs:
+    app: pvcviewer
+
+resources:
+- ../crd
+- ../rbac
+- ../manager
+- ../webhook
+- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+patches:
+# Do not create a namespace
+- path: remove_namespace.yaml
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, please comment the following line.
+- path: manager_auth_proxy_patch.yaml
+- path: manager_webhook_patch.yaml
+- path: cainjection_patch.yaml
+- path: dnsnames_patch.yaml
+vars:
+- name: CERTIFICATE_NAMESPACE 
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert 
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert
+- name: SERVICE_NAMESPACE
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+
+# the following config is for teaching kustomize how to replace vars in Certificates.
+configurations:
+- kustomizeconfig.yaml
+
+# Note: the kustomize version that's being used to execute integration tests currently doesn't support replacemens.
+# Thus, we're using the deprecated vars feature above.
+# Once the kustomize version is updated, we can use the following config instead of the vars feature.
+# Can be removed then: cainjection_patch.yaml, dnsnames_patch.yaml, kustomizeconfig.yaml, their references here and the vars section above.
+# replacements:
+#  - source: # Add cert-manager annotation to ValidatingWebhookConfiguration, MutatingWebhookConfiguration and CRDs
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1
+#      name: serving-cert # this name should match the one in certificate.yaml
+#      fieldPath: .metadata.namespace # namespace of the certificate CR
+#    targets:
+#      - select:
+#          kind: ValidatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#      - select:
+#          kind: MutatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#      - select:
+#          kind: CustomResourceDefinition
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 0
+#          create: true
+#  - source:
+#      kind: Certificate
+#      group: cert-manager.io
+#      version: v1
+#      name: serving-cert # this name should match the one in certificate.yaml
+#      fieldPath: .metadata.name
+#    targets:
+#      - select:
+#          kind: ValidatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: MutatingWebhookConfiguration
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#      - select:
+#          kind: CustomResourceDefinition
+#        fieldPaths:
+#          - .metadata.annotations.[cert-manager.io/inject-ca-from]
+#        options:
+#          delimiter: '/'
+#          index: 1
+#          create: true
+#  - source: # Add cert-manager annotation to the webhook Service
+#      kind: Service
+#      version: v1
+#      name: webhook-service
+#      fieldPath: .metadata.name # namespace of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 0
+#          create: true
+#  - source:
+#      kind: Service
+#      version: v1
+#      name: webhook-service
+#      fieldPath: .metadata.namespace # namespace of the service
+#    targets:
+#      - select:
+#          kind: Certificate
+#          group: cert-manager.io
+#          version: v1
+#        fieldPaths:
+#          - .spec.dnsNames.0
+#          - .spec.dnsNames.1
+#        options:
+#          delimiter: '.'
+#          index: 1
+#          create: true

--- a/components/tensorboard-controller/config/base/kustomization.yaml
+++ b/components/tensorboard-controller/config/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../default
+configMapGenerator:
+- name: tensorboard-controller-config
+  literals:
+  - RWO_PVC_SCHEDULING="True"
+  - TENSORBOARD_IMAGE=tensorflow/tensorflow:2.5.1
+  - ISTIO_GATEWAY=kubeflow/kubeflow-gateway
+  - ISTIO_HOST=*
+patches:
+- path: patches/add_controller_config.yaml
+images:
+- name: ghcr.io/kubeflow/kubeflow/tensorboard-controller
+  newName: ghcr.io/kubeflow/kubeflow/tensorboard-controller
+  newTag: v1.10.0

--- a/components/tensorboard-controller/config/crd/kustomization.yaml
+++ b/components/tensorboard-controller/config/crd/kustomization.yaml
@@ -1,0 +1,21 @@
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+resources:
+- bases/tensorboard.kubeflow.org_tensorboards.yaml
+#+kubebuilder:scaffold:crdkustomizeresource
+
+# patchesStrategicMerge:
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
+# patches here are for enabling the conversion webhook for each CRD
+#- patches/webhook_in_tensorboards.yaml
+#+kubebuilder:scaffold:crdkustomizewebhookpatch
+
+# [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
+# patches here are for enabling the CA injection for each CRD
+#- patches/cainjection_in_tensorboards.yaml
+#+kubebuilder:scaffold:crdkustomizecainjectionpatch
+
+# the following config is for teaching kustomize how to do kustomization for CRDs.
+configurations:
+- kustomizeconfig.yaml

--- a/components/tensorboard-controller/config/default/kustomization.yaml
+++ b/components/tensorboard-controller/config/default/kustomization.yaml
@@ -1,0 +1,76 @@
+# Adds namespace to all resources.
+namespace: tensorboard-controller-system
+
+# Value of this field is prepended to the
+# names of all resources, e.g. a deployment named
+# "wordpress" becomes "alices-wordpress".
+# Note that it should also match with the prefix (text before '-') of the namespace
+# field above.
+namePrefix: tensorboard-controller-
+
+# Labels to add to all resources and selectors.
+labels:
+- includeSelectors: true
+  pairs:
+    app: tensorboard-controller
+    kustomize.component: tensorboard-controller
+resources:
+- ../crd
+- ../rbac
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+#- ../prometheus
+
+patches:
+  # Protect the /metrics endpoint by putting it behind auth.
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, please comment the following line.
+  - path: manager_auth_proxy_patch.yaml
+
+# Mount the controller config file for loading manager configurations
+# through a ComponentConfig type
+#- manager_config_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+# vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/components/tensorboard-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/tensorboard-controller/config/overlays/kubeflow/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+namespace: kubeflow
+patches:
+- path: patches/remove-namespace.yaml


### PR DESCRIPTION
## Overview

This pull request is part of the work related to **kubeflow/manifests#2991**, which aims to eliminate **kustomize deprecation warnings**

---

## Background

The goal is to make the upstream **kustomization files** compatible with current **kustomize best practices**, so that the downstream manifests can be synced without warnings.

---

## What This Pull Request Changes

This pull request updates `kustomization` files under the paths consumed by the **manifests sync scripts** by running:

`kustomize edit fix`

and applying the resulting changes where they are safe to apply.

In particular, it removes or migrates deprecated fields such as:

- `commonLabels`
- `patchesStrategicMerge`
- `bases`
- `patchesJson6902`
- Other fields that `kustomize edit fix` rewrites

---

## Validation Process

For each `kustomization`:

1. I ran `kustomize build` **before** the change and captured the output.
2. I ran `kustomize edit fix` and committed **only the structural changes it produced**.
3. I ran `kustomize build` **after** the change and compared the results.
4. I kept the edits **only when the before/after rendered manifests were identical**.

As a result, this pull request should be a **pure refactor** with **no change to the rendered Kubernetes resources**, only the `kustomization` structure.

The remaining **`vars` deprecation warning** is more involved and will be addressed in a **separate pull request** once this foundation is in place.

---

## Relation to `manifests`

These updates are intended to allow the **kubeflow/manifests sync scripts** to consume **kubeflow/kubeflow** without hitting deprecation warnings for the fields listed above.

My local testing used the `manifests` repository with:

- `REPOSITORY_URL` pointed to the **local clone of this branch**
- `COMMIT=HEAD`

I then performed an installation using the **main `manifests` README workflow**.

With these changes:

- **4 out of 5 previous warnings are removed**
- Only the **`vars` warning** remains

---

## Developer Checklist

- [x] No functional changes, only client-side structural changes  
- [x] Signed-off commit for DCO