### PR TITLE
fix depricated vars

### DIFF
--- a/components/admission-webhook/manifests/base/kustomization.yaml
+++ b/components/admission-webhook/manifests/base/kustomization.yaml
@@ -8,11 +8,6 @@ resources:
 - service-account.yaml
 - service.yaml
 - crd.yaml
-commonLabels:
-  app: poddefaults
-  kustomize.component: poddefaults
-  app.kubernetes.io/component: poddefaults
-  app.kubernetes.io/name: poddefaults
 images:
 - name: ghcr.io/kubeflow/kubeflow/poddefaults-webhook
   newName: ghcr.io/kubeflow/kubeflow/poddefaults-webhook
@@ -20,33 +15,28 @@ images:
 namespace: kubeflow
 generatorOptions:
   disableNameSuffixHash: true
-vars:
-# These vars are used to substitute in the namespace, service name and
-# deployment name into the mutating WebHookConfiguration.
-# Since its a CR kustomize isn't aware of those fields and won't
-# transform them.
-# We need the var names to be relatively unique so that when we
-# compose with other applications they won't conflict.
-- fieldref:
-    fieldPath: metadata.namespace
-  name: podDefaultsNamespace
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: service
-- fieldref:
-    fieldPath: metadata.name
-  name: podDefaultsServiceName
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: service
-- fieldref:
-    fieldPath: metadata.name
-  name: podDefaultsDeploymentName
-  objref:
-    apiVersion: apps/v1
+# Replacement for webhook name (base has no Certificate; overlay has its own replacements).
+replacements:
+- source:
     kind: Deployment
     name: deployment
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+    fieldPaths:
+    - webhooks.0.name
+    options:
+      delimiter: "."
+      index: 0
+
 configurations:
 - params.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: poddefaults
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
+    kustomize.component: poddefaults

--- a/components/admission-webhook/manifests/base/mutating-webhook-configuration.yaml
+++ b/components/admission-webhook/manifests/base/mutating-webhook-configuration.yaml
@@ -13,7 +13,7 @@ webhooks:
       path: /apply-poddefault
   sideEffects: None
   failurePolicy: Fail
-  name: $(podDefaultsDeploymentName).kubeflow.org
+  name: POD_DEFAULT_DEPLOYMENT_NAME_PLACEHOLDER.kubeflow.org
   namespaceSelector:
     matchLabels:
       app.kubernetes.io/part-of: kubeflow-profile

--- a/components/admission-webhook/manifests/overlays/cert-manager/certificate.yaml
+++ b/components/admission-webhook/manifests/overlays/cert-manager/certificate.yaml
@@ -4,10 +4,10 @@ metadata:
   name: cert
 spec:
   isCA: true
-  commonName: $(podDefaultsServiceName).$(podDefaultsNamespace).svc
+  commonName: POD_DEFAULT_SERVICE_NAME_PLACEHOLDER.POD_DEFAULT_NAMESPACE_PLACEHOLDER.svc
   dnsNames:
-  - $(podDefaultsServiceName).$(podDefaultsNamespace).svc
-  - $(podDefaultsServiceName).$(podDefaultsNamespace).svc.cluster.local
+  - POD_DEFAULT_SERVICE_NAME_PLACEHOLDER.POD_DEFAULT_NAMESPACE_PLACEHOLDER.svc
+  - POD_DEFAULT_SERVICE_NAME_PLACEHOLDER.POD_DEFAULT_NAMESPACE_PLACEHOLDER.svc.cluster.local
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer

--- a/components/admission-webhook/manifests/overlays/cert-manager/kustomization.yaml
+++ b/components/admission-webhook/manifests/overlays/cert-manager/kustomization.yaml
@@ -4,44 +4,98 @@
 # the certificate.
 # TODO(jlewi): We should eventually refactor the manifests to delete
 # bootstrap and use certmanager by default.
-bases:
-- ../../base
 
 resources:
+- ../../base
 - certificate.yaml
 
 namespace: kubeflow
 
 namePrefix: admission-webhook-
 
-commonLabels:
-  app: poddefaults
-  kustomize.component: poddefaults
-  app.kubernetes.io/component: poddefaults
-  app.kubernetes.io/name: poddefaults
+labels:
+- includeSelectors: true
+  pairs:
+    app: poddefaults
+    kustomize.component: poddefaults
+    app.kubernetes.io/component: poddefaults
+    app.kubernetes.io/name: poddefaults
 
-patchesStrategicMerge:
-- mutating-webhook-configuration.yaml
-- deployment.yaml
+patches:
+- path: mutating-webhook-configuration.yaml
+- path: deployment.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
 
-vars:
-# These vars are used to substitute in the namespace, service name and
-# deployment name into the mutating WebHookConfiguration.
-# Since its a CR kustomize isn't aware of those fields and won't
-# transform them.
-# We need the var names to be relatively unique so that when we
-# compose with other applications they won't conflict.
-- name: podDefaultsCertName
-  objref:
+replacements:
+# Webhook name: use prefixed deployment name (overlay has namePrefix).
+- source:
+    kind: Deployment
+    name: deployment
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+    fieldPaths:
+    - webhooks.0.name
+    options:
+      delimiter: "."
+      index: 0
+# Service name and namespace for Certificate commonName/dnsNames (index 0 and 1).
+- source:
+    kind: Service
+    name: service
+    fieldPath: metadata.name
+  targets:
+  - select:
       kind: Certificate
-      group: cert-manager.io
-      version: v1
       name: cert
-  fieldref:
-    fieldpath: metadata.name
+    fieldPaths:
+    - spec.commonName
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: "."
+      index: 0
+- source:
+    kind: Service
+    name: service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      name: cert
+    fieldPaths:
+    - spec.commonName
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: "."
+      index: 1
+  - select:
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 0
+# Certificate name for webhook CA injection annotation (index 1).
+- source:
+    kind: Certificate
+    name: cert
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+      name: mutating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 1
 
 configurations:
 - params.yaml

--- a/components/admission-webhook/manifests/overlays/cert-manager/mutating-webhook-configuration.yaml
+++ b/components/admission-webhook/manifests/overlays/cert-manager/mutating-webhook-configuration.yaml
@@ -3,5 +3,5 @@ kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(podDefaultsNamespace)/$(podDefaultsCertName)
+    cert-manager.io/inject-ca-from: POD_DEFAULT_NAMESPACE_PLACEHOLDER/POD_DEFAULT_CERT_NAME
   

