### PR TITLE
fix: update stale issue template repo links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -21,8 +21,8 @@ contact_links:
     about: Please use the `kubeflow/katib` repository
 
   - name: Issues - Kubeflow Model Registry
-    url: https://github.com/kubeflow/model-registry/issues
-    about: Please use the `kubeflow/model-registry` repository
+    url: https://github.com/kubeflow/hub/issues
+    about: Please use the `kubeflow/hub` repository
 
   - name: Issues - Kubeflow MPI Operator
     url: https://github.com/kubeflow/mpi-operator/issues
@@ -57,5 +57,5 @@ contact_links:
     about: Please use the `kubeflow/dashboard` repository
 
   - name: Issues - Kubeflow Platform - Kubeflow Manifests
-    url: https://github.com/kubeflow/manifests/issues
-    about: Please use the `kubeflow/manifests` repository
+    url: https://github.com/kubeflow/community-distribution/issues
+    about: Please use the `kubeflow/community-distribution` repository


### PR DESCRIPTION
Two issue cards in `issues/new/choose` still use old repo names, so users get bounced through GitHub redirects. Kinda small, but it's real and easy to hit.

Repro
1. Open `https://github.com/kubeflow/kubeflow/issues/new/choose`
2. Click `Issues - Kubeflow Model Registry`
3. Click `Issues - Kubeflow Platform - Kubeflow Manifests`

Right now they land here instead:
- `kubeflow/model-registry/issues` -> `kubeflow/hub/issues`
- `kubeflow/manifests/issues` -> `kubeflow/community-distribution/issues`

This patch points both cards at the canonical repos directly, so the card text matches the actual destination. no behavior change besides removing the redirect hop.
