### PR TITLE
docs: clarify platform roadmap references

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ offers modular, scalable, and extensible tools to support your AI use cases.
 
 Please refer to [the official documentation](https://www.kubeflow.org/docs/) for more information.
 
+## Repository Role
+
+This repository is the historical entry point for the Kubeflow AI reference platform. It now serves
+primarily as a gateway to Kubeflow subprojects, shared project metadata, and platform-level planning
+for the integrated reference platform. Most component development happens in the individual
+subproject repositories listed below.
+
 ## What are Kubeflow Projects
 
 Kubeflow is composed of multiple open source projects that address different aspects
@@ -51,6 +58,10 @@ or [Kubeflow Manifests](https://www.kubeflow.org/docs/started/installing-kubeflo
 | [Central Dashboard](https://www.kubeflow.org/docs/components/central-dash/)                         | [`kubeflow/dashboard`](https://github.com/kubeflow/dashboard) |
 | [Profile Controller](https://www.kubeflow.org/docs/components/central-dash/profiles/)               | [`kubeflow/dashboard`](https://github.com/kubeflow/dashboard) |
 | [Kubeflow Manifests](https://www.kubeflow.org/docs/started/installing-kubeflow/#kubeflow-manifests) | [`kubeflow/manifests`](https://github.com/kubeflow/manifests) |
+
+The platform-level roadmap in [`ROADMAP.md`](ROADMAP.md) tracks integrated Kubeflow AI reference
+platform releases. Individual subproject roadmap details live in the corresponding subproject
+repositories.
 
 ## Kubeflow Community
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,5 +1,21 @@
 # Kubeflow AI Reference Platform Roadmap
 
+This roadmap tracks the integrated Kubeflow AI reference platform. Kubeflow is composed of
+independently developed subprojects, and detailed component-level roadmap items are tracked in
+the relevant subproject repositories, release issues, milestones, and release notes.
+
+Current subproject roadmap references:
+
+* [Kubeflow Notebooks](https://github.com/kubeflow/notebooks/blob/main/ROADMAP.md)
+* [Kubeflow Trainer](https://github.com/kubeflow/trainer/blob/master/ROADMAP.md)
+* [Kubeflow Katib](https://github.com/kubeflow/katib/blob/master/ROADMAP.md)
+* [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/blob/master/ROADMAP.md)
+* [Kubeflow Hub](https://github.com/kubeflow/hub/blob/main/ROADMAP.md)
+* [Kubeflow Spark Operator](https://github.com/kubeflow/spark-operator/blob/master/ROADMAP.md)
+
+Current platform and distribution release status is published in the
+[Kubeflow Community Distribution release documentation](https://www.kubeflow.org/docs/kubeflow-distribution/releases/).
+
 ## Kubeflow 1.11 Release, Planned for release: December 2025
 The Kubeflow Community plans to deliver its v1.11 release in December 2025 per this [timeline](https://github.com/kubeflow/community/blob/master/releases/release-1.11/README.md#timeline). The v1.11 release process will be managed by the v1.11 [release team](https://github.com/kubeflow/community/blob/master/releases/release-1.11/release-team.md) using the best practices in the [Release Handbook](https://github.com/kubeflow/community/blob/master/releases/handbook.md).
 
@@ -16,7 +32,7 @@ The Kubeflow Community plans to deliver its v1.11 release in December 2025 per t
 * [KServe](https://github.com/kserve/kserve/releases/tag/v0.15.2)
 * [Katib](https://github.com/kubeflow/katib/releases/tag/v0.19.0)
 * [Kubeflow Pipelines](https://github.com/kubeflow/pipelines/releases/tag/2.15.0)
-* [Notebooks](https://github.com/kubeflow/kubeflow/releases/tag/v1.10.0)
+* [Notebooks](https://github.com/kubeflow/notebooks/blob/main/ROADMAP.md)
 * [Platform (Manifests+Security)](https://github.com/kubeflow/manifests/releases/tag/v1.11.0)
 * [Model Registry](https://github.com/kubeflow/model-registry/releases/tag/v0.3.4)
 * [Spark Operator](https://github.com/kubeflow/spark-operator/releases/tag/v2.4.0)


### PR DESCRIPTION
Ref: kubeflow/community#988

Clarifies the current role of the `kubeflow/kubeflow` repository and updates the platform roadmap to make subproject roadmap references easier to find.

This PR:

- documents that `kubeflow/kubeflow` is now primarily a gateway to subprojects, shared project metadata, and platform-level planning
- explains that `ROADMAP.md` tracks integrated Kubeflow AI reference platform releases
- adds current subproject roadmap references, including Kubeflow Notebooks
- points current platform/distribution release status to the Kubeflow Community Distribution release docs
- updates the 1.11 Notebooks roadmap entry to use the new Notebooks roadmap reference