--- a/components/centraldashboard-angular/manifests/base/deployment.yaml
+++ b/components/centraldashboard-angular/manifests/base/deployment.yaml
@@ -31,13 +31,13 @@ spec:
           protocol: TCP
         env:
         - name: USERID_HEADER
-          value: $(CD_USERID_HEADER)
+          value: placeholder
         - name: USERID_PREFIX
-          value: $(CD_USERID_PREFIX)
+          value: placeholder
         - name: PROFILES_KFAM_SERVICE_HOST
           value: profiles-kfam.kubeflow
         - name: REGISTRATION_FLOW
-          value: $(CD_REGISTRATION_FLOW)
+          value: placeholder
         - name: DASHBOARD_CONFIGMAP
-          value: $(CD_CONFIGMAP_NAME)
+          value: placeholder
       serviceAccountName: centraldashboard-angular

--- a/components/centraldashboard-angular/manifests/base/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/base/kustomization.yaml
@@ -10,11 +10,13 @@ resources:
 - service-account.yaml
 - service.yaml
 - configmap.yaml
-commonLabels:
-  kustomize.component: centraldashboard-angular
-  app: centraldashboard-angular
-  app.kubernetes.io/component: centraldashboard-angular
-  app.kubernetes.io/name: centraldashboard-angular
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: centraldashboard-angular
+    app: centraldashboard-angular
+    app.kubernetes.io/component: centraldashboard-angular
+    app.kubernetes.io/name: centraldashboard-angular
 images:
 - name: ghcr.io/kubeflow/kubeflow/centraldashboard-angular
   newName: ghcr.io/kubeflow/kubeflow/centraldashboard-angular
@@ -25,46 +27,44 @@ configMapGenerator:
   name: centraldashboard-angular-parameters
 generatorOptions:
   disableNameSuffixHash: true
-vars:
-- fieldref:
-    fieldPath: metadata.namespace
-  name: CD_NAMESPACE
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: centraldashboard-angular
-- fieldref:
-    fieldPath: data.CD_CLUSTER_DOMAIN
-  name: CD_CLUSTER_DOMAIN
-  objref:
-    apiVersion: v1
+replacements:
+- source:
     kind: ConfigMap
     name: centraldashboard-angular-parameters
-- fieldref:
     fieldPath: data.CD_USERID_HEADER
-  name: CD_USERID_HEADER
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: centraldashboard-angular
+    fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=USERID_HEADER].value
+- source:
     kind: ConfigMap
     name: centraldashboard-angular-parameters
-- fieldref:
     fieldPath: data.CD_USERID_PREFIX
-  name: CD_USERID_PREFIX
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: centraldashboard-angular
+    fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=USERID_PREFIX].value
+- source:
     kind: ConfigMap
     name: centraldashboard-angular-parameters
-- fieldref:
     fieldPath: data.CD_REGISTRATION_FLOW
-  name: CD_REGISTRATION_FLOW
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: centraldashboard-angular-parameters
-- fieldref:
-    fieldPath: metadata.name
-  name: CD_CONFIGMAP_NAME
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: centraldashboard-angular
+    fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=REGISTRATION_FLOW].value
+- source:
     kind: ConfigMap
     name: centraldashboard-angular-config
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Deployment
+      name: centraldashboard-angular
+    fieldPaths:
+    - spec.template.spec.containers.[name=centraldashboard-angular].env.[name=DASHBOARD_CONFIGMAP].value

--- a/components/centraldashboard-angular/manifests/overlays/istio/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/overlays/istio/kustomization.yaml
@@ -8,11 +8,39 @@ resources:
 
 namespace: kubeflow
 
-commonLabels:
-  kustomize.component: centraldashboard-angular
-  app: centraldashboard-angular
-  app.kubernetes.io/component: centraldashboard-angular
-  app.kubernetes.io/name: centraldashboard-angular
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: centraldashboard-angular
+    app: centraldashboard-angular
+    app.kubernetes.io/component: centraldashboard-angular
+    app.kubernetes.io/name: centraldashboard-angular
 
-configurations:
-- params.yaml
+# Replacements for VirtualService destination host (service.namespace.svc.clusterDomain).
+replacements:
+- source:
+    kind: Service
+    name: centraldashboard-angular
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: VirtualService
+      name: centraldashboard-angular
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 1
+- source:
+    kind: ConfigMap
+    name: centraldashboard-angular-parameters
+    fieldPath: data.CD_CLUSTER_DOMAIN
+  targets:
+  - select:
+      kind: VirtualService
+      name: centraldashboard-angular
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 3

--- a/components/centraldashboard-angular/manifests/overlays/istio/virtual-service.yaml
+++ b/components/centraldashboard-angular/manifests/overlays/istio/virtual-service.yaml
@@ -15,6 +15,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: centraldashboard-angular.$(CD_NAMESPACE).svc.$(CD_CLUSTER_DOMAIN)
+        # host: service.namespace.svc.clusterDomain — index 1 and 3 filled by replacements
+        host: centraldashboard-angular.placeholder.svc.placeholder
         port:
           number: 80

--- a/components/centraldashboard-angular/manifests/overlays/kserve/kustomization.yaml
+++ b/components/centraldashboard-angular/manifests/overlays/kserve/kustomization.yaml
@@ -4,11 +4,13 @@ kind: Kustomization
 resources:
 - ../istio
 
-commonLabels:
-  kustomize.component: centraldashboard-angular
-  app: centraldashboard-angular
-  app.kubernetes.io/component: centraldashboard-angular
-  app.kubernetes.io/name: centraldashboard-angular
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: centraldashboard-angular
+    app: centraldashboard-angular
+    app.kubernetes.io/component: centraldashboard-angular
+    app.kubernetes.io/name: centraldashboard-angular
 
-patchesStrategicMerge:
-- patches/configmap.yaml
+patches:
+- path: patches/configmap.yaml

--- a/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/deployment.yaml
@@ -18,17 +18,17 @@ spec:
           name: logos-volume
         env:
         - name: APP_PREFIX
-          value: $(JWA_PREFIX)
+          value: placeholder
         - name: UI
-          value: $(JWA_UI)
+          value: placeholder
         - name: USERID_HEADER
