### PR TITLE
fix: update stale Kubeflow 1.11 roadmap links

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,6 @@
-# Kubeflow AI Reference Platform Roadmap
+# Kubeflow Community Distribution
+
+This repository is just a placeholder. Please consult https://github.com/kubeflow/community-distribution/releases and https://github.com/kubeflow/community-distribution for up to date information.
 
 ## Kubeflow 1.11 Release, Planned for release: December 2025
 The Kubeflow Community plans to deliver its v1.11 release in December 2025 per this [timeline](https://github.com/kubeflow/community/blob/8a4247b920e6b0ec0d9daa85837ecb0747da9882/releases/release-1.11/README.md#timeline). The v1.11 release process will be managed by the v1.11 [release team](https://github.com/kubeflow/community/blob/8a4247b920e6b0ec0d9daa85837ecb0747da9882/releases/release-1.11/release-team.md) using the best practices in the [Release Handbook](https://github.com/kubeflow/community/blob/master/releases/handbook.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,7 +1,7 @@
 # Kubeflow AI Reference Platform Roadmap
 
 ## Kubeflow 1.11 Release, Planned for release: December 2025
-The Kubeflow Community plans to deliver its v1.11 release in December 2025 per this [timeline](https://github.com/kubeflow/community/blob/master/releases/release-1.11/README.md#timeline). The v1.11 release process will be managed by the v1.11 [release team](https://github.com/kubeflow/community/blob/master/releases/release-1.11/release-team.md) using the best practices in the [Release Handbook](https://github.com/kubeflow/community/blob/master/releases/handbook.md).
+The Kubeflow Community plans to deliver its v1.11 release in December 2025 per this [timeline](https://github.com/kubeflow/community/blob/8a4247b920e6b0ec0d9daa85837ecb0747da9882/releases/release-1.11/README.md#timeline). The v1.11 release process will be managed by the v1.11 [release team](https://github.com/kubeflow/community/blob/8a4247b920e6b0ec0d9daa85837ecb0747da9882/releases/release-1.11/release-team.md) using the best practices in the [Release Handbook](https://github.com/kubeflow/community/blob/master/releases/handbook.md).
 
 ### Themes
 * Trainer V2.0


### PR DESCRIPTION
## What
Fix 2 stale links in `ROADMAP.md` for the Kubeflow 1.11 section.

## Repro
1. Open `ROADMAP.md`
2. Click `timeline` or `release team` in the 1.11 intro line
3. GitHub returns `404`

## Why
The current `kubeflow/community/blob/master/releases/release-1.11/...` links are dead rn.
This swaps them to the stable blob URLs from the merged community PR that added those files. tiny papercut, but its real.

## Check
- old links return `404`
- new links return `200`
- `git diff --check` is clean

Same kind of fix as #7786 and #7754.