### PR TITLE
fix: align issue chooser labels with routed repos

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -20,7 +20,7 @@ contact_links:
     url: https://github.com/kubeflow/katib/issues
     about: Please use the `kubeflow/katib` repository
 
-  - name: Issues - Kubeflow Model Registry
+  - name: Issues - Kubeflow Hub (formerly Model Registry)
     url: https://github.com/kubeflow/hub/issues
     about: Please use the `kubeflow/hub` repository
 
@@ -56,6 +56,6 @@ contact_links:
     url: https://github.com/kubeflow/dashboard/issues
     about: Please use the `kubeflow/dashboard` repository
 
-  - name: Issues - Kubeflow Platform - Kubeflow Manifests
+  - name: Issues - Kubeflow Community Distribution
     url: https://github.com/kubeflow/community-distribution/issues
     about: Please use the `kubeflow/community-distribution` repository


### PR DESCRIPTION
Follow-up to #7791.

The issue chooser still shows 2 stale labels after the repo links were updated. So users click one project name, then land in a differently named repo. Kinda confusing.

This updates the visible labels to match the current targets:
- `Kubeflow Hub (formerly Model Registry)`
- `Kubeflow Community Distribution`

Repro:
1. Open `https://github.com/kubeflow/kubeflow/issues/new/choose`
2. Check `Issues - Kubeflow Model Registry` or `Issues - Kubeflow Platform - Kubeflow Manifests`
3. Click the link

Actual: the label says one thing, the destination repo says another.
Expected: the label matches where you land, nice and clean.