-          value: $(JWA_USERID_HEADER)
+          value: placeholder
         - name: USERID_PREFIX
-          value: $(JWA_USERID_PREFIX)
+          value: placeholder
         - name: APP_SECURE_COOKIES
-          value: $(JWA_APP_SECURE_COOKIES)
+          value: placeholder
         - name: METRICS
-          value: $(JWA_APP_ENABLE_METRICS)
+          value: placeholder
       serviceAccountName: service-account
       volumes:
       - configMap:

--- a/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/base/kustomization.yaml
@@ -17,9 +17,11 @@ resources:
 - configs/logos-configmap.yaml
 namePrefix: jupyter-web-app-
 namespace: kubeflow
-commonLabels:
-  app: jupyter-web-app
-  kustomize.component: jupyter-web-app
+labels:
+- includeSelectors: true
+  pairs:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
 images:
 - name: ghcr.io/kubeflow/kubeflow/jupyter-web-app
   newName: ghcr.io/kubeflow/kubeflow/jupyter-web-app
@@ -33,60 +35,64 @@ configMapGenerator:
 - files:
   - configs/spawner_ui_config.yaml
   name: config
-vars:
-- fieldref:
-    fieldPath: data.JWA_CLUSTER_DOMAIN
-  name: JWA_CLUSTER_DOMAIN
-  objref:
-    apiVersion: v1
+replacements:
+- source:
     kind: ConfigMap
-    name: parameters
-- fieldref:
-    fieldPath: metadata.namespace
-  name: JWA_NAMESPACE
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: service
-- fieldref:
-    fieldPath: data.JWA_USERID_HEADER
-  name: JWA_USERID_HEADER
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
-    fieldPath: data.JWA_USERID_PREFIX
-  name: JWA_USERID_PREFIX
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
-    fieldPath: data.JWA_UI
-  name: JWA_UI
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
+    name: jupyter-web-app-parameters
     fieldPath: data.JWA_PREFIX
-  name: JWA_PREFIX
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: jupyter-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=jupyter-web-app].env.[name=APP_PREFIX].value
+- source:
     kind: ConfigMap
-    name: parameters
-- name: JWA_APP_SECURE_COOKIES
-  fieldref:
+    name: jupyter-web-app-parameters
+    fieldPath: data.JWA_UI
+  targets:
+  - select:
+      kind: Deployment
+      name: jupyter-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=jupyter-web-app].env.[name=UI].value
+- source:
+    kind: ConfigMap
+    name: jupyter-web-app-parameters
+    fieldPath: data.JWA_USERID_PREFIX
+  targets:
+  - select:
+      kind: Deployment
+      name: jupyter-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=jupyter-web-app].env.[name=USERID_PREFIX].value
+- source:
+    kind: ConfigMap
+    name: jupyter-web-app-parameters
+    fieldPath: data.JWA_USERID_HEADER
+  targets:
+  - select:
+      kind: Deployment
+      name: jupyter-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=jupyter-web-app].env.[name=USERID_HEADER].value
+- source:
+    kind: ConfigMap
+    name: jupyter-web-app-parameters
     fieldPath: data.JWA_APP_SECURE_COOKIES
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: jupyter-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=jupyter-web-app].env.[name=APP_SECURE_COOKIES].value
+- source:
     kind: ConfigMap
-    name: parameters
-- name: JWA_APP_ENABLE_METRICS
-  fieldref:
+    name: jupyter-web-app-parameters
     fieldPath: data.JWA_APP_ENABLE_METRICS
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
+  targets:
+  - select:
+      kind: Deployment
+      name: jupyter-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=jupyter-web-app].env.[name=METRICS].value

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/kustomization.yaml
@@ -6,8 +6,36 @@ resources:
 - authorization-policy.yaml
 - destination-rule.yaml
 namespace: kubeflow
-commonLabels:
-  app: jupyter-web-app
-  kustomize.component: jupyter-web-app
-configurations:
-- params.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: jupyter-web-app
+    kustomize.component: jupyter-web-app
+# Replacements for VirtualService destination host (service.namespace.svc.clusterDomain).
+replacements:
+- source:
+    kind: Service
+    name: jupyter-web-app-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: VirtualService
+      name: jupyter-web-app-jupyter-web-app
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 1
+- source:
+    kind: ConfigMap
+    name: jupyter-web-app-parameters
+    fieldPath: data.JWA_CLUSTER_DOMAIN
+  targets:
+  - select:
+      kind: VirtualService
+      name: jupyter-web-app-jupyter-web-app
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 3

--- a/components/crud-web-apps/jupyter/manifests/overlays/istio/virtual-service.yaml
+++ b/components/crud-web-apps/jupyter/manifests/overlays/istio/virtual-service.yaml
@@ -19,6 +19,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: jupyter-web-app-service.$(JWA_NAMESPACE).svc.$(JWA_CLUSTER_DOMAIN)
+        # host: service.namespace.svc.clusterDomain — index 1 and 3 filled by replacements
+        host: jupyter-web-app-service.placeholder.svc.placeholder
         port:
           number: 80

--- a/components/crud-web-apps/tensorboards/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/deployment.yaml
@@ -13,13 +13,13 @@ spec:
         - containerPort: 5000
         env:
         - name: APP_PREFIX
-          value: $(TWA_PREFIX)
+          value: placeholder
         - name: USERID_HEADER
-          value: $(TWA_USERID_HEADER)
+          value: placeholder
         - name: USERID_PREFIX
-          value: $(TWA_USERID_PREFIX)
+          value: placeholder
         - name: APP_SECURE_COOKIES
-          value: $(TWA_APP_SECURE_COOKIES)
+          value: placeholder
         - name: METRICS
-          value: $(TWA_APP_ENABLE_METRICS)
+          value: placeholder
       serviceAccountName: service-account

--- a/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/base/kustomization.yaml
@@ -8,9 +8,11 @@ resources:
 - service.yaml
 namePrefix: tensorboards-web-app-
 namespace: kubeflow
-commonLabels:
-  app: tensorboards-web-app
-  kustomize.component: tensorboards-web-app
+labels:
+- includeSelectors: true
+  pairs:
+    app: tensorboards-web-app
+    kustomize.component: tensorboards-web-app
 images:
 - name: ghcr.io/kubeflow/kubeflow/tensorboards-web-app
   newName: ghcr.io/kubeflow/kubeflow/tensorboards-web-app
