### PR TITLE
Update OWNERS for 2026 KSC members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,13 +2,14 @@
 # Approvers listed here is just a backup in case someone is out.
 approvers:
   - andreyvelich
+  - chasecadet
   - franciscojavierarceo
   - juliusvonkohout 
-  - johnugeorge
-  - terrytangyuan
+  - thesuperzapper
   - zijianjoy
 
 emeritus_approvers:
   - james-jwu
   - jbottum
-
+  - johnugeorge
+  - terrytangyuan


### PR DESCRIPTION
Updates the root OWNERS file for the 2026 Kubeflow Steering Committee transition.

Changes:
- add chasecadet and thesuperzapper as approvers
- move johnugeorge and terrytangyuan to emeritus_approvers
- preserve existing non-KSC approvers

Related: kubeflow/community#950