### PR TITLE
fix: add security disclosure guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,6 +4,10 @@ contact_links:
     url: https://www.kubeflow.org/
     about: Official Kubeflow Documentation
 
+  - name: Security Vulnerabilities
+    url: https://github.com/kubeflow/kubeflow/security/advisories/new
+    about: Please report vulnerabilities privately with GitHub Security Advisories
+
   - name: Kubeflow Slack
     url: https://www.kubeflow.org/docs/about/community/#kubeflow-slack-channels
     about: Join the Kubeflow Slack

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Scope
+
+This repository serves as the top-level Kubeflow gateway and tracks shared project metadata.
+If you discover a vulnerability that affects this repository, please report it privately.
+
+If the issue is isolated to a specific Kubeflow subproject, you can also report it in that
+subproject's repository.
+
+## Reporting a Vulnerability
+
+Please use one of the following private channels:
+
+- GitHub Security Advisories for this repository:
+  https://github.com/kubeflow/kubeflow/security/advisories/new
+- Kubeflow Steering Committee private mailing list: `ksc@kubeflow.org`
+
+Please include the affected repository or component, reproduction details, impact, and any
+suggested mitigations.
+
+## Disclosure Process
+
+- We will acknowledge receipt of your report within 10 business days.
+- Maintainers will validate the report, assess impact, and coordinate a fix.
+- We will coordinate public disclosure after a fix or mitigation is available.
+
+Please do not report security vulnerabilities through public GitHub issues, Slack, or mailing lists.


### PR DESCRIPTION
Related: #7438, #7136, #7450

What
Add a repo-level `SECURITY.md` and add a private security contact link in the issue chooser.

Why
Right now `https://github.com/kubeflow/kubeflow/security` shows `No security policy detected`, and the issue chooser has no private vuln reporting path. So reporters can get nudged toward public issues, which is not great.

Repro
1. Open `https://github.com/kubeflow/kubeflow/security`
2. See `No security policy detected`
3. Open the new issue chooser for this repo
4. See there is no security option, only public routes

Fix
This adds the missing policy page and points the issue chooser to `https://github.com/kubeflow/kubeflow/security/advisories/new`.

Pretty small fix, but it closes the gap cleanly.