@@ -21,53 +23,54 @@ configMapGenerator:
 - envs:
   - params.env
   name: parameters
-vars:
-- fieldref:
-    fieldPath: data.TWA_CLUSTER_DOMAIN
-  name: TWA_CLUSTER_DOMAIN
-  objref:
-    apiVersion: v1
+replacements:
+- source:
     kind: ConfigMap
-    name: parameters
-- fieldref:
-    fieldPath: metadata.namespace
-  name: TWA_NAMESPACE
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: service
-- fieldref:
-    fieldPath: data.TWA_USERID_HEADER
-  name: TWA_USERID_HEADER
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
-    fieldPath: data.TWA_USERID_PREFIX
-  name: TWA_USERID_PREFIX
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
+    name: tensorboards-web-app-parameters
     fieldPath: data.TWA_PREFIX
-  name: TWA_PREFIX
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: tensorboards-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=tensorboards-web-app].env.[name=APP_PREFIX].value
+- source:
     kind: ConfigMap
-    name: parameters
-- fieldref:
+    name: tensorboards-web-app-parameters
+    fieldPath: data.TWA_USERID_HEADER
+  targets:
+  - select:
+      kind: Deployment
+      name: tensorboards-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=tensorboards-web-app].env.[name=USERID_HEADER].value
+- source:
+    kind: ConfigMap
+    name: tensorboards-web-app-parameters
+    fieldPath: data.TWA_USERID_PREFIX
+  targets:
+  - select:
+      kind: Deployment
+      name: tensorboards-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=tensorboards-web-app].env.[name=USERID_PREFIX].value
+- source:
+    kind: ConfigMap
+    name: tensorboards-web-app-parameters
     fieldPath: data.TWA_APP_SECURE_COOKIES
-  name: TWA_APP_SECURE_COOKIES
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: tensorboards-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=tensorboards-web-app].env.[name=APP_SECURE_COOKIES].value
+- source:
     kind: ConfigMap
-    name: parameters
-- name: TWA_APP_ENABLE_METRICS
-  fieldref:
+    name: tensorboards-web-app-parameters
     fieldPath: data.TWA_APP_ENABLE_METRICS
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
+  targets:
+  - select:
+      kind: Deployment
+      name: tensorboards-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=tensorboards-web-app].env.[name=METRICS].value

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/kustomization.yaml
@@ -6,8 +6,37 @@ resources:
 - authorization-policy.yaml
 - destination-rule.yaml
 namespace: kubeflow
-commonLabels:
-  app: tensorboards-web-app
-  kustomize.component: tensorboards-web-app
-configurations:
-- params.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: tensorboards-web-app
+    kustomize.component: tensorboards-web-app
+
+# Replacements for VirtualService destination host (service.namespace.svc.clusterDomain).
+replacements:
+- source:
+    kind: Service
+    name: tensorboards-web-app-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: VirtualService
+      name: tensorboards-web-app-tensorboards-web-app
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 1
+- source:
+    kind: ConfigMap
+    name: tensorboards-web-app-parameters
+    fieldPath: data.TWA_CLUSTER_DOMAIN
+  targets:
+  - select:
+      kind: VirtualService
+      name: tensorboards-web-app-tensorboards-web-app
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 3

--- a/components/crud-web-apps/tensorboards/manifests/overlays/istio/virtual-service.yaml
+++ b/components/crud-web-apps/tensorboards/manifests/overlays/istio/virtual-service.yaml
@@ -19,6 +19,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: tensorboards-web-app-service.$(TWA_NAMESPACE).svc.$(TWA_CLUSTER_DOMAIN)
+        # host: service.namespace.svc.clusterDomain — index 1 and 3 filled by replacements
+        host: tensorboards-web-app-service.placeholder.svc.placeholder
         port:
           number: 80

--- a/components/crud-web-apps/volumes/manifests/base/deployment.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/deployment.yaml
@@ -13,17 +13,17 @@ spec:
         - containerPort: 5000
         env:
         - name: APP_PREFIX
-          value: $(VWA_PREFIX)
+          value: placeholder
         - name: USERID_HEADER
-          value: $(VWA_USERID_HEADER)
+          value: placeholder
         - name: USERID_PREFIX
-          value: $(VWA_USERID_PREFIX)
+          value: placeholder
         - name: APP_SECURE_COOKIES
-          value: $(VWA_APP_SECURE_COOKIES)
+          value: placeholder
         - name: VOLUME_VIEWER_IMAGE
           value: filebrowser/filebrowser:v2.25.0
         - name: METRICS
-          value: $(VWA_APP_ENABLE_METRICS)
+          value: placeholder
         volumeMounts: 
         - name: viewer-spec
           mountPath: /etc/config/viewer-spec.yaml

--- a/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/base/kustomization.yaml
@@ -8,9 +8,11 @@ resources:
 - service.yaml
 namePrefix: volumes-web-app-
 namespace: kubeflow
-commonLabels:
-  app: volumes-web-app
-  kustomize.component: volumes-web-app
+labels:
+- includeSelectors: true
+  pairs:
+    app: volumes-web-app
+    kustomize.component: volumes-web-app
 images:
 - name: ghcr.io/kubeflow/kubeflow/volumes-web-app
   newName: ghcr.io/kubeflow/kubeflow/volumes-web-app
@@ -24,53 +26,54 @@ configMapGenerator:
 - files:
   - viewer-spec.yaml
   name: viewer-spec
-vars:
-- fieldref:
-    fieldPath: data.VWA_CLUSTER_DOMAIN
-  name: VWA_CLUSTER_DOMAIN
-  objref:
-    apiVersion: v1
+replacements:
+- source:
     kind: ConfigMap
-    name: parameters
-- fieldref:
-    fieldPath: metadata.namespace
-  name: VWA_NAMESPACE
-  objref:
-    apiVersion: v1
-    kind: Service
-    name: service
-- fieldref:
-    fieldPath: data.VWA_USERID_HEADER
-  name: VWA_USERID_HEADER
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
-    fieldPath: data.VWA_USERID_PREFIX
-  name: VWA_USERID_PREFIX
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
-- fieldref:
+    name: volumes-web-app-parameters
     fieldPath: data.VWA_PREFIX
-  name: VWA_PREFIX
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: volumes-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=volumes-web-app].env.[name=APP_PREFIX].value
+- source:
     kind: ConfigMap
-    name: parameters
-- name: VWA_APP_SECURE_COOKIES
-  fieldref:
+    name: volumes-web-app-parameters
+    fieldPath: data.VWA_USERID_HEADER
+  targets:
+  - select:
+      kind: Deployment
+      name: volumes-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=volumes-web-app].env.[name=USERID_HEADER].value
+- source:
+    kind: ConfigMap
+    name: volumes-web-app-parameters
+    fieldPath: data.VWA_USERID_PREFIX
+  targets:
+  - select:
+      kind: Deployment
+      name: volumes-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=volumes-web-app].env.[name=USERID_PREFIX].value
+- source:
+    kind: ConfigMap
+    name: volumes-web-app-parameters
     fieldPath: data.VWA_APP_SECURE_COOKIES
-  objref:
-    apiVersion: v1
+  targets:
+  - select:
+      kind: Deployment
+      name: volumes-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=volumes-web-app].env.[name=APP_SECURE_COOKIES].value
+- source:
     kind: ConfigMap
-    name: parameters
-- name: VWA_APP_ENABLE_METRICS
-  fieldref:
+    name: volumes-web-app-parameters
     fieldPath: data.VWA_APP_ENABLE_METRICS
-  objref:
-    apiVersion: v1
-    kind: ConfigMap
-    name: parameters
+  targets:
+  - select:
+      kind: Deployment
+      name: volumes-web-app-deployment
+    fieldPaths:
+    - spec.template.spec.containers.[name=volumes-web-app].env.[name=METRICS].value

--- a/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
+++ b/components/crud-web-apps/volumes/manifests/overlays/istio/kustomization.yaml
@@ -6,8 +6,37 @@ resources:
 - authorization-policy.yaml
 - destination-rule.yaml
 namespace: kubeflow
-commonLabels:
-  app: volumes-web-app
-  kustomize.component: volumes-web-app
-configurations:
-- params.yaml
+labels:
+- includeSelectors: true
+  pairs:
+    app: volumes-web-app
+    kustomize.component: volumes-web-app
+
+# Replacements for VirtualService destination host (service.namespace.svc.clusterDomain).
+replacements:
+- source:
+    kind: Service
+    name: volumes-web-app-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: VirtualService
+      name: volumes-web-app-volumes-web-app
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 1
+- source:
+    kind: ConfigMap
+    name: volumes-web-app-parameters
+    fieldPath: data.VWA_CLUSTER_DOMAIN
+  targets:
+  - select:
+      kind: VirtualService
+      name: volumes-web-app-volumes-web-app
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 3

--- a/components/crud-web-apps/volumes/manifests/overlays/istio/virtual-service.yaml
+++ b/components/crud-web-apps/volumes/manifests/overlays/istio/virtual-service.yaml
@@ -19,6 +19,7 @@ spec:
       uri: /
     route:
     - destination:
-        host: volumes-web-app-service.$(VWA_NAMESPACE).svc.$(VWA_CLUSTER_DOMAIN)
+        # host: service.namespace.svc.clusterDomain — index 1 and 3 filled by replacements
+        host: volumes-web-app-service.placeholder.svc.placeholder
         port:
           number: 80

--- a/components/notebook-controller/config/crd/kustomization.yaml
+++ b/components/notebook-controller/config/crd/kustomization.yaml
@@ -5,9 +5,14 @@ resources:
 - bases/kubeflow.org_notebooks.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-- patches/trivial_conversion_patch.yaml
-
+patches:
+- path: patches/trivial_conversion_patch.yaml
+- target:
+    group: apiextensions.k8s.io
+    version: v1
+    kind: CustomResourceDefinition
+    name: notebooks.kubeflow.org
+  path: patches/validation_patches.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_notebooks.yaml
@@ -22,11 +27,5 @@ patchesStrategicMerge:
 configurations:
 - kustomizeconfig.yaml
 
-patchesJson6902:
-  - target:
-      group: apiextensions.k8s.io
-      version: v1
-      kind: CustomResourceDefinition
-      name: notebooks.kubeflow.org
-    path: patches/validation_patches.yaml
+
 

--- a/components/notebook-controller/config/default/kustomization.yaml
+++ b/components/notebook-controller/config/default/kustomization.yaml
@@ -9,12 +9,13 @@ namespace: notebook-controller-system
 namePrefix: notebook-controller-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app: notebook-controller
-  kustomize.component: notebook-controller
+labels:
+- includeSelectors: true
+  pairs:
+    app: notebook-controller
+    kustomize.component: notebook-controller
 
-
-bases:
+resources:
 - ../rbac
 - ../manager
 - ../crd
@@ -23,53 +24,16 @@ bases:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
 #- ../certmanager
 
-#patchesStrategicMerge:
-#- manager_image_patch.yaml
-  # Protect the /metrics endpoint by putting it behind auth.
-  # Only one of manager_auth_proxy_patch.yaml and
-  # manager_prometheus_metrics_patch.yaml should be enabled.
-#- manager_auth_proxy_patch.yaml
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, uncomment the following line and
-  # comment manager_auth_proxy_patch.yaml.
-  # Only one of manager_auth_proxy_patch.yaml and
-  # manager_prometheus_metrics_patch.yaml should be enabled.
-#- manager_prometheus_metrics_patch.yaml
-
+patches: []
+# - path: manager_image_patch.yaml
+# Protect the /metrics endpoint by putting it behind auth.
+# Only one of manager_auth_proxy_patch.yaml and manager_prometheus_metrics_patch.yaml should be enabled.
+# - path: manager_auth_proxy_patch.yaml
+# If you want your controller-manager to expose the /metrics endpoint w/o any authn/z, uncomment the following and comment manager_auth_proxy_patch.yaml.
+# - path: manager_prometheus_metrics_patch.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
-#- manager_webhook_patch.yaml
-
+# - path: manager_webhook_patch.yaml
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
-# 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
-
-# the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-# - name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#   objref:
-#     kind: Certificate
-#     group: certmanager.k8s.io
-#     version: v1alpha1
-#     name: serving-cert # this name should match the one in certificate.yaml
-#   fieldref:
-#     fieldpath: metadata.namespace
-# - name: CERTIFICATE_NAME
-#   objref:
-#     kind: Certificate
-#     group: certmanager.k8s.io
-#     version: v1alpha1
-#     name: serving-cert # this name should match the one in certificate.yaml
-# - name: SERVICE_NAMESPACE # namespace of the service
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#   fieldref:
-#     fieldpath: metadata.namespace
-# - name: SERVICE_NAME
-#   objref:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
+# - path: webhookcainjection_patch.yaml
+# When CERTMANAGER is enabled, use replacements (not vars) for CA injection; see pvcviewer-controller/config/default for an example.

--- a/components/notebook-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/notebook-controller/config/overlays/kubeflow/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
 - ../../base
 namespace: kubeflow
-patchesStrategicMerge:
-- patches/remove-namespace.yaml
+patches:
+- path: patches/remove-namespace.yaml
 configMapGenerator:
 - name: config
   behavior: merge

--- a/components/profile-controller/config/base/kustomization.yaml
+++ b/components/profile-controller/config/base/kustomization.yaml
@@ -6,9 +6,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../default
-patchesStrategicMerge:
-- patches/manager.yaml
-
+patches:
+- path: patches/manager.yaml
 images:
 - name: ghcr.io/kubeflow/kubeflow/profile-controller
   newName: ghcr.io/kubeflow/kubeflow/profile-controller

--- a/components/profile-controller/config/crd/kustomization.yaml
+++ b/components/profile-controller/config/crd/kustomization.yaml
@@ -5,16 +5,16 @@ resources:
 - bases/kubeflow.org_profiles.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-- patches/trivial_conversion_patch.yaml
+patches:
+- path: patches/trivial_conversion_patch.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_profiles.yaml
+# - path: patches/webhook_in_profiles.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_profiles.yaml
+# - path: patches/cainjection_in_profiles.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/components/profile-controller/config/default/kustomization.yaml
+++ b/components/profile-controller/config/default/kustomization.yaml
@@ -9,10 +9,12 @@ namespace: profiles-system
 namePrefix: profiles-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  kustomize.component: profiles
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: profiles
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -24,53 +26,22 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches: []
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-# - manager_auth_proxy_patch.yaml
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, uncomment the following line and
-  # comment manager_auth_proxy_patch.yaml.
-  # Only one of manager_auth_proxy_patch.yaml and
-  # manager_prometheus_metrics_patch.yaml should be enabled.
-#- manager_prometheus_metrics_patch.yaml
-
+# - path: manager_auth_proxy_patch.yaml
+# If you want your controller-manager to expose the /metrics
+# endpoint w/o any authn/z, uncomment the following line and
+# comment manager_auth_proxy_patch.yaml.
+# Only one of manager_auth_proxy_patch.yaml and
+# manager_prometheus_metrics_patch.yaml should be enabled.
+# - path: manager_prometheus_metrics_patch.yaml
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
-
+# - path: manager_webhook_patch.yaml
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
-
-# the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+# - path: webhookcainjection_patch.yaml
+# When CERTMANAGER is enabled, use replacements (not vars) for CA injection; see pvcviewer-controller/config/default for an example.

--- a/components/profile-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/kustomization.yaml
@@ -7,24 +7,30 @@ resources:
 - virtual-service.yaml
 - authorizationpolicy.yaml
 
-commonLabels:
-  kustomize.component: profiles
+labels:
+- includeSelectors: true
+  pairs:
+    kustomize.component: profiles
 
-patchesStrategicMerge:
-- patches/kfam.yaml
-- patches/remove-namespace.yaml
+patches:
+- path: patches/kfam.yaml
+- path: patches/remove-namespace.yaml
 
-configurations:
-- params.yaml
-
-vars:
-- name: PROFILES_NAMESPACE
-  fieldref:
-    fieldpath: metadata.namespace
-  objref:
-    name: profiles-kfam
+# Replacement for VirtualService destination host (service.namespace.svc.cluster.local).
+replacements:
+- source:
     kind: Service
-    apiVersion: v1
+    name: profiles-kfam
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: VirtualService
+      name: profiles-kfam
+    fieldPaths:
+    - spec.http.0.route.0.destination.host
+    options:
+      delimiter: "."
+      index: 1
 
 images:
 - name: ghcr.io/kubeflow/kubeflow/kfam

--- a/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
+++ b/components/profile-controller/config/overlays/kubeflow/virtual-service.yaml
@@ -19,6 +19,7 @@ spec:
       uri: /kfam/
     route:
     - destination:
-        host: profiles-kfam.$(PROFILES_NAMESPACE).svc.cluster.local
+        # host: service.namespace.svc.cluster.local — index 1 filled by replacement
+        host: profiles-kfam.placeholder.svc.cluster.local
         port:
           number: 8081

--- a/components/pvcviewer-controller/config/crd/kustomization.yaml
+++ b/components/pvcviewer-controller/config/crd/kustomization.yaml
@@ -5,11 +5,11 @@ resources:
 - bases/kubeflow.org_pvcviewers.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
-- patches/webhook_in_pvcviewers.yaml
+patches:
+- path: patches/webhook_in_pvcviewers.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
-- patches/cainjection_in_pvcviewers.yaml
+- path: patches/cainjection_in_pvcviewers.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/components/pvcviewer-controller/config/default/cainjection_patch.yaml
+++ b/components/pvcviewer-controller/config/default/cainjection_patch.yaml
@@ -1,5 +1,4 @@
-# This patch add annotation to admission webhook config and
-# CERTIFICATE_NAMESPACE and CERTIFICATE_NAME will be substituted by kustomize
+# This patch adds annotation; namespace and cert name are filled by replacements.
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -12,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: mutating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: placeholder/placeholder
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -26,11 +25,11 @@ metadata:
     app.kubernetes.io/managed-by: kustomize
   name: validating-webhook-configuration
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: placeholder/placeholder
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: placeholder/placeholder
   name: pvcviewers.kubeflow.org

--- a/components/pvcviewer-controller/config/default/dnsnames_patch.yaml
+++ b/components/pvcviewer-controller/config/default/dnsnames_patch.yaml
@@ -4,6 +4,7 @@ metadata:
   name: serving-cert
   namespace: system
 spec:
+  # dnsNames: service.namespace.svc[.cluster.local] — index 0 and 1 filled by replacements
   dnsNames:
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc
-  - $(SERVICE_NAME).$(SERVICE_NAMESPACE).svc.cluster.local
+  - placeholder.placeholder.svc
+  - placeholder.placeholder.svc.cluster.local

--- a/components/pvcviewer-controller/config/default/kustomization.yaml
+++ b/components/pvcviewer-controller/config/default/kustomization.yaml
@@ -12,8 +12,10 @@ namespace: kubeflow
 namePrefix: pvcviewer-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app: pvcviewer
+labels:
+- includeSelectors: true
+  pairs:
+    app: pvcviewer
 
 resources:
 - ../crd
@@ -24,48 +26,117 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Do not create a namespace
-- remove_namespace.yaml
+- path: remove_namespace.yaml
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
-- manager_webhook_patch.yaml
-- cainjection_patch.yaml
-- dnsnames_patch.yaml
+- path: manager_auth_proxy_patch.yaml
+- path: manager_webhook_patch.yaml
+- path: cainjection_patch.yaml
+- path: dnsnames_patch.yaml
 
-vars:
-- name: CERTIFICATE_NAMESPACE 
-  objref:
+# Replacements for cert-manager CA injection annotation and Certificate dnsNames.
+replacements:
+# Certificate namespace and name → webhook/CRD annotation (format namespace/certname).
+- source:
     kind: Certificate
     group: cert-manager.io
     version: v1
-    name: serving-cert 
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
+    name: pvcviewer-serving-cert
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+      name: pvcviewer-mutating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 0
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: pvcviewer-validating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 0
+  - select:
+      kind: CustomResourceDefinition
+      name: pvcviewers.kubeflow.org
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 0
+- source:
     kind: Certificate
     group: cert-manager.io
     version: v1
-    name: serving-cert
-- name: SERVICE_NAMESPACE
-  objref:
+    name: pvcviewer-serving-cert
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+      name: pvcviewer-mutating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 1
+  - select:
+      kind: ValidatingWebhookConfiguration
+      name: pvcviewer-validating-webhook-configuration
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 1
+  - select:
+      kind: CustomResourceDefinition
+      name: pvcviewers.kubeflow.org
+    fieldPaths:
+    - metadata.annotations.[cert-manager.io/inject-ca-from]
+    options:
+      delimiter: "/"
+      index: 1
+# Service name and namespace → Certificate dnsNames (format service.namespace.svc[.cluster.local]).
+- source:
     kind: Service
     version: v1
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
+    name: pvcviewer-webhook-service
+    fieldPath: metadata.name
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: pvcviewer-serving-cert
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: "."
+      index: 0
+- source:
     kind: Service
     version: v1
-    name: webhook-service
-
-# the following config is for teaching kustomize how to replace vars in Certificates.
-configurations:
-- kustomizeconfig.yaml
+    name: pvcviewer-webhook-service
+    fieldPath: metadata.namespace
+  targets:
+  - select:
+      kind: Certificate
+      group: cert-manager.io
+      version: v1
+      name: pvcviewer-serving-cert
+    fieldPaths:
+    - spec.dnsNames.0
+    - spec.dnsNames.1
+    options:
+      delimiter: "."
+      index: 1
 
 # Note: the kustomize version that's being used to execute integration tests currently doesn't support replacemens.
 # Thus, we're using the deprecated vars feature above.

--- a/components/tensorboard-controller/config/base/kustomization.yaml
+++ b/components/tensorboard-controller/config/base/kustomization.yaml
@@ -9,8 +9,8 @@ configMapGenerator:
   - TENSORBOARD_IMAGE=tensorflow/tensorflow:2.5.1
   - ISTIO_GATEWAY=kubeflow/kubeflow-gateway
   - ISTIO_HOST=*
-patchesStrategicMerge:
-- patches/add_controller_config.yaml
+patches:
+- path: patches/add_controller_config.yaml
 images:
 - name: ghcr.io/kubeflow/kubeflow/tensorboard-controller
   newName: ghcr.io/kubeflow/kubeflow/tensorboard-controller

--- a/components/tensorboard-controller/config/crd/kustomization.yaml
+++ b/components/tensorboard-controller/config/crd/kustomization.yaml
@@ -5,15 +5,15 @@ resources:
 - bases/tensorboard.kubeflow.org_tensorboards.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches: []
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-#- patches/webhook_in_tensorboards.yaml
+# - path: patches/webhook_in_tensorboards.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-#- patches/cainjection_in_tensorboards.yaml
+# - path: patches/cainjection_in_tensorboards.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch
 
 # the following config is for teaching kustomize how to do kustomization for CRDs.

--- a/components/tensorboard-controller/config/default/kustomization.yaml
+++ b/components/tensorboard-controller/config/default/kustomization.yaml
@@ -9,14 +9,16 @@ namespace: tensorboard-controller-system
 namePrefix: tensorboard-controller-
 
 # Labels to add to all resources and selectors.
-commonLabels:
-  app: tensorboard-controller
-  kustomize.component: tensorboard-controller
+labels:
+- includeSelectors: true
+  pairs:
+    app: tensorboard-controller
+    kustomize.component: tensorboard-controller
 
-bases:
-  - ../crd
-  - ../rbac
-  - ../manager
+resources:
+- ../crd
+- ../rbac
+- ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
 #- ../webhook
@@ -25,51 +27,15 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
-  # Protect the /metrics endpoint by putting it behind auth.
-  # If you want your controller-manager to expose the /metrics
-  # endpoint w/o any authn/z, please comment the following line.
-  - manager_auth_proxy_patch.yaml
-
-# Mount the controller config file for loading manager configurations
-# through a ComponentConfig type
-#- manager_config_patch.yaml
-
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- manager_webhook_patch.yaml
-
+patches:
+# Protect the /metrics endpoint by putting it behind auth.
+# If you want your controller-manager to expose the /metrics endpoint w/o any authn/z, please comment the following line.
+- path: manager_auth_proxy_patch.yaml
+# Mount the controller config file for loading manager configurations through a ComponentConfig type
+# - path: manager_config_patch.yaml
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in crd/kustomization.yaml
+# - path: manager_webhook_patch.yaml
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
-# 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
-
-# the following config is for teaching kustomize how to do var substitution
-vars:
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+# - path: webhookcainjection_patch.yaml
+# When CERTMANAGER is enabled, use replacements (not vars) for CA injection; see pvcviewer-controller/config/default for an example.

--- a/components/tensorboard-controller/config/overlays/kubeflow/kustomization.yaml
+++ b/components/tensorboard-controller/config/overlays/kubeflow/kustomization.yaml
@@ -3,5 +3,5 @@ kind: Kustomization
 resources:
 - ../../base
 namespace: kubeflow
-patchesStrategicMerge:
-- patches/remove-namespace.yaml
+patches:
+- path: patches/remove-namespace.yaml


### PR DESCRIPTION
# Merge Request: Migrate Kubeflow Kustomize configs off deprecated fields

## Summary

This MR removes all use of deprecated Kustomize fields across the repository and replaces them with the current, supported equivalents. Build behavior is unchanged: rendered manifests are identical before and after. All `kustomize build` invocations now complete without deprecation warnings.

## Motivation

Kustomize has deprecated several fields and will remove them in future versions. To avoid future breakage and to satisfy current `kustomize build` output without warnings, we:

- Replace **`commonLabels`** with **`labels`** (with `includeSelectors` and `pairs`).
- Replace **`vars`** with **`replacements`** (explicit source/target field substitution).
- Replace **`patchesStrategicMerge`** with **`patches`** (using `path:` for strategic merge, or `target:` + `path:` for JSON6902).
- Replace **`bases`** with **`resources`**.

Where `vars` were used, target resources (e.g. Deployments, VirtualServices, Certificates) were updated to use placeholder values so that `replacements` have concrete fields to overwrite; the final rendered manifests are unchanged.

## Scope of changes

### Components updated

| Component | Changes |
|-----------|--------|
| **admission-webhook** | `vars` → `replacements` (base + cert-manager overlay), `commonLabels` → `labels`, `patchesStrategicMerge` → `patches`, `bases` → `resources`. Placeholders in Certificate and MutatingWebhookConfiguration. |
| **crud-web-apps/jupyter** | `commonLabels` → `labels` (base + istio overlay). All `vars` → `replacements`; `JWA_CLUSTER_DOMAIN`/`JWA_NAMESPACE` moved to istio overlay. Deployment and VirtualService use placeholders. Removed `configurations: params.yaml` where only used for vars. |
| **crud-web-apps/tensorboards** | Same pattern: `labels`, `replacements`, overlay for `TWA_CLUSTER_DOMAIN`/`TWA_NAMESPACE`, placeholders in deployment and VirtualService. |
| **crud-web-apps/volumes** | Same pattern: `labels`, `replacements`, overlay for `VWA_CLUSTER_DOMAIN`/`VWA_NAMESPACE`, placeholders in deployment and VirtualService. |
| **centraldashboard** | `commonLabels` → `labels`, `vars` → `replacements` (base + istio overlay). `patchesStrategicMerge` → `patches` in kserve overlay. |
| **centraldashboard-angular** | Same pattern: `labels`, `replacements` in base and istio overlay, `patchesStrategicMerge` → `patches` in kserve overlay. |
| **pvcviewer-controller** | `commonLabels` → `labels`, `patchesStrategicMerge` → `patches`, `vars` → `replacements`. Certificate and DNS name patches use placeholders. Removed `configurations` where only used for vars. |
| **profile-controller** | `commonLabels` → `labels`, `bases` → `resources`, `patchesStrategicMerge` → `patches`, `vars` removed and replaced with `replacements` in kubeflow overlay. VirtualService placeholder for host. |
| **notebook-controller** | `commonLabels` → `labels`, `bases` → `resources`, `patchesStrategicMerge` → `patches` in default and crd; `patchesJson6902` merged into `patches` in crd. `vars` removed from default. |
| **tensorboard-controller** | Same pattern in default and crd: `labels`, `resources`, `patches` (crd uses `patches: []` with commented `path:` lines for optional webhook/cert-manager). |

### File types touched

- **kustomization.yaml** (many): Swapped deprecated keys for `labels`, `resources`, `patches`, `replacements`; removed or adjusted `configurations` where only used for vars.
- **Deployment / Service / VirtualService / Certificate / MutatingWebhookConfiguration YAMLs**: Where a field was the target of a `var`, it now holds a placeholder value that `replacements` overwrite (e.g. `value: placeholder`, `host: service.placeholder.svc.placeholder`, annotation `placeholder/placeholder`).

No changes to Go code or to the logical behavior of deployed resources.

## How we tested

1. **Build sweep**  
   Ran `kustomize build .` from every directory that contains a `kustomization.yaml` (48 roots under `components/`). All builds succeed with no deprecation warnings (tested with kustomize v5.8.1).

2. **Before/after comparison**  
   For the components that had the most refactoring (e.g. admission-webhook, crud-web-apps/jupyter, crud-web-apps/tensorboards, crud-web-apps/volumes, centraldashboard-angular), we:
   - Built from the same root before and after the changes (using `git stash` to temporarily revert where needed).
   - Diffed the two outputs (`diff before.yaml after.yaml`).
   - Confirmed the diff was empty so that rendered manifests are identical.

3. **Static check**  
   Grepped the repo for deprecated keys (`commonLabels`, `patchesStrategicMerge`, `bases:`, `vars:`, `patchesJson6902`) in YAML; none remain in kustomization files.

## Notes for reviewers

- **Replacements and placeholders**  
  For `replacements` to work, the target field must exist. So we added placeholder values (e.g. `placeholder`, `service.placeholder.svc.placeholder`) in the source YAMLs; kustomize overwrites them at build time. The final manifests are the same as when using `vars`.

- **Overlay vs base**  
  Some `vars` (e.g. namespace, cluster domain) were only used in overlays (e.g. VirtualService host). Those are now defined as `replacements` only in the overlay that consumes them, keeping the base free of overlay-specific substitution.

- **namePrefix**  
  In overlays that use `namePrefix`, replacements that refer to resource names (e.g. webhook name) are defined in the overlay so they apply after the prefix is applied, ensuring the correct final names in the output.

- **CRD and optional patches**  
  In CRD kustomizations (e.g. notebook-controller, tensorboard-controller), optional webhook/cert-manager patches are left as commented lines with the new `patches` style (`# - path: ...`) so that uncommenting preserves the non-deprecated format.

## Checklist

- [x] All `kustomize build` invocations succeed.
- [x] No deprecation warnings (commonLabels, vars, patchesStrategicMerge, bases).
- [x] Rendered manifests unchanged where we ran before/after diffs.
- [x] No remaining deprecated keys in kustomization YAMLs.
